### PR TITLE
brimstone: Update to "Modern CMake"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 project(brimstone)
-
-# For vulkan.h
-include_directories(${CMAKE_SOURCE_DIR}/external/Vulkan-Headers/include ${CMAKE_SOURCE_DIR})
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/application/toascii/CMakeLists.txt
+++ b/application/toascii/CMakeLists.txt
@@ -1,6 +1,15 @@
-set(SOURCE_FILES
-    main.cpp)
+add_executable(grectoascii "")
 
-add_executable(grectoascii ${SOURCE_FILES})
+target_sources(grectoascii
+               PUBLIC
+                   ${CMAKE_SOURCE_DIR}/external/Vulkan-Headers/include/vulkan/vulkan.h
+               PRIVATE
+                   main.cpp
+              )
 
 target_link_libraries(grectoascii brimstone_format)
+
+target_include_directories(grectoascii
+                           PUBLIC
+                               ${CMAKE_SOURCE_DIR}/external/Vulkan-Headers/include
+                          )

--- a/format/CMakeLists.txt
+++ b/format/CMakeLists.txt
@@ -1,29 +1,33 @@
-set(HEADER_FILES
-    api_call_id.h
-    decoder.h
-    file_processor.h
-    format.h
-    parameter_encoder.h
-    pnext_node.h
-    pnext_typed_node.h
-    pointer_decoder_base.h
-    pointer_decoder.h
-    string_array_decoder.h
-    string_decoder.h
-    struct_pointer_decoder.h
-    trace_manager.h
-    trace_pnext_util.h
-    value_decoder.h
-    vulkan_decoder.h)
+add_library(brimstone_format "")
 
-set(SOURCE_FILES
-    file_processor.cpp
-    string_array_decoder.cpp
-    string_decoder.cpp
-    trace_manager.cpp
-    vulkan_decoder.cpp)
+target_sources(brimstone_format
+               PRIVATE
+                   api_call_id.h
+                   decoder.h
+                   file_processor.h
+                   format.h
+                   parameter_encoder.h
+                   pnext_node.h
+                   pnext_typed_node.h
+                   pointer_decoder_base.h
+                   pointer_decoder.h
+                   string_array_decoder.h
+                   string_decoder.h
+                   struct_pointer_decoder.h
+                   trace_manager.h
+                   trace_pnext_util.h
+                   value_decoder.h
+                   vulkan_decoder.h
+                   file_processor.cpp
+                   string_array_decoder.cpp
+                   string_decoder.cpp
+                   trace_manager.cpp
+                   vulkan_decoder.cpp
+              )
 
-add_library(brimstone_format ${HEADER_FILES} ${SOURCE_FILES})
-
-target_include_directories(brimstone_format PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(brimstone_format
+                           PUBLIC
+                               ${CMAKE_SOURCE_DIR}/external/Vulkan-Headers/include
+                               ${CMAKE_SOURCE_DIR}
+                          )
 target_link_libraries(brimstone_format brimstone_util)

--- a/generated/CMakeLists.txt
+++ b/generated/CMakeLists.txt
@@ -1,8 +1,8 @@
-set(HEADER_FILES generated_apicalltrace.inc)
-
-source_group("Header Files" FILES ${HEADER_FILES})
-
 add_library(brimstone_generated INTERFACE)
 
+target_sources(brimstone_generated
+               INTERFACE
+                   ${CMAKE_CURRENT_SOURCE_DIR}/generated_api_call_encoders.inc
+              )
+
 target_compile_definitions(brimstone_generated INTERFACE LIBRARY_HEADER_ONLY)
-target_include_directories(brimstone_generated INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -1,15 +1,12 @@
-set(HEADER_FILES
-    trace_layer.h)
+add_library(brimstone_layer "")
 
-set(SOURCE_FILES
-    dll_main.cpp
-    trace_layer.cpp)
-
-if (WIN32)
-    set(SOURCE_FILES ${SOURCE_FILES} trace_layer.def)
-endif (WIN32)
-
-add_library(brimstone_layer SHARED ${HEADER_FILES} ${SOURCE_FILES})
+target_sources(brimstone_layer
+               PRIVATE
+                   trace_layer.h
+                   dll_main.cpp
+                   trace_layer.cpp
+                   $<$<BOOL:WIN32>:trace_layer.def>
+              )
 
 if (WIN32)
     target_compile_definitions(brimstone_layer PRIVATE -DWIN32_LEAN_AND_MEAN)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,21 +1,25 @@
-set(HEADER_FILES
-    defines.h
-    file_output_stream.h
-    memory_output_stream.h
-    output_stream.h
-    platform.h
-    logging.h
-    metadata.h)
+add_library(brimstone_util "")
 
-set(SOURCE_FILES
-    file_output_stream.cpp
-    memory_output_stream.cpp
-    metadata.cpp)
-
-add_library(brimstone_util ${HEADER_FILES} ${SOURCE_FILES})
+target_sources(brimstone_util
+               PRIVATE
+                   defines.h
+                   file_output_stream.h
+                   memory_output_stream.h
+                   output_stream.h
+                   platform.h
+                   logging.h
+                   metadata.h
+                   file_output_stream.cpp
+                   memory_output_stream.cpp
+                   metadata.cpp
+              )
 
 if (WIN32)
     target_compile_definitions(brimstone_util PRIVATE -DWIN32_LEAN_AND_MEAN)
 endif (WIN32)
 
-target_include_directories(brimstone_util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(brimstone_util
+                           PUBLIC
+                               ${CMAKE_SOURCE_DIR}/external/Vulkan-Headers/include
+                               ${CMAKE_SOURCE_DIR}
+                          )


### PR DESCRIPTION
Update CMake items to conform to "Modern CMake" to reduce the
chance of dependency leakage.  Also, moved from "vulkan.h" to
"vulkan_core.h" which should contain fewer OS dependencies and
lighten up the code.