### PR TITLE
brimstone: clang-format changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,6 +12,8 @@ AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
 BreakBeforeBraces: Custom
 BraceWrapping:
   AfterClass: true


### PR DESCRIPTION
Remove function argument/parameter packing.