### PR TITLE
Fix broken CMake DLL Configuration

### DIFF
--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(brimstone_layer "")
+add_library(brimstone_layer SHARED "")
 
 target_sources(brimstone_layer
                PRIVATE


### PR DESCRIPTION
Undo recent CMake change that  converted the layer project from a
shared library project to a static library project.