### PR TITLE
Disable clang-format Option Not Supported by Default with VS2017

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,11 +19,12 @@ BraceWrapping:
   AfterClass: true
   AfterControlStatement: true
   AfterEnum: true
+  # Not currently supported by the VS2017 built in clang-format v5
+  #AfterExternBlock: true
   AfterFunction: true
   AfterNamespace: true
   AfterStruct: true
   AfterUnion: true
-  AfterExternBlock: true
   BeforeCatch: true
   BeforeElse: true
   SplitEmptyFunction: false


### PR DESCRIPTION
Disable the 'AfterExternBlock' option, which is not currently supported by the default clang-format version that is built into VisualStudio 2017.