### PR TITLE
Use platform::FileOpen with FileProcessor

### DIFF
--- a/format/file_processor.cpp
+++ b/format/file_processor.cpp
@@ -16,6 +16,7 @@
 
 #include <cassert>
 
+#include "util/platform.h"
 #include "format/file_processor.h"
 
 BRIMSTONE_BEGIN_NAMESPACE(brimstone)
@@ -39,9 +40,9 @@ bool FileProcessor::Initialize(const std::string& file_name)
 {
     bool success = false;
 
-    file_descriptor_ = fopen(file_name.c_str(), "rb");
+    int32_t result = util::platform::FileOpen(&file_descriptor_, file_name.c_str(), "rb");
 
-    if (file_descriptor_)
+    if ((result == 0) && (file_descriptor_ != nullptr))
     {
         success = ReadFileHeader();
 
@@ -227,7 +228,7 @@ bool FileProcessor::ReadParameterBuffer(size_t buffer_size)
 
 size_t FileProcessor::ReadBytes(void* buffer, size_t buffer_size)
 {
-    size_t bytes_read = fread(buffer, 1, buffer_size, file_descriptor_);
+    size_t bytes_read = util::platform::FileRead(buffer, 1, buffer_size, file_descriptor_);
     bytes_read_ += bytes_read;
     return bytes_read;
 }


### PR DESCRIPTION
Replace use of fopen in FileProcessor with platform::FileOpen to eliminate an unsafe function warning from the VC++ compiler.