### PR TITLE
Create Command-line Compression Tool

### DIFF
--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(replay)
 add_subdirectory(toascii)
+add_subdirectory(compress)
 
 add_library(brimstone_application STATIC "")
 

--- a/application/compress/CMakeLists.txt
+++ b/application/compress/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_executable(greccompress "")
+
+target_sources(greccompress
+               PRIVATE
+                   main.cpp
+              )
+
+target_include_directories(greccompress
+                           PUBLIC
+                               $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>)
+
+target_link_libraries(greccompress brimstone_format platform_specific)

--- a/application/compress/main.cpp
+++ b/application/compress/main.cpp
@@ -1,0 +1,108 @@
+#include <cassert>
+
+#include "format/file_processor.h"
+#include "format/decompress_decoder.h"
+#include "util/compressor.h"
+
+int main(int argc, char** argv)
+{
+    brimstone::format::FileProcessor file_processor;
+    std::string                      input_bin_file_name    = "D:\\temp\\brimstone_test.bin";
+    std::string                      output_bin_file_name   = "D:\\temp\\brimstone_test_out.bin";
+    brimstone::util::CompressionType compression_type       = brimstone::util::kNone;
+    std::string                      dst_compression_string = "NONE";
+    bool                             print_usage            = false;
+
+    if (argc > 3)
+    {
+        input_bin_file_name  = argv[1];
+        output_bin_file_name = argv[2];
+        if (!strcmp("NONE", argv[3]))
+        {
+            // Nothing to do here.
+        }
+        else if (!strcmp("LZ4", argv[3]))
+        {
+            compression_type       = brimstone::util::kLz4;
+            dst_compression_string = argv[3];
+        }
+        else
+        {
+            print_usage = true;
+        }
+    }
+    else
+    {
+        print_usage = true;
+    }
+
+    if (print_usage)
+    {
+        printf(
+            "%s <input_bin> <output_bin> <output_compression>\n\t<output_compression> may be \"LZ4\" or \"NONE\"\n\n",
+            argv[0]);
+        exit(-1);
+    }
+
+    if (file_processor.Initialize(input_bin_file_name))
+    {
+        brimstone::format::DecompressDecoder decoder;
+
+        if (decoder.Initialize(output_bin_file_name,
+                               file_processor.GetFileHeader(),
+                               file_processor.GetFileOptions(),
+                               compression_type))
+        {
+            std::string src_compression = "NONE";
+            file_processor.AddDecoder(&decoder);
+            file_processor.ProcessAllFrames();
+
+            for (auto& option : file_processor.GetFileOptions())
+            {
+                if (option.key == brimstone::format::kCompressionType)
+                {
+                    switch (option.value)
+                    {
+                        case brimstone::util::kNone:
+                            // Nothing to do
+                            break;
+                        case brimstone::util::kLz4:
+                            src_compression = "LZ4";
+                            break;
+                        default:
+                            printf("ERROR: Unknown source compression type %d", option.value);
+                            assert(false);
+                            break;
+                    }
+                }
+            }
+
+            if (brimstone::util::kNone != compression_type)
+            {
+                size_t bytes_read    = file_processor.NumBytesRead();
+                size_t bytes_written = decoder.NumBytesWritten();
+                float  percent_reduction =
+                    100.f * (1.f - (static_cast<float>(bytes_written) / static_cast<float>(bytes_read)));
+                printf("Compression Results:\n");
+                printf("  Original Size   [Compression: %5s] = %lu bytes\n", src_compression.c_str(), bytes_read);
+                printf("  Compressed Size [Compression: %5s] = %lu bytes\n",
+                       dst_compression_string.c_str(),
+                       bytes_written);
+                printf("  Percent Reduction                    = %.2f%%\n", percent_reduction);
+            }
+            else
+            {
+                size_t bytes_read    = file_processor.NumBytesRead();
+                size_t bytes_written = decoder.NumBytesWritten();
+                float  percent_increase =
+                    100.f * ((static_cast<float>(bytes_written) / static_cast<float>(bytes_read)) - 1.f);
+                printf("Uncompression Results:\n");
+                printf("  Original Size   [Compression: %5s] = %lu bytes\n", src_compression.c_str(), bytes_read);
+                printf("  Uncompressed Size                    = %lu bytes\n", bytes_written);
+                printf("  Percent Increase                     = %.2f%%\n", percent_increase);
+            }
+        }
+    }
+
+    return 0;
+}

--- a/format/CMakeLists.txt
+++ b/format/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(brimstone_format
                    vulkan_enum_util.h
                    vulkan_object_mapper.h
                    window.h
+                   decompress_decoder.h
                    file_processor.cpp
                    string_array_decoder.cpp
                    string_decoder.cpp
@@ -32,6 +33,7 @@ target_sources(brimstone_format
                    vulkan_ascii_consumer.cpp
                    vulkan_replay_consumer.cpp
                    vulkan_decoder.cpp
+                   decompress_decoder.cpp
               )
 
 target_include_directories(brimstone_format

--- a/format/decoder.h
+++ b/format/decoder.h
@@ -28,12 +28,13 @@ BRIMSTONE_BEGIN_NAMESPACE(format)
 
 class Decoder
 {
-public:
-    virtual ~Decoder() { }
+  public:
+    virtual ~Decoder() {}
 
     virtual bool SupportsApiCall(ApiCallId id) = 0;
 
-    virtual void DecodeFunctionCall(ApiCallId id, const uint8_t* buffer, size_t buffer_size) = 0;
+    virtual void
+    DecodeFunctionCall(ApiCallId id, const ApiCallOptions& call_options, const uint8_t* buffer, size_t buffer_size) = 0;
 };
 
 BRIMSTONE_END_NAMESPACE(format)

--- a/format/decompress_decoder.cpp
+++ b/format/decompress_decoder.cpp
@@ -1,0 +1,205 @@
+/*
+** Copyright (c) 2018 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include <cassert>
+
+#include "format/decompress_decoder.h"
+
+BRIMSTONE_BEGIN_NAMESPACE(brimstone)
+BRIMSTONE_BEGIN_NAMESPACE(format)
+
+bool DecompressDecoder::Initialize(std::string                        filename,
+                                   const FileHeader&                  file_header,
+                                   const std::vector<FileOptionPair>& option_list,
+                                   util::CompressionType              target_compression_type)
+{
+    bool success = false;
+
+    // Modify compression setting and write file header to a new file.
+    filename_    = filename;
+    file_stream_ = std::make_unique<util::FileOutputStream>(filename_);
+
+    // Set the default for some other options
+    write_thread_id_       = false;
+    write_begin_end_times_ = false;
+
+    if (util::kNone == target_compression_type)
+    {
+        decompress_mode_ = kDecompress;
+        compressor_      = nullptr;
+    }
+    else
+    {
+        decompress_mode_ = kCompress;
+
+        compressor_ = util::Compressor::CreateCompressor(target_compression_type);
+        if (nullptr == compressor_)
+        {
+            return false;
+        }
+    }
+
+    std::vector<FileOptionPair> new_option_list = option_list;
+    for (auto& option : new_option_list)
+    {
+        switch (option.key)
+        {
+            case kCompressionType:
+                // Change the file option to the new compression type
+                option.value = static_cast<uint32_t>(target_compression_type);
+                break;
+            case kHaveThreadId:
+                write_thread_id_ = (option.value != 0);
+                break;
+            case kHaveBeginEndTimestamp:
+                write_begin_end_times_ = (option.value != 0);
+                break;
+            case kOmitTextures:
+            case kOmitBuffers:
+            case kAddressEncodingSize:
+            case kObjectEncodingSize:
+            case kHandleEncodingSize:
+                // Don't touch these values from the original file
+                break;
+            default:
+                // TODO: Error logging.
+                break;
+        }
+    }
+
+    if (file_stream_->IsValid())
+    {
+        bytes_written_ = 0;
+        bytes_written_ += file_stream_->Write(&file_header, sizeof(file_header));
+        bytes_written_ += file_stream_->Write(new_option_list.data(), new_option_list.size() * sizeof(FileOptionPair));
+        success = true;
+    }
+
+    return success;
+}
+
+void DecompressDecoder::Destroy()
+{
+    if (nullptr != compressor_)
+    {
+        delete compressor_;
+        compressor_ = nullptr;
+    }
+}
+
+void DecompressDecoder::DecodeFunctionCall(ApiCallId             call_id,
+                                           const ApiCallOptions& call_options,
+                                           const uint8_t*        buffer,
+                                           size_t                buffer_size)
+{
+    bool write_uncompressed = (decompress_mode_ == kDecompress);
+
+    if (decompress_mode_ == kCompress)
+    {
+        // Compress the buffer with the new compression format and write to the new file.
+        CompressedFunctionCallHeader compressed_func_call_header = {};
+        size_t                       packet_size                 = 0;
+        size_t                       compressed_size = compressor_->Compress(buffer_size, buffer, &compressed_buffer_);
+
+        if (0 < compressed_size && compressed_size < buffer_size)
+        {
+            compressed_func_call_header.block_header.type = BlockType::kCompressedFunctionCallBlock;
+            compressed_func_call_header.api_call_id       = call_id;
+            compressed_func_call_header.uncompressed_size = buffer_size;
+
+            packet_size += sizeof(compressed_func_call_header.api_call_id) +
+                           sizeof(compressed_func_call_header.uncompressed_size) + compressed_size;
+
+            if (write_thread_id_)
+            {
+                packet_size += sizeof(call_options.thread_id);
+            }
+            if (write_begin_end_times_)
+            {
+                packet_size += sizeof(call_options.begin_time) + sizeof(call_options.end_time);
+            }
+
+            compressed_func_call_header.block_header.size = packet_size;
+
+            // Write compressed function call block header.
+            bytes_written_ += file_stream_->Write(&compressed_func_call_header, sizeof(CompressedFunctionCallHeader));
+
+            // Add optional call items
+            if (write_thread_id_)
+            {
+                bytes_written_ += file_stream_->Write(&call_options.thread_id, sizeof(call_options.thread_id));
+            }
+
+            if (write_begin_end_times_)
+            {
+                bytes_written_ += file_stream_->Write(&call_options.begin_time, sizeof(call_options.begin_time));
+                bytes_written_ += file_stream_->Write(&call_options.end_time, sizeof(call_options.end_time));
+            }
+
+            // Write parameter data.
+            bytes_written_ += file_stream_->Write(compressed_buffer_.data(), compressed_size);
+        }
+        else
+        {
+            // It's bigger compressed than uncompressed, so only write the uncompressed data.
+            write_uncompressed = true;
+        }
+    }
+
+    if (write_uncompressed)
+    {
+        // Buffer is currently not compressed; it was decompressed prior to this call.
+        FunctionCallHeader func_call_header = {};
+        size_t             packet_size      = 0;
+
+        func_call_header.block_header.type = BlockType::kFunctionCallBlock;
+        func_call_header.api_call_id       = call_id;
+
+        packet_size += sizeof(func_call_header.api_call_id) + buffer_size;
+
+        if (write_thread_id_)
+        {
+            packet_size += sizeof(call_options.thread_id);
+        }
+        if (write_begin_end_times_)
+        {
+            packet_size += sizeof(call_options.begin_time) + sizeof(call_options.end_time);
+        }
+
+        func_call_header.block_header.size = packet_size;
+
+        // Write compressed function call block header.
+        bytes_written_ += file_stream_->Write(&func_call_header, sizeof(FunctionCallHeader));
+
+        // Add optional call items
+        if (write_thread_id_)
+        {
+            bytes_written_ += file_stream_->Write(&call_options.thread_id, sizeof(call_options.thread_id));
+        }
+
+        if (write_begin_end_times_)
+        {
+            bytes_written_ += file_stream_->Write(&call_options.begin_time, sizeof(call_options.begin_time));
+            bytes_written_ += file_stream_->Write(&call_options.end_time, sizeof(call_options.end_time));
+        }
+
+        // Write parameter data.
+        bytes_written_ += file_stream_->Write(buffer, buffer_size);
+    }
+}
+
+BRIMSTONE_END_NAMESPACE(format)
+BRIMSTONE_END_NAMESPACE(brimstone)

--- a/format/decompress_decoder.h
+++ b/format/decompress_decoder.h
@@ -1,0 +1,74 @@
+/*
+** Copyright (c) 2018 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef BRIMSTONE_DECOMPRESS_DECODER_H
+#define BRIMSTONE_DECOMPRESS_DECODER_H
+
+#include <mutex>
+#include <string>
+
+#include "format/decoder.h"
+
+#include "util/file_output_stream.h"
+#include "util/memory_output_stream.h"
+#include "util/compressor.h"
+
+BRIMSTONE_BEGIN_NAMESPACE(brimstone)
+BRIMSTONE_BEGIN_NAMESPACE(format)
+
+enum DecompressMode : uint32_t
+{
+    kNone       = 0,
+    kDecompress = 1,
+    kCompress   = 2
+};
+
+class DecompressDecoder : public Decoder
+{
+  public:
+    virtual ~DecompressDecoder() { Destroy(); }
+
+    bool Initialize(std::string                        filename,
+                    const FileHeader&                  file_header,
+                    const std::vector<FileOptionPair>& option_list,
+                    util::CompressionType              target_compression_type);
+    void Destroy();
+
+    virtual bool SupportsApiCall(ApiCallId call_id) override
+    {
+        return ((call_id >= 0x1000) && (call_id <= 0x112b)) ? true : false;
+    }
+    virtual void
+    DecodeFunctionCall(ApiCallId call_id, const ApiCallOptions& call_options, const uint8_t* buffer, size_t buffer_size);
+
+    size_t NumBytesWritten() { return bytes_written_; }
+
+  private:
+    DecompressMode                          decompress_mode_;
+    std::unique_ptr<util::FileOutputStream> file_stream_;
+    std::string                             filename_;
+    std::mutex                              file_lock_;
+    size_t                                  bytes_written_;
+    std::vector<uint8_t>                    compressed_buffer_;
+    util::Compressor*                       compressor_;
+    bool                                    write_thread_id_;
+    bool                                    write_begin_end_times_;
+};
+
+BRIMSTONE_END_NAMESPACE(format)
+BRIMSTONE_END_NAMESPACE(brimstone)
+
+#endif // BRIMSTONE_DECOMPRESS_DECODER_H

--- a/format/file_processor.h
+++ b/format/file_processor.h
@@ -49,6 +49,12 @@ public:
 
     bool ProcessAllFrames();
 
+    FileHeader GetFileHeader() const { return file_header_; }
+
+    const std::vector<FileOptionPair>& GetFileOptions() const { return file_options_; }
+
+    size_t NumBytesRead() { return bytes_read_; }
+
 private:
     bool ReadFileHeader();
 
@@ -62,7 +68,7 @@ private:
 
     size_t ReadBytes(void* buffer, size_t buffer_size);
 
-    void ProcessFunctionCall(ApiCallId call_id, const uint8_t* parameter_buffer, size_t buffer_size);
+    void ProcessFunctionCall(ApiCallId call_id, ApiCallOptions call_options, const uint8_t* parameter_buffer, size_t buffer_size);
 
     bool IsFrameDelimiter(ApiCallId call_id) const;
 
@@ -74,7 +80,8 @@ private:
     FILE*                       file_descriptor_;
     std::string                 file_name_;
     FileHeader                  file_header_;
-    EnabledOptions              file_options_;
+    std::vector<FileOptionPair> file_options_;
+    EnabledOptions              enabled_options_;
     uint64_t                    bytes_read_;
     std::vector<Decoder*>       decoders_;
     std::vector<uint8_t>        parameter_buffer_;

--- a/format/format.h
+++ b/format/format.h
@@ -118,6 +118,13 @@ struct BlockHeader
     BlockType type;
 };
 
+struct ApiCallOptions
+{
+    uint32_t thread_id;
+    uint32_t begin_time;
+    uint32_t end_time;
+};
+
 struct FunctionCallHeader
 {
     BlockHeader block_header;

--- a/format/trace_manager.cpp
+++ b/format/trace_manager.cpp
@@ -84,7 +84,12 @@ bool TraceManager::Initialize(std::string filename, EnabledOptions file_options)
 
 void TraceManager::Destroy()
 {
-    // TODO: Any finalization required for trace file.
+    // Perform any finalization required for trace file.
+    if (nullptr != compressor_)
+    {
+        delete compressor_;
+        compressor_ = nullptr;
+    }
 }
 
 ParameterEncoder* TraceManager::BeginApiCallTrace(ApiCallId call_id)
@@ -163,10 +168,10 @@ void TraceManager::EndApiCallTrace(ParameterEncoder* encoder)
     {
         std::lock_guard<std::mutex> lock(file_lock_);
 
-        // Write standard function call block header.
+        // Write appropriate function call block header.
         bytes_written_ += file_stream_->Write(header_pointer, header_size);
 
-        // Add optional header items.
+        // Add optional call items.
         if (file_options_.record_thread_id)
         {
             bytes_written_ += file_stream_->Write(&thread_data_.thread_id_, sizeof(thread_data_.thread_id_));

--- a/format/vulkan_decoder.cpp
+++ b/format/vulkan_decoder.cpp
@@ -21,13 +21,19 @@
 BRIMSTONE_BEGIN_NAMESPACE(brimstone)
 BRIMSTONE_BEGIN_NAMESPACE(format)
 
-void VulkanDecoder::DecodeFunctionCall(ApiCallId call_id, const uint8_t* parameter_buffer, size_t buffer_size)
+void VulkanDecoder::DecodeFunctionCall(ApiCallId             call_id,
+                                       const ApiCallOptions& call_options,
+                                       const uint8_t*        parameter_buffer,
+                                       size_t                buffer_size)
 {
+    // Unused items
+    (void)call_options;
+
     switch (call_id)
     {
 #include "generated/generated_api_call_decode_cases.inc"
-    default:
-        break;
+        default:
+            break;
     }
 }
 

--- a/format/vulkan_decoder.h
+++ b/format/vulkan_decoder.h
@@ -43,9 +43,12 @@ public:
 
     virtual bool SupportsApiCall(ApiCallId call_id) override { return ((call_id >= 0x1000) && (call_id <= 0x112b)) ? true : false; }
 
-    virtual void DecodeFunctionCall(ApiCallId call_id, const uint8_t* parameter_buffer, size_t buffer_size) override;
+    virtual void DecodeFunctionCall(ApiCallId             call_id,
+                                    const ApiCallOptions& call_options,
+                                    const uint8_t*        parameter_buffer,
+                                    size_t                buffer_size) override;
 
-private:
+  private:
 #include "generated/generated_api_call_decoder_declarations.inc"
 
 private:


### PR DESCRIPTION
This set of changes creates the DecompressDecoder class which is used by a command-line tool to automatically compress/decompress a Brimstone binary file.  

Currently, the format is:

```
cmdlinecompressor <input_bin_file> <output_bin_file> <compression_type>
```

Where:

 * `<input_bin_file>` is the name of the incoming Brimstone binary file
 * `<output_bin_file>` is the name of the file to create
 * `<compression_type>` is the type of compression format to use during
                          outputting the new file.  (Currently only supports a value of "LZ4" and "None",
                          without the quotes)

**NOTE:** I have not tested this out yet, hence the WIP.