### PR TITLE
Fix Code Generator Platform Specific Type Substitution

### DIFF
--- a/generated/framework_generators/base_generator.py
+++ b/generated/framework_generators/base_generator.py
@@ -337,12 +337,12 @@ class BaseGenerator(OutputGenerator):
             # Get type info
             elem = param.find('type')
             baseType = noneStr(elem.text)
+            fullType = (noneStr(param.text) + baseType + noneStr(elem.tail)).strip()
+
             if baseType in self.PLATFORM_TYPES:
                 platformType = self.PLATFORM_TYPES[baseType]
-                baseType = platformType['basetype']
-                fullType = platformType['fulltype']
-            else:
-                fullType = noneStr(param.text) + baseType + noneStr(elem.tail)
+                fullType = fullType.replace(baseType, platformType['replaceWith'])
+                baseType = platformType['baseType']
 
             # Get array length
             arrayLength = self.getArrayLen(param)

--- a/generated/framework_generators/platform_types.json
+++ b/generated/framework_generators/platform_types.json
@@ -1,10 +1,10 @@
 { "windows" : {
     "types" : {
-      "HANDLE"    : { "basetype" : "void",     "fulltype" : "void*" },
-      "HINSTANCE" : { "basetype" : "void",     "fulltype" : "void*" },
-      "HWND"      : { "basetype" : "void",     "fulltype" : "void*" },
-      "LPCWSTR"   : { "basetype" : "char",     "fulltype" : "const char*" },
-      "DWORD"     : { "basetype" : "uint32_t", "fulltype" : "uint32_t" }
+      "HANDLE"    : { "baseType" : "void",     "replaceWith" : "void*" },
+      "HINSTANCE" : { "baseType" : "void",     "replaceWith" : "void*" },
+      "HWND"      : { "baseType" : "void",     "replaceWith" : "void*" },
+      "LPCWSTR"   : { "baseType" : "char",     "replaceWith" : "const char*" },
+      "DWORD"     : { "baseType" : "uint32_t", "replaceWith" : "uint32_t" }
     },
     "structs" : [
       "SECURITY_ATTRIBUTES"


### PR DESCRIPTION
The code generator maps platform defined types such as HANDLE to a trace format type (eg. HANDLE becomes void*).  The code generator was incorrectly replacing the fully decorated type declarations with the trace type, which means 'const HANDLE*' became 'void*'. Only the typename in the expression should have been replaced, so 'const HANDLE*' becomes 'const void**'.