### PR TITLE
Remove Advanced Attribute from CMake Dependency Setup

### DIFF
--- a/cmake/FindLZ4.cmake
+++ b/cmake/FindLZ4.cmake
@@ -14,5 +14,3 @@ include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(LZ4 DEFAULT_MSG
                                   LZ4_LIBRARY
                                   LZ4_INCLUDE_DIR)
-
-MARK_AS_ADVANCED(LZ4_INCLUDE_DIR LZ4_LIBRARY)

--- a/cmake/FindWAYLAND.cmake
+++ b/cmake/FindWAYLAND.cmake
@@ -14,5 +14,3 @@ include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(WAYLAND DEFAULT_MSG
                                   WAYLAND_LIBRARY
                                   WAYLAND_INCLUDE_DIR)
-
-MARK_AS_ADVANCED(WAYLAND_INCLUDE_DIR WAYLAND_LIBRARY)

--- a/cmake/FindXCB.cmake
+++ b/cmake/FindXCB.cmake
@@ -14,5 +14,3 @@ include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(XCB DEFAULT_MSG
                                   XCB_LIBRARY
                                   XCB_INCLUDE_DIR)
-
-MARK_AS_ADVANCED(XCB_INCLUDE_DIR XCB_LIBRARY)


### PR DESCRIPTION
Remove use of the MARK_AS_ADVANCED command from the CMake find modules for the LZ4, Wayland, and XCB dependencies.  This allows the CMake variables for the include and library paths to display in the default ccmake and cmake-gui views.