### PR TITLE
Add DecodeUInt32 overload for DWORD

### DIFF
--- a/format/value_decoder.h
+++ b/format/value_decoder.h
@@ -36,6 +36,10 @@ public:
     static size_t DecodeUInt16Value(const uint8_t* buffer, size_t buffer_size, uint16_t* value) { return DecodeValue(buffer, buffer_size, value); }
     static size_t DecodeInt32Value(const uint8_t* buffer, size_t buffer_size, int32_t* value) { return DecodeValue(buffer, buffer_size, value); }
     static size_t DecodeUInt32Value(const uint8_t* buffer, size_t buffer_size, uint32_t* value) { return DecodeValue(buffer, buffer_size, value); }
+#if defined(WIN32)
+    // Oveload for WIN32 DWORD type.  Pointers from the DWORD typedef of unsigned long are not compatible with uint32_t pointers.
+    static size_t DecodeUInt32Value(const uint8_t* buffer, size_t buffer_size, unsigned long* value) { return DecodeValue(buffer, buffer_size, value); }
+#endif
     static size_t DecodeInt64Value(const uint8_t* buffer, size_t buffer_size, int64_t* value) { return DecodeValue(buffer, buffer_size, value); }
     static size_t DecodeUInt64Value(const uint8_t* buffer, size_t buffer_size, uint64_t* value) { return DecodeValue(buffer, buffer_size, value); }
     static size_t DecodeFloatValue(const uint8_t* buffer, size_t buffer_size, float* value) { return DecodeValue(buffer, buffer_size, value); }


### PR DESCRIPTION
The WIN32 DWORD type is an unsinged long, and DWORD* is not compatible
with uint32_t*.  This is an issue for some WIN32 platform extensions
that used DWORD types.  A WIN32 specific overload of DecodeUInt32 for
the unsigned long* type was added as a workaround.