### PR TITLE
utils: Fix ArgumentParser warning

### DIFF
--- a/util/argument_parser.cpp
+++ b/util/argument_parser.cpp
@@ -22,11 +22,11 @@
 BRIMSTONE_BEGIN_NAMESPACE(brimstone)
 BRIMSTONE_BEGIN_NAMESPACE(util)
 
-ArgumentParser::ArgumentParser(int                argc,
+ArgumentParser::ArgumentParser(int32_t            argc,
                                const char** const argv,
                                const std::string& options,
                                const std::string& arguments,
-                               const uint32_t     expected_non_opt_args)
+                               const int32_t      expected_non_opt_args)
 {
     if (argc > 1 && nullptr != argv)
     {
@@ -96,7 +96,7 @@ ArgumentParser::ArgumentParser(int                argc,
         }
         argument_values_.resize(argument_index);
 
-        for (uint32_t cur_arg = 1; cur_arg < argc; ++cur_arg)
+        for (int32_t cur_arg = 1; cur_arg < argc; ++cur_arg)
         {
             bool is_option   = false;
             bool is_argument = false;
@@ -147,7 +147,7 @@ ArgumentParser::ArgumentParser(int                argc,
             }
             else
             {
-                if (non_option_arguments_present_.size() < expected_non_opt_args)
+                if (non_option_arguments_present_.size() < static_cast<size_t>(expected_non_opt_args))
                 {
                     non_option_arguments_present_.push_back(argv[cur_arg]);
                 }

--- a/util/argument_parser.h
+++ b/util/argument_parser.h
@@ -33,18 +33,18 @@ class ArgumentParser
     // "-c,-b|--binary" where the list is comma-delimited.  If an option/argument
     // can be defined using two different string values (such as "-b" and "--binary")
     // they are further delimited by the pipe "|" symbol.
-    ArgumentParser(int                argc,
+    ArgumentParser(int32_t            argc,
                    const char** const argv,
                    const std::string& options,
                    const std::string& arguments,
-                   const uint32_t     expected_non_opt_args);
+                   const int32_t      expected_non_opt_args);
     ~ArgumentParser() {}
 
     bool                            IsInvalid() { return is_invalid_; }
     const std::vector<std::string>& GetInvalidArgumentOrOptions() { return invalid_values_present_; };
     bool                            IsOptionSet(const std::string& option);
     const std::string&              GetArgumentValue(const std::string& argument);
-    uint32_t                        GetNonOptionArgumentsCount() { return non_option_arguments_present_.size(); }
+    size_t                          GetNonOptionArgumentsCount() { return non_option_arguments_present_.size(); }
     const std::vector<std::string>& GetNonOptionalArguments() { return non_option_arguments_present_; }
 
   private:


### PR DESCRIPTION
Fix compilation warning for size_t to uint32_t conversion on
size return call.