### PR TITLE
Enable Platform Extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,23 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include("FindVulkanVersion")
 
+find_package(LZ4)
+find_package(ZLIB)
+find_package(XCB)
+find_package(WAYLAND)
+
 add_library(windows_specific INTERFACE)
-target_compile_definitions(windows_specific INTERFACE WIN32_LEAN_AND_MEAN NOMINMAX)
+target_compile_definitions(windows_specific INTERFACE WIN32_LEAN_AND_MEAN NOMINMAX VK_USE_PLATFORM_WIN32_KHR)
+
+add_library(linux_specific INTERFACE)
+target_compile_definitions(linux_specific INTERFACE
+    $<$<BOOL:${XCB_FOUND}>:VK_USE_PLATFORM_XCB_KHR>
+    $<$<BOOL:${WAYLAND_FOUND}>:VK_USE_PLATFORM_WAYLAND_KHR>)
 
 add_library(platform_specific INTERFACE)
-target_link_libraries(platform_specific INTERFACE $<$<BOOL:${WIN32}>:windows_specific>)
+target_link_libraries(platform_specific INTERFACE
+    $<$<BOOL:${WIN32}>:windows_specific>
+    $<$<NOT:$<BOOL:${WIN32}>>:linux_specific>)
 
 add_library(vulkan_registry INTERFACE)
 target_include_directories(vulkan_registry INTERFACE ${CMAKE_SOURCE_DIR}/external/Vulkan-Headers/include)
@@ -18,12 +30,7 @@ add_library(volk STATIC "")
 target_include_directories(volk PUBLIC ${CMAKE_SOURCE_DIR}/external/volk)
 target_sources(volk PRIVATE ${CMAKE_SOURCE_DIR}/external/volk/volk.c)
 target_compile_definitions(volk PUBLIC VK_NO_PROTOTYPES)
-target_link_libraries(volk PUBLIC vulkan_registry $<$<NOT:$<BOOL:${WIN32}>>:dl>)
-
-find_package(LZ4)
-find_package(ZLIB)
-find_package(XCB)
-find_package(WAYLAND)
+target_link_libraries(volk PUBLIC vulkan_registry platform_specific $<$<NOT:$<BOOL:${WIN32}>>:dl>)
 
 add_subdirectory(util)
 add_subdirectory(format)

--- a/application/wayland_application.h
+++ b/application/wayland_application.h
@@ -18,10 +18,6 @@
 #define BRIMSTONE_APPLICATION_WAYLAND_APPLICATION_H
 
 #include <wayland-client.h>
-// TEMP //
-#include "vulkan/vulkan.h"
-#include "vulkan/vulkan_wayland.h"
-//////////
 
 #include "application/application.h"
 

--- a/application/win32_application.h
+++ b/application/win32_application.h
@@ -18,10 +18,6 @@
 #define BRIMSTONE_APPLICATION_WIN32_APPLICATION_H
 
 #include <windows.h>
-// TEMP //
-#include "vulkan/vulkan.h"
-#include "vulkan/vulkan_win32.h"
-//////////
 
 #include "application/application.h"
 

--- a/application/win32_window.cpp
+++ b/application/win32_window.cpp
@@ -18,11 +18,7 @@
 
 #include "application/win32_window.h"
 
-// TEMP //
-#define VK_KHR_win32_surface
 #include "volk.h"
-#undef VK_KHR_win32_surface
-//////////
 
 BRIMSTONE_BEGIN_NAMESPACE(brimstone)
 BRIMSTONE_BEGIN_NAMESPACE(application)

--- a/application/xcb_application.h
+++ b/application/xcb_application.h
@@ -18,10 +18,6 @@
 #define BRIMSTONE_APPLICATION_XCB_APPLICATION_H
 
 #include <xcb/xcb.h>
-// TEMP //
-#include "vulkan/vulkan.h"
-#include "vulkan/vulkan_xcb.h"
-//////////
 
 #include "application/application.h"
 


### PR DESCRIPTION
- Enable VK_USE_PLATFORM_WIN32_KHR for Windows builds.
- Enable VK_USE_PLATFORM_XCB_KHR and/or VK_USE_PLATFORM_WAYLAND_KHR for
  Linux builds, if CMake finds the associated developer files.
- Remove temporary preprocessor code from XCB, Wayland, and WIN32
  window/application files.