### PR TITLE
Fix Handle Mapping Issue

### DIFF
--- a/format/vulkan_object_mapper.h
+++ b/format/vulkan_object_mapper.h
@@ -233,7 +233,7 @@ class VulkanObjectMapper
 
         if ((id != 0) && (handle != VK_NULL_HANDLE))
         {
-            map->insert(std::make_pair(id, handle));
+            (*map)[id] = handle;
         }
     }
 


### PR DESCRIPTION
When handles are recycled, ensure that existing entries in the handle
map are overwritten with the new handle mapping.