### PR TITLE
Implement 'Unassisted' Memory Tracking Mode

### DIFF
--- a/format/custom_encoder_commands.h
+++ b/format/custom_encoder_commands.h
@@ -107,6 +107,16 @@ struct CustomEncoderPreCall<ApiCallId_vkFreeMemory>
     }
 };
 
+template <>
+struct CustomEncoderPreCall<ApiCallId_vkQueueSubmit>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PreProcess_vkQueueSubmit(args...);
+    }
+};
+
 BRIMSTONE_END_NAMESPACE(format)
 BRIMSTONE_END_NAMESPACE(brimstone)
 

--- a/format/memory_tracker.cpp
+++ b/format/memory_tracker.cpp
@@ -70,6 +70,13 @@ const MemoryTracker::EntryInfo* MemoryTracker::GetEntryInfo(VkDeviceMemory memor
     return (entry != mapped_memory_.end()) ? &(entry->second) : nullptr;
 }
 
+void MemoryTracker::VisitEntries(std::function<void(VkDeviceMemory, const EntryInfo&)> visit)
+{
+    for (auto entry : mapped_memory_)
+    {
+        visit(entry.first, entry.second);
+    }
+}
 
 BRIMSTONE_END_NAMESPACE(format)
 BRIMSTONE_END_NAMESPACE(brimstone)

--- a/format/memory_tracker.h
+++ b/format/memory_tracker.h
@@ -17,6 +17,7 @@
 #ifndef BRIMSTONE_FORMAT_MEMORY_TRACKER_H
 #define BRIMSTONE_FORMAT_MEMORY_TRACKER_H
 
+#include <functional>
 #include <unordered_map>
 
 #include "vulkan/vulkan.h"
@@ -56,8 +57,10 @@ class MemoryTracker
 
     const EntryInfo* GetEntryInfo(VkDeviceMemory memory) const;
 
+    void VisitEntries(std::function<void(VkDeviceMemory, const EntryInfo&)> visit);
+
   private:
-      std::unordered_map<VkDeviceMemory, EntryInfo> mapped_memory_;
+    std::unordered_map<VkDeviceMemory, EntryInfo> mapped_memory_;
 };
 
 BRIMSTONE_END_NAMESPACE(format)


### PR DESCRIPTION
Implement unassisted and assisted memory tracking modes for trace.
- Unassisted mode writes all mapped memory ranges on vkQueueSubmit.
- Unassisted mode writes the content of mapped memory when it is
  unmapped.
- Assisted mode assumes the application always calls flush after writing
  to memory, and only writes on flush.
- An option has also been added for a page guard mode, which has not
  been implemented.