### PR TITLE
Threading Fixes for Trace

### DIFF
--- a/format/trace_manager.h
+++ b/format/trace_manager.h
@@ -147,6 +147,7 @@ private:
     util::Compressor*                                       compressor_;
     MemoryTrackingMode                                      memory_tracking_mode_;
     MemoryTracker                                           memory_tracker_;
+    mutable std::mutex                                      memory_tracker_lock_;
 };
 
 BRIMSTONE_END_NAMESPACE(format)


### PR DESCRIPTION
- Add locks for the mapped memory tracker.
- Fix initialization of thread local storage data.
    * The TraceManager thread_data_ member, which is thread_local, was a stack
       variable that had two initialization related problems:
       1. Initialization was not performed for threads that started before the layer was loaded.
       2. Initialization was performed for every thread, not just threads that use Vulkan.
    * To address this, thread_data_ was changed to a pointer and allocated/initialized on first use.