### PR TITLE
Fix compile warning with printf and std::string

### DIFF
--- a/util/argument_parser.cpp
+++ b/util/argument_parser.cpp
@@ -162,7 +162,7 @@ ArgumentParser::ArgumentParser(int32_t            argc,
                     // be an invalid value.
                     invalid_values_present_.push_back(current_argument);
                     is_invalid_ = true;
-                    printf("ERROR: Invalid command-line setting \'%s\'\n", current_argument);
+                    printf("ERROR: Invalid command-line setting \'%s\'\n", current_argument.c_str());
                 }
             }
             else


### PR DESCRIPTION
A std::string was provided as the argument for a '%s' printf format
directive.  Changed to use c_str() to obtain a char*.