### PR TITLE
Fix Descriptor Update Template Encoding

### DIFF
--- a/layer/custom_api_call_encoders.cpp
+++ b/layer/custom_api_call_encoders.cpp
@@ -72,7 +72,6 @@ static size_t EncodeDescriptorUpdateTemplateInfo(format::TraceManager*      mana
         }
 
         // Process VkDescriptorBufferInfo
-        bytes_written += encoder->EncodeStructArrayPreamble(data, info->buffer_info.size());
         for (const auto& entry_info : info->buffer_info)
         {
             for (size_t i = 0; i < entry_info.count; ++i)


### PR DESCRIPTION
Remove the struct array preamble that was written in front of the of VkDescriptorBufferInfo data when encoding descriptor update data.  The preamble is not intended to be be written in front the individual arrays that are encoded for update templates.  Instead array sizes for all three arrays are written at the start of the data before the individual arrays.