### PR TITLE
replay_consumer: Fix template count

### DIFF
--- a/format/vulkan_replay_consumer.cpp
+++ b/format/vulkan_replay_consumer.cpp
@@ -371,18 +371,18 @@ VulkanReplayConsumer::OverrideCreateDescriptorUpdateTemplate(PFN_vkCreateDescrip
                 (type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) || (type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) ||
                 (type == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT))
             {
-                ++image_info_count;
+                image_info_count += entry->descriptorCount;
             }
             else if ((type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) || (type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) ||
                      (type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) ||
                      (type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC))
             {
-                ++buffer_info_count;
+                buffer_info_count += entry->descriptorCount;
             }
             else if ((type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER) ||
                      (type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER))
             {
-                ++texel_buffer_view_count;
+                texel_buffer_view_count += entry->descriptorCount;
             }
             else
             {


### PR DESCRIPTION
Fix the entry count for each VkDescriptorUpdateTemplateEntry
of various types.  Previously, we just counted the number of entries,
however, each entry can contain more than one descriptors.  This
resulted in the unpacking properly grabbing the wrong data inside
the driver.