### PR TITLE
Add Replay Override for GetQueryPoolResults

### DIFF
--- a/format/vulkan_replay_consumer.cpp
+++ b/format/vulkan_replay_consumer.cpp
@@ -307,6 +307,26 @@ VkResult VulkanReplayConsumer::OverrideWaitForFences(VkResult       original_res
     return result;
 }
 
+VkResult VulkanReplayConsumer::OverrideGetQueryPoolResults(VkResult           original_result,
+                                                           VkDevice           device,
+                                                           VkQueryPool        queryPool,
+                                                           uint32_t           firstQuery,
+                                                           uint32_t           queryCount,
+                                                           size_t             dataSize,
+                                                           void*              pData,
+                                                           VkDeviceSize       stride,
+                                                           VkQueryResultFlags flags)
+{
+    VkResult result;
+
+    do
+    {
+        result = vkGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags);
+    } while ((original_result == VK_SUCCESS) && (result == VK_NOT_READY));
+
+    return result;
+}
+
 VkResult VulkanReplayConsumer::OverrideMapMemory(VkDevice         device,
                                                  VkDeviceMemory   memory,
                                                  VkDeviceSize     offset,

--- a/format/vulkan_replay_consumer.h
+++ b/format/vulkan_replay_consumer.h
@@ -111,6 +111,16 @@ class VulkanReplayConsumer : public VulkanConsumer
                                    VkBool32       waitAll,
                                    uint64_t       timeout);
 
+   VkResult OverrideGetQueryPoolResults(VkResult           original_result,
+                                        VkDevice           device,
+                                        VkQueryPool        queryPool,
+                                        uint32_t           firstQuery,
+                                        uint32_t           queryCount,
+                                        size_t             dataSize,
+                                        void*              pData,
+                                        VkDeviceSize       stride,
+                                        VkQueryResultFlags flags);
+
     VkResult OverrideMapMemory(VkDevice         device,
                                VkDeviceMemory   memory,
                                VkDeviceSize     offset,
@@ -274,6 +284,18 @@ class VulkanReplayConsumer : public VulkanConsumer
         {
             BRIMSTONE_UNREFERENCED_PARAMETER(func);
             return consumer->OverrideWaitForFences(original_result, args...);
+        }
+    };
+
+    template <typename Ret, typename Pfn>
+    struct Dispatcher<ApiCallId_vkGetQueryPoolResults, Ret, Pfn>
+    {
+        template <typename... Args>
+        static Ret
+        Dispatch(VulkanReplayConsumer* consumer, VkResult original_result, PFN_vkGetQueryPoolResults func, Args... args)
+        {
+            BRIMSTONE_UNREFERENCED_PARAMETER(func);
+            return consumer->OverrideGetQueryPoolResults(original_result, args...);
         }
     };
 


### PR DESCRIPTION
Add an override to VulkanReplayConsumer for vkGetQueryPoolResults, to
wait for the replay return value to match the trace file return value if
the trace value was VK_SUCCESS.  The replay will repeatedly call
vkGetQueryPoolResults while the following expression resolves to true:
  trace_result == VK_SUCCESS && replay_result == VK_NOT_READY