### PR TITLE
Fix Sample Mask Encoding

### DIFF
--- a/generated/generated_struct_encoders.inc
+++ b/generated/generated_struct_encoders.inc
@@ -910,7 +910,7 @@ size_t encode_struct(format::ParameterEncoder* encoder, const VkPipelineMultisam
     result += encoder->EncodeEnumValue(value.rasterizationSamples);
     result += encoder->EncodeVkBool32Value(value.sampleShadingEnable);
     result += encoder->EncodeFloatValue(value.minSampleShading);
-    result += encoder->EncodeVkSampleMaskArray(value.pSampleMask, static_cast<size_t>(ceil(value.rasterizationSamples/32)));
+    result += encoder->EncodeVkSampleMaskArray(value.pSampleMask, static_cast<size_t>(ceil(static_cast<double>(value.rasterizationSamples)/static_cast<double>(32))));
     result += encoder->EncodeVkBool32Value(value.alphaToCoverageEnable);
     result += encoder->EncodeVkBool32Value(value.alphaToOneEnable);
     return result;

--- a/generated/vulkan_generators/base_generator.py
+++ b/generated/vulkan_generators/base_generator.py
@@ -514,7 +514,7 @@ class BaseGenerator(OutputGenerator):
                 raise 'Unrecognized latexmath expression'
             name = match.group(2)
             # TODO: More flexible typecasting support
-            nameExpr = 'static_cast<size_t>({}({}/{}))'.format(*match.group(1, 2, 3))
+            nameExpr = 'static_cast<size_t>({}(static_cast<double>({})/static_cast<double>({})))'.format(*match.group(1, 2, 3))
         else:
             # Matches expressions similar to 'latexmath : [dataSize \over 4]'
             match = re.match(r'latexmath\s*\:\s*\[\s*(\w+)\s*\\over\s*(\d+)\s*\]', source)


### PR DESCRIPTION
The Vulkan registry specifies the array length of VkPipelineMultisampleStateCreateInfo::pSampleMask as 'ceil(rasterizationSamples/32)`, and the code generator produced C++ code using those exact values, where it performed integer division.  This produced invalid array lengths where ceil(1/32) evaulated as 0 instead of 1.  The array length is now computed with doubles instead of integers.