### PR TITLE
Use GCAP File Extension/Four Character Code

### DIFF
--- a/application/compress/CMakeLists.txt
+++ b/application/compress/CMakeLists.txt
@@ -1,12 +1,12 @@
-add_executable(greccompress "")
+add_executable(gcapcompress "")
 
-target_sources(greccompress
+target_sources(gcapcompress
                PRIVATE
                    main.cpp
               )
 
-target_include_directories(greccompress
+target_include_directories(gcapcompress
                            PUBLIC
                                $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>)
 
-target_link_libraries(greccompress brimstone_format platform_specific)
+target_link_libraries(gcapcompress brimstone_format platform_specific)

--- a/application/compress/main.cpp
+++ b/application/compress/main.cpp
@@ -1,6 +1,7 @@
 #include <cassert>
 
 #include "format/file_processor.h"
+#include "format/format.h"
 #include "format/decompress_decoder.h"
 #include "util/compressor.h"
 #include "util/argument_parser.h"
@@ -17,13 +18,13 @@ void PrintUsage(const char* exe_name)
     BRIMSTONE_WRITE_CONSOLE("\n\n%s\tis a compression/decompression tool for working with", app_name.c_str());
     BRIMSTONE_WRITE_CONSOLE("\t\ttrace binary files.\n");
     BRIMSTONE_WRITE_CONSOLE("Usage:");
-    BRIMSTONE_WRITE_CONSOLE("\t%s <input_bin> <output_bin> <output_compression>\n", app_name.c_str());
-    BRIMSTONE_WRITE_CONSOLE("\t<input_bin>\t\tThe filename (including path if necessary) of the ");
+    BRIMSTONE_WRITE_CONSOLE("\t%s <input_file> <output_file> <compression_format>\n", app_name.c_str());
+    BRIMSTONE_WRITE_CONSOLE("\t<input_file>\t\tThe filename (including path if necessary) of the ");
     BRIMSTONE_WRITE_CONSOLE("\t\t\t\tincoming binary file to manipulate");
-    BRIMSTONE_WRITE_CONSOLE("\t<output_bin>\t\tThe filename (including path if necessary) of the ");
+    BRIMSTONE_WRITE_CONSOLE("\t<output_file>\t\tThe filename (including path if necessary) of the ");
     BRIMSTONE_WRITE_CONSOLE("\t\t\t\tresulting binary file to generate");
-    BRIMSTONE_WRITE_CONSOLE("\t<output_compression>\tThe compression to use when generating the");
-    BRIMSTONE_WRITE_CONSOLE("\t\t\t\toutput file.  Possible values are: ");
+    BRIMSTONE_WRITE_CONSOLE("\t<compression_format>\tThe compression format to use when generating");
+    BRIMSTONE_WRITE_CONSOLE("\t\t\t\tthe output file.  Possible values are: ");
     BRIMSTONE_WRITE_CONSOLE("\t\t\t\t\tLZ4  - To output using LZ4 compression");
     BRIMSTONE_WRITE_CONSOLE("\t\t\t\t\tLZ77 - To output using LZ77 compression");
     BRIMSTONE_WRITE_CONSOLE("\t\t\t\t\tNONE - To output without using compression");
@@ -32,11 +33,14 @@ void PrintUsage(const char* exe_name)
 int main(int argc, const char** argv)
 {
     brimstone::format::FileProcessor file_processor;
-    std::string                      input_bin_file_name    = "brimstone_test.bin";
-    std::string                      output_bin_file_name   = "brimstone_test_out.bin";
     brimstone::util::CompressionType compression_type       = brimstone::util::kNone;
     std::string                      dst_compression_string = "NONE";
     bool                             print_usage            = false;
+    std::string                      input_file_name        = "brimstone_out";
+    std::string                      output_file_name       = "gcapcompress_out";
+
+    input_file_name += BRIMSTONE_FILE_EXTENSION;
+    output_file_name += BRIMSTONE_FILE_EXTENSION;
 
     brimstone::util::logging::Init();
 
@@ -48,8 +52,8 @@ int main(int argc, const char** argv)
     }
     else
     {
-        input_bin_file_name  = non_optional_arguments[0];
-        output_bin_file_name = non_optional_arguments[1];
+        input_file_name  = non_optional_arguments[0];
+        output_file_name = non_optional_arguments[1];
         if (non_optional_arguments[2] == "NONE")
         {
             // Nothing to do here.
@@ -77,14 +81,12 @@ int main(int argc, const char** argv)
         exit(-1);
     }
 
-    if (file_processor.Initialize(input_bin_file_name))
+    if (file_processor.Initialize(input_file_name))
     {
         brimstone::format::DecompressDecoder decoder;
 
-        if (decoder.Initialize(output_bin_file_name,
-                               file_processor.GetFileHeader(),
-                               file_processor.GetFileOptions(),
-                               compression_type))
+        if (decoder.Initialize(
+                output_file_name, file_processor.GetFileHeader(), file_processor.GetFileOptions(), compression_type))
         {
             std::string src_compression = "NONE";
             file_processor.AddDecoder(&decoder);

--- a/application/replay/CMakeLists.txt
+++ b/application/replay/CMakeLists.txt
@@ -1,12 +1,12 @@
-add_executable(grecplay "")
+add_executable(gcapplay "")
 
-target_sources(grecplay
+target_sources(gcapplay
                PRIVATE
                    main.cpp
               )
 
-target_include_directories(grecplay
+target_include_directories(gcapplay
                            PUBLIC
                                $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>)
 
-target_link_libraries(grecplay brimstone_util brimstone_format brimstone_application platform_specific)
+target_link_libraries(gcapplay brimstone_util brimstone_format brimstone_application platform_specific)

--- a/application/replay/main.cpp
+++ b/application/replay/main.cpp
@@ -4,6 +4,7 @@
 
 #include "application/application.h"
 #include "format/file_processor.h"
+#include "format/format.h"
 #include "format/vulkan_replay_consumer.h"
 #include "format/vulkan_decoder.h"
 #include "format/window.h"
@@ -37,9 +38,9 @@ void PrintUsage(const char* exe_name)
     BRIMSTONE_WRITE_CONSOLE("\n%s\tis a trace replay tool designed to playback trace binary files.\n",
                             app_name.c_str());
     BRIMSTONE_WRITE_CONSOLE("Usage:");
-    BRIMSTONE_WRITE_CONSOLE("\t%s <binary_file>\n", app_name.c_str());
-    BRIMSTONE_WRITE_CONSOLE("\t<binary_file>\t\tThe filename (including path if necessary) of the ");
-    BRIMSTONE_WRITE_CONSOLE("\t\t\t\ttrace binary file to replay");
+    BRIMSTONE_WRITE_CONSOLE("\t%s <file>\n", app_name.c_str());
+    BRIMSTONE_WRITE_CONSOLE("\t<file>\t\tThe filename (including path if necessary) of the ");
+    BRIMSTONE_WRITE_CONSOLE("\t\t\t\ttrace file to replay");
 }
 
 int main(int argc, const char** argv)
@@ -49,7 +50,7 @@ int main(int argc, const char** argv)
     brimstone::util::logging::Init();
 
     brimstone::format::FileProcessor file_processor;
-    std::string                      bin_file_name;
+    std::string                      filename;
 
     brimstone::util::ArgumentParser arg_parser(argc, argv, "", "", 1);
     const std::vector<std::string>  non_optional_arguments = arg_parser.GetNonOptionalArguments();
@@ -60,16 +61,16 @@ int main(int argc, const char** argv)
     }
     else
     {
-        bin_file_name = non_optional_arguments[0];
+        filename = non_optional_arguments[0];
 
         try
         {
             std::unique_ptr<brimstone::application::Application> application;
             std::unique_ptr<brimstone::format::WindowFactory>    window_factory;
 
-            if (!file_processor.Initialize(bin_file_name))
+            if (!file_processor.Initialize(filename))
             {
-                BRIMSTONE_WRITE_CONSOLE("Failed to load file %s.", bin_file_name.c_str());
+                BRIMSTONE_WRITE_CONSOLE("Failed to load file %s.", filename.c_str());
                 return_code = -1;
             }
             else

--- a/application/toascii/CMakeLists.txt
+++ b/application/toascii/CMakeLists.txt
@@ -1,12 +1,12 @@
-add_executable(grectoascii "")
+add_executable(gcaptoascii "")
 
-target_sources(grectoascii
+target_sources(gcaptoascii
                PRIVATE
                    main.cpp
               )
 
-target_include_directories(grectoascii
+target_include_directories(gcaptoascii
                            PUBLIC
                                $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>)
 
-target_link_libraries(grectoascii brimstone_format platform_specific)
+target_link_libraries(gcaptoascii brimstone_format platform_specific)

--- a/application/toascii/main.cpp
+++ b/application/toascii/main.cpp
@@ -1,4 +1,5 @@
 #include "format/file_processor.h"
+#include "format/format.h"
 #include "format/vulkan_ascii_consumer.h"
 #include "format/vulkan_decoder.h"
 #include "util/argument_parser.h"
@@ -15,18 +16,19 @@ void PrintUsage(const char* exe_name)
     BRIMSTONE_WRITE_CONSOLE("\n\n%s\tis a trace replay tool designed to output the API commands", app_name.c_str());
     BRIMSTONE_WRITE_CONSOLE("\t\tfound inside of a trace binary file.\n");
     BRIMSTONE_WRITE_CONSOLE("Usage:");
-    BRIMSTONE_WRITE_CONSOLE("\t%s <binary_file>\n", app_name.c_str());
-    BRIMSTONE_WRITE_CONSOLE("\t<binary_file>\t\tThe filename (including path if necessary) of the trace");
+    BRIMSTONE_WRITE_CONSOLE("\t%s <file>\n", app_name.c_str());
+    BRIMSTONE_WRITE_CONSOLE("\t<file>\t\tThe filename (including path if necessary) of the trace");
     BRIMSTONE_WRITE_CONSOLE("\t\t\t\tbinary file whose API command contents should be outputted.");
     BRIMSTONE_WRITE_CONSOLE("\t\t\t\tThe results will be output to a file of the same name but");
-    BRIMSTONE_WRITE_CONSOLE("\t\t\t\twith \'.bin\' suffix replaced with \'.txt\'.");
+    BRIMSTONE_WRITE_CONSOLE("\t\t\t\twith \'" BRIMSTONE_FILE_EXTENSION "\' suffix replaced with \'.txt\'.");
 }
 
 int main(int argc, const char** argv)
 {
     brimstone::format::FileProcessor file_processor;
-    std::string                      bin_file_name = "brimstone_test.bin";
     brimstone::util::ArgumentParser  arg_parser(argc, argv, "", "", 1);
+    std::string                      filename = "brimstone_test";
+    filename += BRIMSTONE_FILE_EXTENSION;
 
     brimstone::util::logging::Init();
 
@@ -38,16 +40,16 @@ int main(int argc, const char** argv)
     }
     else
     {
-        bin_file_name = non_optional_arguments[0];
+        filename = non_optional_arguments[0];
     }
 
     if (argc > 1)
     {
-        bin_file_name = argv[1];
+        filename = argv[1];
     }
 
-    std::string text_file_name = bin_file_name;
-    size_t      suffix_pos     = text_file_name.find(".bin");
+    std::string text_file_name = filename;
+    size_t      suffix_pos     = text_file_name.find(BRIMSTONE_FILE_EXTENSION);
     if (suffix_pos == std::string::npos)
     {
         text_file_name += ".txt";
@@ -57,7 +59,7 @@ int main(int argc, const char** argv)
         text_file_name.replace(suffix_pos, 4, ".txt");
     }
 
-    if (file_processor.Initialize(bin_file_name))
+    if (file_processor.Initialize(filename))
     {
         brimstone::format::VulkanDecoder       decoder;
         brimstone::format::VulkanAsciiConsumer ascii_consumer;

--- a/format/format.h
+++ b/format/format.h
@@ -24,6 +24,9 @@
 #include "format/api_call_id.h"
 #include "util/compressor.h"
 
+#define BRIMSTONE_FOURCC BRIMSTONE_MAKE_FOURCC('G', 'C', 'A', 'P')
+#define BRIMSTONE_FILE_EXTENSION ".gcap"
+
 BRIMSTONE_BEGIN_NAMESPACE(brimstone)
 BRIMSTONE_BEGIN_NAMESPACE(format)
 

--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -29,7 +29,7 @@
 #include "generated/generated_layer_func_table.inc"
 
 static const VkLayerProperties LayerProps = {
-    "VK_LAYER_LUNARG_vktrace", VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION), 1, "LunarG tracing layer",
+    "VK_LAYER_LUNARG_brimstone", VK_MAKE_VERSION(1, 0, VK_HEADER_VERSION), 1, "LunarG API Capture Layer",
 };
 
 static const VkLayerInstanceCreateInfo* get_instance_chain_info(const VkInstanceCreateInfo* pCreateInfo, VkLayerFunction func)
@@ -76,8 +76,9 @@ bool init_layer()
     }
 
     // TODO: load settings from file.
-    std::string            binary_file_name = "./brimstone_test.bin";
     format::EnabledOptions options;
+    std::string            binary_file_name = "./brimstone_out";
+    binary_file_name += BRIMSTONE_FILE_EXTENSION;
 
 #if defined(ENABLE_LZ4_COMPRESSION)
     options.compression_type = util::CompressionType::kLz4;

--- a/util/defines.h
+++ b/util/defines.h
@@ -36,8 +36,6 @@
     (static_cast<uint32_t>(c0) | (static_cast<uint32_t>(c1) << 8) | (static_cast<uint32_t>(c2) << 16) | \
      (static_cast<uint32_t>(c3) << 24))
 
-#define BRIMSTONE_FOURCC BRIMSTONE_MAKE_FOURCC('G', 'R', 'E', 'C')
-
 // Determine if a type conversion would result in a loss of data.  Intended to check uint64_t to size_t conversions.
 #define BRIMSTONE_CHECK_CONVERSION_DATA_LOSS(DstType, Value) assert(std::numeric_limits<DstType>::max() <= Value);
 


### PR DESCRIPTION
- Change the capture file extension to .gcap
- Change the capture file four character code to GCAP
- Use gcap prefix with command line utilities
- Remove references to 'bin' from command line utilities