### PR TITLE
Initialize FileProcessor::compressor_ to NULL

### DIFF
--- a/format/file_processor.cpp
+++ b/format/file_processor.cpp
@@ -24,11 +24,7 @@
 BRIMSTONE_BEGIN_NAMESPACE(brimstone)
 BRIMSTONE_BEGIN_NAMESPACE(format)
 
-FileProcessor::FileProcessor() :
-    file_descriptor_(nullptr),
-    bytes_read_(0)
-{
-}
+FileProcessor::FileProcessor() : file_descriptor_(nullptr), bytes_read_(0), compressor_(nullptr) {}
 
 FileProcessor::~FileProcessor()
 {


### PR DESCRIPTION
The FileProcessor compressor_ member was not initialized by the
constructor, leading to a crash in the destructor when trying to
delete uninitialized memory if FileProcessor::Initialize failed.