### PR TITLE
Add override functions for synchronization

### DIFF
--- a/format/vulkan_replay_consumer.cpp
+++ b/format/vulkan_replay_consumer.cpp
@@ -308,6 +308,30 @@ VkResult VulkanReplayConsumer::OverrideWaitForFences(VkResult       original_res
     return result;
 }
 
+VkResult VulkanReplayConsumer::OverrideGetFenceStatus(VkResult original_result, VkDevice device, VkFence fence)
+{
+    VkResult result;
+
+    do
+    {
+        result = vkGetFenceStatus(device, fence);
+    } while ((original_result == VK_SUCCESS) && (result == VK_NOT_READY));
+
+    return result;
+}
+
+VkResult VulkanReplayConsumer::OverrideGetEventStatus(VkResult original_result, VkDevice device, VkEvent event)
+{
+    VkResult result;
+
+    do
+    {
+        result = vkGetEventStatus(device, event);
+    } while ((original_result == VK_EVENT_SET) && (result == VK_EVENT_RESET));
+
+    return result;
+}
+
 VkResult VulkanReplayConsumer::OverrideGetQueryPoolResults(VkResult           original_result,
                                                            VkDevice           device,
                                                            VkQueryPool        queryPool,
@@ -731,5 +755,5 @@ void VulkanReplayConsumer::Process_vkRegisterObjectsNVX(
 
 #include "generated/generated_api_call_replay_consumer_definitions.inc"
 
-    BRIMSTONE_END_NAMESPACE(format)
-    BRIMSTONE_END_NAMESPACE(brimstone)
+BRIMSTONE_END_NAMESPACE(format)
+BRIMSTONE_END_NAMESPACE(brimstone)

--- a/format/vulkan_replay_consumer.h
+++ b/format/vulkan_replay_consumer.h
@@ -111,15 +111,19 @@ class VulkanReplayConsumer : public VulkanConsumer
                                    VkBool32       waitAll,
                                    uint64_t       timeout);
 
-   VkResult OverrideGetQueryPoolResults(VkResult           original_result,
-                                        VkDevice           device,
-                                        VkQueryPool        queryPool,
-                                        uint32_t           firstQuery,
-                                        uint32_t           queryCount,
-                                        size_t             dataSize,
-                                        void*              pData,
-                                        VkDeviceSize       stride,
-                                        VkQueryResultFlags flags);
+    VkResult OverrideGetFenceStatus(VkResult original_result, VkDevice device, VkFence fence);
+
+    VkResult OverrideGetEventStatus(VkResult original_result, VkDevice device, VkEvent event);
+
+    VkResult OverrideGetQueryPoolResults(VkResult           original_result,
+                                         VkDevice           device,
+                                         VkQueryPool        queryPool,
+                                         uint32_t           firstQuery,
+                                         uint32_t           queryCount,
+                                         size_t             dataSize,
+                                         void*              pData,
+                                         VkDeviceSize       stride,
+                                         VkQueryResultFlags flags);
 
     VkResult OverrideMapMemory(VkDevice         device,
                                VkDeviceMemory   memory,
@@ -284,6 +288,30 @@ class VulkanReplayConsumer : public VulkanConsumer
         {
             BRIMSTONE_UNREFERENCED_PARAMETER(func);
             return consumer->OverrideWaitForFences(original_result, args...);
+        }
+    };
+
+    template <typename Ret, typename Pfn>
+    struct Dispatcher<ApiCallId_vkGetFenceStatus, Ret, Pfn>
+    {
+        template <typename... Args>
+        static Ret
+        Dispatch(VulkanReplayConsumer* consumer, VkResult original_result, PFN_vkGetFenceStatus func, Args... args)
+        {
+            BRIMSTONE_UNREFERENCED_PARAMETER(func);
+            return consumer->OverrideGetFenceStatus(original_result, args...);
+        }
+    };
+
+    template <typename Ret, typename Pfn>
+    struct Dispatcher<ApiCallId_vkGetEventStatus, Ret, Pfn>
+    {
+        template <typename... Args>
+        static Ret
+        Dispatch(VulkanReplayConsumer* consumer, VkResult original_result, PFN_vkGetEventStatus func, Args... args)
+        {
+            BRIMSTONE_UNREFERENCED_PARAMETER(func);
+            return consumer->OverrideGetEventStatus(original_result, args...);
         }
     };
 


### PR DESCRIPTION
We need to override vkGetFenceStatus on replay because some games
use that instaead of vkWaitFences.  Basically, it's the same
kind of behavior, wait until success if that's the value that was
returned before.

Same with vkGetEventStatus.  No one appears to use this right now,
but it could also be used for a wait and needed to be overridden.