### PR TITLE
Address Invalid Error Messages

### DIFF
--- a/application/replay/main.cpp
+++ b/application/replay/main.cpp
@@ -99,26 +99,26 @@ int main(int argc, const char** argv)
                 window_factory = std::make_unique<brimstone::application::WaylandWindowFactory>(wayland_application);
 #endif
 #endif
-            }
 
-            if (!window_factory || !application || !application->Initialize(&file_processor))
-            {
-                BRIMSTONE_WRITE_CONSOLE(
-                    "Failed to initialize platform specific window system management.\nEnsure that the appropriate "
-                    "Vulkan platform extensions have been enabled.");
-                return_code = -1;
-            }
-            else
-            {
-                brimstone::format::VulkanDecoder        decoder;
-                brimstone::format::VulkanReplayConsumer replay_consumer(window_factory.get());
+                if (!window_factory || !application || !application->Initialize(&file_processor))
+                {
+                    BRIMSTONE_WRITE_CONSOLE(
+                        "Failed to initialize platform specific window system management.\nEnsure that the appropriate "
+                        "Vulkan platform extensions have been enabled.");
+                    return_code = -1;
+                }
+                else
+                {
+                    brimstone::format::VulkanDecoder        decoder;
+                    brimstone::format::VulkanReplayConsumer replay_consumer(window_factory.get());
 
-                replay_consumer.SetFatalErrorHandler([](const char* message) { throw std::runtime_error(message); });
+                    replay_consumer.SetFatalErrorHandler([](const char* message) { throw std::runtime_error(message); });
 
-                decoder.AddConsumer(&replay_consumer);
-                file_processor.AddDecoder(&decoder);
+                    decoder.AddConsumer(&replay_consumer);
+                    file_processor.AddDecoder(&decoder);
 
-                application->Run();
+                    application->Run();
+                }
             }
         }
         catch (std::runtime_error error)

--- a/format/vulkan_replay_consumer.cpp
+++ b/format/vulkan_replay_consumer.cpp
@@ -188,8 +188,10 @@ void VulkanReplayConsumer::CheckResult(const char* func_name, VkResult original,
     }
     else
     {
-        // Report error when replay result is different than the original result.
-        if (original != replay)
+        // Report error when replay result is different than the original result, unless the replay results indicates
+        // that a wait operation completed before the original.
+        if ((original != replay) &&
+            !((replay == VK_SUCCESS) && ((original == VK_TIMEOUT) || (original == VK_NOT_READY))))
         {
             BRIMSTONE_LOG_ERROR("API call (%s) returned value %s that does not match return value from trace file %s.",
                                 func_name,
@@ -197,7 +199,7 @@ void VulkanReplayConsumer::CheckResult(const char* func_name, VkResult original,
                                 enumutil::GetResultValueString(original));
         }
 
-        // Warn when an API call returned a failure, regardless of original result (excluding fromat not supported
+        // Warn when an API call returned a failure, regardless of original result (excluding format not supported
         // results).
         if ((replay < 0) && (replay != VK_ERROR_FORMAT_NOT_SUPPORTED))
         {


### PR DESCRIPTION
- Suppress error messages when replay result is VK_SUCCESS and trace
  result was VK_NOT_READY or VK_TIMEOUT.
- Fix GCAPPlay error reporting where an additional, invalid error
  message was printed after a failed to open file error message.