### PR TITLE
Fix Exit on Programmatic Window Close

### DIFF
--- a/application/win32_application.cpp
+++ b/application/win32_application.cpp
@@ -52,7 +52,6 @@ LRESULT WINAPI Win32Application::WindowProc(HWND window, unsigned int msg, WPARA
             break;
         }
         case WM_CLOSE:
-        case WM_DESTROY:
             PostQuitMessage(0);
             break;
         case WM_NCCREATE:


### PR DESCRIPTION
The WIN32 event handler was posting a quit message when the replay consumer destroyed a window in response to vkDestroySurface.  This change eliminates the generation of a quit message when receiving WM_DESTROY (window destroyed), and only posts a quit message in response to WM_CLOSE (user clicked the close button).