### PR TITLE
Fix Handle Mapping Error Message

### DIFF
--- a/framework/decode/vulkan_object_mapper.h
+++ b/framework/decode/vulkan_object_mapper.h
@@ -140,7 +140,7 @@ class VulkanObjectMapper
             }
             else
             {
-                BRIMSTONE_LOG_ERROR("Failed to map handle for object id " PRIx64, id);
+                BRIMSTONE_LOG_WARNING("Failed to map handle for object id %" PRIx64, id);
             }
         }
 


### PR DESCRIPTION
Fix issues with the error message that is printed during replay when a handle and an entry cannot be found for a handle ID:
- Fix formatting error.
- Change error type to warning as there are currently some legitimate related cases where this message is printed.