### PR TITLE
Add Android logging

### DIFF
--- a/android/layer/CMakeLists.txt
+++ b/android/layer/CMakeLists.txt
@@ -29,4 +29,5 @@ target_link_libraries(VkLayer_brimstone
                       brimstone_format
                       brimstone_util
                       vulkan_registry
-                      platform_specific)
+                      platform_specific
+                      log)


### PR DESCRIPTION
For Android, when we're to write out to the "console" we should
use the Logcat logging commands.  Also, we want to make sure we
don't add any additional prefixes/indents when we're writing to
that since it can easily get polluted with too much information.