### PR TITLE
Add ability to output unique filenames

### DIFF
--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -20,6 +20,8 @@ target_sources(brimstone_util
                    page_guard_manager.cpp
                    page_status_tracker.h
                    platform.h
+                   date_time.h
+                   file_path.h
               )
 
 target_compile_definitions(brimstone_util

--- a/framework/util/date_time.h
+++ b/framework/util/date_time.h
@@ -1,0 +1,118 @@
+/*
+** Copyright (c) 2018 Valve Corporation
+** Copyright (c) 2018 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef BRIMSTONE_UTIL_DATE_TIME_H
+#define BRIMSTONE_UTIL_DATE_TIME_H
+
+#include "util/defines.h"
+#include "util/logging.h"
+#include "util/platform.h"
+
+#include <ctime>
+#include <string>
+
+#if defined(WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif // WIN32
+
+BRIMSTONE_BEGIN_NAMESPACE(brimstone)
+BRIMSTONE_BEGIN_NAMESPACE(util)
+BRIMSTONE_BEGIN_NAMESPACE(datetime)
+
+#if defined(WIN32)
+
+inline uint64_t GetTimestamp()
+{
+    LARGE_INTEGER StartingTime;
+    LARGE_INTEGER Frequency;
+
+    // Get time and convert ticks to microseconds
+    QueryPerformanceFrequency(&Frequency);
+    QueryPerformanceCounter(&StartingTime);
+    StartingTime.QuadPart *= 1000000;
+    StartingTime.QuadPart /= Frequency.QuadPart;
+
+    // Convert to nanoseconds
+    return (static_cast<int64_t>(StartingTime.QuadPart) * 1000);
+}
+
+#else // !defined(WIN32)
+
+inline int64_t GetTimestamp()
+{
+    timespec time;
+    clock_gettime(CLOCK_REALTIME, &time);
+    int64_t timestamp = (1000000000 * static_cast<int64_t>(time.tv_sec)) + static_cast<int64_t>(time.tv_nsec);
+    return timestamp;
+}
+
+#endif // WIN32
+
+inline int64_t DiffTimestamps(int64_t start, int64_t end)
+{
+    return end - start;
+}
+
+inline std::string GetDateTimeString(bool use_gmt)
+{
+    tm          now;
+    time_t      timer  = time(nullptr);
+    int32_t     result = 0;
+    std::string datetime;
+
+    if (use_gmt)
+    {
+        result = platform::GMTime(&now, &timer);
+    }
+    else
+    {
+        result = platform::LocalTime(&now, &timer);
+    }
+
+    if (result == 0)
+    {
+        char time_char_buffer[17] = { 0 };
+        strftime(time_char_buffer, 17, "%Y%m%dT%H%M%S", &now);
+
+        if (use_gmt)
+        {
+            time_char_buffer[15] = 'Z';
+            time_char_buffer[16] = '\0';
+        }
+        else
+        {
+            time_char_buffer[15] = '\0';
+        }
+
+        datetime = time_char_buffer;
+    }
+    else
+    {
+        BRIMSTONE_LOG_ERROR("GetDateTimeString failed to retrieve localtime/gmtime");
+    }
+
+    return datetime;
+}
+
+BRIMSTONE_END_NAMESPACE(datetime)
+BRIMSTONE_END_NAMESPACE(util)
+BRIMSTONE_END_NAMESPACE(brimstone)
+
+#endif // BRIMSTONE_UTIL_DATE_TIME_H

--- a/framework/util/file_path.h
+++ b/framework/util/file_path.h
@@ -1,0 +1,54 @@
+/*
+** Copyright (c) 2018 Valve Corporation
+** Copyright (c) 2018 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef BRIMSTONE_UTIL_FILE_PATH_H
+#define BRIMSTONE_UTIL_FILE_PATH_H
+
+#include "util/date_time.h"
+#include "util/defines.h"
+
+#include <string>
+
+BRIMSTONE_BEGIN_NAMESPACE(brimstone)
+BRIMSTONE_BEGIN_NAMESPACE(util)
+BRIMSTONE_BEGIN_NAMESPACE(filepath)
+
+inline std::string GenerateTimestampedFilename(const std::string& filename, bool use_gmt = false)
+{
+    std::string file_extension;
+    std::string core_filename;
+    size_t      period_loc = filename.rfind('.');
+
+    if (period_loc != std::string::npos)
+    {
+        file_extension = filename.substr(period_loc, filename.length() - period_loc + 1);
+        core_filename  = filename.substr(0, period_loc);
+    }
+    else
+    {
+        file_extension = "";
+        core_filename  = filename;
+    }
+
+    return core_filename + "_" + util::datetime::GetDateTimeString(use_gmt) + file_extension;
+}
+
+BRIMSTONE_END_NAMESPACE(filepath)
+BRIMSTONE_END_NAMESPACE(util)
+BRIMSTONE_END_NAMESPACE(brimstone)
+
+#endif // BRIMSTONE_UTIL_FILE_PATH_H

--- a/framework/util/platform.h
+++ b/framework/util/platform.h
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <ctime>
 #include <cwchar>
 #include <thread>
 
@@ -145,6 +146,16 @@ inline int32_t FileVprintf(FILE* stream, const char* format, va_list vlist)
     return vfprintf_s(stream, format, vlist);
 }
 
+inline int32_t LocalTime(tm* local_time, const time_t* timer)
+{
+    return static_cast<int32_t>(localtime_s(local_time, timer));
+}
+
+inline int32_t GMTime(tm* gm_time, const time_t* timer)
+{
+    return static_cast<int32_t>(gmtime_s(gm_time, timer));
+}
+
 #else // !defined(WIN32)
 
 // Error value indicating string was truncated
@@ -260,6 +271,34 @@ inline size_t FileReadNoLock(void* buffer, size_t element_size, size_t element_c
 inline int32_t FileVprintf(FILE* stream, const char* format, va_list vlist)
 {
     return vfprintf(stream, format, vlist);
+}
+
+inline int32_t LocalTime(tm* local_time, const time_t* timer)
+{
+    tm* result = localtime(timer);
+    if (result != nullptr)
+    {
+        memcpy(local_time, result, sizeof(tm));
+        return 0;
+    }
+    else
+    {
+        return errno;
+    }
+}
+
+inline int32_t GMTime(tm* gm_time, const time_t* timer)
+{
+    tm* result = gmtime(timer);
+    if (result != nullptr)
+    {
+        memcpy(gm_time, result, sizeof(tm));
+        return 0;
+    }
+    else
+    {
+        return errno;
+    }
 }
 
 #endif // WIN32


### PR DESCRIPTION
On some platforms, it can output multiple capture files per game/
benchmark run.  This can overwrite necessary information.  Now,
when enabled, the current GMTZ time is added to the filename to
produce a unique file.