### PR TITLE
Initialize Capture in vkCreateInstance

### DIFF
--- a/framework/encode/custom_encoder_commands.h
+++ b/framework/encode/custom_encoder_commands.h
@@ -45,6 +45,28 @@ struct CustomEncoderPostCall
     {}
 };
 
+// Dispatch custom command to initialize capture at instance creation.
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateInstance>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager*, Args...)
+    {
+        TraceManager::Create();
+    }
+};
+
+// Dispatch custom command to finalize capture at instance destruction.
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyInstance>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager*, Args...)
+    {
+        TraceManager::Destroy();
+    }
+};
+
 // Dispatch custom command for window resize command generation.
 template <>
 struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateSwapchainKHR>

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -72,7 +72,7 @@ class TraceManager
     };
 
   public:
-    static bool Create(std::string filename, format::EnabledOptions file_options, MemoryTrackingMode mode);
+    static void Create();
 
     static void Destroy();
 
@@ -202,6 +202,8 @@ class TraceManager
 
   private:
     static TraceManager*                            instance_;
+    static uint32_t                                 instance_count_;
+    static std::mutex                               instance_lock_;
     static thread_local std::unique_ptr<ThreadData> thread_data_;
     format::EnabledOptions                          file_options_;
     std::unique_ptr<util::FileOutputStream>         file_stream_;

--- a/layer/dll_main.cpp
+++ b/layer/dll_main.cpp
@@ -15,7 +15,7 @@
 ** limitations under the License.
 */
 
-#include "layer/trace_layer.h"
+#include "encode/trace_manager.h"
 
 #if defined(WIN32)
 
@@ -27,16 +27,6 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 
     switch (fdwReason)
     {
-        case DLL_PROCESS_ATTACH:
-            // TODO: Layer initialization will use the CRT, which we assume to be safe here
-            //       because the layer is loaded by a LoadLibrary call made from vkCreateInstance
-            //       and CRT would already be initialized, but this should be confirmed.
-            if (!brimstone::init_layer())
-            {
-                // If initialization fails, return FALSE so that the layer is not loaded.
-                success = FALSE;
-            }
-            break;
         case DLL_PROCESS_DETACH:
             // TODO: We assume that lpvReserved will always be NULL, because FreeLibrary should be
             //       invoked by the loader from vkDestroyInstance.  If this is not always the case,
@@ -46,7 +36,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
             //       not terminating.
             if (lpvReserved == nullptr)
             {
-                brimstone::destroy_layer();
+                // TODO: Ensure that the trace is finalized.
             }
             break;
     }
@@ -56,14 +46,9 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 
 #else // WIN32
 
-__attribute__((constructor)) static void initialize_trace_layer()
-{
-    brimstone::init_layer();
-}
-
 __attribute__((destructor)) static void destroy_trace_layer()
 {
-    brimstone::destroy_layer();
+    // TODO: Ensure that the trace is finalized.
 }
 
 #endif // WIN32

--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -77,40 +77,6 @@ BRIMSTONE_BEGIN_NAMESPACE(brimstone)
 
 std::mutex g_create_destroy_mutex;
 
-bool init_layer()
-{
-    if (brimstone::encode::TraceManager::Get() != nullptr)
-    {
-        return true;
-    }
-
-    // TODO: load settings from file.
-    format::EnabledOptions options;
-#if defined(__ANDROID__)
-    std::string binary_file_name = "/sdcard/captures/brimstone_out" BRIMSTONE_FILE_EXTENSION;
-#else
-    std::string binary_file_name = "./brimstone_out" BRIMSTONE_FILE_EXTENSION;
-#endif
-
-#if defined(ENABLE_LZ4_COMPRESSION)
-    options.compression_type = format::CompressionType::kLz4;
-#endif
-
-    // Check to see if there's an environment variable overriding the default binary location value.
-    std::string env_variable = brimstone::util::platform::GetEnv("BRIMSTONE_BINARY_FILE");
-    if (!env_variable.empty())
-    {
-        binary_file_name = env_variable;
-    }
-
-    return brimstone::encode::TraceManager::Create(binary_file_name, options, encode::TraceManager::kPageGuard);
-}
-
-void destroy_layer()
-{
-    brimstone::encode::TraceManager::Destroy();
-}
-
 void init_instance_table(VkInstance instance, PFN_vkGetInstanceProcAddr gpa)
 {
     auto& table = instance_table[get_dispatch_key(instance)];

--- a/layer/trace_layer.h
+++ b/layer/trace_layer.h
@@ -56,9 +56,6 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumerateDeviceLayerProperties(VkPhysicalDevice  
                                                               uint32_t*          pPropertyCount,
                                                               VkLayerProperties* pProperties);
 
-bool init_layer();
-void destroy_layer();
-
 void init_instance_table(VkInstance instance, PFN_vkGetInstanceProcAddr gpa);
 void init_device_table(VkDevice device, PFN_vkGetDeviceProcAddr gpa);
 


### PR DESCRIPTION
Move capture initialization/destruction from DLLMain to vkCreateInstance/vkDestroyInstance.  These functions are responsible for loading/unloading the layer, so these operarions are still effectively happening at the same time.  This change prevents the layer from creating empty files on Android when the loader loads the layer to query for its properties.