### PR TITLE
Layer DEF file out of date

### DIFF
--- a/layer/trace_layer.def
+++ b/layer/trace_layer.def
@@ -1,4 +1,4 @@
-LIBRARY gfxreconstruct_layer
+LIBRARY VkLayer_gfxreconstruct
 EXPORTS
 vkGetInstanceProcAddr
 vkGetDeviceProcAddr


### PR DESCRIPTION
The VkLayer_gfxreconstruct layer DEF file needed to be updated
with the new name.  Without this fix, it generates a build
warning.