### PR TITLE
Log Packets Before API Calls With No Output Parameters

### DIFF
--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -41,24 +41,18 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(
     const VkAllocationCallbacks*                pAllocator,
     VkInstance*                                 pInstance)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateInstance>::Dispatch(encode::TraceManager::Get(), pCreateInfo, pAllocator, pInstance);
 
+    VkResult result = dispatch_CreateInstance(pCreateInfo, pAllocator, pInstance);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateInstance);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = dispatch_CreateInstance(pCreateInfo, pAllocator, pInstance);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateInstance);
-        if (encoder)
-        {
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pInstance);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pInstance);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateInstance>::Dispatch(encode::TraceManager::Get(), result, pCreateInfo, pAllocator, pInstance);
@@ -72,19 +66,15 @@ VKAPI_ATTR void VKAPI_CALL DestroyInstance(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyInstance>::Dispatch(encode::TraceManager::Get(), instance, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyInstance);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_instance_table(instance)->DestroyInstance(instance, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyInstance);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_instance_table(instance)->DestroyInstance(instance, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyInstance>::Dispatch(encode::TraceManager::Get(), instance, pAllocator);
 }
@@ -250,25 +240,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(
     const VkAllocationCallbacks*                pAllocator,
     VkDevice*                                   pDevice)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateDevice>::Dispatch(encode::TraceManager::Get(), physicalDevice, pCreateInfo, pAllocator, pDevice);
 
+    VkResult result = dispatch_CreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDevice);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = dispatch_CreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDevice);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(physicalDevice);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pDevice);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(physicalDevice);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pDevice);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDevice>::Dispatch(encode::TraceManager::Get(), result, physicalDevice, pCreateInfo, pAllocator, pDevice);
@@ -282,19 +266,15 @@ VKAPI_ATTR void VKAPI_CALL DestroyDevice(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyDevice>::Dispatch(encode::TraceManager::Get(), device, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyDevice);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyDevice(device, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyDevice);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyDevice(device, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDevice>::Dispatch(encode::TraceManager::Get(), device, pAllocator);
 }
@@ -394,25 +374,19 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateMemory(
     const VkAllocationCallbacks*                pAllocator,
     VkDeviceMemory*                             pMemory)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkAllocateMemory>::Dispatch(encode::TraceManager::Get(), device, pAllocateInfo, pAllocator, pMemory);
 
+    VkResult result = get_device_table(device)->AllocateMemory(device, pAllocateInfo, pAllocator, pMemory);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkAllocateMemory);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->AllocateMemory(device, pAllocateInfo, pAllocator, pMemory);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkAllocateMemory);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pAllocateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pMemory);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pAllocateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pMemory);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateMemory>::Dispatch(encode::TraceManager::Get(), result, device, pAllocateInfo, pAllocator, pMemory);
@@ -427,20 +401,16 @@ VKAPI_ATTR void VKAPI_CALL FreeMemory(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkFreeMemory>::Dispatch(encode::TraceManager::Get(), device, memory, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkFreeMemory);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->FreeMemory(device, memory, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkFreeMemory);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(memory);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(memory);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->FreeMemory(device, memory, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeMemory>::Dispatch(encode::TraceManager::Get(), device, memory, pAllocator);
 }
@@ -481,8 +451,6 @@ VKAPI_ATTR void VKAPI_CALL UnmapMemory(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkUnmapMemory>::Dispatch(encode::TraceManager::Get(), device, memory);
 
-    get_device_table(device)->UnmapMemory(device, memory);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkUnmapMemory);
     if (encoder)
     {
@@ -490,6 +458,8 @@ VKAPI_ATTR void VKAPI_CALL UnmapMemory(
         encoder->EncodeHandleIdValue(memory);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->UnmapMemory(device, memory);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkUnmapMemory>::Dispatch(encode::TraceManager::Get(), device, memory);
 }
@@ -743,25 +713,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFence(
     const VkAllocationCallbacks*                pAllocator,
     VkFence*                                    pFence)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateFence>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pFence);
 
+    VkResult result = get_device_table(device)->CreateFence(device, pCreateInfo, pAllocator, pFence);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateFence);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateFence(device, pCreateInfo, pAllocator, pFence);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateFence);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pFence);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pFence);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateFence>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pFence);
@@ -776,20 +740,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyFence(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyFence>::Dispatch(encode::TraceManager::Get(), device, fence, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyFence);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyFence(device, fence, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyFence);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(fence);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(fence);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyFence(device, fence, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyFence>::Dispatch(encode::TraceManager::Get(), device, fence, pAllocator);
 }
@@ -874,25 +834,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSemaphore(
     const VkAllocationCallbacks*                pAllocator,
     VkSemaphore*                                pSemaphore)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateSemaphore>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pSemaphore);
 
+    VkResult result = get_device_table(device)->CreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateSemaphore);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateSemaphore);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pSemaphore);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pSemaphore);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSemaphore>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pSemaphore);
@@ -907,20 +861,16 @@ VKAPI_ATTR void VKAPI_CALL DestroySemaphore(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroySemaphore>::Dispatch(encode::TraceManager::Get(), device, semaphore, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroySemaphore);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroySemaphore(device, semaphore, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroySemaphore);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(semaphore);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(semaphore);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroySemaphore(device, semaphore, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySemaphore>::Dispatch(encode::TraceManager::Get(), device, semaphore, pAllocator);
 }
@@ -931,25 +881,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateEvent(
     const VkAllocationCallbacks*                pAllocator,
     VkEvent*                                    pEvent)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateEvent>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pEvent);
 
+    VkResult result = get_device_table(device)->CreateEvent(device, pCreateInfo, pAllocator, pEvent);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateEvent);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateEvent(device, pCreateInfo, pAllocator, pEvent);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateEvent);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pEvent);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pEvent);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateEvent>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pEvent);
@@ -964,20 +908,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyEvent(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyEvent>::Dispatch(encode::TraceManager::Get(), device, event, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyEvent);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyEvent(device, event, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyEvent);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(event);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(event);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyEvent(device, event, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyEvent>::Dispatch(encode::TraceManager::Get(), device, event, pAllocator);
 }
@@ -1054,25 +994,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateQueryPool(
     const VkAllocationCallbacks*                pAllocator,
     VkQueryPool*                                pQueryPool)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateQueryPool>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pQueryPool);
 
+    VkResult result = get_device_table(device)->CreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateQueryPool);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateQueryPool);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pQueryPool);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pQueryPool);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateQueryPool>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pQueryPool);
@@ -1087,20 +1021,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyQueryPool(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyQueryPool>::Dispatch(encode::TraceManager::Get(), device, queryPool, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyQueryPool);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyQueryPool(device, queryPool, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyQueryPool);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(queryPool);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(queryPool);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyQueryPool(device, queryPool, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyQueryPool>::Dispatch(encode::TraceManager::Get(), device, queryPool, pAllocator);
 }
@@ -1145,25 +1075,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBuffer(
     const VkAllocationCallbacks*                pAllocator,
     VkBuffer*                                   pBuffer)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateBuffer>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pBuffer);
 
+    VkResult result = get_device_table(device)->CreateBuffer(device, pCreateInfo, pAllocator, pBuffer);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateBuffer);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateBuffer(device, pCreateInfo, pAllocator, pBuffer);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateBuffer);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pBuffer);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pBuffer);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateBuffer>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pBuffer);
@@ -1178,20 +1102,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyBuffer(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyBuffer>::Dispatch(encode::TraceManager::Get(), device, buffer, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyBuffer);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyBuffer(device, buffer, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyBuffer);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(buffer);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(buffer);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyBuffer(device, buffer, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyBuffer>::Dispatch(encode::TraceManager::Get(), device, buffer, pAllocator);
 }
@@ -1202,25 +1122,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBufferView(
     const VkAllocationCallbacks*                pAllocator,
     VkBufferView*                               pView)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateBufferView>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pView);
 
+    VkResult result = get_device_table(device)->CreateBufferView(device, pCreateInfo, pAllocator, pView);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateBufferView);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateBufferView(device, pCreateInfo, pAllocator, pView);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateBufferView);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pView);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pView);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateBufferView>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pView);
@@ -1235,20 +1149,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyBufferView(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyBufferView>::Dispatch(encode::TraceManager::Get(), device, bufferView, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyBufferView);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyBufferView(device, bufferView, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyBufferView);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(bufferView);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(bufferView);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyBufferView(device, bufferView, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyBufferView>::Dispatch(encode::TraceManager::Get(), device, bufferView, pAllocator);
 }
@@ -1259,25 +1169,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImage(
     const VkAllocationCallbacks*                pAllocator,
     VkImage*                                    pImage)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateImage>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pImage);
 
+    VkResult result = get_device_table(device)->CreateImage(device, pCreateInfo, pAllocator, pImage);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateImage);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateImage(device, pCreateInfo, pAllocator, pImage);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateImage);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pImage);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pImage);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateImage>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pImage);
@@ -1292,20 +1196,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyImage(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyImage>::Dispatch(encode::TraceManager::Get(), device, image, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyImage);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyImage(device, image, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyImage);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(image);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(image);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyImage(device, image, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyImage>::Dispatch(encode::TraceManager::Get(), device, image, pAllocator);
 }
@@ -1339,25 +1239,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImageView(
     const VkAllocationCallbacks*                pAllocator,
     VkImageView*                                pView)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateImageView>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pView);
 
+    VkResult result = get_device_table(device)->CreateImageView(device, pCreateInfo, pAllocator, pView);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateImageView);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateImageView(device, pCreateInfo, pAllocator, pView);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateImageView);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pView);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pView);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateImageView>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pView);
@@ -1372,20 +1266,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyImageView(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyImageView>::Dispatch(encode::TraceManager::Get(), device, imageView, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyImageView);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyImageView(device, imageView, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyImageView);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(imageView);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(imageView);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyImageView(device, imageView, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyImageView>::Dispatch(encode::TraceManager::Get(), device, imageView, pAllocator);
 }
@@ -1396,25 +1286,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(
     const VkAllocationCallbacks*                pAllocator,
     VkShaderModule*                             pShaderModule)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateShaderModule>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pShaderModule);
 
+    VkResult result = get_device_table(device)->CreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateShaderModule);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateShaderModule);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pShaderModule);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pShaderModule);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateShaderModule>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pShaderModule);
@@ -1429,20 +1313,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderModule(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyShaderModule>::Dispatch(encode::TraceManager::Get(), device, shaderModule, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyShaderModule);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyShaderModule(device, shaderModule, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyShaderModule);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(shaderModule);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(shaderModule);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyShaderModule(device, shaderModule, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyShaderModule>::Dispatch(encode::TraceManager::Get(), device, shaderModule, pAllocator);
 }
@@ -1453,25 +1333,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineCache(
     const VkAllocationCallbacks*                pAllocator,
     VkPipelineCache*                            pPipelineCache)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreatePipelineCache>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pPipelineCache);
 
+    VkResult result = get_device_table(device)->CreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreatePipelineCache);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreatePipelineCache);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pPipelineCache);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pPipelineCache);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreatePipelineCache>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pPipelineCache);
@@ -1486,20 +1360,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineCache(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyPipelineCache>::Dispatch(encode::TraceManager::Get(), device, pipelineCache, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyPipelineCache);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyPipelineCache(device, pipelineCache, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyPipelineCache);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(pipelineCache);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(pipelineCache);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyPipelineCache(device, pipelineCache, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipelineCache>::Dispatch(encode::TraceManager::Get(), device, pipelineCache, pAllocator);
 }
@@ -1564,27 +1434,21 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(
     const VkAllocationCallbacks*                pAllocator,
     VkPipeline*                                 pPipelines)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateGraphicsPipelines>::Dispatch(encode::TraceManager::Get(), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
 
+    VkResult result = get_device_table(device)->CreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateGraphicsPipelines);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateGraphicsPipelines);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(pipelineCache);
-            encoder->EncodeUInt32Value(createInfoCount);
-            encode_struct_array(encoder, pCreateInfos, createInfoCount);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(pipelineCache);
+        encoder->EncodeUInt32Value(createInfoCount);
+        encode_struct_array(encoder, pCreateInfos, createInfoCount);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateGraphicsPipelines>::Dispatch(encode::TraceManager::Get(), result, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
@@ -1600,27 +1464,21 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(
     const VkAllocationCallbacks*                pAllocator,
     VkPipeline*                                 pPipelines)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateComputePipelines>::Dispatch(encode::TraceManager::Get(), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
 
+    VkResult result = get_device_table(device)->CreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateComputePipelines);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateComputePipelines);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(pipelineCache);
-            encoder->EncodeUInt32Value(createInfoCount);
-            encode_struct_array(encoder, pCreateInfos, createInfoCount);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(pipelineCache);
+        encoder->EncodeUInt32Value(createInfoCount);
+        encode_struct_array(encoder, pCreateInfos, createInfoCount);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateComputePipelines>::Dispatch(encode::TraceManager::Get(), result, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
@@ -1635,20 +1493,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipeline(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyPipeline>::Dispatch(encode::TraceManager::Get(), device, pipeline, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyPipeline);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyPipeline(device, pipeline, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyPipeline);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(pipeline);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(pipeline);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyPipeline(device, pipeline, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipeline>::Dispatch(encode::TraceManager::Get(), device, pipeline, pAllocator);
 }
@@ -1659,25 +1513,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(
     const VkAllocationCallbacks*                pAllocator,
     VkPipelineLayout*                           pPipelineLayout)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreatePipelineLayout>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pPipelineLayout);
 
+    VkResult result = get_device_table(device)->CreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreatePipelineLayout);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreatePipelineLayout);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pPipelineLayout);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pPipelineLayout);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreatePipelineLayout>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pPipelineLayout);
@@ -1692,20 +1540,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineLayout(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyPipelineLayout>::Dispatch(encode::TraceManager::Get(), device, pipelineLayout, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyPipelineLayout);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyPipelineLayout(device, pipelineLayout, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyPipelineLayout);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(pipelineLayout);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(pipelineLayout);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyPipelineLayout(device, pipelineLayout, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyPipelineLayout>::Dispatch(encode::TraceManager::Get(), device, pipelineLayout, pAllocator);
 }
@@ -1716,25 +1560,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSampler(
     const VkAllocationCallbacks*                pAllocator,
     VkSampler*                                  pSampler)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateSampler>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pSampler);
 
+    VkResult result = get_device_table(device)->CreateSampler(device, pCreateInfo, pAllocator, pSampler);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateSampler);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateSampler(device, pCreateInfo, pAllocator, pSampler);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateSampler);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pSampler);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pSampler);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSampler>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pSampler);
@@ -1749,20 +1587,16 @@ VKAPI_ATTR void VKAPI_CALL DestroySampler(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroySampler>::Dispatch(encode::TraceManager::Get(), device, sampler, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroySampler);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroySampler(device, sampler, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroySampler);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(sampler);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(sampler);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroySampler(device, sampler, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySampler>::Dispatch(encode::TraceManager::Get(), device, sampler, pAllocator);
 }
@@ -1773,25 +1607,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorSetLayout(
     const VkAllocationCallbacks*                pAllocator,
     VkDescriptorSetLayout*                      pSetLayout)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateDescriptorSetLayout>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pSetLayout);
 
+    VkResult result = get_device_table(device)->CreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDescriptorSetLayout);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDescriptorSetLayout);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pSetLayout);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pSetLayout);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorSetLayout>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pSetLayout);
@@ -1806,20 +1634,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorSetLayout(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyDescriptorSetLayout>::Dispatch(encode::TraceManager::Get(), device, descriptorSetLayout, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyDescriptorSetLayout);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyDescriptorSetLayout);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(descriptorSetLayout);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(descriptorSetLayout);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorSetLayout>::Dispatch(encode::TraceManager::Get(), device, descriptorSetLayout, pAllocator);
 }
@@ -1830,25 +1654,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorPool(
     const VkAllocationCallbacks*                pAllocator,
     VkDescriptorPool*                           pDescriptorPool)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateDescriptorPool>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pDescriptorPool);
 
+    VkResult result = get_device_table(device)->CreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDescriptorPool);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDescriptorPool);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pDescriptorPool);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pDescriptorPool);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorPool>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pDescriptorPool);
@@ -1863,20 +1681,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorPool(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyDescriptorPool>::Dispatch(encode::TraceManager::Get(), device, descriptorPool, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyDescriptorPool);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyDescriptorPool(device, descriptorPool, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyDescriptorPool);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(descriptorPool);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(descriptorPool);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyDescriptorPool(device, descriptorPool, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorPool>::Dispatch(encode::TraceManager::Get(), device, descriptorPool, pAllocator);
 }
@@ -1910,24 +1724,18 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(
     const VkDescriptorSetAllocateInfo*          pAllocateInfo,
     VkDescriptorSet*                            pDescriptorSets)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkAllocateDescriptorSets>::Dispatch(encode::TraceManager::Get(), device, pAllocateInfo, pDescriptorSets);
 
+    VkResult result = get_device_table(device)->AllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkAllocateDescriptorSets);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->AllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkAllocateDescriptorSets);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pAllocateInfo);
-            encoder->EncodeHandleIdArray(pDescriptorSets, pAllocateInfo->descriptorSetCount);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pAllocateInfo);
+        encoder->EncodeHandleIdArray(pDescriptorSets, pAllocateInfo->descriptorSetCount);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateDescriptorSets>::Dispatch(encode::TraceManager::Get(), result, device, pAllocateInfo, pDescriptorSets);
@@ -1941,25 +1749,19 @@ VKAPI_ATTR VkResult VKAPI_CALL FreeDescriptorSets(
     uint32_t                                    descriptorSetCount,
     const VkDescriptorSet*                      pDescriptorSets)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkFreeDescriptorSets>::Dispatch(encode::TraceManager::Get(), device, descriptorPool, descriptorSetCount, pDescriptorSets);
 
+    VkResult result = get_device_table(device)->FreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkFreeDescriptorSets);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->FreeDescriptorSets(device, descriptorPool, descriptorSetCount, pDescriptorSets);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkFreeDescriptorSets);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(descriptorPool);
-            encoder->EncodeUInt32Value(descriptorSetCount);
-            encoder->EncodeHandleIdArray(pDescriptorSets, descriptorSetCount);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(descriptorPool);
+        encoder->EncodeUInt32Value(descriptorSetCount);
+        encoder->EncodeHandleIdArray(pDescriptorSets, descriptorSetCount);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeDescriptorSets>::Dispatch(encode::TraceManager::Get(), result, device, descriptorPool, descriptorSetCount, pDescriptorSets);
@@ -1976,8 +1778,6 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSets(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkUpdateDescriptorSets>::Dispatch(encode::TraceManager::Get(), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies);
 
-    get_device_table(device)->UpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkUpdateDescriptorSets);
     if (encoder)
     {
@@ -1989,6 +1789,8 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSets(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(device)->UpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkUpdateDescriptorSets>::Dispatch(encode::TraceManager::Get(), device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies);
 }
 
@@ -1998,25 +1800,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFramebuffer(
     const VkAllocationCallbacks*                pAllocator,
     VkFramebuffer*                              pFramebuffer)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateFramebuffer>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pFramebuffer);
 
+    VkResult result = get_device_table(device)->CreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateFramebuffer);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateFramebuffer);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pFramebuffer);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pFramebuffer);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateFramebuffer>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pFramebuffer);
@@ -2031,20 +1827,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyFramebuffer(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyFramebuffer>::Dispatch(encode::TraceManager::Get(), device, framebuffer, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyFramebuffer);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyFramebuffer(device, framebuffer, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyFramebuffer);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(framebuffer);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(framebuffer);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyFramebuffer(device, framebuffer, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyFramebuffer>::Dispatch(encode::TraceManager::Get(), device, framebuffer, pAllocator);
 }
@@ -2055,25 +1847,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass(
     const VkAllocationCallbacks*                pAllocator,
     VkRenderPass*                               pRenderPass)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateRenderPass>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pRenderPass);
 
+    VkResult result = get_device_table(device)->CreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateRenderPass);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateRenderPass);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pRenderPass);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pRenderPass);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRenderPass>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pRenderPass);
@@ -2088,20 +1874,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyRenderPass(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyRenderPass>::Dispatch(encode::TraceManager::Get(), device, renderPass, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyRenderPass);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyRenderPass(device, renderPass, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyRenderPass);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(renderPass);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(renderPass);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyRenderPass(device, renderPass, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyRenderPass>::Dispatch(encode::TraceManager::Get(), device, renderPass, pAllocator);
 }
@@ -2133,25 +1915,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateCommandPool(
     const VkAllocationCallbacks*                pAllocator,
     VkCommandPool*                              pCommandPool)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateCommandPool>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pCommandPool);
 
+    VkResult result = get_device_table(device)->CreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateCommandPool);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateCommandPool);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pCommandPool);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pCommandPool);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateCommandPool>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pCommandPool);
@@ -2166,20 +1942,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyCommandPool(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyCommandPool>::Dispatch(encode::TraceManager::Get(), device, commandPool, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyCommandPool);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyCommandPool(device, commandPool, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyCommandPool);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(commandPool);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(commandPool);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyCommandPool(device, commandPool, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyCommandPool>::Dispatch(encode::TraceManager::Get(), device, commandPool, pAllocator);
 }
@@ -2213,24 +1985,18 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateCommandBuffers(
     const VkCommandBufferAllocateInfo*          pAllocateInfo,
     VkCommandBuffer*                            pCommandBuffers)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkAllocateCommandBuffers>::Dispatch(encode::TraceManager::Get(), device, pAllocateInfo, pCommandBuffers);
 
+    VkResult result = get_device_table(device)->AllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkAllocateCommandBuffers);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->AllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkAllocateCommandBuffers);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pAllocateInfo);
-            encoder->EncodeHandleIdArray(pCommandBuffers, pAllocateInfo->commandBufferCount);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pAllocateInfo);
+        encoder->EncodeHandleIdArray(pCommandBuffers, pAllocateInfo->commandBufferCount);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateCommandBuffers>::Dispatch(encode::TraceManager::Get(), result, device, pAllocateInfo, pCommandBuffers);
@@ -2246,21 +2012,17 @@ VKAPI_ATTR void VKAPI_CALL FreeCommandBuffers(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkFreeCommandBuffers>::Dispatch(encode::TraceManager::Get(), device, commandPool, commandBufferCount, pCommandBuffers);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkFreeCommandBuffers);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->FreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkFreeCommandBuffers);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(commandPool);
-            encoder->EncodeUInt32Value(commandBufferCount);
-            encoder->EncodeHandleIdArray(pCommandBuffers, commandBufferCount);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(commandPool);
+        encoder->EncodeUInt32Value(commandBufferCount);
+        encoder->EncodeHandleIdArray(pCommandBuffers, commandBufferCount);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->FreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeCommandBuffers>::Dispatch(encode::TraceManager::Get(), device, commandPool, commandBufferCount, pCommandBuffers);
 }
@@ -2336,8 +2098,6 @@ VKAPI_ATTR void VKAPI_CALL CmdBindPipeline(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdBindPipeline>::Dispatch(encode::TraceManager::Get(), commandBuffer, pipelineBindPoint, pipeline);
 
-    get_device_table(commandBuffer)->CmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdBindPipeline);
     if (encoder)
     {
@@ -2346,6 +2106,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindPipeline(
         encoder->EncodeHandleIdValue(pipeline);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindPipeline>::Dispatch(encode::TraceManager::Get(), commandBuffer, pipelineBindPoint, pipeline);
 }
@@ -2358,8 +2120,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewport(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetViewport>::Dispatch(encode::TraceManager::Get(), commandBuffer, firstViewport, viewportCount, pViewports);
 
-    get_device_table(commandBuffer)->CmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetViewport);
     if (encoder)
     {
@@ -2369,6 +2129,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewport(
         encode_struct_array(encoder, pViewports, viewportCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetViewport>::Dispatch(encode::TraceManager::Get(), commandBuffer, firstViewport, viewportCount, pViewports);
 }
@@ -2381,8 +2143,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissor(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetScissor>::Dispatch(encode::TraceManager::Get(), commandBuffer, firstScissor, scissorCount, pScissors);
 
-    get_device_table(commandBuffer)->CmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetScissor);
     if (encoder)
     {
@@ -2393,6 +2153,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissor(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetScissor>::Dispatch(encode::TraceManager::Get(), commandBuffer, firstScissor, scissorCount, pScissors);
 }
 
@@ -2402,8 +2164,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineWidth(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetLineWidth>::Dispatch(encode::TraceManager::Get(), commandBuffer, lineWidth);
 
-    get_device_table(commandBuffer)->CmdSetLineWidth(commandBuffer, lineWidth);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetLineWidth);
     if (encoder)
     {
@@ -2411,6 +2171,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetLineWidth(
         encoder->EncodeFloatValue(lineWidth);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdSetLineWidth(commandBuffer, lineWidth);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetLineWidth>::Dispatch(encode::TraceManager::Get(), commandBuffer, lineWidth);
 }
@@ -2423,8 +2185,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBias(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetDepthBias>::Dispatch(encode::TraceManager::Get(), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
 
-    get_device_table(commandBuffer)->CmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetDepthBias);
     if (encoder)
     {
@@ -2435,6 +2195,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBias(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthBias>::Dispatch(encode::TraceManager::Get(), commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
 }
 
@@ -2444,8 +2206,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetBlendConstants(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetBlendConstants>::Dispatch(encode::TraceManager::Get(), commandBuffer, blendConstants);
 
-    get_device_table(commandBuffer)->CmdSetBlendConstants(commandBuffer, blendConstants);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetBlendConstants);
     if (encoder)
     {
@@ -2453,6 +2213,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetBlendConstants(
         encoder->EncodeFloatArray(blendConstants, 4);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdSetBlendConstants(commandBuffer, blendConstants);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetBlendConstants>::Dispatch(encode::TraceManager::Get(), commandBuffer, blendConstants);
 }
@@ -2464,8 +2226,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBounds(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetDepthBounds>::Dispatch(encode::TraceManager::Get(), commandBuffer, minDepthBounds, maxDepthBounds);
 
-    get_device_table(commandBuffer)->CmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetDepthBounds);
     if (encoder)
     {
@@ -2474,6 +2234,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDepthBounds(
         encoder->EncodeFloatValue(maxDepthBounds);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDepthBounds>::Dispatch(encode::TraceManager::Get(), commandBuffer, minDepthBounds, maxDepthBounds);
 }
@@ -2485,8 +2247,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilCompareMask(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetStencilCompareMask>::Dispatch(encode::TraceManager::Get(), commandBuffer, faceMask, compareMask);
 
-    get_device_table(commandBuffer)->CmdSetStencilCompareMask(commandBuffer, faceMask, compareMask);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetStencilCompareMask);
     if (encoder)
     {
@@ -2495,6 +2255,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilCompareMask(
         encoder->EncodeUInt32Value(compareMask);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdSetStencilCompareMask(commandBuffer, faceMask, compareMask);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetStencilCompareMask>::Dispatch(encode::TraceManager::Get(), commandBuffer, faceMask, compareMask);
 }
@@ -2506,8 +2268,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilWriteMask(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetStencilWriteMask>::Dispatch(encode::TraceManager::Get(), commandBuffer, faceMask, writeMask);
 
-    get_device_table(commandBuffer)->CmdSetStencilWriteMask(commandBuffer, faceMask, writeMask);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetStencilWriteMask);
     if (encoder)
     {
@@ -2516,6 +2276,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilWriteMask(
         encoder->EncodeUInt32Value(writeMask);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdSetStencilWriteMask(commandBuffer, faceMask, writeMask);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetStencilWriteMask>::Dispatch(encode::TraceManager::Get(), commandBuffer, faceMask, writeMask);
 }
@@ -2527,8 +2289,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilReference(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetStencilReference>::Dispatch(encode::TraceManager::Get(), commandBuffer, faceMask, reference);
 
-    get_device_table(commandBuffer)->CmdSetStencilReference(commandBuffer, faceMask, reference);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetStencilReference);
     if (encoder)
     {
@@ -2537,6 +2297,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetStencilReference(
         encoder->EncodeUInt32Value(reference);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdSetStencilReference(commandBuffer, faceMask, reference);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetStencilReference>::Dispatch(encode::TraceManager::Get(), commandBuffer, faceMask, reference);
 }
@@ -2553,8 +2315,6 @@ VKAPI_ATTR void VKAPI_CALL CmdBindDescriptorSets(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdBindDescriptorSets>::Dispatch(encode::TraceManager::Get(), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets);
 
-    get_device_table(commandBuffer)->CmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdBindDescriptorSets);
     if (encoder)
     {
@@ -2569,6 +2329,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindDescriptorSets(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindDescriptorSets>::Dispatch(encode::TraceManager::Get(), commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets);
 }
 
@@ -2580,8 +2342,6 @@ VKAPI_ATTR void VKAPI_CALL CmdBindIndexBuffer(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdBindIndexBuffer>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, indexType);
 
-    get_device_table(commandBuffer)->CmdBindIndexBuffer(commandBuffer, buffer, offset, indexType);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdBindIndexBuffer);
     if (encoder)
     {
@@ -2591,6 +2351,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindIndexBuffer(
         encoder->EncodeEnumValue(indexType);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdBindIndexBuffer(commandBuffer, buffer, offset, indexType);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindIndexBuffer>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, indexType);
 }
@@ -2604,8 +2366,6 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdBindVertexBuffers>::Dispatch(encode::TraceManager::Get(), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets);
 
-    get_device_table(commandBuffer)->CmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdBindVertexBuffers);
     if (encoder)
     {
@@ -2616,6 +2376,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers(
         encoder->EncodeVkDeviceSizeArray(pOffsets, bindingCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindVertexBuffers>::Dispatch(encode::TraceManager::Get(), commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets);
 }
@@ -2629,8 +2391,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDraw(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDraw>::Dispatch(encode::TraceManager::Get(), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
 
-    get_device_table(commandBuffer)->CmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDraw);
     if (encoder)
     {
@@ -2641,6 +2401,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDraw(
         encoder->EncodeUInt32Value(firstInstance);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDraw>::Dispatch(encode::TraceManager::Get(), commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
 }
@@ -2655,8 +2417,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexed(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDrawIndexed>::Dispatch(encode::TraceManager::Get(), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
 
-    get_device_table(commandBuffer)->CmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDrawIndexed);
     if (encoder)
     {
@@ -2668,6 +2428,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexed(
         encoder->EncodeUInt32Value(firstInstance);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndexed>::Dispatch(encode::TraceManager::Get(), commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
 }
@@ -2681,8 +2443,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirect(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDrawIndirect>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, drawCount, stride);
 
-    get_device_table(commandBuffer)->CmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDrawIndirect);
     if (encoder)
     {
@@ -2693,6 +2453,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirect(
         encoder->EncodeUInt32Value(stride);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndirect>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, drawCount, stride);
 }
@@ -2706,8 +2468,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirect(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirect>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, drawCount, stride);
 
-    get_device_table(commandBuffer)->CmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirect);
     if (encoder)
     {
@@ -2718,6 +2478,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirect(
         encoder->EncodeUInt32Value(stride);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirect>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, drawCount, stride);
 }
@@ -2730,8 +2492,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatch(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDispatch>::Dispatch(encode::TraceManager::Get(), commandBuffer, groupCountX, groupCountY, groupCountZ);
 
-    get_device_table(commandBuffer)->CmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDispatch);
     if (encoder)
     {
@@ -2741,6 +2501,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatch(
         encoder->EncodeUInt32Value(groupCountZ);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDispatch>::Dispatch(encode::TraceManager::Get(), commandBuffer, groupCountX, groupCountY, groupCountZ);
 }
@@ -2752,8 +2514,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchIndirect(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDispatchIndirect>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset);
 
-    get_device_table(commandBuffer)->CmdDispatchIndirect(commandBuffer, buffer, offset);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDispatchIndirect);
     if (encoder)
     {
@@ -2762,6 +2522,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchIndirect(
         encoder->EncodeVkDeviceSizeValue(offset);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdDispatchIndirect(commandBuffer, buffer, offset);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDispatchIndirect>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset);
 }
@@ -2775,8 +2537,6 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdCopyBuffer>::Dispatch(encode::TraceManager::Get(), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions);
 
-    get_device_table(commandBuffer)->CmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdCopyBuffer);
     if (encoder)
     {
@@ -2787,6 +2547,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer(
         encode_struct_array(encoder, pRegions, regionCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyBuffer>::Dispatch(encode::TraceManager::Get(), commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions);
 }
@@ -2802,8 +2564,6 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdCopyImage>::Dispatch(encode::TraceManager::Get(), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
 
-    get_device_table(commandBuffer)->CmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdCopyImage);
     if (encoder)
     {
@@ -2816,6 +2576,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage(
         encode_struct_array(encoder, pRegions, regionCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyImage>::Dispatch(encode::TraceManager::Get(), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
 }
@@ -2832,8 +2594,6 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdBlitImage>::Dispatch(encode::TraceManager::Get(), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter);
 
-    get_device_table(commandBuffer)->CmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdBlitImage);
     if (encoder)
     {
@@ -2848,6 +2608,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBlitImage>::Dispatch(encode::TraceManager::Get(), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter);
 }
 
@@ -2861,8 +2623,6 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdCopyBufferToImage>::Dispatch(encode::TraceManager::Get(), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions);
 
-    get_device_table(commandBuffer)->CmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdCopyBufferToImage);
     if (encoder)
     {
@@ -2874,6 +2634,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage(
         encode_struct_array(encoder, pRegions, regionCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyBufferToImage>::Dispatch(encode::TraceManager::Get(), commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions);
 }
@@ -2888,8 +2650,6 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdCopyImageToBuffer>::Dispatch(encode::TraceManager::Get(), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions);
 
-    get_device_table(commandBuffer)->CmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdCopyImageToBuffer);
     if (encoder)
     {
@@ -2901,6 +2661,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer(
         encode_struct_array(encoder, pRegions, regionCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyImageToBuffer>::Dispatch(encode::TraceManager::Get(), commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions);
 }
@@ -2914,8 +2676,6 @@ VKAPI_ATTR void VKAPI_CALL CmdUpdateBuffer(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdUpdateBuffer>::Dispatch(encode::TraceManager::Get(), commandBuffer, dstBuffer, dstOffset, dataSize, pData);
 
-    get_device_table(commandBuffer)->CmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdUpdateBuffer);
     if (encoder)
     {
@@ -2926,6 +2686,8 @@ VKAPI_ATTR void VKAPI_CALL CmdUpdateBuffer(
         encoder->EncodeVoidArray(pData, dataSize);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdUpdateBuffer>::Dispatch(encode::TraceManager::Get(), commandBuffer, dstBuffer, dstOffset, dataSize, pData);
 }
@@ -2939,8 +2701,6 @@ VKAPI_ATTR void VKAPI_CALL CmdFillBuffer(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdFillBuffer>::Dispatch(encode::TraceManager::Get(), commandBuffer, dstBuffer, dstOffset, size, data);
 
-    get_device_table(commandBuffer)->CmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdFillBuffer);
     if (encoder)
     {
@@ -2951,6 +2711,8 @@ VKAPI_ATTR void VKAPI_CALL CmdFillBuffer(
         encoder->EncodeUInt32Value(data);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdFillBuffer>::Dispatch(encode::TraceManager::Get(), commandBuffer, dstBuffer, dstOffset, size, data);
 }
@@ -2965,8 +2727,6 @@ VKAPI_ATTR void VKAPI_CALL CmdClearColorImage(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdClearColorImage>::Dispatch(encode::TraceManager::Get(), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
 
-    get_device_table(commandBuffer)->CmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdClearColorImage);
     if (encoder)
     {
@@ -2978,6 +2738,8 @@ VKAPI_ATTR void VKAPI_CALL CmdClearColorImage(
         encode_struct_array(encoder, pRanges, rangeCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdClearColorImage>::Dispatch(encode::TraceManager::Get(), commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
 }
@@ -2992,8 +2754,6 @@ VKAPI_ATTR void VKAPI_CALL CmdClearDepthStencilImage(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdClearDepthStencilImage>::Dispatch(encode::TraceManager::Get(), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges);
 
-    get_device_table(commandBuffer)->CmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdClearDepthStencilImage);
     if (encoder)
     {
@@ -3005,6 +2765,8 @@ VKAPI_ATTR void VKAPI_CALL CmdClearDepthStencilImage(
         encode_struct_array(encoder, pRanges, rangeCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdClearDepthStencilImage>::Dispatch(encode::TraceManager::Get(), commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges);
 }
@@ -3018,8 +2780,6 @@ VKAPI_ATTR void VKAPI_CALL CmdClearAttachments(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdClearAttachments>::Dispatch(encode::TraceManager::Get(), commandBuffer, attachmentCount, pAttachments, rectCount, pRects);
 
-    get_device_table(commandBuffer)->CmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdClearAttachments);
     if (encoder)
     {
@@ -3030,6 +2790,8 @@ VKAPI_ATTR void VKAPI_CALL CmdClearAttachments(
         encode_struct_array(encoder, pRects, rectCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdClearAttachments>::Dispatch(encode::TraceManager::Get(), commandBuffer, attachmentCount, pAttachments, rectCount, pRects);
 }
@@ -3045,8 +2807,6 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdResolveImage>::Dispatch(encode::TraceManager::Get(), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
 
-    get_device_table(commandBuffer)->CmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdResolveImage);
     if (encoder)
     {
@@ -3060,6 +2820,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdResolveImage>::Dispatch(encode::TraceManager::Get(), commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
 }
 
@@ -3070,8 +2832,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetEvent>::Dispatch(encode::TraceManager::Get(), commandBuffer, event, stageMask);
 
-    get_device_table(commandBuffer)->CmdSetEvent(commandBuffer, event, stageMask);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetEvent);
     if (encoder)
     {
@@ -3080,6 +2840,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent(
         encoder->EncodeFlagsValue(stageMask);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdSetEvent(commandBuffer, event, stageMask);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetEvent>::Dispatch(encode::TraceManager::Get(), commandBuffer, event, stageMask);
 }
@@ -3091,8 +2853,6 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdResetEvent>::Dispatch(encode::TraceManager::Get(), commandBuffer, event, stageMask);
 
-    get_device_table(commandBuffer)->CmdResetEvent(commandBuffer, event, stageMask);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdResetEvent);
     if (encoder)
     {
@@ -3101,6 +2861,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent(
         encoder->EncodeFlagsValue(stageMask);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdResetEvent(commandBuffer, event, stageMask);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdResetEvent>::Dispatch(encode::TraceManager::Get(), commandBuffer, event, stageMask);
 }
@@ -3120,8 +2882,6 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdWaitEvents>::Dispatch(encode::TraceManager::Get(), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
 
-    get_device_table(commandBuffer)->CmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdWaitEvents);
     if (encoder)
     {
@@ -3138,6 +2898,8 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents(
         encode_struct_array(encoder, pImageMemoryBarriers, imageMemoryBarrierCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWaitEvents>::Dispatch(encode::TraceManager::Get(), commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
 }
@@ -3156,8 +2918,6 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdPipelineBarrier>::Dispatch(encode::TraceManager::Get(), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
 
-    get_device_table(commandBuffer)->CmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdPipelineBarrier);
     if (encoder)
     {
@@ -3174,6 +2934,8 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPipelineBarrier>::Dispatch(encode::TraceManager::Get(), commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
 }
 
@@ -3185,8 +2947,6 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginQuery(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdBeginQuery>::Dispatch(encode::TraceManager::Get(), commandBuffer, queryPool, query, flags);
 
-    get_device_table(commandBuffer)->CmdBeginQuery(commandBuffer, queryPool, query, flags);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdBeginQuery);
     if (encoder)
     {
@@ -3196,6 +2956,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginQuery(
         encoder->EncodeFlagsValue(flags);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdBeginQuery(commandBuffer, queryPool, query, flags);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginQuery>::Dispatch(encode::TraceManager::Get(), commandBuffer, queryPool, query, flags);
 }
@@ -3207,8 +2969,6 @@ VKAPI_ATTR void VKAPI_CALL CmdEndQuery(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdEndQuery>::Dispatch(encode::TraceManager::Get(), commandBuffer, queryPool, query);
 
-    get_device_table(commandBuffer)->CmdEndQuery(commandBuffer, queryPool, query);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdEndQuery);
     if (encoder)
     {
@@ -3217,6 +2977,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndQuery(
         encoder->EncodeUInt32Value(query);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdEndQuery(commandBuffer, queryPool, query);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndQuery>::Dispatch(encode::TraceManager::Get(), commandBuffer, queryPool, query);
 }
@@ -3229,8 +2991,6 @@ VKAPI_ATTR void VKAPI_CALL CmdResetQueryPool(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdResetQueryPool>::Dispatch(encode::TraceManager::Get(), commandBuffer, queryPool, firstQuery, queryCount);
 
-    get_device_table(commandBuffer)->CmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdResetQueryPool);
     if (encoder)
     {
@@ -3240,6 +3000,8 @@ VKAPI_ATTR void VKAPI_CALL CmdResetQueryPool(
         encoder->EncodeUInt32Value(queryCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdResetQueryPool>::Dispatch(encode::TraceManager::Get(), commandBuffer, queryPool, firstQuery, queryCount);
 }
@@ -3252,8 +3014,6 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdWriteTimestamp>::Dispatch(encode::TraceManager::Get(), commandBuffer, pipelineStage, queryPool, query);
 
-    get_device_table(commandBuffer)->CmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdWriteTimestamp);
     if (encoder)
     {
@@ -3263,6 +3023,8 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp(
         encoder->EncodeUInt32Value(query);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWriteTimestamp>::Dispatch(encode::TraceManager::Get(), commandBuffer, pipelineStage, queryPool, query);
 }
@@ -3279,8 +3041,6 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyQueryPoolResults(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdCopyQueryPoolResults>::Dispatch(encode::TraceManager::Get(), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags);
 
-    get_device_table(commandBuffer)->CmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdCopyQueryPoolResults);
     if (encoder)
     {
@@ -3295,6 +3055,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyQueryPoolResults(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyQueryPoolResults>::Dispatch(encode::TraceManager::Get(), commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags);
 }
 
@@ -3308,8 +3070,6 @@ VKAPI_ATTR void VKAPI_CALL CmdPushConstants(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdPushConstants>::Dispatch(encode::TraceManager::Get(), commandBuffer, layout, stageFlags, offset, size, pValues);
 
-    get_device_table(commandBuffer)->CmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdPushConstants);
     if (encoder)
     {
@@ -3322,6 +3082,8 @@ VKAPI_ATTR void VKAPI_CALL CmdPushConstants(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPushConstants>::Dispatch(encode::TraceManager::Get(), commandBuffer, layout, stageFlags, offset, size, pValues);
 }
 
@@ -3332,8 +3094,6 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdBeginRenderPass>::Dispatch(encode::TraceManager::Get(), commandBuffer, pRenderPassBegin, contents);
 
-    get_device_table(commandBuffer)->CmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdBeginRenderPass);
     if (encoder)
     {
@@ -3342,6 +3102,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass(
         encoder->EncodeEnumValue(contents);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginRenderPass>::Dispatch(encode::TraceManager::Get(), commandBuffer, pRenderPassBegin, contents);
 }
@@ -3352,8 +3114,6 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdNextSubpass>::Dispatch(encode::TraceManager::Get(), commandBuffer, contents);
 
-    get_device_table(commandBuffer)->CmdNextSubpass(commandBuffer, contents);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdNextSubpass);
     if (encoder)
     {
@@ -3361,6 +3121,8 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass(
         encoder->EncodeEnumValue(contents);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdNextSubpass(commandBuffer, contents);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdNextSubpass>::Dispatch(encode::TraceManager::Get(), commandBuffer, contents);
 }
@@ -3370,14 +3132,14 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdEndRenderPass>::Dispatch(encode::TraceManager::Get(), commandBuffer);
 
-    get_device_table(commandBuffer)->CmdEndRenderPass(commandBuffer);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdEndRenderPass);
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdEndRenderPass(commandBuffer);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndRenderPass>::Dispatch(encode::TraceManager::Get(), commandBuffer);
 }
@@ -3389,8 +3151,6 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteCommands(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdExecuteCommands>::Dispatch(encode::TraceManager::Get(), commandBuffer, commandBufferCount, pCommandBuffers);
 
-    get_device_table(commandBuffer)->CmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdExecuteCommands);
     if (encoder)
     {
@@ -3399,6 +3159,8 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteCommands(
         encoder->EncodeHandleIdArray(pCommandBuffers, commandBufferCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdExecuteCommands>::Dispatch(encode::TraceManager::Get(), commandBuffer, commandBufferCount, pCommandBuffers);
 }
@@ -3482,8 +3244,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDeviceMask(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetDeviceMask>::Dispatch(encode::TraceManager::Get(), commandBuffer, deviceMask);
 
-    get_device_table(commandBuffer)->CmdSetDeviceMask(commandBuffer, deviceMask);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetDeviceMask);
     if (encoder)
     {
@@ -3491,6 +3251,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDeviceMask(
         encoder->EncodeUInt32Value(deviceMask);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdSetDeviceMask(commandBuffer, deviceMask);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDeviceMask>::Dispatch(encode::TraceManager::Get(), commandBuffer, deviceMask);
 }
@@ -3506,8 +3268,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchBase(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDispatchBase>::Dispatch(encode::TraceManager::Get(), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
 
-    get_device_table(commandBuffer)->CmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDispatchBase);
     if (encoder)
     {
@@ -3520,6 +3280,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchBase(
         encoder->EncodeUInt32Value(groupCountZ);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDispatchBase>::Dispatch(encode::TraceManager::Get(), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
 }
@@ -3766,8 +3528,6 @@ VKAPI_ATTR void VKAPI_CALL TrimCommandPool(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkTrimCommandPool>::Dispatch(encode::TraceManager::Get(), device, commandPool, flags);
 
-    get_device_table(device)->TrimCommandPool(device, commandPool, flags);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkTrimCommandPool);
     if (encoder)
     {
@@ -3776,6 +3536,8 @@ VKAPI_ATTR void VKAPI_CALL TrimCommandPool(
         encoder->EncodeFlagsValue(flags);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->TrimCommandPool(device, commandPool, flags);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkTrimCommandPool>::Dispatch(encode::TraceManager::Get(), device, commandPool, flags);
 }
@@ -3807,25 +3569,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversion(
     const VkAllocationCallbacks*                pAllocator,
     VkSamplerYcbcrConversion*                   pYcbcrConversion)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversion>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pYcbcrConversion);
 
+    VkResult result = get_device_table(device)->CreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversion);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversion);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pYcbcrConversion);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pYcbcrConversion);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversion>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pYcbcrConversion);
@@ -3840,20 +3596,16 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversion(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversion>::Dispatch(encode::TraceManager::Get(), device, ycbcrConversion, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversion);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversion);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(ycbcrConversion);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(ycbcrConversion);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversion>::Dispatch(encode::TraceManager::Get(), device, ycbcrConversion, pAllocator);
 }
@@ -3864,25 +3616,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplate(
     const VkAllocationCallbacks*                pAllocator,
     VkDescriptorUpdateTemplate*                 pDescriptorUpdateTemplate)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplate>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
 
+    VkResult result = get_device_table(device)->CreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplate);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplate);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pDescriptorUpdateTemplate);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pDescriptorUpdateTemplate);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplate>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
@@ -3897,20 +3643,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplate(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplate>::Dispatch(encode::TraceManager::Get(), device, descriptorUpdateTemplate, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplate);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplate);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(descriptorUpdateTemplate);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(descriptorUpdateTemplate);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplate>::Dispatch(encode::TraceManager::Get(), device, descriptorUpdateTemplate, pAllocator);
 }
@@ -4006,20 +3748,16 @@ VKAPI_ATTR void VKAPI_CALL DestroySurfaceKHR(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroySurfaceKHR>::Dispatch(encode::TraceManager::Get(), instance, surface, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroySurfaceKHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_instance_table(instance)->DestroySurfaceKHR(instance, surface, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroySurfaceKHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encoder->EncodeHandleIdValue(surface);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encoder->EncodeHandleIdValue(surface);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_instance_table(instance)->DestroySurfaceKHR(instance, surface, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySurfaceKHR>::Dispatch(encode::TraceManager::Get(), instance, surface, pAllocator);
 }
@@ -4132,25 +3870,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSwapchainKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSwapchainKHR*                             pSwapchain)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateSwapchainKHR>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pSwapchain);
 
+    VkResult result = get_device_table(device)->CreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateSwapchainKHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateSwapchainKHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pSwapchain);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pSwapchain);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSwapchainKHR>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pSwapchain);
@@ -4165,20 +3897,16 @@ VKAPI_ATTR void VKAPI_CALL DestroySwapchainKHR(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroySwapchainKHR>::Dispatch(encode::TraceManager::Get(), device, swapchain, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroySwapchainKHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroySwapchainKHR(device, swapchain, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroySwapchainKHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(swapchain);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(swapchain);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroySwapchainKHR(device, swapchain, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySwapchainKHR>::Dispatch(encode::TraceManager::Get(), device, swapchain, pAllocator);
 }
@@ -4464,26 +4192,20 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayModeKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkDisplayModeKHR*                           pMode)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateDisplayModeKHR>::Dispatch(encode::TraceManager::Get(), physicalDevice, display, pCreateInfo, pAllocator, pMode);
 
+    VkResult result = get_instance_table(physicalDevice)->CreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDisplayModeKHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_instance_table(physicalDevice)->CreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDisplayModeKHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(physicalDevice);
-            encoder->EncodeHandleIdValue(display);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pMode);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(physicalDevice);
+        encoder->EncodeHandleIdValue(display);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pMode);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDisplayModeKHR>::Dispatch(encode::TraceManager::Get(), result, physicalDevice, display, pCreateInfo, pAllocator, pMode);
@@ -4523,25 +4245,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayPlaneSurfaceKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateDisplayPlaneSurfaceKHR>::Dispatch(encode::TraceManager::Get(), instance, pCreateInfo, pAllocator, pSurface);
 
+    VkResult result = get_instance_table(instance)->CreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDisplayPlaneSurfaceKHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_instance_table(instance)->CreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDisplayPlaneSurfaceKHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pSurface);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pSurface);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDisplayPlaneSurfaceKHR>::Dispatch(encode::TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -4556,26 +4272,20 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSharedSwapchainsKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSwapchainKHR*                             pSwapchains)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateSharedSwapchainsKHR>::Dispatch(encode::TraceManager::Get(), device, swapchainCount, pCreateInfos, pAllocator, pSwapchains);
 
+    VkResult result = get_device_table(device)->CreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateSharedSwapchainsKHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateSharedSwapchainsKHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeUInt32Value(swapchainCount);
-            encode_struct_array(encoder, pCreateInfos, swapchainCount);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdArray(pSwapchains, swapchainCount);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeUInt32Value(swapchainCount);
+        encode_struct_array(encoder, pCreateInfos, swapchainCount);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdArray(pSwapchains, swapchainCount);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSharedSwapchainsKHR>::Dispatch(encode::TraceManager::Get(), result, device, swapchainCount, pCreateInfos, pAllocator, pSwapchains);
@@ -4590,25 +4300,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXlibSurfaceKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateXlibSurfaceKHR>::Dispatch(encode::TraceManager::Get(), instance, pCreateInfo, pAllocator, pSurface);
 
+    VkResult result = get_instance_table(instance)->CreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateXlibSurfaceKHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_instance_table(instance)->CreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateXlibSurfaceKHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pSurface);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pSurface);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateXlibSurfaceKHR>::Dispatch(encode::TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -4650,25 +4354,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXcbSurfaceKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateXcbSurfaceKHR>::Dispatch(encode::TraceManager::Get(), instance, pCreateInfo, pAllocator, pSurface);
 
+    VkResult result = get_instance_table(instance)->CreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateXcbSurfaceKHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_instance_table(instance)->CreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateXcbSurfaceKHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pSurface);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pSurface);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateXcbSurfaceKHR>::Dispatch(encode::TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -4710,25 +4408,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWaylandSurfaceKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateWaylandSurfaceKHR>::Dispatch(encode::TraceManager::Get(), instance, pCreateInfo, pAllocator, pSurface);
 
+    VkResult result = get_instance_table(instance)->CreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateWaylandSurfaceKHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_instance_table(instance)->CreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateWaylandSurfaceKHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pSurface);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pSurface);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateWaylandSurfaceKHR>::Dispatch(encode::TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -4768,25 +4460,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMirSurfaceKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateMirSurfaceKHR>::Dispatch(encode::TraceManager::Get(), instance, pCreateInfo, pAllocator, pSurface);
 
+    VkResult result = get_instance_table(instance)->CreateMirSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateMirSurfaceKHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_instance_table(instance)->CreateMirSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateMirSurfaceKHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pSurface);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pSurface);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateMirSurfaceKHR>::Dispatch(encode::TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -4826,25 +4512,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAndroidSurfaceKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateAndroidSurfaceKHR>::Dispatch(encode::TraceManager::Get(), instance, pCreateInfo, pAllocator, pSurface);
 
+    VkResult result = get_instance_table(instance)->CreateAndroidSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateAndroidSurfaceKHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_instance_table(instance)->CreateAndroidSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateAndroidSurfaceKHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pSurface);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pSurface);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateAndroidSurfaceKHR>::Dispatch(encode::TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -4860,25 +4540,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWin32SurfaceKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateWin32SurfaceKHR>::Dispatch(encode::TraceManager::Get(), instance, pCreateInfo, pAllocator, pSurface);
 
+    VkResult result = get_instance_table(instance)->CreateWin32SurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateWin32SurfaceKHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_instance_table(instance)->CreateWin32SurfaceKHR(instance, pCreateInfo, pAllocator, pSurface);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateWin32SurfaceKHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pSurface);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pSurface);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateWin32SurfaceKHR>::Dispatch(encode::TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -5086,8 +4760,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDeviceMaskKHR(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetDeviceMaskKHR>::Dispatch(encode::TraceManager::Get(), commandBuffer, deviceMask);
 
-    get_device_table(commandBuffer)->CmdSetDeviceMaskKHR(commandBuffer, deviceMask);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetDeviceMaskKHR);
     if (encoder)
     {
@@ -5095,6 +4767,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDeviceMaskKHR(
         encoder->EncodeUInt32Value(deviceMask);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdSetDeviceMaskKHR(commandBuffer, deviceMask);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDeviceMaskKHR>::Dispatch(encode::TraceManager::Get(), commandBuffer, deviceMask);
 }
@@ -5110,8 +4784,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchBaseKHR(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDispatchBaseKHR>::Dispatch(encode::TraceManager::Get(), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
 
-    get_device_table(commandBuffer)->CmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDispatchBaseKHR);
     if (encoder)
     {
@@ -5125,6 +4797,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchBaseKHR(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDispatchBaseKHR>::Dispatch(encode::TraceManager::Get(), commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
 }
 
@@ -5135,8 +4809,6 @@ VKAPI_ATTR void VKAPI_CALL TrimCommandPoolKHR(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkTrimCommandPoolKHR>::Dispatch(encode::TraceManager::Get(), device, commandPool, flags);
 
-    get_device_table(device)->TrimCommandPoolKHR(device, commandPool, flags);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkTrimCommandPoolKHR);
     if (encoder)
     {
@@ -5145,6 +4817,8 @@ VKAPI_ATTR void VKAPI_CALL TrimCommandPoolKHR(
         encoder->EncodeFlagsValue(flags);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->TrimCommandPoolKHR(device, commandPool, flags);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkTrimCommandPoolKHR>::Dispatch(encode::TraceManager::Get(), device, commandPool, flags);
 }
@@ -5421,8 +5095,6 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetKHR(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSetKHR>::Dispatch(encode::TraceManager::Get(), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites);
 
-    get_device_table(commandBuffer)->CmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdPushDescriptorSetKHR);
     if (encoder)
     {
@@ -5435,6 +5107,8 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetKHR(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSetKHR>::Dispatch(encode::TraceManager::Get(), commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites);
 }
 
@@ -5444,25 +5118,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplateKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkDescriptorUpdateTemplate*                 pDescriptorUpdateTemplate)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplateKHR>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
 
+    VkResult result = get_device_table(device)->CreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplateKHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateDescriptorUpdateTemplateKHR(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplateKHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pDescriptorUpdateTemplate);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pDescriptorUpdateTemplate);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplateKHR>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
@@ -5477,20 +5145,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplateKHR(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplateKHR>::Dispatch(encode::TraceManager::Get(), device, descriptorUpdateTemplate, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplateKHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplateKHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(descriptorUpdateTemplate);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(descriptorUpdateTemplate);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplateKHR>::Dispatch(encode::TraceManager::Get(), device, descriptorUpdateTemplate, pAllocator);
 }
@@ -5501,25 +5165,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(
     const VkAllocationCallbacks*                pAllocator,
     VkRenderPass*                               pRenderPass)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateRenderPass2KHR>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pRenderPass);
 
+    VkResult result = get_device_table(device)->CreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateRenderPass2KHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateRenderPass2KHR(device, pCreateInfo, pAllocator, pRenderPass);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateRenderPass2KHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pRenderPass);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pRenderPass);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRenderPass2KHR>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pRenderPass);
@@ -5534,8 +5192,6 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass2KHR(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdBeginRenderPass2KHR>::Dispatch(encode::TraceManager::Get(), commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
 
-    get_device_table(commandBuffer)->CmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdBeginRenderPass2KHR);
     if (encoder)
     {
@@ -5544,6 +5200,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass2KHR(
         encode_struct_ptr(encoder, pSubpassBeginInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginRenderPass2KHR>::Dispatch(encode::TraceManager::Get(), commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
 }
@@ -5555,8 +5213,6 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass2KHR(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdNextSubpass2KHR>::Dispatch(encode::TraceManager::Get(), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
 
-    get_device_table(commandBuffer)->CmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdNextSubpass2KHR);
     if (encoder)
     {
@@ -5565,6 +5221,8 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass2KHR(
         encode_struct_ptr(encoder, pSubpassEndInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdNextSubpass2KHR>::Dispatch(encode::TraceManager::Get(), commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
 }
@@ -5575,8 +5233,6 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass2KHR(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdEndRenderPass2KHR>::Dispatch(encode::TraceManager::Get(), commandBuffer, pSubpassEndInfo);
 
-    get_device_table(commandBuffer)->CmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdEndRenderPass2KHR);
     if (encoder)
     {
@@ -5584,6 +5240,8 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass2KHR(
         encode_struct_ptr(encoder, pSubpassEndInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndRenderPass2KHR>::Dispatch(encode::TraceManager::Get(), commandBuffer, pSubpassEndInfo);
 }
@@ -5944,25 +5602,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversionKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSamplerYcbcrConversion*                   pYcbcrConversion)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversionKHR>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pYcbcrConversion);
 
+    VkResult result = get_device_table(device)->CreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversionKHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateSamplerYcbcrConversionKHR(device, pCreateInfo, pAllocator, pYcbcrConversion);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversionKHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pYcbcrConversion);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pYcbcrConversion);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversionKHR>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pYcbcrConversion);
@@ -5977,20 +5629,16 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversionKHR(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversionKHR>::Dispatch(encode::TraceManager::Get(), device, ycbcrConversion, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversionKHR);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversionKHR);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(ycbcrConversion);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(ycbcrConversion);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversionKHR>::Dispatch(encode::TraceManager::Get(), device, ycbcrConversion, pAllocator);
 }
@@ -6075,8 +5723,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountKHR(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDrawIndirectCountKHR>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 
-    get_device_table(commandBuffer)->CmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDrawIndirectCountKHR);
     if (encoder)
     {
@@ -6089,6 +5735,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountKHR(
         encoder->EncodeUInt32Value(stride);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndirectCountKHR>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
@@ -6104,8 +5752,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountKHR(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCountKHR>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 
-    get_device_table(commandBuffer)->CmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCountKHR);
     if (encoder)
     {
@@ -6119,6 +5765,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountKHR(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCountKHR>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
 
@@ -6128,25 +5776,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugReportCallbackEXT(
     const VkAllocationCallbacks*                pAllocator,
     VkDebugReportCallbackEXT*                   pCallback)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateDebugReportCallbackEXT>::Dispatch(encode::TraceManager::Get(), instance, pCreateInfo, pAllocator, pCallback);
 
+    VkResult result = get_instance_table(instance)->CreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDebugReportCallbackEXT);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_instance_table(instance)->CreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDebugReportCallbackEXT);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pCallback);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pCallback);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDebugReportCallbackEXT>::Dispatch(encode::TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pCallback);
@@ -6161,20 +5803,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugReportCallbackEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyDebugReportCallbackEXT>::Dispatch(encode::TraceManager::Get(), instance, callback, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyDebugReportCallbackEXT);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_instance_table(instance)->DestroyDebugReportCallbackEXT(instance, callback, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyDebugReportCallbackEXT);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encoder->EncodeHandleIdValue(callback);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encoder->EncodeHandleIdValue(callback);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_instance_table(instance)->DestroyDebugReportCallbackEXT(instance, callback, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDebugReportCallbackEXT>::Dispatch(encode::TraceManager::Get(), instance, callback, pAllocator);
 }
@@ -6191,8 +5829,6 @@ VKAPI_ATTR void VKAPI_CALL DebugReportMessageEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDebugReportMessageEXT>::Dispatch(encode::TraceManager::Get(), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage);
 
-    get_instance_table(instance)->DebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDebugReportMessageEXT);
     if (encoder)
     {
@@ -6206,6 +5842,8 @@ VKAPI_ATTR void VKAPI_CALL DebugReportMessageEXT(
         encoder->EncodeString(pMessage);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_instance_table(instance)->DebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDebugReportMessageEXT>::Dispatch(encode::TraceManager::Get(), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage);
 }
@@ -6260,8 +5898,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerBeginEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDebugMarkerBeginEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer, pMarkerInfo);
 
-    get_device_table(commandBuffer)->CmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDebugMarkerBeginEXT);
     if (encoder)
     {
@@ -6269,6 +5905,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerBeginEXT(
         encode_struct_ptr(encoder, pMarkerInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDebugMarkerBeginEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer, pMarkerInfo);
 }
@@ -6278,14 +5916,14 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerEndEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDebugMarkerEndEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer);
 
-    get_device_table(commandBuffer)->CmdDebugMarkerEndEXT(commandBuffer);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDebugMarkerEndEXT);
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdDebugMarkerEndEXT(commandBuffer);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDebugMarkerEndEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer);
 }
@@ -6296,8 +5934,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerInsertEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDebugMarkerInsertEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer, pMarkerInfo);
 
-    get_device_table(commandBuffer)->CmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDebugMarkerInsertEXT);
     if (encoder)
     {
@@ -6305,6 +5941,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerInsertEXT(
         encode_struct_ptr(encoder, pMarkerInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDebugMarkerInsertEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer, pMarkerInfo);
 }
@@ -6320,8 +5958,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountAMD(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDrawIndirectCountAMD>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 
-    get_device_table(commandBuffer)->CmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDrawIndirectCountAMD);
     if (encoder)
     {
@@ -6334,6 +5970,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountAMD(
         encoder->EncodeUInt32Value(stride);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndirectCountAMD>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
@@ -6349,8 +5987,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountAMD(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCountAMD>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 
-    get_device_table(commandBuffer)->CmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCountAMD);
     if (encoder)
     {
@@ -6363,6 +5999,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountAMD(
         encoder->EncodeUInt32Value(stride);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCountAMD>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
@@ -6466,25 +6104,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateViSurfaceNN(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateViSurfaceNN>::Dispatch(encode::TraceManager::Get(), instance, pCreateInfo, pAllocator, pSurface);
 
+    VkResult result = get_instance_table(instance)->CreateViSurfaceNN(instance, pCreateInfo, pAllocator, pSurface);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateViSurfaceNN);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_instance_table(instance)->CreateViSurfaceNN(instance, pCreateInfo, pAllocator, pSurface);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateViSurfaceNN);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pSurface);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pSurface);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateViSurfaceNN>::Dispatch(encode::TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -6499,8 +6131,6 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginConditionalRenderingEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdBeginConditionalRenderingEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer, pConditionalRenderingBegin);
 
-    get_device_table(commandBuffer)->CmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdBeginConditionalRenderingEXT);
     if (encoder)
     {
@@ -6508,6 +6138,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginConditionalRenderingEXT(
         encode_struct_ptr(encoder, pConditionalRenderingBegin);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginConditionalRenderingEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer, pConditionalRenderingBegin);
 }
@@ -6517,14 +6149,14 @@ VKAPI_ATTR void VKAPI_CALL CmdEndConditionalRenderingEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdEndConditionalRenderingEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer);
 
-    get_device_table(commandBuffer)->CmdEndConditionalRenderingEXT(commandBuffer);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdEndConditionalRenderingEXT);
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdEndConditionalRenderingEXT(commandBuffer);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndConditionalRenderingEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer);
 }
@@ -6535,8 +6167,6 @@ VKAPI_ATTR void VKAPI_CALL CmdProcessCommandsNVX(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdProcessCommandsNVX>::Dispatch(encode::TraceManager::Get(), commandBuffer, pProcessCommandsInfo);
 
-    get_device_table(commandBuffer)->CmdProcessCommandsNVX(commandBuffer, pProcessCommandsInfo);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdProcessCommandsNVX);
     if (encoder)
     {
@@ -6544,6 +6174,8 @@ VKAPI_ATTR void VKAPI_CALL CmdProcessCommandsNVX(
         encode_struct_ptr(encoder, pProcessCommandsInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdProcessCommandsNVX(commandBuffer, pProcessCommandsInfo);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdProcessCommandsNVX>::Dispatch(encode::TraceManager::Get(), commandBuffer, pProcessCommandsInfo);
 }
@@ -6554,8 +6186,6 @@ VKAPI_ATTR void VKAPI_CALL CmdReserveSpaceForCommandsNVX(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdReserveSpaceForCommandsNVX>::Dispatch(encode::TraceManager::Get(), commandBuffer, pReserveSpaceInfo);
 
-    get_device_table(commandBuffer)->CmdReserveSpaceForCommandsNVX(commandBuffer, pReserveSpaceInfo);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdReserveSpaceForCommandsNVX);
     if (encoder)
     {
@@ -6563,6 +6193,8 @@ VKAPI_ATTR void VKAPI_CALL CmdReserveSpaceForCommandsNVX(
         encode_struct_ptr(encoder, pReserveSpaceInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdReserveSpaceForCommandsNVX(commandBuffer, pReserveSpaceInfo);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdReserveSpaceForCommandsNVX>::Dispatch(encode::TraceManager::Get(), commandBuffer, pReserveSpaceInfo);
 }
@@ -6573,25 +6205,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIndirectCommandsLayoutNVX(
     const VkAllocationCallbacks*                pAllocator,
     VkIndirectCommandsLayoutNVX*                pIndirectCommandsLayout)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateIndirectCommandsLayoutNVX>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pIndirectCommandsLayout);
 
+    VkResult result = get_device_table(device)->CreateIndirectCommandsLayoutNVX(device, pCreateInfo, pAllocator, pIndirectCommandsLayout);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateIndirectCommandsLayoutNVX);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateIndirectCommandsLayoutNVX(device, pCreateInfo, pAllocator, pIndirectCommandsLayout);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateIndirectCommandsLayoutNVX);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pIndirectCommandsLayout);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pIndirectCommandsLayout);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateIndirectCommandsLayoutNVX>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pIndirectCommandsLayout);
@@ -6606,20 +6232,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyIndirectCommandsLayoutNVX(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyIndirectCommandsLayoutNVX>::Dispatch(encode::TraceManager::Get(), device, indirectCommandsLayout, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyIndirectCommandsLayoutNVX);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyIndirectCommandsLayoutNVX(device, indirectCommandsLayout, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyIndirectCommandsLayoutNVX);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(indirectCommandsLayout);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(indirectCommandsLayout);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyIndirectCommandsLayoutNVX(device, indirectCommandsLayout, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyIndirectCommandsLayoutNVX>::Dispatch(encode::TraceManager::Get(), device, indirectCommandsLayout, pAllocator);
 }
@@ -6630,25 +6252,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateObjectTableNVX(
     const VkAllocationCallbacks*                pAllocator,
     VkObjectTableNVX*                           pObjectTable)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateObjectTableNVX>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pObjectTable);
 
+    VkResult result = get_device_table(device)->CreateObjectTableNVX(device, pCreateInfo, pAllocator, pObjectTable);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateObjectTableNVX);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateObjectTableNVX(device, pCreateInfo, pAllocator, pObjectTable);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateObjectTableNVX);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pObjectTable);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pObjectTable);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateObjectTableNVX>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pObjectTable);
@@ -6663,20 +6279,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyObjectTableNVX(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyObjectTableNVX>::Dispatch(encode::TraceManager::Get(), device, objectTable, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyObjectTableNVX);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyObjectTableNVX(device, objectTable, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyObjectTableNVX);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(objectTable);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(objectTable);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyObjectTableNVX(device, objectTable, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyObjectTableNVX>::Dispatch(encode::TraceManager::Get(), device, objectTable, pAllocator);
 }
@@ -6738,8 +6350,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWScalingNV(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetViewportWScalingNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, firstViewport, viewportCount, pViewportWScalings);
 
-    get_device_table(commandBuffer)->CmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetViewportWScalingNV);
     if (encoder)
     {
@@ -6749,6 +6359,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWScalingNV(
         encode_struct_array(encoder, pViewportWScalings, viewportCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetViewportWScalingNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, firstViewport, viewportCount, pViewportWScalings);
 }
@@ -7013,8 +6625,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetDiscardRectangleEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles);
 
-    get_device_table(commandBuffer)->CmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetDiscardRectangleEXT);
     if (encoder)
     {
@@ -7024,6 +6634,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleEXT(
         encode_struct_array(encoder, pDiscardRectangles, discardRectangleCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetDiscardRectangleEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles);
 }
@@ -7036,8 +6648,6 @@ VKAPI_ATTR void VKAPI_CALL SetHdrMetadataEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkSetHdrMetadataEXT>::Dispatch(encode::TraceManager::Get(), device, swapchainCount, pSwapchains, pMetadata);
 
-    get_device_table(device)->SetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkSetHdrMetadataEXT);
     if (encoder)
     {
@@ -7047,6 +6657,8 @@ VKAPI_ATTR void VKAPI_CALL SetHdrMetadataEXT(
         encode_struct_array(encoder, pMetadata, swapchainCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->SetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkSetHdrMetadataEXT>::Dispatch(encode::TraceManager::Get(), device, swapchainCount, pSwapchains, pMetadata);
 }
@@ -7058,25 +6670,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIOSSurfaceMVK(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateIOSSurfaceMVK>::Dispatch(encode::TraceManager::Get(), instance, pCreateInfo, pAllocator, pSurface);
 
+    VkResult result = get_instance_table(instance)->CreateIOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateIOSSurfaceMVK);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_instance_table(instance)->CreateIOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateIOSSurfaceMVK);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pSurface);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pSurface);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateIOSSurfaceMVK>::Dispatch(encode::TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -7092,25 +6698,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMacOSSurfaceMVK(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateMacOSSurfaceMVK>::Dispatch(encode::TraceManager::Get(), instance, pCreateInfo, pAllocator, pSurface);
 
+    VkResult result = get_instance_table(instance)->CreateMacOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateMacOSSurfaceMVK);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_instance_table(instance)->CreateMacOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateMacOSSurfaceMVK);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pSurface);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pSurface);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateMacOSSurfaceMVK>::Dispatch(encode::TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -7169,8 +6769,6 @@ VKAPI_ATTR void VKAPI_CALL QueueBeginDebugUtilsLabelEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueBeginDebugUtilsLabelEXT>::Dispatch(encode::TraceManager::Get(), queue, pLabelInfo);
 
-    get_device_table(queue)->QueueBeginDebugUtilsLabelEXT(queue, pLabelInfo);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkQueueBeginDebugUtilsLabelEXT);
     if (encoder)
     {
@@ -7178,6 +6776,8 @@ VKAPI_ATTR void VKAPI_CALL QueueBeginDebugUtilsLabelEXT(
         encode_struct_ptr(encoder, pLabelInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(queue)->QueueBeginDebugUtilsLabelEXT(queue, pLabelInfo);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueBeginDebugUtilsLabelEXT>::Dispatch(encode::TraceManager::Get(), queue, pLabelInfo);
 }
@@ -7187,14 +6787,14 @@ VKAPI_ATTR void VKAPI_CALL QueueEndDebugUtilsLabelEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueEndDebugUtilsLabelEXT>::Dispatch(encode::TraceManager::Get(), queue);
 
-    get_device_table(queue)->QueueEndDebugUtilsLabelEXT(queue);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkQueueEndDebugUtilsLabelEXT);
     if (encoder)
     {
         encoder->EncodeHandleIdValue(queue);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(queue)->QueueEndDebugUtilsLabelEXT(queue);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueEndDebugUtilsLabelEXT>::Dispatch(encode::TraceManager::Get(), queue);
 }
@@ -7205,8 +6805,6 @@ VKAPI_ATTR void VKAPI_CALL QueueInsertDebugUtilsLabelEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueInsertDebugUtilsLabelEXT>::Dispatch(encode::TraceManager::Get(), queue, pLabelInfo);
 
-    get_device_table(queue)->QueueInsertDebugUtilsLabelEXT(queue, pLabelInfo);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkQueueInsertDebugUtilsLabelEXT);
     if (encoder)
     {
@@ -7214,6 +6812,8 @@ VKAPI_ATTR void VKAPI_CALL QueueInsertDebugUtilsLabelEXT(
         encode_struct_ptr(encoder, pLabelInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(queue)->QueueInsertDebugUtilsLabelEXT(queue, pLabelInfo);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueInsertDebugUtilsLabelEXT>::Dispatch(encode::TraceManager::Get(), queue, pLabelInfo);
 }
@@ -7224,8 +6824,6 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginDebugUtilsLabelEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdBeginDebugUtilsLabelEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer, pLabelInfo);
 
-    get_device_table(commandBuffer)->CmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdBeginDebugUtilsLabelEXT);
     if (encoder)
     {
@@ -7233,6 +6831,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginDebugUtilsLabelEXT(
         encode_struct_ptr(encoder, pLabelInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginDebugUtilsLabelEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer, pLabelInfo);
 }
@@ -7242,14 +6842,14 @@ VKAPI_ATTR void VKAPI_CALL CmdEndDebugUtilsLabelEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdEndDebugUtilsLabelEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer);
 
-    get_device_table(commandBuffer)->CmdEndDebugUtilsLabelEXT(commandBuffer);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdEndDebugUtilsLabelEXT);
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdEndDebugUtilsLabelEXT(commandBuffer);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndDebugUtilsLabelEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer);
 }
@@ -7260,8 +6860,6 @@ VKAPI_ATTR void VKAPI_CALL CmdInsertDebugUtilsLabelEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdInsertDebugUtilsLabelEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer, pLabelInfo);
 
-    get_device_table(commandBuffer)->CmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdInsertDebugUtilsLabelEXT);
     if (encoder)
     {
@@ -7269,6 +6867,8 @@ VKAPI_ATTR void VKAPI_CALL CmdInsertDebugUtilsLabelEXT(
         encode_struct_ptr(encoder, pLabelInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdInsertDebugUtilsLabelEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer, pLabelInfo);
 }
@@ -7279,25 +6879,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugUtilsMessengerEXT(
     const VkAllocationCallbacks*                pAllocator,
     VkDebugUtilsMessengerEXT*                   pMessenger)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateDebugUtilsMessengerEXT>::Dispatch(encode::TraceManager::Get(), instance, pCreateInfo, pAllocator, pMessenger);
 
+    VkResult result = get_instance_table(instance)->CreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDebugUtilsMessengerEXT);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_instance_table(instance)->CreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateDebugUtilsMessengerEXT);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pMessenger);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pMessenger);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDebugUtilsMessengerEXT>::Dispatch(encode::TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pMessenger);
@@ -7312,20 +6906,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugUtilsMessengerEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyDebugUtilsMessengerEXT>::Dispatch(encode::TraceManager::Get(), instance, messenger, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyDebugUtilsMessengerEXT);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_instance_table(instance)->DestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyDebugUtilsMessengerEXT);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encoder->EncodeHandleIdValue(messenger);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encoder->EncodeHandleIdValue(messenger);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_instance_table(instance)->DestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyDebugUtilsMessengerEXT>::Dispatch(encode::TraceManager::Get(), instance, messenger, pAllocator);
 }
@@ -7338,8 +6928,6 @@ VKAPI_ATTR void VKAPI_CALL SubmitDebugUtilsMessageEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkSubmitDebugUtilsMessageEXT>::Dispatch(encode::TraceManager::Get(), instance, messageSeverity, messageTypes, pCallbackData);
 
-    get_instance_table(instance)->SubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkSubmitDebugUtilsMessageEXT);
     if (encoder)
     {
@@ -7349,6 +6937,8 @@ VKAPI_ATTR void VKAPI_CALL SubmitDebugUtilsMessageEXT(
         encode_struct_ptr(encoder, pCallbackData);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_instance_table(instance)->SubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkSubmitDebugUtilsMessageEXT>::Dispatch(encode::TraceManager::Get(), instance, messageSeverity, messageTypes, pCallbackData);
 }
@@ -7409,8 +6999,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleLocationsEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetSampleLocationsEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer, pSampleLocationsInfo);
 
-    get_device_table(commandBuffer)->CmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetSampleLocationsEXT);
     if (encoder)
     {
@@ -7418,6 +7006,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleLocationsEXT(
         encode_struct_ptr(encoder, pSampleLocationsInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetSampleLocationsEXT>::Dispatch(encode::TraceManager::Get(), commandBuffer, pSampleLocationsInfo);
 }
@@ -7449,25 +7039,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateValidationCacheEXT(
     const VkAllocationCallbacks*                pAllocator,
     VkValidationCacheEXT*                       pValidationCache)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateValidationCacheEXT>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pValidationCache);
 
+    VkResult result = get_device_table(device)->CreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateValidationCacheEXT);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateValidationCacheEXT(device, pCreateInfo, pAllocator, pValidationCache);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateValidationCacheEXT);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pValidationCache);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pValidationCache);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateValidationCacheEXT>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pValidationCache);
@@ -7482,20 +7066,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyValidationCacheEXT(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyValidationCacheEXT>::Dispatch(encode::TraceManager::Get(), device, validationCache, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyValidationCacheEXT);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyValidationCacheEXT(device, validationCache, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyValidationCacheEXT);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(validationCache);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(validationCache);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyValidationCacheEXT(device, validationCache, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyValidationCacheEXT>::Dispatch(encode::TraceManager::Get(), device, validationCache, pAllocator);
 }
@@ -7559,8 +7139,6 @@ VKAPI_ATTR void VKAPI_CALL CmdBindShadingRateImageNV(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdBindShadingRateImageNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, imageView, imageLayout);
 
-    get_device_table(commandBuffer)->CmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdBindShadingRateImageNV);
     if (encoder)
     {
@@ -7569,6 +7147,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBindShadingRateImageNV(
         encoder->EncodeEnumValue(imageLayout);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBindShadingRateImageNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, imageView, imageLayout);
 }
@@ -7581,8 +7161,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportShadingRatePaletteNV(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetViewportShadingRatePaletteNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes);
 
-    get_device_table(commandBuffer)->CmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetViewportShadingRatePaletteNV);
     if (encoder)
     {
@@ -7592,6 +7170,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportShadingRatePaletteNV(
         encode_struct_array(encoder, pShadingRatePalettes, viewportCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetViewportShadingRatePaletteNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, firstViewport, viewportCount, pShadingRatePalettes);
 }
@@ -7604,8 +7184,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoarseSampleOrderNV(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetCoarseSampleOrderNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders);
 
-    get_device_table(commandBuffer)->CmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetCoarseSampleOrderNV);
     if (encoder)
     {
@@ -7616,6 +7194,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoarseSampleOrderNV(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetCoarseSampleOrderNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders);
 }
 
@@ -7625,25 +7205,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureNVX(
     const VkAllocationCallbacks*                pAllocator,
     VkAccelerationStructureNVX*                 pAccelerationStructure)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateAccelerationStructureNVX>::Dispatch(encode::TraceManager::Get(), device, pCreateInfo, pAllocator, pAccelerationStructure);
 
+    VkResult result = get_device_table(device)->CreateAccelerationStructureNVX(device, pCreateInfo, pAllocator, pAccelerationStructure);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateAccelerationStructureNVX);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateAccelerationStructureNVX(device, pCreateInfo, pAllocator, pAccelerationStructure);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateAccelerationStructureNVX);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pAccelerationStructure);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pAccelerationStructure);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateAccelerationStructureNVX>::Dispatch(encode::TraceManager::Get(), result, device, pCreateInfo, pAllocator, pAccelerationStructure);
@@ -7658,20 +7232,16 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureNVX(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyAccelerationStructureNVX>::Dispatch(encode::TraceManager::Get(), device, accelerationStructure, pAllocator);
 
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyAccelerationStructureNVX);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        get_device_table(device)->DestroyAccelerationStructureNVX(device, accelerationStructure, pAllocator);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDestroyAccelerationStructureNVX);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(accelerationStructure);
-            encode_struct_ptr(encoder, pAllocator);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(accelerationStructure);
+        encode_struct_ptr(encoder, pAllocator);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(device)->DestroyAccelerationStructureNVX(device, accelerationStructure, pAllocator);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyAccelerationStructureNVX>::Dispatch(encode::TraceManager::Get(), device, accelerationStructure, pAllocator);
 }
@@ -7759,8 +7329,6 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructureNVX(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructureNVX>::Dispatch(encode::TraceManager::Get(), commandBuffer, type, instanceCount, instanceData, instanceOffset, geometryCount, pGeometries, flags, update, dst, src, scratch, scratchOffset);
 
-    get_device_table(commandBuffer)->CmdBuildAccelerationStructureNVX(commandBuffer, type, instanceCount, instanceData, instanceOffset, geometryCount, pGeometries, flags, update, dst, src, scratch, scratchOffset);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructureNVX);
     if (encoder)
     {
@@ -7780,6 +7348,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructureNVX(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdBuildAccelerationStructureNVX(commandBuffer, type, instanceCount, instanceData, instanceOffset, geometryCount, pGeometries, flags, update, dst, src, scratch, scratchOffset);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructureNVX>::Dispatch(encode::TraceManager::Get(), commandBuffer, type, instanceCount, instanceData, instanceOffset, geometryCount, pGeometries, flags, update, dst, src, scratch, scratchOffset);
 }
 
@@ -7791,8 +7361,6 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureNVX(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdCopyAccelerationStructureNVX>::Dispatch(encode::TraceManager::Get(), commandBuffer, dst, src, mode);
 
-    get_device_table(commandBuffer)->CmdCopyAccelerationStructureNVX(commandBuffer, dst, src, mode);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdCopyAccelerationStructureNVX);
     if (encoder)
     {
@@ -7802,6 +7370,8 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureNVX(
         encoder->EncodeEnumValue(mode);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdCopyAccelerationStructureNVX(commandBuffer, dst, src, mode);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdCopyAccelerationStructureNVX>::Dispatch(encode::TraceManager::Get(), commandBuffer, dst, src, mode);
 }
@@ -7821,8 +7391,6 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysNVX(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdTraceRaysNVX>::Dispatch(encode::TraceManager::Get(), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, width, height);
 
-    get_device_table(commandBuffer)->CmdTraceRaysNVX(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, width, height);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdTraceRaysNVX);
     if (encoder)
     {
@@ -7840,6 +7408,8 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysNVX(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdTraceRaysNVX(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, width, height);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdTraceRaysNVX>::Dispatch(encode::TraceManager::Get(), commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, width, height);
 }
 
@@ -7851,27 +7421,21 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRaytracingPipelinesNVX(
     const VkAllocationCallbacks*                pAllocator,
     VkPipeline*                                 pPipelines)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateRaytracingPipelinesNVX>::Dispatch(encode::TraceManager::Get(), device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
 
+    VkResult result = get_device_table(device)->CreateRaytracingPipelinesNVX(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateRaytracingPipelinesNVX);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_device_table(device)->CreateRaytracingPipelinesNVX(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateRaytracingPipelinesNVX);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(device);
-            encoder->EncodeHandleIdValue(pipelineCache);
-            encoder->EncodeUInt32Value(createInfoCount);
-            encode_struct_array(encoder, pCreateInfos, createInfoCount);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(device);
+        encoder->EncodeHandleIdValue(pipelineCache);
+        encoder->EncodeUInt32Value(createInfoCount);
+        encode_struct_array(encoder, pCreateInfos, createInfoCount);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRaytracingPipelinesNVX>::Dispatch(encode::TraceManager::Get(), result, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
@@ -7944,8 +7508,6 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteAccelerationStructurePropertiesNVX(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdWriteAccelerationStructurePropertiesNVX>::Dispatch(encode::TraceManager::Get(), commandBuffer, accelerationStructure, queryType, queryPool, query);
 
-    get_device_table(commandBuffer)->CmdWriteAccelerationStructurePropertiesNVX(commandBuffer, accelerationStructure, queryType, queryPool, query);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdWriteAccelerationStructurePropertiesNVX);
     if (encoder)
     {
@@ -7956,6 +7518,8 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteAccelerationStructurePropertiesNVX(
         encoder->EncodeUInt32Value(query);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdWriteAccelerationStructurePropertiesNVX(commandBuffer, accelerationStructure, queryType, queryPool, query);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWriteAccelerationStructurePropertiesNVX>::Dispatch(encode::TraceManager::Get(), commandBuffer, accelerationStructure, queryType, queryPool, query);
 }
@@ -8019,8 +7583,6 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteBufferMarkerAMD(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdWriteBufferMarkerAMD>::Dispatch(encode::TraceManager::Get(), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
 
-    get_device_table(commandBuffer)->CmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdWriteBufferMarkerAMD);
     if (encoder)
     {
@@ -8032,6 +7594,8 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteBufferMarkerAMD(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWriteBufferMarkerAMD>::Dispatch(encode::TraceManager::Get(), commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
 }
 
@@ -8042,8 +7606,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksNV(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDrawMeshTasksNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, taskCount, firstTask);
 
-    get_device_table(commandBuffer)->CmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDrawMeshTasksNV);
     if (encoder)
     {
@@ -8052,6 +7614,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksNV(
         encoder->EncodeUInt32Value(firstTask);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawMeshTasksNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, taskCount, firstTask);
 }
@@ -8065,8 +7629,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectNV(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, drawCount, stride);
 
-    get_device_table(commandBuffer)->CmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectNV);
     if (encoder)
     {
@@ -8077,6 +7639,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectNV(
         encoder->EncodeUInt32Value(stride);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, drawCount, stride);
 }
@@ -8092,8 +7656,6 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectCountNV(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectCountNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 
-    get_device_table(commandBuffer)->CmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectCountNV);
     if (encoder)
     {
@@ -8107,6 +7669,8 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectCountNV(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectCountNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
 
@@ -8118,8 +7682,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExclusiveScissorNV(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetExclusiveScissorNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors);
 
-    get_device_table(commandBuffer)->CmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetExclusiveScissorNV);
     if (encoder)
     {
@@ -8130,6 +7692,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExclusiveScissorNV(
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
+    get_device_table(commandBuffer)->CmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors);
+
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetExclusiveScissorNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors);
 }
 
@@ -8139,8 +7703,6 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCheckpointNV(
 {
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCmdSetCheckpointNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, pCheckpointMarker);
 
-    get_device_table(commandBuffer)->CmdSetCheckpointNV(commandBuffer, pCheckpointMarker);
-
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCmdSetCheckpointNV);
     if (encoder)
     {
@@ -8148,6 +7710,8 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCheckpointNV(
         encoder->EncodeVoidPtr(pCheckpointMarker);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
+
+    get_device_table(commandBuffer)->CmdSetCheckpointNV(commandBuffer, pCheckpointMarker);
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdSetCheckpointNV>::Dispatch(encode::TraceManager::Get(), commandBuffer, pCheckpointMarker);
 }
@@ -8180,25 +7744,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface)
 {
-    VkResult result;
-
     encode::CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateImagePipeSurfaceFUCHSIA>::Dispatch(encode::TraceManager::Get(), instance, pCreateInfo, pAllocator, pSurface);
 
+    VkResult result = get_instance_table(instance)->CreateImagePipeSurfaceFUCHSIA(instance, pCreateInfo, pAllocator, pSurface);
+
+    auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateImagePipeSurfaceFUCHSIA);
+    if (encoder)
     {
-        std::lock_guard<std::mutex> create_destroy_lock(g_create_destroy_mutex);
-
-        result = get_instance_table(instance)->CreateImagePipeSurfaceFUCHSIA(instance, pCreateInfo, pAllocator, pSurface);
-
-        auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateImagePipeSurfaceFUCHSIA);
-        if (encoder)
-        {
-            encoder->EncodeHandleIdValue(instance);
-            encode_struct_ptr(encoder, pCreateInfo);
-            encode_struct_ptr(encoder, pAllocator);
-            encoder->EncodeHandleIdPtr(pSurface);
-            encoder->EncodeEnumValue(result);
-            encode::TraceManager::Get()->EndApiCallTrace(encoder);
-        }
+        encoder->EncodeHandleIdValue(instance);
+        encode_struct_ptr(encoder, pCreateInfo);
+        encode_struct_ptr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pSurface);
+        encoder->EncodeEnumValue(result);
+        encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateImagePipeSurfaceFUCHSIA>::Dispatch(encode::TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);

--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -75,8 +75,6 @@ static std::unordered_map<const void*, VkLayerDispatchTable>         device_tabl
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 
-std::mutex g_create_destroy_mutex;
-
 void init_instance_table(VkInstance instance, PFN_vkGetInstanceProcAddr gpa)
 {
     auto& table = instance_table[get_dispatch_key(instance)];

--- a/layer/trace_layer.h
+++ b/layer/trace_layer.h
@@ -36,8 +36,6 @@
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 
-extern std::mutex g_create_destroy_mutex;
-
 // The following prototype declarations are required so the dispatch table can find these
 // functions which are defined in trace_layer.cpp
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance, const char* pName);


### PR DESCRIPTION
- Modify the code generator for the API call encoder to write the
  parameters before making the API call if the API call does not return
  a value and does not have output parameters.
- Remove the create destroy lock, which was intended to prevent one
  thread from creating an object in between another thread's call to
  destroy an object and log the parameters for the call, where an object
  handle may be recycled.