### PR TITLE
Fix inverted logic for warning message

### DIFF
--- a/framework/decode/struct_pointer_decoder.h
+++ b/framework/decode/struct_pointer_decoder.h
@@ -95,17 +95,15 @@ class StructPointerDecoder : public PointerDecoderBase
 
                 if ((struct_memory_ == nullptr) || (len > capacity_))
                 {
-                    is_memory_external_ = false;
-                    struct_memory_      = new typename T::struct_type[len];
-                    capacity_           = len;
-                }
-                else
-                {
                     GFXRECON_LOG_WARNING("Struct pointer decoder's external memory capacity (%" PRIuPTR
                                          ") is smaller than the decoded array size (%" PRIuPTR
                                          "); an internal memory allocation will be used instead",
                                          capacity_,
                                          len);
+
+                    is_memory_external_ = false;
+                    struct_memory_      = new typename T::struct_type[len];
+                    capacity_           = len;
                 }
             }
 


### PR DESCRIPTION
StructPointerDecoder was printing a warning for a successful operation,
due to a logic issue when testing for success.