### PR TITLE
Fix page guard signal handler reference count

### DIFF
--- a/framework/encode/memory_tracker.cpp
+++ b/framework/encode/memory_tracker.cpp
@@ -74,9 +74,25 @@ void MemoryTracker::UnmapEntry(VkDeviceMemory memory)
     }
 }
 
-void MemoryTracker::RemoveEntry(VkDeviceMemory memory)
+void MemoryTracker::RemoveEntry(VkDeviceMemory memory, bool* is_mapped)
 {
-    mapped_memory_.erase(memory);
+    auto entry = mapped_memory_.find(memory);
+    if (entry != mapped_memory_.end())
+    {
+        if (is_mapped != nullptr)
+        {
+            if (entry->second.mapped_memory == nullptr)
+            {
+                (*is_mapped) = false;
+            }
+            else
+            {
+                (*is_mapped) = true;
+            }
+        }
+
+        mapped_memory_.erase(entry);
+    }
 }
 
 const MemoryTracker::EntryInfo* MemoryTracker::GetEntryInfo(VkDeviceMemory memory) const

--- a/framework/encode/memory_tracker.h
+++ b/framework/encode/memory_tracker.h
@@ -59,7 +59,7 @@ class MemoryTracker
 
     void UnmapEntry(VkDeviceMemory memory);
 
-    void RemoveEntry(VkDeviceMemory memory);
+    void RemoveEntry(VkDeviceMemory memory, bool* is_mapped);
 
     const EntryInfo* GetEntryInfo(VkDeviceMemory memory) const;
 

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -644,9 +644,11 @@ void TraceManager::PreProcess_vkFreeMemory(VkDevice                     device,
     GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
 
     std::lock_guard<std::mutex> lock(memory_tracker_lock_);
-    memory_tracker_.RemoveEntry(memory);
 
-    if (memory_tracking_mode_ == MemoryTrackingMode::kPageGuard)
+    bool is_mapped = false;
+    memory_tracker_.RemoveEntry(memory, &is_mapped);
+
+    if ((memory_tracking_mode_ == MemoryTrackingMode::kPageGuard) && is_mapped)
     {
         util::PageGuardManager* manager = util::PageGuardManager::Get();
         assert(manager != nullptr);

--- a/framework/util/page_guard_manager.cpp
+++ b/framework/util/page_guard_manager.cpp
@@ -675,13 +675,13 @@ void PageGuardManager::RemoveMemory(uint64_t memory_id)
 {
     std::lock_guard<std::mutex> lock(tracked_memory_lock_);
 
-    RemoveExceptionHandler();
-
     auto entry = memory_info_.find(memory_id);
     if (entry != memory_info_.end())
     {
         bool              success     = true;
         const MemoryInfo& memory_info = entry->second;
+
+        RemoveExceptionHandler();
 
         if (memory_info.shadow_memory)
         {


### PR DESCRIPTION
The page gaurd code for tracking modifications to mapped memory was
always decrementing the reference count used to determine when the
signal handler should removed on all calls to vkFreeMemory.  The
reference count is now only decremented by vkFreeMemory if the memory
being freed is actually mapped.