### PR TITLE
Remove <application> from Android layer's manifest

### DIFF
--- a/android/layer/src/main/AndroidManifest.xml
+++ b/android/layer/src/main/AndroidManifest.xml
@@ -4,10 +4,4 @@
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-    </application>
-
 </manifest>

--- a/android/layer/src/main/res/values/strings.xml
+++ b/android/layer/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">gfxreconstruct_layer</string>
-</resources>


### PR DESCRIPTION
Remove the <android> section from the capture layer's
AndroidManifest.xml file, which was setting values that the layer
did not require.