### PR TITLE
WindowFactory Destroys Windows it Created

### DIFF
--- a/framework/application/android_window.cpp
+++ b/framework/application/android_window.cpp
@@ -114,6 +114,12 @@ AndroidWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t wi
     return android_application_->GetWindow();
 }
 
+void AndroidWindowFactory::Destroy(decode::Window* window)
+{
+    // Android currently has a single window whose lifetime is managed by AndroidApplication.
+    GFXRECON_UNREFERENCED_PARAMETER(window);
+}
+
 VkBool32 AndroidWindowFactory::GetPhysicalDevicePresentationSupport(VkPhysicalDevice physical_device,
                                                                     uint32_t         queue_family_index)
 {

--- a/framework/application/android_window.h
+++ b/framework/application/android_window.h
@@ -81,6 +81,8 @@ class AndroidWindowFactory : public decode::WindowFactory
     virtual decode::Window*
     Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) override;
 
+    void Destroy(decode::Window* window) override;
+
     virtual VkBool32 GetPhysicalDevicePresentationSupport(VkPhysicalDevice physical_device,
                                                           uint32_t         queue_family_index) override;
 

--- a/framework/application/wayland_window.cpp
+++ b/framework/application/wayland_window.cpp
@@ -178,6 +178,15 @@ WaylandWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t wi
     return window;
 }
 
+void WaylandWindowFactory::Destroy(decode::Window* window)
+{
+    if (window != nullptr)
+    {
+        window->Destroy();
+        delete window;
+    }
+}
+
 VkBool32 WaylandWindowFactory::GetPhysicalDevicePresentationSupport(VkPhysicalDevice physical_device,
                                                                     uint32_t         queue_family_index)
 {

--- a/framework/application/wayland_window.h
+++ b/framework/application/wayland_window.h
@@ -92,6 +92,8 @@ class WaylandWindowFactory : public decode::WindowFactory
     virtual decode::Window*
     Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) override;
 
+    void Destroy(decode::Window* window) override;
+
     virtual VkBool32 GetPhysicalDevicePresentationSupport(VkPhysicalDevice physical_device,
                                                           uint32_t         queue_family_index) override;
 

--- a/framework/application/win32_window.cpp
+++ b/framework/application/win32_window.cpp
@@ -271,6 +271,15 @@ Win32WindowFactory::Create(const int32_t x, const int32_t y, const uint32_t widt
     return window;
 }
 
+void Win32WindowFactory::Destroy(decode::Window* window)
+{
+    if (window != nullptr)
+    {
+        window->Destroy();
+        delete window;
+    }
+}
+
 VkBool32 Win32WindowFactory::GetPhysicalDevicePresentationSupport(VkPhysicalDevice physical_device,
                                                                   uint32_t         queue_family_index)
 {

--- a/framework/application/win32_window.h
+++ b/framework/application/win32_window.h
@@ -85,6 +85,8 @@ class Win32WindowFactory : public decode::WindowFactory
     virtual decode::Window*
     Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) override;
 
+    void Destroy(decode::Window* window) override;
+
     virtual VkBool32 GetPhysicalDevicePresentationSupport(VkPhysicalDevice physical_device,
                                                           uint32_t         queue_family_index) override;
 

--- a/framework/application/xcb_window.cpp
+++ b/framework/application/xcb_window.cpp
@@ -450,6 +450,15 @@ decode::Window* XcbWindowFactory::Create(const int32_t x, const int32_t y, const
     return window;
 }
 
+void XcbWindowFactory::Destroy(decode::Window* window)
+{
+    if (window != nullptr)
+    {
+        window->Destroy();
+        delete window;
+    }
+}
+
 VkBool32 XcbWindowFactory::GetPhysicalDevicePresentationSupport(VkPhysicalDevice physical_device,
                                                                 uint32_t         queue_family_index)
 {

--- a/framework/application/xcb_window.h
+++ b/framework/application/xcb_window.h
@@ -125,6 +125,8 @@ class XcbWindowFactory : public decode::WindowFactory
     virtual decode::Window*
     Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) override;
 
+    void Destroy(decode::Window* window) override;
+
     virtual VkBool32 GetPhysicalDevicePresentationSupport(VkPhysicalDevice physical_device,
                                                           uint32_t         queue_family_index) override;
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -52,12 +52,7 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
     // Destroy any windows that were created for Vulkan surfaces.
     for (const auto& entry : window_map_)
     {
-        Window* window = entry.second;
-
-        assert(window != nullptr);
-
-        window->Destroy();
-        delete window;
+        window_factory_->Destroy(entry.second);
     }
 }
 
@@ -624,12 +619,7 @@ void VulkanReplayConsumerBase::OverrideDestroySurfaceKHR(VkInstance             
 
         if (entry != window_map_.end())
         {
-            Window* window = entry->second;
-
-            assert(window != nullptr);
-
-            window->Destroy();
-            delete window;
+            window_factory_->Destroy(entry->second);
             window_map_.erase(entry);
         }
     }

--- a/framework/decode/window.h
+++ b/framework/decode/window.h
@@ -68,6 +68,8 @@ class WindowFactory
 
     virtual Window* Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) = 0;
 
+    virtual void Destroy(Window* window) = 0;
+
     virtual VkBool32 GetPhysicalDevicePresentationSupport(VkPhysicalDevice physical_device,
                                                           uint32_t         queue_family_index) = 0;
 };


### PR DESCRIPTION
Modify WindowFactory to destroy windows that it created.  This moves the delete operation from the replay consumer to the factory, and is necessary for cases where the factory did not allocate the window with new.  This is specifically required for the Android replay, where there is only one window object to wrap the NativeActivity's NativeWindow.  For the Android case, AndroidApplication manages the lifetime of the ANativeWindow wrapper and the factory simply returns a pointer to the AndroidApplication's window.