### PR TITLE
Remove Vulkan Feature Protect from Layer

### DIFF
--- a/framework/generated/generated_encode_pnext_struct.cpp
+++ b/framework/generated/generated_encode_pnext_struct.cpp
@@ -183,30 +183,24 @@ void encode_pnext_struct(ParameterEncoder* encoder, const void* value)
         case VK_STRUCTURE_TYPE_DISPLAY_PRESENT_INFO_KHR:
             encode_struct_ptr(encoder, reinterpret_cast<const VkDisplayPresentInfoKHR*>(value));
             break;
-#ifdef VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR:
             encode_struct_ptr(encoder, reinterpret_cast<const VkImportMemoryWin32HandleInfoKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR:
             encode_struct_ptr(encoder, reinterpret_cast<const VkExportMemoryWin32HandleInfoKHR*>(value));
             break;
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR:
             encode_struct_ptr(encoder, reinterpret_cast<const VkImportMemoryFdInfoKHR*>(value));
             break;
-#ifdef VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR:
             encode_struct_ptr(encoder, reinterpret_cast<const VkWin32KeyedMutexAcquireReleaseInfoKHR*>(value));
             break;
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
-#ifdef VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR:
             encode_struct_ptr(encoder, reinterpret_cast<const VkExportSemaphoreWin32HandleInfoKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHR:
             encode_struct_ptr(encoder, reinterpret_cast<const VkD3D12FenceSubmitInfoKHR*>(value));
             break;
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR:
             encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDevicePushDescriptorPropertiesKHR*>(value));
             break;
@@ -216,11 +210,9 @@ void encode_pnext_struct(ParameterEncoder* encoder, const void* value)
         case VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR:
             encode_struct_ptr(encoder, reinterpret_cast<const VkSharedPresentSurfaceCapabilitiesKHR*>(value));
             break;
-#ifdef VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_EXPORT_FENCE_WIN32_HANDLE_INFO_KHR:
             encode_struct_ptr(encoder, reinterpret_cast<const VkExportFenceWin32HandleInfoKHR*>(value));
             break;
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
         case VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO_KHR:
             encode_struct_ptr(encoder, reinterpret_cast<const VkImageFormatListCreateInfoKHR*>(value));
             break;
@@ -263,19 +255,15 @@ void encode_pnext_struct(ParameterEncoder* encoder, const void* value)
         case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_NV:
             encode_struct_ptr(encoder, reinterpret_cast<const VkExportMemoryAllocateInfoNV*>(value));
             break;
-#ifdef VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_NV:
             encode_struct_ptr(encoder, reinterpret_cast<const VkImportMemoryWin32HandleInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_NV:
             encode_struct_ptr(encoder, reinterpret_cast<const VkExportMemoryWin32HandleInfoNV*>(value));
             break;
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
-#ifdef VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV:
             encode_struct_ptr(encoder, reinterpret_cast<const VkWin32KeyedMutexAcquireReleaseInfoNV*>(value));
             break;
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
         case VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT:
             encode_struct_ptr(encoder, reinterpret_cast<const VkValidationFlagsEXT*>(value));
             break;
@@ -321,7 +309,6 @@ void encode_pnext_struct(ParameterEncoder* encoder, const void* value)
         case VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT:
             encode_struct_ptr(encoder, reinterpret_cast<const VkDebugUtilsMessengerCreateInfoEXT*>(value));
             break;
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
         case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID:
             encode_struct_ptr(encoder, reinterpret_cast<const VkAndroidHardwareBufferUsageANDROID*>(value));
             break;
@@ -334,7 +321,6 @@ void encode_pnext_struct(ParameterEncoder* encoder, const void* value)
         case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID:
             encode_struct_ptr(encoder, reinterpret_cast<const VkExternalFormatANDROID*>(value));
             break;
-#endif /* VK_USE_PLATFORM_ANDROID_KHR */
         case VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO_EXT:
             encode_struct_ptr(encoder, reinterpret_cast<const VkSamplerReductionModeCreateInfoEXT*>(value));
             break;

--- a/framework/generated/generated_layer_func_table.h
+++ b/framework/generated/generated_layer_func_table.h
@@ -221,29 +221,17 @@ const std::unordered_map<std::string, PFN_vkVoidFunction> func_table = {
     { "vkGetDisplayPlaneCapabilitiesKHR",                                                                    reinterpret_cast<PFN_vkVoidFunction>(GetDisplayPlaneCapabilitiesKHR) },
     { "vkCreateDisplayPlaneSurfaceKHR",                                                                      reinterpret_cast<PFN_vkVoidFunction>(CreateDisplayPlaneSurfaceKHR) },
     { "vkCreateSharedSwapchainsKHR",                                                                         reinterpret_cast<PFN_vkVoidFunction>(CreateSharedSwapchainsKHR) },
-#ifdef VK_USE_PLATFORM_XLIB_KHR
     { "vkCreateXlibSurfaceKHR",                                                                              reinterpret_cast<PFN_vkVoidFunction>(CreateXlibSurfaceKHR) },
     { "vkGetPhysicalDeviceXlibPresentationSupportKHR",                                                       reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceXlibPresentationSupportKHR) },
-#endif /* VK_USE_PLATFORM_XLIB_KHR */
-#ifdef VK_USE_PLATFORM_XCB_KHR
     { "vkCreateXcbSurfaceKHR",                                                                               reinterpret_cast<PFN_vkVoidFunction>(CreateXcbSurfaceKHR) },
     { "vkGetPhysicalDeviceXcbPresentationSupportKHR",                                                        reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceXcbPresentationSupportKHR) },
-#endif /* VK_USE_PLATFORM_XCB_KHR */
-#ifdef VK_USE_PLATFORM_WAYLAND_KHR
     { "vkCreateWaylandSurfaceKHR",                                                                           reinterpret_cast<PFN_vkVoidFunction>(CreateWaylandSurfaceKHR) },
     { "vkGetPhysicalDeviceWaylandPresentationSupportKHR",                                                    reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceWaylandPresentationSupportKHR) },
-#endif /* VK_USE_PLATFORM_WAYLAND_KHR */
-#ifdef VK_USE_PLATFORM_MIR_KHR
     { "vkCreateMirSurfaceKHR",                                                                               reinterpret_cast<PFN_vkVoidFunction>(CreateMirSurfaceKHR) },
     { "vkGetPhysicalDeviceMirPresentationSupportKHR",                                                        reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceMirPresentationSupportKHR) },
-#endif /* VK_USE_PLATFORM_MIR_KHR */
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
     { "vkCreateAndroidSurfaceKHR",                                                                           reinterpret_cast<PFN_vkVoidFunction>(CreateAndroidSurfaceKHR) },
-#endif /* VK_USE_PLATFORM_ANDROID_KHR */
-#ifdef VK_USE_PLATFORM_WIN32_KHR
     { "vkCreateWin32SurfaceKHR",                                                                             reinterpret_cast<PFN_vkVoidFunction>(CreateWin32SurfaceKHR) },
     { "vkGetPhysicalDeviceWin32PresentationSupportKHR",                                                      reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceWin32PresentationSupportKHR) },
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
     { "vkGetPhysicalDeviceFeatures2KHR",                                                                     reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceFeatures2KHR) },
     { "vkGetPhysicalDeviceProperties2KHR",                                                                   reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceProperties2KHR) },
     { "vkGetPhysicalDeviceFormatProperties2KHR",                                                             reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceFormatProperties2KHR) },
@@ -257,17 +245,13 @@ const std::unordered_map<std::string, PFN_vkVoidFunction> func_table = {
     { "vkTrimCommandPoolKHR",                                                                                reinterpret_cast<PFN_vkVoidFunction>(TrimCommandPoolKHR) },
     { "vkEnumeratePhysicalDeviceGroupsKHR",                                                                  reinterpret_cast<PFN_vkVoidFunction>(EnumeratePhysicalDeviceGroupsKHR) },
     { "vkGetPhysicalDeviceExternalBufferPropertiesKHR",                                                      reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceExternalBufferPropertiesKHR) },
-#ifdef VK_USE_PLATFORM_WIN32_KHR
     { "vkGetMemoryWin32HandleKHR",                                                                           reinterpret_cast<PFN_vkVoidFunction>(GetMemoryWin32HandleKHR) },
     { "vkGetMemoryWin32HandlePropertiesKHR",                                                                 reinterpret_cast<PFN_vkVoidFunction>(GetMemoryWin32HandlePropertiesKHR) },
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
     { "vkGetMemoryFdKHR",                                                                                    reinterpret_cast<PFN_vkVoidFunction>(GetMemoryFdKHR) },
     { "vkGetMemoryFdPropertiesKHR",                                                                          reinterpret_cast<PFN_vkVoidFunction>(GetMemoryFdPropertiesKHR) },
     { "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR",                                                   reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceExternalSemaphorePropertiesKHR) },
-#ifdef VK_USE_PLATFORM_WIN32_KHR
     { "vkImportSemaphoreWin32HandleKHR",                                                                     reinterpret_cast<PFN_vkVoidFunction>(ImportSemaphoreWin32HandleKHR) },
     { "vkGetSemaphoreWin32HandleKHR",                                                                        reinterpret_cast<PFN_vkVoidFunction>(GetSemaphoreWin32HandleKHR) },
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
     { "vkImportSemaphoreFdKHR",                                                                              reinterpret_cast<PFN_vkVoidFunction>(ImportSemaphoreFdKHR) },
     { "vkGetSemaphoreFdKHR",                                                                                 reinterpret_cast<PFN_vkVoidFunction>(GetSemaphoreFdKHR) },
     { "vkCmdPushDescriptorSetKHR",                                                                           reinterpret_cast<PFN_vkVoidFunction>(CmdPushDescriptorSetKHR) },
@@ -281,10 +265,8 @@ const std::unordered_map<std::string, PFN_vkVoidFunction> func_table = {
     { "vkCmdEndRenderPass2KHR",                                                                              reinterpret_cast<PFN_vkVoidFunction>(CmdEndRenderPass2KHR) },
     { "vkGetSwapchainStatusKHR",                                                                             reinterpret_cast<PFN_vkVoidFunction>(GetSwapchainStatusKHR) },
     { "vkGetPhysicalDeviceExternalFencePropertiesKHR",                                                       reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceExternalFencePropertiesKHR) },
-#ifdef VK_USE_PLATFORM_WIN32_KHR
     { "vkImportFenceWin32HandleKHR",                                                                         reinterpret_cast<PFN_vkVoidFunction>(ImportFenceWin32HandleKHR) },
     { "vkGetFenceWin32HandleKHR",                                                                            reinterpret_cast<PFN_vkVoidFunction>(GetFenceWin32HandleKHR) },
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
     { "vkImportFenceFdKHR",                                                                                  reinterpret_cast<PFN_vkVoidFunction>(ImportFenceFdKHR) },
     { "vkGetFenceFdKHR",                                                                                     reinterpret_cast<PFN_vkVoidFunction>(GetFenceFdKHR) },
     { "vkGetPhysicalDeviceSurfaceCapabilities2KHR",                                                          reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceSurfaceCapabilities2KHR) },
@@ -315,12 +297,8 @@ const std::unordered_map<std::string, PFN_vkVoidFunction> func_table = {
     { "vkCmdDrawIndexedIndirectCountAMD",                                                                    reinterpret_cast<PFN_vkVoidFunction>(CmdDrawIndexedIndirectCountAMD) },
     { "vkGetShaderInfoAMD",                                                                                  reinterpret_cast<PFN_vkVoidFunction>(GetShaderInfoAMD) },
     { "vkGetPhysicalDeviceExternalImageFormatPropertiesNV",                                                  reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceExternalImageFormatPropertiesNV) },
-#ifdef VK_USE_PLATFORM_WIN32_KHR
     { "vkGetMemoryWin32HandleNV",                                                                            reinterpret_cast<PFN_vkVoidFunction>(GetMemoryWin32HandleNV) },
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
-#ifdef VK_USE_PLATFORM_VI_NN
     { "vkCreateViSurfaceNN",                                                                                 reinterpret_cast<PFN_vkVoidFunction>(CreateViSurfaceNN) },
-#endif /* VK_USE_PLATFORM_VI_NN */
     { "vkCmdBeginConditionalRenderingEXT",                                                                   reinterpret_cast<PFN_vkVoidFunction>(CmdBeginConditionalRenderingEXT) },
     { "vkCmdEndConditionalRenderingEXT",                                                                     reinterpret_cast<PFN_vkVoidFunction>(CmdEndConditionalRenderingEXT) },
     { "vkCmdProcessCommandsNVX",                                                                             reinterpret_cast<PFN_vkVoidFunction>(CmdProcessCommandsNVX) },
@@ -334,10 +312,8 @@ const std::unordered_map<std::string, PFN_vkVoidFunction> func_table = {
     { "vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX",                                                   reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceGeneratedCommandsPropertiesNVX) },
     { "vkCmdSetViewportWScalingNV",                                                                          reinterpret_cast<PFN_vkVoidFunction>(CmdSetViewportWScalingNV) },
     { "vkReleaseDisplayEXT",                                                                                 reinterpret_cast<PFN_vkVoidFunction>(ReleaseDisplayEXT) },
-#ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
     { "vkAcquireXlibDisplayEXT",                                                                             reinterpret_cast<PFN_vkVoidFunction>(AcquireXlibDisplayEXT) },
     { "vkGetRandROutputDisplayEXT",                                                                          reinterpret_cast<PFN_vkVoidFunction>(GetRandROutputDisplayEXT) },
-#endif /* VK_USE_PLATFORM_XLIB_XRANDR_EXT */
     { "vkGetPhysicalDeviceSurfaceCapabilities2EXT",                                                          reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceSurfaceCapabilities2EXT) },
     { "vkDisplayPowerControlEXT",                                                                            reinterpret_cast<PFN_vkVoidFunction>(DisplayPowerControlEXT) },
     { "vkRegisterDeviceEventEXT",                                                                            reinterpret_cast<PFN_vkVoidFunction>(RegisterDeviceEventEXT) },
@@ -347,12 +323,8 @@ const std::unordered_map<std::string, PFN_vkVoidFunction> func_table = {
     { "vkGetPastPresentationTimingGOOGLE",                                                                   reinterpret_cast<PFN_vkVoidFunction>(GetPastPresentationTimingGOOGLE) },
     { "vkCmdSetDiscardRectangleEXT",                                                                         reinterpret_cast<PFN_vkVoidFunction>(CmdSetDiscardRectangleEXT) },
     { "vkSetHdrMetadataEXT",                                                                                 reinterpret_cast<PFN_vkVoidFunction>(SetHdrMetadataEXT) },
-#ifdef VK_USE_PLATFORM_IOS_MVK
     { "vkCreateIOSSurfaceMVK",                                                                               reinterpret_cast<PFN_vkVoidFunction>(CreateIOSSurfaceMVK) },
-#endif /* VK_USE_PLATFORM_IOS_MVK */
-#ifdef VK_USE_PLATFORM_MACOS_MVK
     { "vkCreateMacOSSurfaceMVK",                                                                             reinterpret_cast<PFN_vkVoidFunction>(CreateMacOSSurfaceMVK) },
-#endif /* VK_USE_PLATFORM_MACOS_MVK */
     { "vkSetDebugUtilsObjectNameEXT",                                                                        reinterpret_cast<PFN_vkVoidFunction>(SetDebugUtilsObjectNameEXT) },
     { "vkSetDebugUtilsObjectTagEXT",                                                                         reinterpret_cast<PFN_vkVoidFunction>(SetDebugUtilsObjectTagEXT) },
     { "vkQueueBeginDebugUtilsLabelEXT",                                                                      reinterpret_cast<PFN_vkVoidFunction>(QueueBeginDebugUtilsLabelEXT) },
@@ -364,10 +336,8 @@ const std::unordered_map<std::string, PFN_vkVoidFunction> func_table = {
     { "vkCreateDebugUtilsMessengerEXT",                                                                      reinterpret_cast<PFN_vkVoidFunction>(CreateDebugUtilsMessengerEXT) },
     { "vkDestroyDebugUtilsMessengerEXT",                                                                     reinterpret_cast<PFN_vkVoidFunction>(DestroyDebugUtilsMessengerEXT) },
     { "vkSubmitDebugUtilsMessageEXT",                                                                        reinterpret_cast<PFN_vkVoidFunction>(SubmitDebugUtilsMessageEXT) },
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
     { "vkGetAndroidHardwareBufferPropertiesANDROID",                                                         reinterpret_cast<PFN_vkVoidFunction>(GetAndroidHardwareBufferPropertiesANDROID) },
     { "vkGetMemoryAndroidHardwareBufferANDROID",                                                             reinterpret_cast<PFN_vkVoidFunction>(GetMemoryAndroidHardwareBufferANDROID) },
-#endif /* VK_USE_PLATFORM_ANDROID_KHR */
     { "vkCmdSetSampleLocationsEXT",                                                                          reinterpret_cast<PFN_vkVoidFunction>(CmdSetSampleLocationsEXT) },
     { "vkGetPhysicalDeviceMultisamplePropertiesEXT",                                                         reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceMultisamplePropertiesEXT) },
     { "vkCreateValidationCacheEXT",                                                                          reinterpret_cast<PFN_vkVoidFunction>(CreateValidationCacheEXT) },
@@ -398,9 +368,7 @@ const std::unordered_map<std::string, PFN_vkVoidFunction> func_table = {
     { "vkCmdSetExclusiveScissorNV",                                                                          reinterpret_cast<PFN_vkVoidFunction>(CmdSetExclusiveScissorNV) },
     { "vkCmdSetCheckpointNV",                                                                                reinterpret_cast<PFN_vkVoidFunction>(CmdSetCheckpointNV) },
     { "vkGetQueueCheckpointDataNV",                                                                          reinterpret_cast<PFN_vkVoidFunction>(GetQueueCheckpointDataNV) },
-#ifdef VK_USE_PLATFORM_FUCHSIA
     { "vkCreateImagePipeSurfaceFUCHSIA",                                                                     reinterpret_cast<PFN_vkVoidFunction>(CreateImagePipeSurfaceFUCHSIA) },
-#endif /* VK_USE_PLATFORM_FUCHSIA */
 
     // Special case handling of "vk_layerGetPhysicalDeviceProcAddr"
     { "vk_layerGetPhysicalDeviceProcAddr",                                                                   reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceProcAddr) },

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -32,8 +32,6 @@
 
 #include "vulkan/vulkan.h"
 
-#include <mutex>
-
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(
@@ -4293,7 +4291,6 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSharedSwapchainsKHR(
     return result;
 }
 
-#ifdef VK_USE_PLATFORM_XLIB_KHR
 VKAPI_ATTR VkResult VKAPI_CALL CreateXlibSurfaceKHR(
     VkInstance                                  instance,
     const VkXlibSurfaceCreateInfoKHR*           pCreateInfo,
@@ -4345,9 +4342,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceXlibPresentationSupportKHR(
 
     return result;
 }
-#endif /* VK_USE_PLATFORM_XLIB_KHR */
 
-#ifdef VK_USE_PLATFORM_XCB_KHR
 VKAPI_ATTR VkResult VKAPI_CALL CreateXcbSurfaceKHR(
     VkInstance                                  instance,
     const VkXcbSurfaceCreateInfoKHR*            pCreateInfo,
@@ -4399,9 +4394,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceXcbPresentationSupportKHR(
 
     return result;
 }
-#endif /* VK_USE_PLATFORM_XCB_KHR */
 
-#ifdef VK_USE_PLATFORM_WAYLAND_KHR
 VKAPI_ATTR VkResult VKAPI_CALL CreateWaylandSurfaceKHR(
     VkInstance                                  instance,
     const VkWaylandSurfaceCreateInfoKHR*        pCreateInfo,
@@ -4451,9 +4444,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceWaylandPresentationSupportKHR(
 
     return result;
 }
-#endif /* VK_USE_PLATFORM_WAYLAND_KHR */
 
-#ifdef VK_USE_PLATFORM_MIR_KHR
 VKAPI_ATTR VkResult VKAPI_CALL CreateMirSurfaceKHR(
     VkInstance                                  instance,
     const VkMirSurfaceCreateInfoKHR*            pCreateInfo,
@@ -4503,9 +4494,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceMirPresentationSupportKHR(
 
     return result;
 }
-#endif /* VK_USE_PLATFORM_MIR_KHR */
 
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
 VKAPI_ATTR VkResult VKAPI_CALL CreateAndroidSurfaceKHR(
     VkInstance                                  instance,
     const VkAndroidSurfaceCreateInfoKHR*        pCreateInfo,
@@ -4531,9 +4520,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAndroidSurfaceKHR(
 
     return result;
 }
-#endif /* VK_USE_PLATFORM_ANDROID_KHR */
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 VKAPI_ATTR VkResult VKAPI_CALL CreateWin32SurfaceKHR(
     VkInstance                                  instance,
     const VkWin32SurfaceCreateInfoKHR*          pCreateInfo,
@@ -4581,7 +4568,6 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceWin32PresentationSupportKHR(
 
     return result;
 }
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures2KHR(
     VkPhysicalDevice                            physicalDevice,
@@ -4868,7 +4854,6 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferPropertiesKHR(
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalBufferPropertiesKHR>::Dispatch(encode::TraceManager::Get(), physicalDevice, pExternalBufferInfo, pExternalBufferProperties);
 }
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleKHR(
     VkDevice                                    device,
     const VkMemoryGetWin32HandleInfoKHR*        pGetWin32HandleInfo,
@@ -4918,7 +4903,6 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandlePropertiesKHR(
 
     return result;
 }
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdKHR(
     VkDevice                                    device,
@@ -4991,7 +4975,6 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalSemaphorePropertiesKHR(
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR>::Dispatch(encode::TraceManager::Get(), physicalDevice, pExternalSemaphoreInfo, pExternalSemaphoreProperties);
 }
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreWin32HandleKHR(
     VkDevice                                    device,
     const VkImportSemaphoreWin32HandleInfoKHR*  pImportSemaphoreWin32HandleInfo)
@@ -5037,7 +5020,6 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreWin32HandleKHR(
 
     return result;
 }
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreFdKHR(
     VkDevice                                    device,
@@ -5289,7 +5271,6 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalFencePropertiesKHR(
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalFencePropertiesKHR>::Dispatch(encode::TraceManager::Get(), physicalDevice, pExternalFenceInfo, pExternalFenceProperties);
 }
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 VKAPI_ATTR VkResult VKAPI_CALL ImportFenceWin32HandleKHR(
     VkDevice                                    device,
     const VkImportFenceWin32HandleInfoKHR*      pImportFenceWin32HandleInfo)
@@ -5335,7 +5316,6 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceWin32HandleKHR(
 
     return result;
 }
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 VKAPI_ATTR VkResult VKAPI_CALL ImportFenceFdKHR(
     VkDevice                                    device,
@@ -6069,7 +6049,6 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceExternalImageFormatPropertiesNV(
     return result;
 }
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleNV(
     VkDevice                                    device,
     VkDeviceMemory                              memory,
@@ -6095,9 +6074,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleNV(
 
     return result;
 }
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
-#ifdef VK_USE_PLATFORM_VI_NN
 VKAPI_ATTR VkResult VKAPI_CALL CreateViSurfaceNN(
     VkInstance                                  instance,
     const VkViSurfaceCreateInfoNN*              pCreateInfo,
@@ -6123,7 +6100,6 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateViSurfaceNN(
 
     return result;
 }
-#endif /* VK_USE_PLATFORM_VI_NN */
 
 VKAPI_ATTR void VKAPI_CALL CmdBeginConditionalRenderingEXT(
     VkCommandBuffer                             commandBuffer,
@@ -6387,7 +6363,6 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseDisplayEXT(
     return result;
 }
 
-#ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
 VKAPI_ATTR VkResult VKAPI_CALL AcquireXlibDisplayEXT(
     VkPhysicalDevice                            physicalDevice,
     Display*                                    dpy,
@@ -6437,7 +6412,6 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRandROutputDisplayEXT(
 
     return result;
 }
-#endif /* VK_USE_PLATFORM_XLIB_XRANDR_EXT */
 
 VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2EXT(
     VkPhysicalDevice                            physicalDevice,
@@ -6663,7 +6637,6 @@ VKAPI_ATTR void VKAPI_CALL SetHdrMetadataEXT(
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkSetHdrMetadataEXT>::Dispatch(encode::TraceManager::Get(), device, swapchainCount, pSwapchains, pMetadata);
 }
 
-#ifdef VK_USE_PLATFORM_IOS_MVK
 VKAPI_ATTR VkResult VKAPI_CALL CreateIOSSurfaceMVK(
     VkInstance                                  instance,
     const VkIOSSurfaceCreateInfoMVK*            pCreateInfo,
@@ -6689,9 +6662,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIOSSurfaceMVK(
 
     return result;
 }
-#endif /* VK_USE_PLATFORM_IOS_MVK */
 
-#ifdef VK_USE_PLATFORM_MACOS_MVK
 VKAPI_ATTR VkResult VKAPI_CALL CreateMacOSSurfaceMVK(
     VkInstance                                  instance,
     const VkMacOSSurfaceCreateInfoMVK*          pCreateInfo,
@@ -6717,7 +6688,6 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMacOSSurfaceMVK(
 
     return result;
 }
-#endif /* VK_USE_PLATFORM_MACOS_MVK */
 
 VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectNameEXT(
     VkDevice                                    device,
@@ -6943,7 +6913,6 @@ VKAPI_ATTR void VKAPI_CALL SubmitDebugUtilsMessageEXT(
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkSubmitDebugUtilsMessageEXT>::Dispatch(encode::TraceManager::Get(), instance, messageSeverity, messageTypes, pCallbackData);
 }
 
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
 VKAPI_ATTR VkResult VKAPI_CALL GetAndroidHardwareBufferPropertiesANDROID(
     VkDevice                                    device,
     const struct AHardwareBuffer*               buffer,
@@ -6991,7 +6960,6 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryAndroidHardwareBufferANDROID(
 
     return result;
 }
-#endif /* VK_USE_PLATFORM_ANDROID_KHR */
 
 VKAPI_ATTR void VKAPI_CALL CmdSetSampleLocationsEXT(
     VkCommandBuffer                             commandBuffer,
@@ -7737,7 +7705,6 @@ VKAPI_ATTR void VKAPI_CALL GetQueueCheckpointDataNV(
     encode::CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetQueueCheckpointDataNV>::Dispatch(encode::TraceManager::Get(), queue, pCheckpointDataCount, pCheckpointData);
 }
 
-#ifdef VK_USE_PLATFORM_FUCHSIA
 VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(
     VkInstance                                  instance,
     const VkImagePipeSurfaceCreateInfoFUCHSIA*  pCreateInfo,
@@ -7763,6 +7730,5 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(
 
     return result;
 }
-#endif /* VK_USE_PLATFORM_FUCHSIA */
 
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/generated_vulkan_api_call_encoders.h
+++ b/framework/generated/generated_vulkan_api_call_encoders.h
@@ -23,6 +23,7 @@
 #ifndef  GFXRECON_GENERATED_VULKAN_API_CALL_ENCODERS_H
 #define  GFXRECON_GENERATED_VULKAN_API_CALL_ENCODERS_H
 
+#include "format/platform_types.h"
 #include "util/defines.h"
 
 #include "vulkan/vulkan.h"
@@ -1059,7 +1060,6 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSharedSwapchainsKHR(
     const VkAllocationCallbacks*                pAllocator,
     VkSwapchainKHR*                             pSwapchains);
 
-#ifdef VK_USE_PLATFORM_XLIB_KHR
 VKAPI_ATTR VkResult VKAPI_CALL CreateXlibSurfaceKHR(
     VkInstance                                  instance,
     const VkXlibSurfaceCreateInfoKHR*           pCreateInfo,
@@ -1071,9 +1071,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceXlibPresentationSupportKHR(
     uint32_t                                    queueFamilyIndex,
     Display*                                    dpy,
     VisualID                                    visualID);
-#endif /* VK_USE_PLATFORM_XLIB_KHR */
 
-#ifdef VK_USE_PLATFORM_XCB_KHR
 VKAPI_ATTR VkResult VKAPI_CALL CreateXcbSurfaceKHR(
     VkInstance                                  instance,
     const VkXcbSurfaceCreateInfoKHR*            pCreateInfo,
@@ -1085,9 +1083,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceXcbPresentationSupportKHR(
     uint32_t                                    queueFamilyIndex,
     xcb_connection_t*                           connection,
     xcb_visualid_t                              visual_id);
-#endif /* VK_USE_PLATFORM_XCB_KHR */
 
-#ifdef VK_USE_PLATFORM_WAYLAND_KHR
 VKAPI_ATTR VkResult VKAPI_CALL CreateWaylandSurfaceKHR(
     VkInstance                                  instance,
     const VkWaylandSurfaceCreateInfoKHR*        pCreateInfo,
@@ -1098,9 +1094,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceWaylandPresentationSupportKHR(
     VkPhysicalDevice                            physicalDevice,
     uint32_t                                    queueFamilyIndex,
     struct wl_display*                          display);
-#endif /* VK_USE_PLATFORM_WAYLAND_KHR */
 
-#ifdef VK_USE_PLATFORM_MIR_KHR
 VKAPI_ATTR VkResult VKAPI_CALL CreateMirSurfaceKHR(
     VkInstance                                  instance,
     const VkMirSurfaceCreateInfoKHR*            pCreateInfo,
@@ -1111,17 +1105,13 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceMirPresentationSupportKHR(
     VkPhysicalDevice                            physicalDevice,
     uint32_t                                    queueFamilyIndex,
     MirConnection*                              connection);
-#endif /* VK_USE_PLATFORM_MIR_KHR */
 
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
 VKAPI_ATTR VkResult VKAPI_CALL CreateAndroidSurfaceKHR(
     VkInstance                                  instance,
     const VkAndroidSurfaceCreateInfoKHR*        pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface);
-#endif /* VK_USE_PLATFORM_ANDROID_KHR */
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 VKAPI_ATTR VkResult VKAPI_CALL CreateWin32SurfaceKHR(
     VkInstance                                  instance,
     const VkWin32SurfaceCreateInfoKHR*          pCreateInfo,
@@ -1131,7 +1121,6 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWin32SurfaceKHR(
 VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceWin32PresentationSupportKHR(
     VkPhysicalDevice                            physicalDevice,
     uint32_t                                    queueFamilyIndex);
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures2KHR(
     VkPhysicalDevice                            physicalDevice,
@@ -1201,7 +1190,6 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferPropertiesKHR(
     const VkPhysicalDeviceExternalBufferInfo*   pExternalBufferInfo,
     VkExternalBufferProperties*                 pExternalBufferProperties);
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleKHR(
     VkDevice                                    device,
     const VkMemoryGetWin32HandleInfoKHR*        pGetWin32HandleInfo,
@@ -1212,7 +1200,6 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandlePropertiesKHR(
     VkExternalMemoryHandleTypeFlagBits          handleType,
     HANDLE                                      handle,
     VkMemoryWin32HandlePropertiesKHR*           pMemoryWin32HandleProperties);
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdKHR(
     VkDevice                                    device,
@@ -1230,7 +1217,6 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalSemaphorePropertiesKHR(
     const VkPhysicalDeviceExternalSemaphoreInfo* pExternalSemaphoreInfo,
     VkExternalSemaphoreProperties*              pExternalSemaphoreProperties);
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreWin32HandleKHR(
     VkDevice                                    device,
     const VkImportSemaphoreWin32HandleInfoKHR*  pImportSemaphoreWin32HandleInfo);
@@ -1239,7 +1225,6 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreWin32HandleKHR(
     VkDevice                                    device,
     const VkSemaphoreGetWin32HandleInfoKHR*     pGetWin32HandleInfo,
     HANDLE*                                     pHandle);
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreFdKHR(
     VkDevice                                    device,
@@ -1298,7 +1283,6 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalFencePropertiesKHR(
     const VkPhysicalDeviceExternalFenceInfo*    pExternalFenceInfo,
     VkExternalFenceProperties*                  pExternalFenceProperties);
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 VKAPI_ATTR VkResult VKAPI_CALL ImportFenceWin32HandleKHR(
     VkDevice                                    device,
     const VkImportFenceWin32HandleInfoKHR*      pImportFenceWin32HandleInfo);
@@ -1307,7 +1291,6 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceWin32HandleKHR(
     VkDevice                                    device,
     const VkFenceGetWin32HandleInfoKHR*         pGetWin32HandleInfo,
     HANDLE*                                     pHandle);
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 VKAPI_ATTR VkResult VKAPI_CALL ImportFenceFdKHR(
     VkDevice                                    device,
@@ -1486,21 +1469,17 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceExternalImageFormatPropertiesNV(
     VkExternalMemoryHandleTypeFlagsNV           externalHandleType,
     VkExternalImageFormatPropertiesNV*          pExternalImageFormatProperties);
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleNV(
     VkDevice                                    device,
     VkDeviceMemory                              memory,
     VkExternalMemoryHandleTypeFlagsNV           handleType,
     HANDLE*                                     pHandle);
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
-#ifdef VK_USE_PLATFORM_VI_NN
 VKAPI_ATTR VkResult VKAPI_CALL CreateViSurfaceNN(
     VkInstance                                  instance,
     const VkViSurfaceCreateInfoNN*              pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface);
-#endif /* VK_USE_PLATFORM_VI_NN */
 
 VKAPI_ATTR void VKAPI_CALL CmdBeginConditionalRenderingEXT(
     VkCommandBuffer                             commandBuffer,
@@ -1561,7 +1540,6 @@ VKAPI_ATTR VkResult VKAPI_CALL ReleaseDisplayEXT(
     VkPhysicalDevice                            physicalDevice,
     VkDisplayKHR                                display);
 
-#ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
 VKAPI_ATTR VkResult VKAPI_CALL AcquireXlibDisplayEXT(
     VkPhysicalDevice                            physicalDevice,
     Display*                                    dpy,
@@ -1572,7 +1550,6 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRandROutputDisplayEXT(
     Display*                                    dpy,
     RROutput                                    rrOutput,
     VkDisplayKHR*                               pDisplay);
-#endif /* VK_USE_PLATFORM_XLIB_XRANDR_EXT */
 
 VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2EXT(
     VkPhysicalDevice                            physicalDevice,
@@ -1626,21 +1603,17 @@ VKAPI_ATTR void VKAPI_CALL SetHdrMetadataEXT(
     const VkSwapchainKHR*                       pSwapchains,
     const VkHdrMetadataEXT*                     pMetadata);
 
-#ifdef VK_USE_PLATFORM_IOS_MVK
 VKAPI_ATTR VkResult VKAPI_CALL CreateIOSSurfaceMVK(
     VkInstance                                  instance,
     const VkIOSSurfaceCreateInfoMVK*            pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface);
-#endif /* VK_USE_PLATFORM_IOS_MVK */
 
-#ifdef VK_USE_PLATFORM_MACOS_MVK
 VKAPI_ATTR VkResult VKAPI_CALL CreateMacOSSurfaceMVK(
     VkInstance                                  instance,
     const VkMacOSSurfaceCreateInfoMVK*          pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface);
-#endif /* VK_USE_PLATFORM_MACOS_MVK */
 
 VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectNameEXT(
     VkDevice                                    device,
@@ -1689,7 +1662,6 @@ VKAPI_ATTR void VKAPI_CALL SubmitDebugUtilsMessageEXT(
     VkDebugUtilsMessageTypeFlagsEXT             messageTypes,
     const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData);
 
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
 VKAPI_ATTR VkResult VKAPI_CALL GetAndroidHardwareBufferPropertiesANDROID(
     VkDevice                                    device,
     const struct AHardwareBuffer*               buffer,
@@ -1699,7 +1671,6 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryAndroidHardwareBufferANDROID(
     VkDevice                                    device,
     const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo,
     struct AHardwareBuffer**                    pBuffer);
-#endif /* VK_USE_PLATFORM_ANDROID_KHR */
 
 VKAPI_ATTR void VKAPI_CALL CmdSetSampleLocationsEXT(
     VkCommandBuffer                             commandBuffer,
@@ -1893,13 +1864,11 @@ VKAPI_ATTR void VKAPI_CALL GetQueueCheckpointDataNV(
     uint32_t*                                   pCheckpointDataCount,
     VkCheckpointDataNV*                         pCheckpointData);
 
-#ifdef VK_USE_PLATFORM_FUCHSIA
 VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(
     VkInstance                                  instance,
     const VkImagePipeSurfaceCreateInfoFUCHSIA*  pCreateInfo,
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface);
-#endif /* VK_USE_PLATFORM_FUCHSIA */
 
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/generated/generated_vulkan_struct_encoders.cpp
+++ b/framework/generated/generated_vulkan_struct_encoders.cpp
@@ -1932,7 +1932,6 @@ void encode_struct(ParameterEncoder* encoder, const VkDisplayPresentInfoKHR& val
     encoder->EncodeVkBool32Value(value.persistent);
 }
 
-#ifdef VK_USE_PLATFORM_XLIB_KHR
 void encode_struct(ParameterEncoder* encoder, const VkXlibSurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -1941,9 +1940,7 @@ void encode_struct(ParameterEncoder* encoder, const VkXlibSurfaceCreateInfoKHR& 
     encoder->EncodeVoidPtr(value.dpy);
     encoder->EncodeSizeTValue(value.window);
 }
-#endif /* VK_USE_PLATFORM_XLIB_KHR */
 
-#ifdef VK_USE_PLATFORM_XCB_KHR
 void encode_struct(ParameterEncoder* encoder, const VkXcbSurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -1952,9 +1949,7 @@ void encode_struct(ParameterEncoder* encoder, const VkXcbSurfaceCreateInfoKHR& v
     encoder->EncodeVoidPtr(value.connection);
     encoder->EncodeUInt32Value(value.window);
 }
-#endif /* VK_USE_PLATFORM_XCB_KHR */
 
-#ifdef VK_USE_PLATFORM_WAYLAND_KHR
 void encode_struct(ParameterEncoder* encoder, const VkWaylandSurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -1963,9 +1958,7 @@ void encode_struct(ParameterEncoder* encoder, const VkWaylandSurfaceCreateInfoKH
     encoder->EncodeVoidPtr(value.display);
     encoder->EncodeVoidPtr(value.surface);
 }
-#endif /* VK_USE_PLATFORM_WAYLAND_KHR */
 
-#ifdef VK_USE_PLATFORM_MIR_KHR
 void encode_struct(ParameterEncoder* encoder, const VkMirSurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -1974,9 +1967,7 @@ void encode_struct(ParameterEncoder* encoder, const VkMirSurfaceCreateInfoKHR& v
     encoder->EncodeVoidPtr(value.connection);
     encoder->EncodeVoidPtr(value.mirSurface);
 }
-#endif /* VK_USE_PLATFORM_MIR_KHR */
 
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
 void encode_struct(ParameterEncoder* encoder, const VkAndroidSurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -1984,9 +1975,7 @@ void encode_struct(ParameterEncoder* encoder, const VkAndroidSurfaceCreateInfoKH
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.window);
 }
-#endif /* VK_USE_PLATFORM_ANDROID_KHR */
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 void encode_struct(ParameterEncoder* encoder, const VkWin32SurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -1995,9 +1984,7 @@ void encode_struct(ParameterEncoder* encoder, const VkWin32SurfaceCreateInfoKHR&
     encoder->EncodeVoidPtr(value.hinstance);
     encoder->EncodeVoidPtr(value.hwnd);
 }
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 void encode_struct(ParameterEncoder* encoder, const VkImportMemoryWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -2030,7 +2017,6 @@ void encode_struct(ParameterEncoder* encoder, const VkMemoryGetWin32HandleInfoKH
     encoder->EncodeHandleIdValue(value.memory);
     encoder->EncodeEnumValue(value.handleType);
 }
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 void encode_struct(ParameterEncoder* encoder, const VkImportMemoryFdInfoKHR& value)
 {
@@ -2055,7 +2041,6 @@ void encode_struct(ParameterEncoder* encoder, const VkMemoryGetFdInfoKHR& value)
     encoder->EncodeEnumValue(value.handleType);
 }
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 void encode_struct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireReleaseInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -2068,9 +2053,7 @@ void encode_struct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireRele
     encoder->EncodeHandleIdArray(value.pReleaseSyncs, value.releaseCount);
     encoder->EncodeUInt64Array(value.pReleaseKeys, value.releaseCount);
 }
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 void encode_struct(ParameterEncoder* encoder, const VkImportSemaphoreWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -2108,7 +2091,6 @@ void encode_struct(ParameterEncoder* encoder, const VkSemaphoreGetWin32HandleInf
     encoder->EncodeHandleIdValue(value.semaphore);
     encoder->EncodeEnumValue(value.handleType);
 }
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 void encode_struct(ParameterEncoder* encoder, const VkImportSemaphoreFdInfoKHR& value)
 {
@@ -2246,7 +2228,6 @@ void encode_struct(ParameterEncoder* encoder, const VkSharedPresentSurfaceCapabi
     encoder->EncodeFlagsValue(value.sharedPresentSupportedUsageFlags);
 }
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 void encode_struct(ParameterEncoder* encoder, const VkImportFenceWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -2274,7 +2255,6 @@ void encode_struct(ParameterEncoder* encoder, const VkFenceGetWin32HandleInfoKHR
     encoder->EncodeHandleIdValue(value.fence);
     encoder->EncodeEnumValue(value.handleType);
 }
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 void encode_struct(ParameterEncoder* encoder, const VkImportFenceFdInfoKHR& value)
 {
@@ -2524,7 +2504,6 @@ void encode_struct(ParameterEncoder* encoder, const VkExportMemoryAllocateInfoNV
     encoder->EncodeFlagsValue(value.handleTypes);
 }
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 void encode_struct(ParameterEncoder* encoder, const VkImportMemoryWin32HandleInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -2540,9 +2519,7 @@ void encode_struct(ParameterEncoder* encoder, const VkExportMemoryWin32HandleInf
     encode_struct_ptr(encoder, value.pAttributes);
     encoder->EncodeUInt32Value(value.dwAccess);
 }
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 void encode_struct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireReleaseInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -2555,7 +2532,6 @@ void encode_struct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireRele
     encoder->EncodeHandleIdArray(value.pReleaseSyncs, value.releaseCount);
     encoder->EncodeUInt64Array(value.pReleaseKeys, value.releaseCount);
 }
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 void encode_struct(ParameterEncoder* encoder, const VkValidationFlagsEXT& value)
 {
@@ -2565,7 +2541,6 @@ void encode_struct(ParameterEncoder* encoder, const VkValidationFlagsEXT& value)
     encoder->EncodeEnumArray(value.pDisabledValidationChecks, value.disabledValidationCheckCount);
 }
 
-#ifdef VK_USE_PLATFORM_VI_NN
 void encode_struct(ParameterEncoder* encoder, const VkViSurfaceCreateInfoNN& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -2573,7 +2548,6 @@ void encode_struct(ParameterEncoder* encoder, const VkViSurfaceCreateInfoNN& val
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.window);
 }
-#endif /* VK_USE_PLATFORM_VI_NN */
 
 void encode_struct(ParameterEncoder* encoder, const VkImageViewASTCDecodeModeEXT& value)
 {
@@ -2907,7 +2881,6 @@ void encode_struct(ParameterEncoder* encoder, const VkHdrMetadataEXT& value)
     encoder->EncodeFloatValue(value.maxFrameAverageLightLevel);
 }
 
-#ifdef VK_USE_PLATFORM_IOS_MVK
 void encode_struct(ParameterEncoder* encoder, const VkIOSSurfaceCreateInfoMVK& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -2915,9 +2888,7 @@ void encode_struct(ParameterEncoder* encoder, const VkIOSSurfaceCreateInfoMVK& v
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.pView);
 }
-#endif /* VK_USE_PLATFORM_IOS_MVK */
 
-#ifdef VK_USE_PLATFORM_MACOS_MVK
 void encode_struct(ParameterEncoder* encoder, const VkMacOSSurfaceCreateInfoMVK& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -2925,7 +2896,6 @@ void encode_struct(ParameterEncoder* encoder, const VkMacOSSurfaceCreateInfoMVK&
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.pView);
 }
-#endif /* VK_USE_PLATFORM_MACOS_MVK */
 
 void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsObjectNameInfoEXT& value)
 {
@@ -2982,7 +2952,6 @@ void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsMessengerCreateI
     encoder->EncodeVoidPtr(value.pUserData);
 }
 
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
 void encode_struct(ParameterEncoder* encoder, const VkAndroidHardwareBufferUsageANDROID& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -3032,7 +3001,6 @@ void encode_struct(ParameterEncoder* encoder, const VkExternalFormatANDROID& val
     encode_pnext_struct(encoder, value.pNext);
     encoder->EncodeUInt64Value(value.externalFormat);
 }
-#endif /* VK_USE_PLATFORM_ANDROID_KHR */
 
 void encode_struct(ParameterEncoder* encoder, const VkSamplerReductionModeCreateInfoEXT& value)
 {
@@ -3625,7 +3593,6 @@ void encode_struct(ParameterEncoder* encoder, const VkCheckpointDataNV& value)
     encoder->EncodeVoidPtr(value.pCheckpointMarker);
 }
 
-#ifdef VK_USE_PLATFORM_FUCHSIA
 void encode_struct(ParameterEncoder* encoder, const VkImagePipeSurfaceCreateInfoFUCHSIA& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -3633,7 +3600,6 @@ void encode_struct(ParameterEncoder* encoder, const VkImagePipeSurfaceCreateInfo
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.imagePipeHandle);
 }
-#endif /* VK_USE_PLATFORM_FUCHSIA */
 
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/generated_vulkan_struct_encoders.h
+++ b/framework/generated/generated_vulkan_struct_encoders.h
@@ -24,6 +24,7 @@
 #define  GFXRECON_GENERATED_VULKAN_STRUCT_ENCODERS_H
 
 #include "encode/parameter_encoder.h"
+#include "format/platform_types.h"
 #include "util/defines.h"
 
 #include "vulkan/vulkan.h"
@@ -232,51 +233,33 @@ void encode_struct(ParameterEncoder* encoder, const VkDisplaySurfaceCreateInfoKH
 
 void encode_struct(ParameterEncoder* encoder, const VkDisplayPresentInfoKHR& value);
 
-#ifdef VK_USE_PLATFORM_XLIB_KHR
 void encode_struct(ParameterEncoder* encoder, const VkXlibSurfaceCreateInfoKHR& value);
-#endif /* VK_USE_PLATFORM_XLIB_KHR */
 
-#ifdef VK_USE_PLATFORM_XCB_KHR
 void encode_struct(ParameterEncoder* encoder, const VkXcbSurfaceCreateInfoKHR& value);
-#endif /* VK_USE_PLATFORM_XCB_KHR */
 
-#ifdef VK_USE_PLATFORM_WAYLAND_KHR
 void encode_struct(ParameterEncoder* encoder, const VkWaylandSurfaceCreateInfoKHR& value);
-#endif /* VK_USE_PLATFORM_WAYLAND_KHR */
 
-#ifdef VK_USE_PLATFORM_MIR_KHR
 void encode_struct(ParameterEncoder* encoder, const VkMirSurfaceCreateInfoKHR& value);
-#endif /* VK_USE_PLATFORM_MIR_KHR */
 
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
 void encode_struct(ParameterEncoder* encoder, const VkAndroidSurfaceCreateInfoKHR& value);
-#endif /* VK_USE_PLATFORM_ANDROID_KHR */
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 void encode_struct(ParameterEncoder* encoder, const VkWin32SurfaceCreateInfoKHR& value);
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 void encode_struct(ParameterEncoder* encoder, const VkImportMemoryWin32HandleInfoKHR& value);
 void encode_struct(ParameterEncoder* encoder, const VkExportMemoryWin32HandleInfoKHR& value);
 void encode_struct(ParameterEncoder* encoder, const VkMemoryWin32HandlePropertiesKHR& value);
 void encode_struct(ParameterEncoder* encoder, const VkMemoryGetWin32HandleInfoKHR& value);
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 void encode_struct(ParameterEncoder* encoder, const VkImportMemoryFdInfoKHR& value);
 void encode_struct(ParameterEncoder* encoder, const VkMemoryFdPropertiesKHR& value);
 void encode_struct(ParameterEncoder* encoder, const VkMemoryGetFdInfoKHR& value);
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 void encode_struct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireReleaseInfoKHR& value);
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 void encode_struct(ParameterEncoder* encoder, const VkImportSemaphoreWin32HandleInfoKHR& value);
 void encode_struct(ParameterEncoder* encoder, const VkExportSemaphoreWin32HandleInfoKHR& value);
 void encode_struct(ParameterEncoder* encoder, const VkD3D12FenceSubmitInfoKHR& value);
 void encode_struct(ParameterEncoder* encoder, const VkSemaphoreGetWin32HandleInfoKHR& value);
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 void encode_struct(ParameterEncoder* encoder, const VkImportSemaphoreFdInfoKHR& value);
 void encode_struct(ParameterEncoder* encoder, const VkSemaphoreGetFdInfoKHR& value);
@@ -297,11 +280,9 @@ void encode_struct(ParameterEncoder* encoder, const VkSubpassEndInfoKHR& value);
 
 void encode_struct(ParameterEncoder* encoder, const VkSharedPresentSurfaceCapabilitiesKHR& value);
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 void encode_struct(ParameterEncoder* encoder, const VkImportFenceWin32HandleInfoKHR& value);
 void encode_struct(ParameterEncoder* encoder, const VkExportFenceWin32HandleInfoKHR& value);
 void encode_struct(ParameterEncoder* encoder, const VkFenceGetWin32HandleInfoKHR& value);
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 void encode_struct(ParameterEncoder* encoder, const VkImportFenceFdInfoKHR& value);
 void encode_struct(ParameterEncoder* encoder, const VkFenceGetFdInfoKHR& value);
@@ -351,20 +332,14 @@ void encode_struct(ParameterEncoder* encoder, const VkExternalImageFormatPropert
 void encode_struct(ParameterEncoder* encoder, const VkExternalMemoryImageCreateInfoNV& value);
 void encode_struct(ParameterEncoder* encoder, const VkExportMemoryAllocateInfoNV& value);
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 void encode_struct(ParameterEncoder* encoder, const VkImportMemoryWin32HandleInfoNV& value);
 void encode_struct(ParameterEncoder* encoder, const VkExportMemoryWin32HandleInfoNV& value);
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
-#ifdef VK_USE_PLATFORM_WIN32_KHR
 void encode_struct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireReleaseInfoNV& value);
-#endif /* VK_USE_PLATFORM_WIN32_KHR */
 
 void encode_struct(ParameterEncoder* encoder, const VkValidationFlagsEXT& value);
 
-#ifdef VK_USE_PLATFORM_VI_NN
 void encode_struct(ParameterEncoder* encoder, const VkViSurfaceCreateInfoNN& value);
-#endif /* VK_USE_PLATFORM_VI_NN */
 
 void encode_struct(ParameterEncoder* encoder, const VkImageViewASTCDecodeModeEXT& value);
 void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceASTCDecodeFeaturesEXT& value);
@@ -416,13 +391,9 @@ void encode_struct(ParameterEncoder* encoder, const VkPipelineRasterizationConse
 void encode_struct(ParameterEncoder* encoder, const VkXYColorEXT& value);
 void encode_struct(ParameterEncoder* encoder, const VkHdrMetadataEXT& value);
 
-#ifdef VK_USE_PLATFORM_IOS_MVK
 void encode_struct(ParameterEncoder* encoder, const VkIOSSurfaceCreateInfoMVK& value);
-#endif /* VK_USE_PLATFORM_IOS_MVK */
 
-#ifdef VK_USE_PLATFORM_MACOS_MVK
 void encode_struct(ParameterEncoder* encoder, const VkMacOSSurfaceCreateInfoMVK& value);
-#endif /* VK_USE_PLATFORM_MACOS_MVK */
 
 void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsObjectNameInfoEXT& value);
 void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsObjectTagInfoEXT& value);
@@ -430,14 +401,12 @@ void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsLabelEXT& value)
 void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsMessengerCallbackDataEXT& value);
 void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsMessengerCreateInfoEXT& value);
 
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
 void encode_struct(ParameterEncoder* encoder, const VkAndroidHardwareBufferUsageANDROID& value);
 void encode_struct(ParameterEncoder* encoder, const VkAndroidHardwareBufferPropertiesANDROID& value);
 void encode_struct(ParameterEncoder* encoder, const VkAndroidHardwareBufferFormatPropertiesANDROID& value);
 void encode_struct(ParameterEncoder* encoder, const VkImportAndroidHardwareBufferInfoANDROID& value);
 void encode_struct(ParameterEncoder* encoder, const VkMemoryGetAndroidHardwareBufferInfoANDROID& value);
 void encode_struct(ParameterEncoder* encoder, const VkExternalFormatANDROID& value);
-#endif /* VK_USE_PLATFORM_ANDROID_KHR */
 
 void encode_struct(ParameterEncoder* encoder, const VkSamplerReductionModeCreateInfoEXT& value);
 void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT& value);
@@ -524,9 +493,7 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceExclusiveSci
 void encode_struct(ParameterEncoder* encoder, const VkQueueFamilyCheckpointPropertiesNV& value);
 void encode_struct(ParameterEncoder* encoder, const VkCheckpointDataNV& value);
 
-#ifdef VK_USE_PLATFORM_FUCHSIA
 void encode_struct(ParameterEncoder* encoder, const VkImagePipeSurfaceCreateInfoFUCHSIA& value);
-#endif /* VK_USE_PLATFORM_FUCHSIA */
 
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/vulkan_generators/gencode.py
+++ b/framework/generated/vulkan_generators/gencode.py
@@ -266,7 +266,7 @@ def makeGenOpts(args):
             platformTypes     = platformTypes,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFile       = True,
-            protectFeature    = True)
+            protectFeature    = False)
         ]
 
     genOpts['generated_vulkan_api_call_encoders.cpp'] = [
@@ -278,7 +278,7 @@ def makeGenOpts(args):
             platformTypes     = platformTypes,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFile       = False,
-            protectFeature    = True)
+            protectFeature    = False)
         ]
 
     genOpts['generated_layer_func_table.h'] = [
@@ -288,7 +288,7 @@ def makeGenOpts(args):
             directory         = directory,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFile       = True,
-            protectFeature    = True)
+            protectFeature    = False)
         ]
 
     #
@@ -302,7 +302,7 @@ def makeGenOpts(args):
             platformTypes     = platformTypes,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFile       = False,
-            protectFeature    = True)
+            protectFeature    = False)
         ]
 
     genOpts['generated_vulkan_struct_encoders.h'] = [
@@ -314,7 +314,7 @@ def makeGenOpts(args):
             platformTypes     = platformTypes,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFile       = True,
-            protectFeature    = True)
+            protectFeature    = False)
         ]
 
     genOpts['generated_encode_pnext_struct.cpp'] = [
@@ -324,7 +324,7 @@ def makeGenOpts(args):
             directory         = directory,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFile       = False,
-            protectFeature    = True)
+            protectFeature    = False)
         ]
 
 # Generate a target based on the options in the matching genOpts{} object.

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_header_generator.py
@@ -48,6 +48,7 @@ class VulkanApiCallEncodersHeaderGenerator(BaseGenerator):
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
 
+        write('#include "format/platform_types.h"', file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
         write('#include "vulkan/vulkan.h"', file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_struct_encoders_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_encoders_header_generator.py
@@ -49,6 +49,7 @@ class VulkanStructEncodersHeaderGenerator(BaseGenerator):
         BaseGenerator.beginFile(self, genOpts)
 
         write('#include "encode/parameter_encoder.h"', file=self.outFile)
+        write('#include "format/platform_types.h"', file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
         write('#include "vulkan/vulkan.h"', file=self.outFile)

--- a/layer/trace_layer.h
+++ b/layer/trace_layer.h
@@ -20,6 +20,7 @@
 
 #include "encode/parameter_encoder.h"
 #include "encode/trace_manager.h"
+#include "format/platform_types.h"
 #include "util/defines.h"
 
 #include "vulkan/vulkan.h"

--- a/layer/vk_layer_dispatch_table.h
+++ b/layer/vk_layer_dispatch_table.h
@@ -83,49 +83,27 @@ typedef struct VkLayerInstanceDispatchTable_ {
     PFN_vkCreateDisplayPlaneSurfaceKHR CreateDisplayPlaneSurfaceKHR;
 
     // ---- VK_KHR_xlib_surface extension commands
-#ifdef VK_USE_PLATFORM_XLIB_KHR
     PFN_vkCreateXlibSurfaceKHR CreateXlibSurfaceKHR;
-#endif // VK_USE_PLATFORM_XLIB_KHR
-#ifdef VK_USE_PLATFORM_XLIB_KHR
     PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR GetPhysicalDeviceXlibPresentationSupportKHR;
-#endif // VK_USE_PLATFORM_XLIB_KHR
 
     // ---- VK_KHR_xcb_surface extension commands
-#ifdef VK_USE_PLATFORM_XCB_KHR
     PFN_vkCreateXcbSurfaceKHR CreateXcbSurfaceKHR;
-#endif // VK_USE_PLATFORM_XCB_KHR
-#ifdef VK_USE_PLATFORM_XCB_KHR
     PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR GetPhysicalDeviceXcbPresentationSupportKHR;
-#endif // VK_USE_PLATFORM_XCB_KHR
 
     // ---- VK_KHR_wayland_surface extension commands
-#ifdef VK_USE_PLATFORM_WAYLAND_KHR
     PFN_vkCreateWaylandSurfaceKHR CreateWaylandSurfaceKHR;
-#endif // VK_USE_PLATFORM_WAYLAND_KHR
-#ifdef VK_USE_PLATFORM_WAYLAND_KHR
     PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR GetPhysicalDeviceWaylandPresentationSupportKHR;
-#endif // VK_USE_PLATFORM_WAYLAND_KHR
 
     // ---- VK_KHR_mir_surface extension commands
-#ifdef VK_USE_PLATFORM_MIR_KHR
     PFN_vkCreateMirSurfaceKHR CreateMirSurfaceKHR;
-#endif // VK_USE_PLATFORM_MIR_KHR
-#ifdef VK_USE_PLATFORM_MIR_KHR
     PFN_vkGetPhysicalDeviceMirPresentationSupportKHR GetPhysicalDeviceMirPresentationSupportKHR;
-#endif // VK_USE_PLATFORM_MIR_KHR
 
     // ---- VK_KHR_android_surface extension commands
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
     PFN_vkCreateAndroidSurfaceKHR CreateAndroidSurfaceKHR;
-#endif // VK_USE_PLATFORM_ANDROID_KHR
 
     // ---- VK_KHR_win32_surface extension commands
-#ifdef VK_USE_PLATFORM_WIN32_KHR
     PFN_vkCreateWin32SurfaceKHR CreateWin32SurfaceKHR;
-#endif // VK_USE_PLATFORM_WIN32_KHR
-#ifdef VK_USE_PLATFORM_WIN32_KHR
     PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR GetPhysicalDeviceWin32PresentationSupportKHR;
-#endif // VK_USE_PLATFORM_WIN32_KHR
 
     // ---- VK_KHR_get_physical_device_properties2 extension commands
     PFN_vkGetPhysicalDeviceFeatures2KHR GetPhysicalDeviceFeatures2KHR;
@@ -167,9 +145,7 @@ typedef struct VkLayerInstanceDispatchTable_ {
     PFN_vkGetPhysicalDeviceExternalImageFormatPropertiesNV GetPhysicalDeviceExternalImageFormatPropertiesNV;
 
     // ---- VK_NN_vi_surface extension commands
-#ifdef VK_USE_PLATFORM_VI_NN
     PFN_vkCreateViSurfaceNN CreateViSurfaceNN;
-#endif // VK_USE_PLATFORM_VI_NN
 
     // ---- VK_NVX_device_generated_commands extension commands
     PFN_vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX GetPhysicalDeviceGeneratedCommandsPropertiesNVX;
@@ -178,25 +154,17 @@ typedef struct VkLayerInstanceDispatchTable_ {
     PFN_vkReleaseDisplayEXT ReleaseDisplayEXT;
 
     // ---- VK_EXT_acquire_xlib_display extension commands
-#ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
     PFN_vkAcquireXlibDisplayEXT AcquireXlibDisplayEXT;
-#endif // VK_USE_PLATFORM_XLIB_XRANDR_EXT
-#ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
     PFN_vkGetRandROutputDisplayEXT GetRandROutputDisplayEXT;
-#endif // VK_USE_PLATFORM_XLIB_XRANDR_EXT
 
     // ---- VK_EXT_display_surface_counter extension commands
     PFN_vkGetPhysicalDeviceSurfaceCapabilities2EXT GetPhysicalDeviceSurfaceCapabilities2EXT;
 
     // ---- VK_MVK_ios_surface extension commands
-#ifdef VK_USE_PLATFORM_IOS_MVK
     PFN_vkCreateIOSSurfaceMVK CreateIOSSurfaceMVK;
-#endif // VK_USE_PLATFORM_IOS_MVK
 
     // ---- VK_MVK_macos_surface extension commands
-#ifdef VK_USE_PLATFORM_MACOS_MVK
     PFN_vkCreateMacOSSurfaceMVK CreateMacOSSurfaceMVK;
-#endif // VK_USE_PLATFORM_MACOS_MVK
 
     // ---- VK_EXT_debug_utils extension commands
     PFN_vkCreateDebugUtilsMessengerEXT CreateDebugUtilsMessengerEXT;
@@ -207,9 +175,7 @@ typedef struct VkLayerInstanceDispatchTable_ {
     PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT GetPhysicalDeviceMultisamplePropertiesEXT;
 
     // ---- VK_FUCHSIA_imagepipe_surface extension commands
-#ifdef VK_USE_PLATFORM_FUCHSIA
     PFN_vkCreateImagePipeSurfaceFUCHSIA CreateImagePipeSurfaceFUCHSIA;
-#endif // VK_USE_PLATFORM_FUCHSIA
 } VkLayerInstanceDispatchTable;
 
 // Device function pointer dispatch table
@@ -378,24 +344,16 @@ typedef struct VkLayerDispatchTable_ {
     PFN_vkTrimCommandPoolKHR TrimCommandPoolKHR;
 
     // ---- VK_KHR_external_memory_win32 extension commands
-#ifdef VK_USE_PLATFORM_WIN32_KHR
     PFN_vkGetMemoryWin32HandleKHR GetMemoryWin32HandleKHR;
-#endif // VK_USE_PLATFORM_WIN32_KHR
-#ifdef VK_USE_PLATFORM_WIN32_KHR
     PFN_vkGetMemoryWin32HandlePropertiesKHR GetMemoryWin32HandlePropertiesKHR;
-#endif // VK_USE_PLATFORM_WIN32_KHR
 
     // ---- VK_KHR_external_memory_fd extension commands
     PFN_vkGetMemoryFdKHR GetMemoryFdKHR;
     PFN_vkGetMemoryFdPropertiesKHR GetMemoryFdPropertiesKHR;
 
     // ---- VK_KHR_external_semaphore_win32 extension commands
-#ifdef VK_USE_PLATFORM_WIN32_KHR
     PFN_vkImportSemaphoreWin32HandleKHR ImportSemaphoreWin32HandleKHR;
-#endif // VK_USE_PLATFORM_WIN32_KHR
-#ifdef VK_USE_PLATFORM_WIN32_KHR
     PFN_vkGetSemaphoreWin32HandleKHR GetSemaphoreWin32HandleKHR;
-#endif // VK_USE_PLATFORM_WIN32_KHR
 
     // ---- VK_KHR_external_semaphore_fd extension commands
     PFN_vkImportSemaphoreFdKHR ImportSemaphoreFdKHR;
@@ -420,12 +378,8 @@ typedef struct VkLayerDispatchTable_ {
     PFN_vkGetSwapchainStatusKHR GetSwapchainStatusKHR;
 
     // ---- VK_KHR_external_fence_win32 extension commands
-#ifdef VK_USE_PLATFORM_WIN32_KHR
     PFN_vkImportFenceWin32HandleKHR ImportFenceWin32HandleKHR;
-#endif // VK_USE_PLATFORM_WIN32_KHR
-#ifdef VK_USE_PLATFORM_WIN32_KHR
     PFN_vkGetFenceWin32HandleKHR GetFenceWin32HandleKHR;
-#endif // VK_USE_PLATFORM_WIN32_KHR
 
     // ---- VK_KHR_external_fence_fd extension commands
     PFN_vkImportFenceFdKHR ImportFenceFdKHR;
@@ -466,9 +420,7 @@ typedef struct VkLayerDispatchTable_ {
     PFN_vkGetShaderInfoAMD GetShaderInfoAMD;
 
     // ---- VK_NV_external_memory_win32 extension commands
-#ifdef VK_USE_PLATFORM_WIN32_KHR
     PFN_vkGetMemoryWin32HandleNV GetMemoryWin32HandleNV;
-#endif // VK_USE_PLATFORM_WIN32_KHR
 
     // ---- VK_EXT_conditional_rendering extension commands
     PFN_vkCmdBeginConditionalRenderingEXT CmdBeginConditionalRenderingEXT;
@@ -514,12 +466,8 @@ typedef struct VkLayerDispatchTable_ {
     PFN_vkCmdInsertDebugUtilsLabelEXT CmdInsertDebugUtilsLabelEXT;
 
     // ---- VK_ANDROID_external_memory_android_hardware_buffer extension commands
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
     PFN_vkGetAndroidHardwareBufferPropertiesANDROID GetAndroidHardwareBufferPropertiesANDROID;
-#endif // VK_USE_PLATFORM_ANDROID_KHR
-#ifdef VK_USE_PLATFORM_ANDROID_KHR
     PFN_vkGetMemoryAndroidHardwareBufferANDROID GetMemoryAndroidHardwareBufferANDROID;
-#endif // VK_USE_PLATFORM_ANDROID_KHR
 
     // ---- VK_EXT_sample_locations extension commands
     PFN_vkCmdSetSampleLocationsEXT CmdSetSampleLocationsEXT;


### PR DESCRIPTION
Remove the VK_USE_PLATFORM_XXX feature protection macros from the layer
functions.  The layer does not depend on the platform functions being
available, only the platform specific type definitions, which
platform_types.h will define when missing from the current platform.