### PR TITLE
Update Argument Parser

### DIFF
--- a/framework/util/argument_parser.h
+++ b/framework/util/argument_parser.h
@@ -15,8 +15,8 @@
 ** limitations under the License.
 */
 
-#ifndef GFXRECON_ARGUMENT_PARSER_H
-#define GFXRECON_ARGUMENT_PARSER_H
+#ifndef GFXRECON_UTIL_ARGUMENT_PARSER_H
+#define GFXRECON_UTIL_ARGUMENT_PARSER_H
 
 #include "util/defines.h"
 
@@ -39,26 +39,26 @@ class ArgumentParser
                    const char** const argv,
                    const std::string& options,
                    const std::string& arguments,
-                   const int32_t      expected_non_opt_args);
+                   const int32_t      min_positional_args);
     ArgumentParser(bool               first_is_exe_name,
                    const char*        args,
                    const std::string& options,
                    const std::string& arguments,
-                   const int32_t      expected_non_opt_args);
+                   const int32_t      min_positional_args);
     ~ArgumentParser() {}
 
     bool                            IsInvalid() { return is_invalid_; }
     const std::vector<std::string>& GetInvalidArgumentOrOptions() { return invalid_values_present_; };
     bool                            IsOptionSet(const std::string& option);
     const std::string&              GetArgumentValue(const std::string& argument);
-    size_t                          GetNonOptionArgumentsCount() { return non_option_arguments_present_.size(); }
-    const std::vector<std::string>& GetNonOptionalArguments() { return non_option_arguments_present_; }
+    size_t                          GetPositionalArgumentsCount() { return positional_arguments_present_.size(); }
+    const std::vector<std::string>& GetPositionalArguments() { return positional_arguments_present_; }
 
   private:
     void Init(std::vector<std::string> command_line_args,
               const std::string&       options,
               const std::string&       arguments,
-              const int32_t            expected_non_opt_args);
+              const int32_t            min_positional_args);
 
     bool                     is_invalid_;
     std::vector<std::string> invalid_values_present_;
@@ -72,10 +72,10 @@ class ArgumentParser
     std::vector<bool>                         options_present_;
     std::unordered_map<std::string, uint32_t> arguments_indices_;
     std::vector<std::string>                  argument_values_;
-    std::vector<std::string>                  non_option_arguments_present_;
+    std::vector<std::string>                  positional_arguments_present_;
 };
 
 GFXRECON_END_NAMESPACE(util)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
-#endif // GFXRECON_ARGUMENT_PARSER_H
+#endif // GFXRECON_UTIL_ARGUMENT_PARSER_H

--- a/tools/compress/main.cpp
+++ b/tools/compress/main.cpp
@@ -53,25 +53,25 @@ int main(int argc, const char** argv)
     gfxrecon::format::CompressionType compression_type       = gfxrecon::format::kNone;
     std::string                       dst_compression_string = "NONE";
     bool                              print_usage            = false;
-    std::string                       input_file_name        = "gfxrecon_out";
-    std::string                       output_file_name       = "compress_out";
+    std::string                       input_filename;
+    std::string                       output_filename;
 
-    input_file_name += GFXRECON_FILE_EXTENSION;
-    output_file_name += GFXRECON_FILE_EXTENSION;
-
-    gfxrecon::util::Log::Init();
+    gfxrecon::util::Log::Init(gfxrecon::util::Log::kInfoSeverity);
 
     gfxrecon::util::ArgumentParser arg_parser(argc, argv, "", "", 3);
-    const std::vector<std::string> non_optional_arguments = arg_parser.GetNonOptionalArguments();
-    if (arg_parser.IsInvalid() || non_optional_arguments.size() != 3)
+
+    if (arg_parser.IsInvalid() || (arg_parser.GetPositionalArgumentsCount() != 3))
     {
         print_usage = true;
     }
     else
     {
-        input_file_name        = non_optional_arguments[0];
-        output_file_name       = non_optional_arguments[1];
-        dst_compression_string = non_optional_arguments[2];
+        const std::vector<std::string>& positional_arguments = arg_parser.GetPositionalArguments();
+
+        input_filename         = positional_arguments[0];
+        output_filename        = positional_arguments[1];
+        dst_compression_string = positional_arguments[2];
+
         if (dst_compression_string != "NONE")
         {
             if (dst_compression_string == "LZ4")
@@ -84,7 +84,7 @@ int main(int argc, const char** argv)
             }
             else
             {
-                GFXRECON_LOG_ERROR("Unsupported compression format \'%s\'", non_optional_arguments[2].c_str());
+                GFXRECON_LOG_ERROR("Unsupported compression format \'%s\'", positional_arguments[2].c_str());
                 print_usage = true;
             }
         }
@@ -93,14 +93,16 @@ int main(int argc, const char** argv)
     if (print_usage)
     {
         PrintUsage(argv[0]);
+        gfxrecon::util::Log::Release();
         exit(-1);
     }
-    if (file_processor.Initialize(input_file_name))
+
+    if (file_processor.Initialize(input_filename))
     {
         gfxrecon::decode::CompressionConverter decoder;
 
         if (decoder.Initialize(
-                output_file_name, file_processor.GetFileHeader(), file_processor.GetFileOptions(), compression_type))
+                output_filename, file_processor.GetFileHeader(), file_processor.GetFileOptions(), compression_type))
         {
             std::string src_compression = "NONE";
             file_processor.AddDecoder(&decoder);

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -50,24 +50,23 @@ void android_main(struct android_app* app)
     gfxrecon::util::Log::Init(gfxrecon::util::Log::kInfoSeverity);
 
     std::string                    args = GetIntentExtra(app, kArgsExtentKey);
-    gfxrecon::util::ArgumentParser arg_parser(false, args.c_str(), "", "", 1);
-    const std::vector<std::string> non_optional_arguments = arg_parser.GetNonOptionalArguments();
+    gfxrecon::util::ArgumentParser arg_parser(false, args.c_str(), "", "", 0);
 
     app->onAppCmd     = ProcessAppCmd;
     app->onInputEvent = ProcessInputEvent;
 
-    if (arg_parser.IsInvalid())
+    if (arg_parser.IsInvalid() || (arg_parser.GetPositionalArgumentsCount() > 1))
     {
         PrintUsage(kApplicationName);
     }
     else
     {
-        // std::string filename = non_optional_arguments[0];
         std::string filename = kDefaultCaptureFile;
 
-        if (non_optional_arguments.size() == 1)
+        if (arg_parser.GetPositionalArgumentsCount() == 1)
         {
-            filename = non_optional_arguments[0];
+            const std::vector<std::string>& positional_arguments = arg_parser.GetPositionalArguments();
+            filename                                             = positional_arguments[0];
         }
 
         try

--- a/tools/toascii/main.cpp
+++ b/tools/toascii/main.cpp
@@ -42,39 +42,39 @@ void PrintUsage(const char* exe_name)
 
 int main(int argc, const char** argv)
 {
+    std::string                     input_filename;
     gfxrecon::decode::FileProcessor file_processor;
     gfxrecon::util::ArgumentParser  arg_parser(argc, argv, "", "", 1);
-    std::string                     filename = "gfxrecon_test";
-    filename += GFXRECON_FILE_EXTENSION;
 
-    gfxrecon::util::Log::Init();
+    gfxrecon::util::Log::Init(gfxrecon::util::Log::kInfoSeverity);
 
-    const std::vector<std::string> non_optional_arguments = arg_parser.GetNonOptionalArguments();
-    if (arg_parser.IsInvalid() || non_optional_arguments.size() != 1)
+    if (arg_parser.IsInvalid() || (arg_parser.GetPositionalArgumentsCount() != 1))
     {
         PrintUsage(argv[0]);
+        gfxrecon::util::Log::Release();
         exit(-1);
     }
     else
     {
-        filename = non_optional_arguments[0];
+        const std::vector<std::string>& positional_arguments = arg_parser.GetPositionalArguments();
+        input_filename                                       = positional_arguments[0];
     }
 
-    std::string text_file_name = filename;
-    size_t      suffix_pos     = text_file_name.find(GFXRECON_FILE_EXTENSION);
+    std::string output_filename = input_filename;
+    size_t      suffix_pos      = output_filename.find(GFXRECON_FILE_EXTENSION);
     if (suffix_pos != std::string::npos)
     {
-        text_file_name = text_file_name.substr(0, suffix_pos);
+        output_filename = output_filename.substr(0, suffix_pos);
     }
 
-    text_file_name += ".txt";
+    output_filename += ".txt";
 
-    if (file_processor.Initialize(filename))
+    if (file_processor.Initialize(input_filename))
     {
         gfxrecon::decode::VulkanDecoder       decoder;
         gfxrecon::decode::VulkanAsciiConsumer ascii_consumer;
 
-        ascii_consumer.Initialize(text_file_name);
+        ascii_consumer.Initialize(output_filename);
         decoder.AddConsumer(&ascii_consumer);
 
         file_processor.AddDecoder(&decoder);


### PR DESCRIPTION
- Fix for uninitialized 'is_invalid_' member when argument list is empty.
- Check for a minimum number of positional arguments, instead of an
  exact number.
- Ignore argument string when it only contains the executable name.
- Update command line tools for positional argument change, plus
  additional cleanup of argument parsing related code:
    * Consistent naming for filename vs. file_name.
    * Limit scope of argument parser related variables.
    * Remove unused default filenames for values the are required to
      be specified as command line arguments.
    * Cleanup logging when exiting after printing usage when
      receiving invalid arguments.