### PR TITLE
Win32 High Resolution Monitors

### DIFF
--- a/framework/application/win32_window.cpp
+++ b/framework/application/win32_window.cpp
@@ -52,6 +52,10 @@ bool Win32Window::Create(
 {
     const char class_name[] = "GFXReconstruct Window";
 
+    // Inform Windows that we can handle monitor resolutions above 2560x1440.  Otherwise,
+    // GetWindowRect() will always clamp the desktop size to 2560x1440.
+    SetProcessDPIAware();
+
     hinstance_ = GetModuleHandle(nullptr);
     if (hinstance_ == nullptr)
     {


### PR DESCRIPTION
Support Win32 High Resolution Monitors.  By default, Windows will
stop reporting any resolution above 2560x1440 to windowed apps
unless the application tells the OS that it is High DPI aware.