### PR TITLE
Set DPI Awareness at App Init

### DIFF
--- a/framework/application/win32_application.cpp
+++ b/framework/application/win32_application.cpp
@@ -22,7 +22,13 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
-Win32Application::Win32Application(const std::string& name) : Application(name) {}
+Win32Application::Win32Application(const std::string& name, bool dpi_aware) : Application(name)
+{
+    if (dpi_aware)
+    {
+        SetProcessDPIAware();
+    }
+}
 
 bool Win32Application::Initialize(decode::FileProcessor* file_processor)
 {

--- a/framework/application/win32_application.h
+++ b/framework/application/win32_application.h
@@ -28,7 +28,7 @@ GFXRECON_BEGIN_NAMESPACE(application)
 class Win32Application : public Application
 {
   public:
-    Win32Application(const std::string& name);
+    Win32Application(const std::string& name, bool dpi_aware = true);
 
     virtual ~Win32Application() {}
 

--- a/framework/application/win32_window.cpp
+++ b/framework/application/win32_window.cpp
@@ -52,10 +52,6 @@ bool Win32Window::Create(
 {
     const char class_name[] = "GFXReconstruct Window";
 
-    // Inform Windows that we can handle monitor resolutions above 2560x1440.  Otherwise,
-    // GetWindowRect() will always clamp the desktop size to 2560x1440.
-    SetProcessDPIAware();
-
     hinstance_ = GetModuleHandle(nullptr);
     if (hinstance_ == nullptr)
     {


### PR DESCRIPTION
When initializing Win32Application, set the process DPI awareness as
system aware to prevent DPI scaling from being applied to the values
returned by GetWindowRect().

This change moves the call to SetProcessDPIAware() from window creation
to app initialization, and makes the call conditional so that it can be
disabled if the application is setting DPI awareness at a different
point.