### PR TITLE
Add FPS output to desktop replay

### DIFF
--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -27,7 +27,9 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-FileProcessor::FileProcessor() : file_descriptor_(nullptr), bytes_read_(0), compressor_(nullptr) {}
+FileProcessor::FileProcessor() :
+    file_descriptor_(nullptr), current_frame_number_(1), bytes_read_(0), compressor_(nullptr)
+{}
 
 FileProcessor::~FileProcessor()
 {
@@ -97,6 +99,8 @@ bool FileProcessor::ProcessNextFrame()
                     // Break from loop on frame delimiter.
                     if (IsFrameDelimiter(api_call_id))
                     {
+                        // Make sure to increment the frame number on the way out.
+                        ++current_frame_number_;
                         break;
                     }
                 }

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -52,6 +52,8 @@ class FileProcessor
 
     bool ProcessAllFrames();
 
+    uint32_t CurrentFrameNumber() { return current_frame_number_; }
+
     const format::FileHeader& GetFileHeader() const { return file_header_; }
 
     const std::vector<format::FileOptionPair>& GetFileOptions() const { return file_options_; }
@@ -92,6 +94,7 @@ class FileProcessor
     format::FileHeader                  file_header_;
     std::vector<format::FileOptionPair> file_options_;
     format::EnabledOptions              enabled_options_;
+    uint32_t                            current_frame_number_;
     uint64_t                            bytes_read_;
     std::vector<ApiDecoder*>            decoders_;
     std::vector<uint8_t>                parameter_buffer_;

--- a/framework/util/date_time.h
+++ b/framework/util/date_time.h
@@ -70,6 +70,18 @@ inline int64_t DiffTimestamps(int64_t start, int64_t end)
     return end - start;
 }
 
+inline double ConvertTimestampToMilliseconds(int64_t timestamp)
+{
+    // Timestamp is in nano-seconds, so convert to milliseconds
+    return static_cast<double>(timestamp) / 1000000.0;
+}
+
+inline double ConvertTimestampToSeconds(int64_t timestamp)
+{
+    // Timestamp is in nano-seconds, so convert to seconds
+    return static_cast<double>(timestamp) / 1000000000.0;
+}
+
 inline std::string GetDateTimeString(bool use_gmt)
 {
     tm          now;

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -21,6 +21,7 @@
 #include "generated/generated_vulkan_decoder.h"
 #include "generated/generated_vulkan_replay_consumer.h"
 #include "util/argument_parser.h"
+#include "util/date_time.h"
 #include "util/logging.h"
 
 #include <exception>
@@ -153,7 +154,26 @@ int main(int argc, const char** argv)
                 // Warn if the capture layer is active.
                 CheckActiveLayers();
 
+                // Grab the start frame/time information for the FPS result.
+                uint32_t start_frame = file_processor.CurrentFrameNumber();
+                int64_t  start_time  = gfxrecon::util::datetime::GetTimestamp();
+
                 application->Run();
+
+                // Grab the end frame/time information and calculate out FPS.
+                int64_t end_time      = gfxrecon::util::datetime::GetTimestamp();
+                double  diff_time_sec = gfxrecon::util::datetime::ConvertTimestampToSeconds(
+                    gfxrecon::util::datetime::DiffTimestamps(start_time, end_time));
+                uint32_t end_frame    = file_processor.CurrentFrameNumber();
+                uint32_t total_frames = end_frame - start_frame;
+                double   fps          = static_cast<double>(total_frames) / diff_time_sec;
+                GFXRECON_WRITE_CONSOLE("%f fps, %f seconds, %u frame%s, 1 loop, framerange %u-%u",
+                                       fps,
+                                       diff_time_sec,
+                                       total_frames,
+                                       total_frames > 1 ? "s" : "",
+                                       start_frame,
+                                       end_frame - 1);
             }
         }
     }


### PR DESCRIPTION
Output an FPS string on completion of a GFXReconstruct replay that
is similar to that of a VkReplay output.  This simplifies the
amount of work needed to update our other tools used to process
frame replays.