### PR TITLE
Update the settings and add Capture Flush

### DIFF
--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2019 Valve Corporation
+** Copyright (c) 2018-2019 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -27,14 +27,106 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
+// Available settings (upper and lower-case)
+// clang-format off
+#define CAPTURE_COMPRESSION_TYPE_LOWER      "capture_compression_type"
+#define CAPTURE_COMPRESSION_TYPE_UPPER      "CAPTURE_COMPRESSION_TYPE"
+#define CAPTURE_FILE_NAME_LOWER             "capture_file"
+#define CAPTURE_FILE_NAME_UPPER             "CAPTURE_FILE"
+#define CAPTURE_FILE_USE_TIMESTAMP_LOWER    "capture_file_timestamp"
+#define CAPTURE_FILE_USE_TIMESTAMP_UPPER    "CAPTURE_FILE_TIMESTAMP"
+#define CAPTURE_FILE_FORCE_FLUSH_LOWER      "capture_file_force_flush"
+#define CAPTURE_FILE_FORCE_FLUSH_UPPER      "CAPTURE_FILE_FORCE_FLUSH"
+#define LOG_ALLOW_INDENTS_LOWER             "log_allow_indents"
+#define LOG_ALLOW_INDENTS_UPPER             "LOG_ALLOW_INDENTS"
+#define LOG_BREAK_ON_ERROR_LOWER            "log_break_on_error"
+#define LOG_BREAK_ON_ERROR_UPPER            "LOG_BREAK_ON_ERROR"
+#define LOG_ERRORS_TO_STDERR_LOWER          "log_errors_to_stderr"
+#define LOG_ERRORS_TO_STDERR_UPPER          "LOG_ERRORS_TO_STDERR"
+#define LOG_DETAILED_LOWER                  "log_detailed"
+#define LOG_DETAILED_UPPER                  "LOG_DETAILED"
+#define LOG_FILE_NAME_LOWER                 "log_file"
+#define LOG_FILE_NAME_UPPER                 "LOG_FILE"
+#define LOG_FILE_CREATE_NEW_LOWER           "log_file_create_new"
+#define LOG_FILE_CREATE_NEW_UPPER           "LOG_FILE_CREATE_NEW"
+#define LOG_FILE_FLUSH_AFTER_WRITE_LOWER    "log_file_flush_after_write"
+#define LOG_FILE_FLUSH_AFTER_WRITE_UPPER    "LOG_FILE_FLUSH_AFTER_WRITE"
+#define LOG_FILE_KEEP_OPEN_LOWER            "log_file_keep_open"
+#define LOG_FILE_KEEP_OPEN_UPPER            "LOG_FILE_KEEP_OPEN"
+#define LOG_LEVEL_LOWER                     "log_level"
+#define LOG_LEVEL_UPPER                     "LOG_LEVEL"
+#define LOG_OUTPUT_TO_CONSOLE_LOWER         "log_output_to_console"
+#define LOG_OUTPUT_TO_CONSOLE_UPPER         "LOG_OUTPUT_TO_CONSOLE"
+#define LOG_OUTPUT_TO_OS_DEBUG_STRING_LOWER "log_output_to_os_debug_string"
+#define LOG_OUTPUT_TO_OS_DEBUG_STRING_UPPER "LOG_OUTPUT_TO_OS_DEBUG_STRING"
+#define MEMORY_TRACKING_MODE_LOWER          "memory_tracking_mode"
+#define MEMORY_TRACKING_MODE_UPPER          "MEMORY_TRACKING_MODE"
+// clang-format on
+
 #if defined(__ANDROID__)
-const char kDefaultCaptureFile[] = "/sdcard/gfxrecon_capture" GFXRECON_FILE_EXTENSION;
-const char kCaptureFileEnvVar[]  = "debug.gfxrecon.capture_file";
+const char CaptureSettings::kDefaultCaptureFileName[] = "/sdcard/gfxrecon_capture" GFXRECON_FILE_EXTENSION;
+
+// Android Properties
+#define GFXRECON_ENV_VAR_PREFIX "debug.gfxrecon."
+const char kCaptureCompressionTypeEnvVar[]   = GFXRECON_ENV_VAR_PREFIX CAPTURE_COMPRESSION_TYPE_LOWER;
+const char kCaptureFileForceFlushEnvVar[]    = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_FORCE_FLUSH_LOWER;
+const char kCaptureFileNameEnvVar[]          = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_NAME_LOWER;
+const char kCaptureFileUseTimestampEnvVar[]  = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_USE_TIMESTAMP_LOWER;
+const char kLogAllowIndentsEnvVar[]          = GFXRECON_ENV_VAR_PREFIX LOG_ALLOW_INDENTS_LOWER;
+const char kLogBreakOnErrorEnvVar[]          = GFXRECON_ENV_VAR_PREFIX LOG_BREAK_ON_ERROR_LOWER;
+const char kLogDetailedEnvVar[]              = GFXRECON_ENV_VAR_PREFIX LOG_DETAILED_LOWER;
+const char kLogErrorsToStderrEnvVar[]        = GFXRECON_ENV_VAR_PREFIX LOG_ERRORS_TO_STDERR_LOWER;
+const char kLogFileNameEnvVar[]              = GFXRECON_ENV_VAR_PREFIX LOG_FILE_NAME_LOWER;
+const char kLogFileCreateNewEnvVar[]         = GFXRECON_ENV_VAR_PREFIX LOG_FILE_CREATE_NEW_LOWER;
+const char kLogFileFlushAfterWriteEnvVar[]   = GFXRECON_ENV_VAR_PREFIX LOG_FILE_FLUSH_AFTER_WRITE_LOWER;
+const char kLogFileKeepFileOpenEnvVar[]      = GFXRECON_ENV_VAR_PREFIX LOG_FILE_KEEP_OPEN_LOWER;
+const char kLogLevelEnvVar[]                 = GFXRECON_ENV_VAR_PREFIX LOG_LEVEL_LOWER;
+const char kLogOutputToConsoleEnvVar[]       = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_CONSOLE_LOWER;
+const char kLogOutputToOsDebugStringEnvVar[] = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_OS_DEBUG_STRING_LOWER;
+const char kMemoryTrackingModeEnvVar[]       = GFXRECON_ENV_VAR_PREFIX MEMORY_TRACKING_MODE_LOWER;
 #else
-const char                    kDefaultCaptureFile[]   = "gfxrecon_capture" GFXRECON_FILE_EXTENSION;
-const char                    kCaptureFileEnvVar[]    = "GFXRECON_CAPTURE_FILE";
+const char CaptureSettings::kDefaultCaptureFileName[] = "gfxrecon_capture" GFXRECON_FILE_EXTENSION;
+
+// Desktop environment settings
+#define GFXRECON_ENV_VAR_PREFIX "GFXRECON_"
+const char kCaptureCompressionTypeEnvVar[]           = GFXRECON_ENV_VAR_PREFIX CAPTURE_COMPRESSION_TYPE_UPPER;
+const char kCaptureFileForceFlushEnvVar[]            = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_FORCE_FLUSH_UPPER;
+const char kCaptureFileNameEnvVar[]                  = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_NAME_UPPER;
+const char kCaptureFileUseTimestampEnvVar[]          = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_USE_TIMESTAMP_UPPER;
+const char kLogAllowIndentsEnvVar[]                  = GFXRECON_ENV_VAR_PREFIX LOG_ALLOW_INDENTS_UPPER;
+const char kLogBreakOnErrorEnvVar[]                  = GFXRECON_ENV_VAR_PREFIX LOG_BREAK_ON_ERROR_UPPER;
+const char kLogDetailedEnvVar[]                      = GFXRECON_ENV_VAR_PREFIX LOG_DETAILED_UPPER;
+const char kLogErrorsToStderrEnvVar[]                = GFXRECON_ENV_VAR_PREFIX LOG_ERRORS_TO_STDERR_UPPER;
+const char kLogFileNameEnvVar[]                      = GFXRECON_ENV_VAR_PREFIX LOG_FILE_NAME_UPPER;
+const char kLogFileCreateNewEnvVar[]                 = GFXRECON_ENV_VAR_PREFIX LOG_FILE_CREATE_NEW_UPPER;
+const char kLogFileFlushAfterWriteEnvVar[]           = GFXRECON_ENV_VAR_PREFIX LOG_FILE_FLUSH_AFTER_WRITE_UPPER;
+const char kLogFileKeepFileOpenEnvVar[]              = GFXRECON_ENV_VAR_PREFIX LOG_FILE_KEEP_OPEN_UPPER;
+const char kLogLevelEnvVar[]                         = GFXRECON_ENV_VAR_PREFIX LOG_LEVEL_UPPER;
+const char kLogOutputToConsoleEnvVar[]               = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_CONSOLE_UPPER;
+const char kLogOutputToOsDebugStringEnvVar[]         = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_OS_DEBUG_STRING_UPPER;
+const char kMemoryTrackingModeEnvVar[]               = GFXRECON_ENV_VAR_PREFIX MEMORY_TRACKING_MODE_UPPER;
 #endif
+
+// Capture options for settings file.
+// clang-format off
 const char kSettingsFilter[] = "lunarg_gfxrecon.";
+const std::string kOptionKeyCaptureCompressionType   = std::string(kSettingsFilter) + std::string(CAPTURE_COMPRESSION_TYPE_LOWER);
+const std::string kOptionKeyCaptureFile              = std::string(kSettingsFilter) + std::string(CAPTURE_FILE_NAME_LOWER);
+const std::string kOptionKeyCaptureFileForceFlush    = std::string(kSettingsFilter) + std::string(CAPTURE_FILE_FORCE_FLUSH_LOWER);
+const std::string kOptionKeyCaptureFileUseTimestamp  = std::string(kSettingsFilter) + std::string(CAPTURE_FILE_USE_TIMESTAMP_LOWER);
+const std::string kOptionKeyLogAllowIndents          = std::string(kSettingsFilter) + std::string(LOG_ALLOW_INDENTS_LOWER);
+const std::string kOptionKeyLogBreakOnError          = std::string(kSettingsFilter) + std::string(LOG_BREAK_ON_ERROR_LOWER);
+const std::string kOptionKeyLogDetailed              = std::string(kSettingsFilter) + std::string(LOG_DETAILED_LOWER);
+const std::string kOptionKeyLogErrorsToStderr        = std::string(kSettingsFilter) + std::string(LOG_ERRORS_TO_STDERR_LOWER);
+const std::string kOptionKeyLogFile                  = std::string(kSettingsFilter) + std::string(LOG_FILE_NAME_LOWER);
+const std::string kOptionKeyLogFileCreateNew         = std::string(kSettingsFilter) + std::string(LOG_FILE_CREATE_NEW_LOWER);
+const std::string kOptionKeyLogFileFlushAfterWrite   = std::string(kSettingsFilter) + std::string(LOG_FILE_FLUSH_AFTER_WRITE_LOWER);
+const std::string kOptionKeyLogFileKeepOpen          = std::string(kSettingsFilter) + std::string(LOG_FILE_KEEP_OPEN_LOWER);
+const std::string kOptionKeyLogLevel                 = std::string(kSettingsFilter) + std::string(LOG_LEVEL_LOWER);
+const std::string kOptionKeyLogOutputToConsole       = std::string(kSettingsFilter) + std::string(LOG_OUTPUT_TO_CONSOLE_LOWER);
+const std::string kOptionKeyLogOutputToOsDebugString = std::string(kSettingsFilter) + std::string(LOG_OUTPUT_TO_OS_DEBUG_STRING_LOWER);
+const std::string kOptionKeyMemoryTrackingMode       = std::string(kSettingsFilter) + std::string(MEMORY_TRACKING_MODE_LOWER);
+// clang-format on
 
 #if defined(ENABLE_LZ4_COMPRESSION)
 const format::CompressionType kDefaultCompressionType = format::CompressionType::kLz4;
@@ -42,19 +134,7 @@ const format::CompressionType kDefaultCompressionType = format::CompressionType:
 const format::CompressionType kDefaultCompressionType = format::CompressionType::kNone;
 #endif
 
-// Capture option names for settings file.
-const std::string kOptionKeyCaptureFile        = std::string(kSettingsFilter) + "capture_file";
-const std::string kOptionKeyTimestampFile      = std::string(kSettingsFilter) + "timestamp_file";
-const std::string kOptionKeyMemoryTrackingMode = std::string(kSettingsFilter) + "memory_tracking_mode";
-const std::string kOptionKeyCompressionType    = std::string(kSettingsFilter) + "compression_type";
-
-// Logging options from settings file.
-const std::string kOptionLogLevel = std::string(kSettingsFilter) + "log_level";
-const std::string kOptionLogFile  = std::string(kSettingsFilter) + "log_file";
-
-CaptureSettings::CaptureSettings() :
-    capture_file_(kDefaultCaptureFile), timestamped_filename_(true), memory_tracking_mode_(kPageGuard)
-{}
+CaptureSettings::CaptureSettings() {}
 
 CaptureSettings::~CaptureSettings() {}
 
@@ -66,7 +146,32 @@ void CaptureSettings::LoadSettings(CaptureSettings* settings)
 
         LoadOptionsFile(&capture_settings);
         LoadOptionsEnvVar(&capture_settings);
-        ProcessOptions(capture_settings, settings);
+        ProcessOptions(&capture_settings, settings);
+
+        // Valid options are removed as they are read from the OptionsMap.  Therefore, if anything
+        // is remaining in it after we're done, it's an invalid setting.
+        if (!capture_settings.empty())
+        {
+            for (auto iter = capture_settings.begin(); iter != capture_settings.end(); ++iter)
+            {
+                GFXRECON_LOG_WARNING("Settings Loader: Ignoring unrecognized option \"%s\" with value \"%s\"",
+                                     iter->first.c_str(),
+                                     iter->second.c_str());
+            }
+        }
+    }
+}
+
+void CaptureSettings::LoadSingleOptionEnvVar(OptionsMap*        options,
+                                             const std::string& environment_variable,
+                                             const std::string& option_key)
+{
+    std::string value = util::platform::GetEnv(environment_variable.c_str());
+    if (!value.empty())
+    {
+        GFXRECON_LOG_INFO(
+            "Settings Loader: Found option \"%s\" with value \"%s\"", environment_variable.c_str(), value.c_str());
+        (*options)[option_key] = value;
     }
 }
 
@@ -74,11 +179,25 @@ void CaptureSettings::LoadOptionsEnvVar(OptionsMap* options)
 {
     assert(options != nullptr);
 
-    std::string env_variable = util::platform::GetEnv(kCaptureFileEnvVar);
-    if (!env_variable.empty())
-    {
-        (*options)[kOptionKeyCaptureFile] = env_variable;
-    }
+    // Capture file environment variables
+    LoadSingleOptionEnvVar(options, kCaptureFileNameEnvVar, kOptionKeyCaptureFile);
+    LoadSingleOptionEnvVar(options, kCaptureFileUseTimestampEnvVar, kOptionKeyCaptureFileUseTimestamp);
+    LoadSingleOptionEnvVar(options, kCaptureCompressionTypeEnvVar, kOptionKeyCaptureCompressionType);
+    LoadSingleOptionEnvVar(options, kCaptureFileForceFlushEnvVar, kOptionKeyCaptureFileForceFlush);
+    // Logging environment variables
+    LoadSingleOptionEnvVar(options, kLogAllowIndentsEnvVar, kOptionKeyLogAllowIndents);
+    LoadSingleOptionEnvVar(options, kLogBreakOnErrorEnvVar, kOptionKeyLogBreakOnError);
+    LoadSingleOptionEnvVar(options, kLogDetailedEnvVar, kOptionKeyLogDetailed);
+    LoadSingleOptionEnvVar(options, kLogErrorsToStderrEnvVar, kOptionKeyLogErrorsToStderr);
+    LoadSingleOptionEnvVar(options, kLogFileNameEnvVar, kOptionKeyLogFile);
+    LoadSingleOptionEnvVar(options, kLogFileCreateNewEnvVar, kOptionKeyLogFileCreateNew);
+    LoadSingleOptionEnvVar(options, kLogFileFlushAfterWriteEnvVar, kOptionKeyLogFileFlushAfterWrite);
+    LoadSingleOptionEnvVar(options, kLogFileKeepFileOpenEnvVar, kOptionKeyLogFileKeepOpen);
+    LoadSingleOptionEnvVar(options, kLogLevelEnvVar, kOptionKeyLogLevel);
+    LoadSingleOptionEnvVar(options, kLogOutputToConsoleEnvVar, kOptionKeyLogOutputToConsole);
+    LoadSingleOptionEnvVar(options, kLogOutputToOsDebugStringEnvVar, kOptionKeyLogOutputToOsDebugString);
+    // Memory environment variables
+    LoadSingleOptionEnvVar(options, kMemoryTrackingModeEnvVar, kOptionKeyMemoryTrackingMode);
 }
 
 void CaptureSettings::LoadOptionsFile(OptionsMap* options)
@@ -104,33 +223,60 @@ void CaptureSettings::LoadOptionsFile(OptionsMap* options)
     }
 }
 
-void CaptureSettings::ProcessOptions(const OptionsMap& options, CaptureSettings* settings)
+void CaptureSettings::ProcessOptions(OptionsMap* options, CaptureSettings* settings)
 {
     assert(settings != nullptr);
 
-    settings->capture_file_ = FindOption(options, kOptionKeyCaptureFile, settings->capture_file_);
-    settings->timestamped_filename_ =
-        ParseBoolString(FindOption(options, kOptionKeyTimestampFile), settings->timestamped_filename_);
-    settings->memory_tracking_mode_ = ParseMemoryTrackingModeString(FindOption(options, kOptionKeyMemoryTrackingMode),
-                                                                    settings->memory_tracking_mode_);
-
-    settings->capture_file_options_.compression_type =
-        ParseCompressionTypeString(FindOption(options, kOptionKeyCompressionType), kDefaultCompressionType);
-
+    // Capture file options
+    settings->trace_settings_.capture_file_options.compression_type =
+        ParseCompressionTypeString(FindOption(options, kOptionKeyCaptureCompressionType), kDefaultCompressionType);
+    settings->trace_settings_.capture_file =
+        FindOption(options, kOptionKeyCaptureFile, settings->trace_settings_.capture_file);
+    settings->trace_settings_.time_stamp_file = ParseBoolString(FindOption(options, kOptionKeyCaptureFileUseTimestamp),
+                                                                settings->trace_settings_.time_stamp_file);
+    settings->trace_settings_.force_flush =
+        ParseBoolString(FindOption(options, kOptionKeyCaptureFileForceFlush), settings->trace_settings_.force_flush);
+    settings->trace_settings_.memory_tracking_mode = ParseMemoryTrackingModeString(
+        FindOption(options, kOptionKeyMemoryTrackingMode), settings->trace_settings_.memory_tracking_mode);
+    // Log options
+    settings->log_settings_.use_indent =
+        ParseBoolString(FindOption(options, kOptionKeyLogAllowIndents), settings->log_settings_.use_indent);
+    settings->log_settings_.break_on_error =
+        ParseBoolString(FindOption(options, kOptionKeyLogBreakOnError), settings->log_settings_.break_on_error);
+    settings->log_settings_.output_detailed_log_info =
+        ParseBoolString(FindOption(options, kOptionKeyLogDetailed), settings->log_settings_.output_detailed_log_info);
+    settings->log_settings_.file_name = FindOption(options, kOptionKeyLogFile, settings->log_settings_.file_name);
+    settings->log_settings_.create_new =
+        ParseBoolString(FindOption(options, kOptionKeyLogFileCreateNew), settings->log_settings_.create_new);
+    settings->log_settings_.flush_after_write = ParseBoolString(FindOption(options, kOptionKeyLogFileFlushAfterWrite),
+                                                                settings->log_settings_.flush_after_write);
+    settings->log_settings_.leave_file_open =
+        ParseBoolString(FindOption(options, kOptionKeyLogFileKeepOpen), settings->log_settings_.leave_file_open);
+    settings->log_settings_.output_errors_to_stderr = ParseBoolString(FindOption(options, kOptionKeyLogErrorsToStderr),
+                                                                      settings->log_settings_.output_errors_to_stderr);
+    settings->log_settings_.write_to_console =
+        ParseBoolString(FindOption(options, kOptionKeyLogOutputToConsole), settings->log_settings_.write_to_console);
+    settings->log_settings_.output_to_os_debug_string = ParseBoolString(
+        FindOption(options, kOptionKeyLogOutputToOsDebugString), settings->log_settings_.output_to_os_debug_string);
     settings->log_settings_.min_severity =
-        ParseLogLevelString(FindOption(options, kOptionLogLevel), settings->log_settings_.min_severity);
-    settings->log_settings_.file_name = FindOption(options, kOptionLogFile, settings->log_settings_.file_name);
+        ParseLogLevelString(FindOption(options, kOptionKeyLogLevel), settings->log_settings_.min_severity);
 }
 
-std::string
-CaptureSettings::FindOption(const OptionsMap& options, const std::string& key, const std::string& default_value)
+std::string CaptureSettings::FindOption(OptionsMap* options, const std::string& key, const std::string& default_value)
 {
+    assert(options != nullptr);
+
     std::string result = default_value;
 
-    auto entry = options.find(key);
-    if (entry != options.end())
+    auto entry = options->find(key);
+    if (entry != options->end())
     {
         result = entry->second;
+        GFXRECON_LOG_DEBUG("Settings Loader: Found option \"%s\" with value \"%s\"", key.c_str(), result.c_str());
+
+        // Erase the option as it comes in so that we should have no valid options remaining in the
+        // map when we're done.
+        options->erase(key);
     }
 
     return result;

--- a/framework/encode/capture_settings.h
+++ b/framework/encode/capture_settings.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2019 Valve Corporation
+** Copyright (c) 2018-2019 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -29,6 +29,9 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 
 class CaptureSettings
 {
+  private:
+    const static char kDefaultCaptureFileName[];
+
   public:
     enum MemoryTrackingMode
     {
@@ -41,18 +44,21 @@ class CaptureSettings
         kPageGuard = 2
     };
 
+    struct TraceSettings
+    {
+        std::string            capture_file{ kDefaultCaptureFileName };
+        format::EnabledOptions capture_file_options;
+        bool                   time_stamp_file{ true };
+        MemoryTrackingMode     memory_tracking_mode{ kPageGuard };
+        bool                   force_flush{ false };
+    };
+
   public:
     CaptureSettings();
 
     ~CaptureSettings();
 
-    const std::string& GetCaptureFile() const { return capture_file_; }
-
-    bool GetTimestampedFilename() const { return timestamped_filename_; }
-
-    MemoryTrackingMode GetMemoryTrackingMode() const { return memory_tracking_mode_; }
-
-    const format::EnabledOptions& GetCaptureFileOptions() const { return capture_file_options_; }
+    const TraceSettings& GetTraceSettings() const { return trace_settings_; }
 
     const util::Log::Settings& GetLogSettings() const { return log_settings_; }
 
@@ -62,14 +68,16 @@ class CaptureSettings
     typedef std::unordered_map<std::string, std::string> OptionsMap;
 
   private:
+    static void
+    LoadSingleOptionEnvVar(OptionsMap* options, const std::string& environment_variable, const std::string& option_key);
+
     static void LoadOptionsEnvVar(OptionsMap* options);
 
     static void LoadOptionsFile(OptionsMap* options);
 
-    static void ProcessOptions(const OptionsMap& options, CaptureSettings* settings);
+    static void ProcessOptions(OptionsMap* options, CaptureSettings* settings);
 
-    static std::string
-    FindOption(const OptionsMap& options, const std::string& key, const std::string& default_value = "");
+    static std::string FindOption(OptionsMap* options, const std::string& key, const std::string& default_value = "");
 
     static bool ParseBoolString(const std::string& value_string, bool default_value);
 
@@ -82,11 +90,8 @@ class CaptureSettings
     static util::Log::Severity ParseLogLevelString(const std::string& value_string, util::Log::Severity default_value);
 
   private:
-    std::string            capture_file_;
-    bool                   timestamped_filename_;
-    MemoryTrackingMode     memory_tracking_mode_;
-    format::EnabledOptions capture_file_options_;
-    util::Log::Settings    log_settings_;
+    TraceSettings       trace_settings_;
+    util::Log::Settings log_settings_;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -139,9 +139,8 @@ class TraceManager
 
     ~TraceManager() {}
 
-    bool Initialize(std::string                         filename,
-                    const format::EnabledOptions&       file_options,
-                    CaptureSettings::MemoryTrackingMode mode);
+    bool Initialize(std::string                           filename,
+                    const CaptureSettings::TraceSettings& trace_settings);
 
   private:
     class ThreadData
@@ -199,6 +198,7 @@ class TraceManager
     std::unique_ptr<util::FileOutputStream>         file_stream_;
     std::string                                     filename_;
     std::mutex                                      file_lock_;
+    bool                                            force_file_flush_;
     uint64_t                                        bytes_written_;
     std::unique_ptr<util::Compressor>               compressor_;
     CaptureSettings::MemoryTrackingMode             memory_tracking_mode_;

--- a/framework/util/file_output_stream.h
+++ b/framework/util/file_output_stream.h
@@ -41,6 +41,8 @@ class FileOutputStream : public OutputStream
 
     virtual size_t Write(const void* data, size_t len) override;
 
+    virtual void Flush() override { platform::FileFlush(file_); }
+
   private:
     FILE* file_;
     bool  own_file_;

--- a/framework/util/output_stream.h
+++ b/framework/util/output_stream.h
@@ -35,6 +35,8 @@ class OutputStream
     virtual void Reset() {}
 
     virtual size_t Write(const void* data, size_t len) = 0;
+
+    virtual void Flush() {}
 };
 
 GFXRECON_END_NAMESPACE(util)

--- a/layer/USAGE_android.md
+++ b/layer/USAGE_android.md
@@ -55,7 +55,7 @@ Debugger > LLDP Post Attach Commands
 
 Where you can click the `+` and add it manually.
 
-
+<br></br>
 
 ## Globally Enabling the Layer
 
@@ -70,6 +70,46 @@ When done, disable the layer using:
 ```
 adb shell "setprop debug.vulkan.layers ''"
 ```
+
+<br></br>
+
+## GFXRecon Debug Options
+
+THe GFXReconstruct has multiple options that can be adjusted by using
+Android properties.
+Each property **must** begin with the prefix `debug.gfxrecon.`.
+This may be done by performed by using `adb shell` in the following way:
+
+```
+adb shell "setprop <option> '<value>'"
+```
+
+For example, to set the log_level to "warning", you would call:
+
+```
+adb shell "setprop debug.gfxrecon.log_level 'warning'"
+```
+
+<br></br>
+
+Option | Property | Type | Description
+------| ------------- |------|-------------
+Capture Compression Type | debug.gfxrecon.capture_compression_type | STRING | Define a specific compression type to use when capturing content.  Valid values are: "LZ4", "LZ77", and "NONE".
+Capture File | debug.gfxrecon.capture_file | STRING | This option allows you to override the default path and name of the capture file.
+Capture File Timestamp | debug.gfxrecon.capture_file_timestamp | BOOL | This option lets you indicate if you want the capture file name to include the timestamp at creation time. This is important if your application could generate more than one and would normally clobber the original file's contents.
+Log Allow Indents | debug.gfxrecon.log_allow_indents | BOOL | This is an option to allow indent formatting in the strings to attempt to make things easier to read. Although indenting is used in very limited circumstances currently.
+Log Break On Error | debug.gfxrecon.log_break_on_error | BOOL | This option allows you to force the layer to break if it encounters an error so you can debug it easily.
+Log Detailed | debug.gfxrecon.log_detailed | BOOL | Enable detailed logging messages (includes file name and location where triggered from).
+Errors To Stderr | debug.gfxrecon.log_errors_to_stderr | BOOL | This option allows you to force all error messages that would be normally logged to also output to stderr.
+Log File | debug.gfxrecon.log_file | STRING | This option allows you to define the path and name of a log file that will be generated with log messages.
+Log File Create New | debug.gfxrecon.log_file_create_new | BOOL | This option indicates that you want to either create a new file every time the layer is triggered, or append to the old log file.
+Log File Flush After Write | debug.gfxrecon.log_file_flush_after_write | BOOL | This option allows you to force a flush after every log file write to make sure you don't loose messages in a buffer.
+Log File Keep Open | debug.gfxrecon.log_file_keep_open | BOOL | This option forces the log file to remain open after it's created to allow for faster recording of log messages.
+Log Level | debug.gfxrecon.log_level | STRING | This option allows you to choose what log level you desire to trigger.  Available options include: "debug", "info", "warning", "error", and "fatal".  Any level selected will include all levels listed after it.  For example, choosing "warning" will also log out "error" and "fatal" messages.
+Log Output To Console | debug.gfxrecon.log_output_to_console | BOOL | This option allows log messages to be written out to stdout (or whatever debug console is available on the target platform.
+Memory Tracking Mode | debug.gfxrecon.memory_tracking_mode | STRING | This option allows the user to determine what memory tracking mode the layer uses when handling memory.  Available options are: "page_guard", "assisted" and "unassisted".  <ul><li>"unassisted" assumes the application does not flush, so writes all mapped data on an `vkUnmapMemory` or `vkQueueSubmit` call.</li> <li>"assisted" assumes the application will always flush after writing to mapped memory, so will only write on a flush.</li> <li>"page_guard" is used to determine which regions of memory to write on an `vkUnmapMemory` or `vkQueueSubmit` call.  "page_guard" also shadows uncached memory so as to properly provide all memory it can.</li></ul>
+
+<br></br>
 
 ## Capture Files
 
@@ -91,7 +131,7 @@ has completed which can result in overwritten capture data.
 
 You may override the name and location of the capture file by setting the
 property `debug.gfxrecon.capture_file` to point to what you would like to
-output.
+output as defined above in [GFXRecon Debug Options](#gfxrecon-debug-options).
 
 This may be done by performed by using `adb shell` in the following way:
 

--- a/layer/USAGE_desktop.md
+++ b/layer/USAGE_desktop.md
@@ -52,28 +52,62 @@ set VK_INSTANCE_LAYERS=VK_LAYER_LUNARG_gfxreconstruct
 export VK_INSTANCE_LAYERS=VK_LAYER_LUNARG_gfxreconstruct
 ```
 
-## Defining the Output Location
+<br></br>
 
-By default, the layer will generate a file called `gfxrecon_capture.gfxr` in
-the current working directory.
-However, you may define the environment variable `GFXRECON_CAPTURE_FILE` on
-desktop to indicate the location and name of the resulting capture file.
-This can be simply a filename, or an entire path.
-If this variable is not set, then 
+## GFXRecon Debug Options
 
+THe GFXReconstruct has multiple options that can be adjusted by using
+environment variables.
+Just as above, you use "set" or "export" (depending upon your platform) to
+define an environment variable.
+Each environment variable **must** begin with the prefix `GFXRECON_`.
+
+For example, to set the log_level to "warning", you would call:
 
 #### Windows
 
 ```
-set GFXRECON_CAPTURE_FILE=dota2_capture.gfxr
+set GFXRECON_LOG_LEVEL=warning
 ```
 
 #### Linux
 
 ```
-export GFXRECON_CAPTURE_FILE=/home/vulkan_developer/artifact_capture.gfxr
+export GFXRECON_LOG_LEVEL=warning
 ```
 
+<br></br>
+
+Option | Environment Variable | Type | Description
+------| ------------- |------|-------------
+Capture Compression Type | GFXRECON_CAPTURE_COMPRESSION_TYPE | STRING | Define a specific compression type to use when capturing content.  Valid values are: "LZ4", "LZ77", and "NONE".
+Capture File | GFXRECON_CAPTURE_FILE | STRING | This option allows you to override the default path and name of the capture file.
+Capture File Timestamp | GFXRECON_CAPTURE_FILE_TIMESTAMP | BOOL | This option lets you indicate if you want the capture file name to include the timestamp at creation time. This is important if your application could generate more than one and would normally clobber the original file's contents.
+Log Allow Indents | GFXRECON_LOG_ALLOW_INDENTS | BOOL | This is an option to allow indent formatting in the strings to attempt to make things easier to read. Although indenting is used in very limited circumstances currently.
+Log Break On Error | GFXRECON_LOG_BREAK_ON_ERROR | BOOL | This option allows you to force the layer to break if it encounters an error so you can debug it easily.
+Log Detailed | GFXRECON_LOG_DETAILED | BOOL | Enable detailed logging messages (includes file name and location where triggered from).
+Errors To Stderr | GFXRECON_LOG_ERRORS_TO_STDERR | BOOL | This option allows you to force all error messages that would be normally logged to also output to stderr.
+Log File | GFXRECON_LOG_FILE | STRING | This option allows you to define the path and name of a log file that will be generated with log messages.
+Log File Create New | GFXRECON_LOG_FILE_CREATE_NEW | BOOL | This option indicates that you want to either create a new file every time the layer is triggered, or append to the old log file.
+Log File Flush After Write | GFXRECON_LOG_FILE_FLUSH_AFTER_WRITE | BOOL | This option allows you to force a flush after every log file write to make sure you don't loose messages in a buffer.
+Log File Keep Open | GFXRECON_LOG_FILE_KEEP_OPEN | BOOL | This option forces the log file to remain open after it's created to allow for faster recording of log messages.
+Log Level | GFXRECON_LOG_LEVEL | STRING | This option allows you to choose what log level you desire to trigger.  Available options include: "debug", "info", "warning", "error", and "fatal".  Any level selected will include all levels listed after it.  For example, choosing "warning" will also log out "error" and "fatal" messages.
+Log Output To Console | GFXRECON_LOG_OUTPUT_TO_CONSOLE | BOOL | This option allows log messages to be written out to stdout (or whatever debug console is available on the target platform.
+Log Output To OS Debug String | GFXRECON_LOG_OUTPUT_TO_OS_DEBUG_STRING | BOOL | This option allows log messages to be written out to the OS-specific logging mechanism.  Currently only works for Windows, but allows debug messages to re-direct from the console to `OutputDebugStringA`.
+Memory Tracking Mode | GFXRECON_MEMORY_TRACKING_MODE | STRING | This option allows the user to determine what memory tracking mode the layer uses when handling memory.  Available options are: "page_guard", "assisted" and "unassisted".  <ul><li>"unassisted" assumes the application does not flush, so writes all mapped data on an `vkUnmapMemory` or `vkQueueSubmit` call.</li> <li>"assisted" assumes the application will always flush after writing to mapped memory, so will only write on a flush.</li> <li>"page_guard" is used to determine which regions of memory to write on an `vkUnmapMemory` or `vkQueueSubmit` call.  "page_guard" also shadows uncached memory so as to properly provide all memory it can.</li></ul>
+
+<br></br>
+
+## Defining the Output Location
+
+By default, the layer will generate a file called `gfxrecon_capture.gfxr` in
+the current working directory.
+However, you may define the environment variable `GFXRECON_CAPTURE_FILE` on
+desktop to indicate the location and name of the resulting capture file
+as defined above in [GFXRecon Debug Options](#gfxrecon-debug-options).
+
+
+<br></br>
 
 ## Using
 


### PR DESCRIPTION
Add settings for a variety of logging options including adding a new constructor to the logging class that takes all the settings directly.
Also removed unused settings and settings that should always be on or off (thread ID should always be on, and begin/end times should be removed).
Added logging for extra settings found in the vk_layer_settings file with the prefix for the gfxreconstruct layer.
Updated the layer documentation so that all settings are listed clearly.
Added a new option to flush the contents of the capture file and add the logic to do so after every completed API call write.