### PR TITLE
Fix CodeGen Return Type Encoding

### DIFF
--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -4334,7 +4334,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceXlibPresentationSupportKHR(
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeVoidPtr(dpy);
         encoder->EncodeSizeTValue(visualID);
-        encoder->EncodeEnumValue(result);
+        encoder->EncodeVkBool32Value(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -4386,7 +4386,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceXcbPresentationSupportKHR(
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeVoidPtr(connection);
         encoder->EncodeUInt32Value(visual_id);
-        encoder->EncodeEnumValue(result);
+        encoder->EncodeVkBool32Value(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -4436,7 +4436,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceWaylandPresentationSupportKHR(
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeVoidPtr(display);
-        encoder->EncodeEnumValue(result);
+        encoder->EncodeVkBool32Value(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -4510,7 +4510,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL GetPhysicalDeviceWin32PresentationSupportKHR(
     {
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeUInt32Value(queueFamilyIndex);
-        encoder->EncodeEnumValue(result);
+        encoder->EncodeVkBool32Value(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -7905,7 +7905,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressEXT(
     {
         encoder->EncodeHandleIdValue(device);
         encode_struct_ptr(encoder, pInfo);
-        encoder->EncodeEnumValue(result);
+        encoder->EncodeVkDeviceAddressValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -185,7 +185,8 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
             body += indent + '{};\n'.format(methodCall)
 
         if returnType and returnType != 'void':
-            body += indent + 'encoder->EncodeEnumValue(result);\n'
+            methodCall = self.makeEncoderMethodCall(ValueInfo('result', returnType, returnType), [], '')
+            body += indent + '{};\n'.format(methodCall)
 
         body += indent + 'encode::TraceManager::Get()->EndApiCallTrace(encoder);\n'
         indent = indent[0:-self.INDENT_SIZE]


### PR DESCRIPTION
Return types were always being encoded as 32-bit integers.  They are now encoded using the appropriate type, which was needed for 64-bit VkDeviceAddress encoding.