### PR TITLE
Rename LZ77 to Zlib

### DIFF
--- a/android/framework/util/CMakeLists.txt
+++ b/android/framework/util/CMakeLists.txt
@@ -15,8 +15,8 @@ target_sources(gfxrecon_util
                    ${GFXRECON_SOURCE_DIR}/framework/util/logging.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/util/lz4_compressor.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/lz4_compressor.cpp
-                   ${GFXRECON_SOURCE_DIR}/framework/util/lz77_compressor.h
-                   ${GFXRECON_SOURCE_DIR}/framework/util/lz77_compressor.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/util/zlib_compressor.h
+                   ${GFXRECON_SOURCE_DIR}/framework/util/zlib_compressor.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/util/memory_output_stream.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/memory_output_stream.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/util/output_stream.h
@@ -31,7 +31,7 @@ target_sources(gfxrecon_util
 target_compile_definitions(gfxrecon_util
                            PUBLIC
                                $<$<BOOL:${LZ4_FOUND}>:ENABLE_LZ4_COMPRESSION>
-                               $<$<BOOL:${ZLIB_FOUND}>:ENABLE_LZ77_COMPRESSION>)
+                               $<$<BOOL:${ZLIB_FOUND}>:ENABLE_ZLIB_COMPRESSION>)
 
 target_include_directories(gfxrecon_util
                            PUBLIC

--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -350,9 +350,9 @@ format::CompressionType CaptureSettings::ParseCompressionTypeString(const std::s
     {
         result = format::CompressionType::kLz4;
     }
-    else if (util::platform::StringCompareNoCase("lz77", value_string.c_str()) == 0)
+    else if (util::platform::StringCompareNoCase("zlib", value_string.c_str()) == 0)
     {
-        result = format::CompressionType::kLz77;
+        result = format::CompressionType::kZlib;
     }
     else
     {

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2019 Valve Corporation
+** Copyright (c) 2018-2019 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ enum CompressionType : uint32_t
 {
     kNone = 0,
     kLz4  = 1,
-    kLz77 = 2
+    kZlib = 2
 };
 
 enum FileOption : uint32_t

--- a/framework/format/format_util.cpp
+++ b/framework/format/format_util.cpp
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2019 Valve Corporation
+** Copyright (c) 2018-2019 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 #include "util/logging.h"
 #include "util/lz4_compressor.h"
-#include "util/lz77_compressor.h"
+#include "util/zlib_compressor.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(format)
@@ -50,11 +50,11 @@ util::Compressor* CreateCompressor(CompressionType type)
             compressor = new util::Lz4Compressor();
             break;
 #endif // ENABLE_LZ4_COMPRESSION
-#ifdef ENABLE_LZ77_COMPRESSION
-        case kLz77:
-            compressor = new util::Lz77Compressor();
+#ifdef ENABLE_ZLIB_COMPRESSION
+        case kZlib:
+            compressor = new util::ZlibCompressor();
             break;
-#endif // ENABLE_LZ77_COMPRESSION
+#endif // ENABLE_ZLIB_COMPRESSION
         case kNone:
             // Nothing to do here.
             break;

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -15,8 +15,8 @@ target_sources(gfxrecon_util
                    logging.cpp
                    lz4_compressor.h
                    lz4_compressor.cpp
-                   lz77_compressor.h
-                   lz77_compressor.cpp
+                   zlib_compressor.h
+                   zlib_compressor.cpp
                    memory_output_stream.h
                    memory_output_stream.cpp
                    output_stream.h
@@ -31,7 +31,7 @@ target_sources(gfxrecon_util
 target_compile_definitions(gfxrecon_util
                            PUBLIC
                                $<$<BOOL:${LZ4_FOUND}>:ENABLE_LZ4_COMPRESSION>
-                               $<$<BOOL:${ZLIB_FOUND}>:ENABLE_LZ77_COMPRESSION>)
+                               $<$<BOOL:${ZLIB_FOUND}>:ENABLE_ZLIB_COMPRESSION>)
 
 target_include_directories(gfxrecon_util
                            PUBLIC

--- a/framework/util/zlib_compressor.cpp
+++ b/framework/util/zlib_compressor.cpp
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2019 Valve Corporation
+** Copyright (c) 2018-2019 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -15,16 +15,16 @@
 ** limitations under the License.
 */
 
-#ifdef ENABLE_LZ77_COMPRESSION
+#ifdef ENABLE_ZLIB_COMPRESSION
 
-#include "util/lz77_compressor.h"
+#include "util/zlib_compressor.h"
 
 #include "zlib.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)
 
-size_t Lz77Compressor::Compress(const size_t          uncompressed_size,
+size_t ZlibCompressor::Compress(const size_t          uncompressed_size,
                                 const uint8_t*        uncompressed_data,
                                 std::vector<uint8_t>* compressed_data)
 {
@@ -65,7 +65,7 @@ size_t Lz77Compressor::Compress(const size_t          uncompressed_size,
     return copy_size;
 }
 
-size_t Lz77Compressor::Decompress(const size_t                compressed_size,
+size_t ZlibCompressor::Decompress(const size_t                compressed_size,
                                   const std::vector<uint8_t>& compressed_data,
                                   const size_t                expected_uncompressed_size,
                                   std::vector<uint8_t>*       uncompressed_data)
@@ -105,4 +105,4 @@ size_t Lz77Compressor::Decompress(const size_t                compressed_size,
 GFXRECON_END_NAMESPACE(util)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
-#endif // ENABLE_LZ77_COMPRESSION
+#endif // ENABLE_ZLIB_COMPRESSION

--- a/framework/util/zlib_compressor.h
+++ b/framework/util/zlib_compressor.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2019 Valve Corporation
+** Copyright (c) 2018-2019 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -15,20 +15,20 @@
 ** limitations under the License.
 */
 
-#ifndef GFXRECON_UTIL_LZ77_COMPRESSOR_H
-#define GFXRECON_UTIL_LZ77_COMPRESSOR_H
+#ifndef GFXRECON_UTIL_ZLIB_COMPRESSOR_H
+#define GFXRECON_UTIL_ZLIB_COMPRESSOR_H
 
 #include "util/compressor.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)
 
-class Lz77Compressor : public Compressor
+class ZlibCompressor : public Compressor
 {
   public:
-    Lz77Compressor() {}
+    ZlibCompressor() {}
 
-    virtual ~Lz77Compressor() {}
+    virtual ~ZlibCompressor() {}
 
     virtual size_t Compress(const size_t          uncompressed_size,
                             const uint8_t*        uncompressed_data,
@@ -43,4 +43,4 @@ class Lz77Compressor : public Compressor
 GFXRECON_END_NAMESPACE(util)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
-#endif // GFXRECON_UTIL_LZ77_COMPRESSOR_H
+#endif // GFXRECON_UTIL_ZLIB_COMPRESSOR_H

--- a/layer/USAGE_android.md
+++ b/layer/USAGE_android.md
@@ -94,7 +94,7 @@ adb shell "setprop debug.gfxrecon.log_level 'warning'"
 
 Option | Property | Type | Description
 ------| ------------- |------|-------------
-Capture Compression Type | debug.gfxrecon.capture_compression_type | STRING | Define a specific compression type to use when capturing content.  Valid values are: "LZ4", "LZ77", and "NONE".
+Capture Compression Type | debug.gfxrecon.capture_compression_type | STRING | Define a specific compression type to use when capturing content.  Valid values are: "LZ4", "ZLIB", and "NONE".
 Capture File | debug.gfxrecon.capture_file | STRING | This option allows you to override the default path and name of the capture file.
 Capture File Timestamp | debug.gfxrecon.capture_file_timestamp | BOOL | This option lets you indicate if you want the capture file name to include the timestamp at creation time. This is important if your application could generate more than one and would normally clobber the original file's contents.
 Log Allow Indents | debug.gfxrecon.log_allow_indents | BOOL | This is an option to allow indent formatting in the strings to attempt to make things easier to read. Although indenting is used in very limited circumstances currently.

--- a/layer/USAGE_desktop.md
+++ b/layer/USAGE_desktop.md
@@ -80,7 +80,7 @@ export GFXRECON_LOG_LEVEL=warning
 
 Option | Environment Variable | Type | Description
 ------| ------------- |------|-------------
-Capture Compression Type | GFXRECON_CAPTURE_COMPRESSION_TYPE | STRING | Define a specific compression type to use when capturing content.  Valid values are: "LZ4", "LZ77", and "NONE".
+Capture Compression Type | GFXRECON_CAPTURE_COMPRESSION_TYPE | STRING | Define a specific compression type to use when capturing content.  Valid values are: "LZ4", "ZLIB", and "NONE".
 Capture File | GFXRECON_CAPTURE_FILE | STRING | This option allows you to override the default path and name of the capture file.
 Capture File Timestamp | GFXRECON_CAPTURE_FILE_TIMESTAMP | BOOL | This option lets you indicate if you want the capture file name to include the timestamp at creation time. This is important if your application could generate more than one and would normally clobber the original file's contents.
 Log Allow Indents | GFXRECON_LOG_ALLOW_INDENTS | BOOL | This is an option to allow indent formatting in the strings to attempt to make things easier to read. Although indenting is used in very limited circumstances currently.

--- a/tools/compress/main.cpp
+++ b/tools/compress/main.cpp
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2019 Valve Corporation
+** Copyright (c) 2018-2019 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t<compression_format>\tThe compression format to use when generating");
     GFXRECON_WRITE_CONSOLE("\t\t\t\tthe output file.  Possible values are: ");
     GFXRECON_WRITE_CONSOLE("\t\t\t\t\tLZ4  - To output using LZ4 compression");
-    GFXRECON_WRITE_CONSOLE("\t\t\t\t\tLZ77 - To output using LZ77 compression");
+    GFXRECON_WRITE_CONSOLE("\t\t\t\t\tZLIB - To output using Zlib compression");
     GFXRECON_WRITE_CONSOLE("\t\t\t\t\tNONE - To output without using compression");
 }
 
@@ -78,9 +78,9 @@ int main(int argc, const char** argv)
             {
                 compression_type = gfxrecon::format::CompressionType::kLz4;
             }
-            else if (dst_compression_string == "LZ77")
+            else if (dst_compression_string == "ZLIB")
             {
-                compression_type = gfxrecon::format::CompressionType::kLz77;
+                compression_type = gfxrecon::format::CompressionType::kZlib;
             }
             else
             {
@@ -120,8 +120,8 @@ int main(int argc, const char** argv)
                         case gfxrecon::format::CompressionType::kLz4:
                             src_compression = "LZ4";
                             break;
-                        case gfxrecon::format::CompressionType::kLz77:
-                            src_compression = "LZ77";
+                        case gfxrecon::format::CompressionType::kZlib:
+                            src_compression = "ZLIB";
                             break;
                         default:
                             GFXRECON_LOG_ERROR("Unknown source compression type %d", option.value);


### PR DESCRIPTION
Rename all the LZ77 items back to Zlib.  Dustin pointed out that
Zlib actually uses more than LZ77 in its heuristics.  Therefore,
we should just stick to calling it Zlib.