### PR TITLE
Fix Build Warnings

### DIFF
--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -135,7 +135,10 @@ class TraceManager
 #endif
 
   protected:
-    TraceManager() : bytes_written_(0), memory_tracking_mode_(CaptureSettings::MemoryTrackingMode::kUnassisted) {}
+    TraceManager() :
+        force_file_flush_(false), bytes_written_(0),
+        memory_tracking_mode_(CaptureSettings::MemoryTrackingMode::kUnassisted)
+    {}
 
     ~TraceManager() {}
 

--- a/framework/util/argument_parser.cpp
+++ b/framework/util/argument_parser.cpp
@@ -30,7 +30,7 @@ ArgumentParser::ArgumentParser(int32_t            argc,
                                const char** const argv,
                                const std::string& options,
                                const std::string& arguments,
-                               const int32_t      min_positional_args) :
+                               const uint32_t     min_positional_args) :
     is_invalid_(false)
 {
     if (argc > 1 && nullptr != argv)
@@ -54,7 +54,7 @@ ArgumentParser::ArgumentParser(bool               first_is_exe_name,
                                const char*        args,
                                const std::string& options,
                                const std::string& arguments,
-                               const int32_t      min_positional_args) :
+                               const uint32_t     min_positional_args) :
     is_invalid_(false)
 {
     std::vector<std::string> command_line_args;
@@ -126,7 +126,7 @@ ArgumentParser::ArgumentParser(bool               first_is_exe_name,
 void ArgumentParser::Init(std::vector<std::string> command_line_args,
                           const std::string&       options,
                           const std::string&       arguments,
-                          const int32_t            min_positional_args)
+                          const uint32_t           min_positional_args)
 {
     std::vector<std::string> valid_options;
     std::string              sub_string;
@@ -192,7 +192,7 @@ void ArgumentParser::Init(std::vector<std::string> command_line_args,
     }
     argument_values_.resize(argument_index);
 
-    for (int32_t cur_arg = 0; cur_arg < command_line_args.size(); ++cur_arg)
+    for (size_t cur_arg = 0; cur_arg < command_line_args.size(); ++cur_arg)
     {
         bool is_option   = false;
         bool is_argument = false;

--- a/framework/util/argument_parser.h
+++ b/framework/util/argument_parser.h
@@ -39,12 +39,12 @@ class ArgumentParser
                    const char** const argv,
                    const std::string& options,
                    const std::string& arguments,
-                   const int32_t      min_positional_args);
+                   const uint32_t     min_positional_args);
     ArgumentParser(bool               first_is_exe_name,
                    const char*        args,
                    const std::string& options,
                    const std::string& arguments,
-                   const int32_t      min_positional_args);
+                   const uint32_t     min_positional_args);
     ~ArgumentParser() {}
 
     bool                            IsInvalid() { return is_invalid_; }
@@ -58,7 +58,7 @@ class ArgumentParser
     void Init(std::vector<std::string> command_line_args,
               const std::string&       options,
               const std::string&       arguments,
-              const int32_t            min_positional_args);
+              const uint32_t           min_positional_args);
 
     bool                     is_invalid_;
     std::vector<std::string> invalid_values_present_;

--- a/framework/util/zlib_compressor.cpp
+++ b/framework/util/zlib_compressor.cpp
@@ -46,9 +46,13 @@ size_t ZlibCompressor::Compress(const size_t          uncompressed_size,
         compress_stream.zalloc    = Z_NULL;
         compress_stream.zfree     = Z_NULL;
         compress_stream.opaque    = Z_NULL;
-        compress_stream.avail_in  = uncompressed_size;
+
+        GFXRECON_CHECK_CONVERSION_DATA_LOSS(uInt, uncompressed_size);
+        compress_stream.avail_in  = static_cast<uInt>(uncompressed_size);
         compress_stream.next_in   = const_cast<Bytef*>(uncompressed_data);
-        compress_stream.avail_out = compressed_data->size();
+
+        GFXRECON_CHECK_CONVERSION_DATA_LOSS(uInt, compressed_data->size());
+        compress_stream.avail_out = static_cast<uInt>(compressed_data->size());
         compress_stream.next_out  = compressed_data->data();
 
         // Perform the compression (deflate the data).
@@ -83,9 +87,13 @@ size_t ZlibCompressor::Decompress(const size_t                compressed_size,
         decompress_stream.zalloc    = Z_NULL;
         decompress_stream.zfree     = Z_NULL;
         decompress_stream.opaque    = Z_NULL;
-        decompress_stream.avail_in  = compressed_size;
+
+        GFXRECON_CHECK_CONVERSION_DATA_LOSS(uInt, compressed_size);
+        decompress_stream.avail_in  = static_cast<uInt>(compressed_size);
         decompress_stream.next_in   = const_cast<Bytef*>(compressed_data.data());
-        decompress_stream.avail_out = expected_uncompressed_size;
+
+        GFXRECON_CHECK_CONVERSION_DATA_LOSS(uInt, expected_uncompressed_size);
+        decompress_stream.avail_out = static_cast<uInt>(expected_uncompressed_size);
         decompress_stream.next_out  = uncompressed_data->data();
 
         // Perform the decompression (inflate the data).


### PR DESCRIPTION
Address warnings generated by VS2017 builds:
- Fix size_t to uInt conversion warning from 64-bit builds
- Fix signed/unsigned comparison warning from 32-bit builds
- Fix uint64_t to size_t conversion warnin from 32-bit builds
- Fix uninitialized class member warning (static analysis)