### PR TITLE
Adjust struct encode/decode func names

### DIFF
--- a/framework/decode/custom_vulkan_struct_decoders.cpp
+++ b/framework/decode/custom_vulkan_struct_decoders.cpp
@@ -25,7 +25,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearColorValue* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearColorValue* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -38,7 +38,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearC
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearValue* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearValue* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -46,7 +46,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearV
     VkClearValue* value      = wrapper->value;
 
     wrapper->color.value = &(value->color);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->color));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->color));
 
     return bytes_read;
 }
@@ -74,7 +74,7 @@ static std::unique_ptr<uint8_t[]> unpack_sid_struct(const PointerDecoder<uint8_t
     return unpacked_memory;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_ACL* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_ACL* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -92,7 +92,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_ACL* wra
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_SECURITY_DESCRIPTOR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_SECURITY_DESCRIPTOR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -121,7 +121,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_SECURITY
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_SECURITY_ATTRIBUTES* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_SECURITY_ATTRIBUTES* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 

--- a/framework/decode/custom_vulkan_struct_decoders_forward.h
+++ b/framework/decode/custom_vulkan_struct_decoders_forward.h
@@ -28,8 +28,8 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 struct Decoded_VkClearColorValue;
 struct Decoded_VkClearValue;
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearColorValue* wrapper);
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearValue* wrapper);
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearColorValue* wrapper);
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearValue* wrapper);
 
 // Decoded struct wrappers for Vulkan structures that require special processing.
 struct Decoded_VkObjectTableEntryNVX;
@@ -39,9 +39,9 @@ struct Decoded_ACL;
 struct Decoded_SECURITY_DESCRIPTOR;
 struct Decoded_SECURITY_ATTRIBUTES;
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_ACL* wrapper);
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_SECURITY_DESCRIPTOR* wrapper);
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_SECURITY_ATTRIBUTES* wrapper);
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_ACL* wrapper);
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_SECURITY_DESCRIPTOR* wrapper);
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_SECURITY_ATTRIBUTES* wrapper);
 
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/descriptor_update_template_decoder.cpp
+++ b/framework/decode/descriptor_update_template_decoder.cpp
@@ -65,7 +65,7 @@ size_t DescriptorUpdateTemplateDecoder::Decode(const uint8_t* buffer, size_t buf
             for (size_t i = 0; i < image_info_count_; ++i)
             {
                 decoded_image_info_[i].value = &image_info_[i];
-                bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &decoded_image_info_[i]);
+                bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &decoded_image_info_[i]);
             }
         }
 
@@ -78,7 +78,7 @@ size_t DescriptorUpdateTemplateDecoder::Decode(const uint8_t* buffer, size_t buf
             {
                 decoded_buffer_info_[i].value = &buffer_info_[i];
                 bytes_read +=
-                    decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &decoded_buffer_info_[i]);
+                    DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &decoded_buffer_info_[i]);
             }
         }
 

--- a/framework/decode/struct_pointer_decoder.h
+++ b/framework/decode/struct_pointer_decoder.h
@@ -116,7 +116,7 @@ class StructPointerDecoder : public PointerDecoderBase
                 // Note: We only expect this class to be used with structs that have a decode_struct function.
                 //       If an error is encoutered here due to a new struct type, the struct decoders need to be
                 //       updated to support the new type.
-                bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &decoded_structs_[i]);
+                bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &decoded_structs_[i]);
             }
         }
 

--- a/framework/decode/struct_pointer_decoder_nvx.h
+++ b/framework/decode/struct_pointer_decoder_nvx.h
@@ -125,7 +125,7 @@ class StructPointerDecoder<Decoded_VkObjectTableEntryNVX> : public PointerDecode
                         struct_memory_[i]   = reinterpret_cast<VkObjectTableEntryNVX*>(value);
                         wrapper->value      = value;
 
-                        bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), wrapper);
+                        bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper);
                     }
                     else if (base_type->type == VK_OBJECT_ENTRY_TYPE_PIPELINE_NVX)
                     {
@@ -136,7 +136,7 @@ class StructPointerDecoder<Decoded_VkObjectTableEntryNVX> : public PointerDecode
                         struct_memory_[i]   = reinterpret_cast<VkObjectTableEntryNVX*>(value);
                         wrapper->value      = value;
 
-                        bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), wrapper);
+                        bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper);
                     }
                     else if (base_type->type == VK_OBJECT_ENTRY_TYPE_INDEX_BUFFER_NVX)
                     {
@@ -148,7 +148,7 @@ class StructPointerDecoder<Decoded_VkObjectTableEntryNVX> : public PointerDecode
                         struct_memory_[i]   = reinterpret_cast<VkObjectTableEntryNVX*>(value);
                         wrapper->value      = value;
 
-                        bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), wrapper);
+                        bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper);
                     }
                     else if (base_type->type == VK_OBJECT_ENTRY_TYPE_VERTEX_BUFFER_NVX)
                     {
@@ -160,7 +160,7 @@ class StructPointerDecoder<Decoded_VkObjectTableEntryNVX> : public PointerDecode
                         struct_memory_[i]   = reinterpret_cast<VkObjectTableEntryNVX*>(value);
                         wrapper->value      = value;
 
-                        bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), wrapper);
+                        bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper);
                     }
                     else if (base_type->type == VK_OBJECT_ENTRY_TYPE_PUSH_CONSTANT_NVX)
                     {
@@ -172,7 +172,7 @@ class StructPointerDecoder<Decoded_VkObjectTableEntryNVX> : public PointerDecode
                         struct_memory_[i]   = reinterpret_cast<VkObjectTableEntryNVX*>(value);
                         wrapper->value      = value;
 
-                        bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), wrapper);
+                        bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper);
                     }
                     else
                     {

--- a/framework/encode/custom_vulkan_struct_encoders.cpp
+++ b/framework/encode/custom_vulkan_struct_encoders.cpp
@@ -26,37 +26,37 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-void encode_struct(ParameterEncoder* encoder, const VkClearColorValue& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkClearColorValue& value)
 {
     encoder->EncodeUInt32Array(value.uint32, 4);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkClearValue& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkClearValue& value)
 {
     // VkClearColorValue is used becaue it is the larger of the two union members.
-    encode_struct(encoder, value.color);
+    EncodeStruct(encoder, value.color);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkObjectTableEntryNVX* value)
+void EncodeStruct(ParameterEncoder* encoder, const VkObjectTableEntryNVX* value)
 {
     if (value != nullptr)
     {
         switch (value->type)
         {
             case VK_OBJECT_ENTRY_TYPE_DESCRIPTOR_SET_NVX:
-                encode_struct_ptr(encoder, reinterpret_cast<const VkObjectTableDescriptorSetEntryNVX*>(value));
+                EncodeStructPtr(encoder, reinterpret_cast<const VkObjectTableDescriptorSetEntryNVX*>(value));
                 break;
             case VK_OBJECT_ENTRY_TYPE_PIPELINE_NVX:
-                encode_struct_ptr(encoder, reinterpret_cast<const VkObjectTablePipelineEntryNVX*>(value));
+                EncodeStructPtr(encoder, reinterpret_cast<const VkObjectTablePipelineEntryNVX*>(value));
                 break;
             case VK_OBJECT_ENTRY_TYPE_INDEX_BUFFER_NVX:
-                encode_struct_ptr(encoder, reinterpret_cast<const VkObjectTableIndexBufferEntryNVX*>(value));
+                EncodeStructPtr(encoder, reinterpret_cast<const VkObjectTableIndexBufferEntryNVX*>(value));
                 break;
             case VK_OBJECT_ENTRY_TYPE_VERTEX_BUFFER_NVX:
-                encode_struct_ptr(encoder, reinterpret_cast<const VkObjectTableVertexBufferEntryNVX*>(value));
+                EncodeStructPtr(encoder, reinterpret_cast<const VkObjectTableVertexBufferEntryNVX*>(value));
                 break;
             case VK_OBJECT_ENTRY_TYPE_PUSH_CONSTANT_NVX:
-                encode_struct_ptr(encoder, reinterpret_cast<const VkObjectTablePushConstantEntryNVX*>(value));
+                EncodeStructPtr(encoder, reinterpret_cast<const VkObjectTablePushConstantEntryNVX*>(value));
                 break;
             default:
                 GFXRECON_LOG_WARNING("Skipping custom struct encoding for unrecognized VkObjectEntryTypeNVX %u",
@@ -89,7 +89,7 @@ static void pack_sid_struct(const SID* sid, std::vector<uint8_t>* buffer)
     buffer->insert(buffer->end(), sub_authority, sub_authority + sub_authority_size);
 }
 
-void encode_struct(ParameterEncoder* encoder, const ACL& value)
+void EncodeStruct(ParameterEncoder* encoder, const ACL& value)
 {
     encoder->EncodeUInt8Value(value.AclRevision);
     encoder->EncodeUInt8Value(value.Sbz1);
@@ -98,7 +98,7 @@ void encode_struct(ParameterEncoder* encoder, const ACL& value)
     encoder->EncodeUInt16Value(value.Sbz2);
 }
 
-void encode_struct(ParameterEncoder* encoder, const SECURITY_DESCRIPTOR& value)
+void EncodeStruct(ParameterEncoder* encoder, const SECURITY_DESCRIPTOR& value)
 {
     encoder->EncodeUInt8Value(value.Revision);
     encoder->EncodeUInt8Value(value.Sbz1);
@@ -129,14 +129,14 @@ void encode_struct(ParameterEncoder* encoder, const SECURITY_DESCRIPTOR& value)
         encoder->EncodeUInt8Array(nullptr, 0);
     }
 
-    encode_struct_ptr(encoder, value.Sacl);
-    encode_struct_ptr(encoder, value.Dacl);
+    EncodeStructPtr(encoder, value.Sacl);
+    EncodeStructPtr(encoder, value.Dacl);
 }
 
-void encode_struct(ParameterEncoder* encoder, const SECURITY_ATTRIBUTES& value)
+void EncodeStruct(ParameterEncoder* encoder, const SECURITY_ATTRIBUTES& value)
 {
     encoder->EncodeUInt32Value(value.nLength);
-    encode_struct_ptr(encoder, reinterpret_cast<SECURITY_DESCRIPTOR*>(value.lpSecurityDescriptor));
+    EncodeStructPtr(encoder, reinterpret_cast<SECURITY_DESCRIPTOR*>(value.lpSecurityDescriptor));
     encoder->EncodeInt32Value(value.bInheritHandle);
 }
 

--- a/framework/encode/custom_vulkan_struct_encoders.h
+++ b/framework/encode/custom_vulkan_struct_encoders.h
@@ -28,16 +28,16 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
 // Unions.
-void encode_struct(encode::ParameterEncoder* encoder, const VkClearColorValue& value);
-void encode_struct(encode::ParameterEncoder* encoder, const VkClearValue& value);
+void EncodeStruct(encode::ParameterEncoder* encoder, const VkClearColorValue& value);
+void EncodeStruct(encode::ParameterEncoder* encoder, const VkClearValue& value);
 
 // Vulkan structures that require special processing that the code generator cannot infer from the XML registry.
-void encode_struct(encode::ParameterEncoder* encoder, const VkObjectTableEntryNVX* value);
+void EncodeStruct(encode::ParameterEncoder* encoder, const VkObjectTableEntryNVX* value);
 
 // Platform defined structures that are external to Vulkan.
-void encode_struct(encode::ParameterEncoder* encoder, const ACL& value);
-void encode_struct(encode::ParameterEncoder* encoder, const SECURITY_DESCRIPTOR& value);
-void encode_struct(encode::ParameterEncoder* encoder, const SECURITY_ATTRIBUTES& value);
+void EncodeStruct(encode::ParameterEncoder* encoder, const ACL& value);
+void EncodeStruct(encode::ParameterEncoder* encoder, const SECURITY_DESCRIPTOR& value);
+void EncodeStruct(encode::ParameterEncoder* encoder, const SECURITY_ATTRIBUTES& value);
 
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/struct_pointer_encoder.h
+++ b/framework/encode/struct_pointer_encoder.h
@@ -28,24 +28,24 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
 template <typename T>
-void encode_struct_ptr(ParameterEncoder* encoder, const T* value)
+void EncodeStructPtr(ParameterEncoder* encoder, const T* value)
 {
     encoder->EncodeStructPtrPreamble(value);
     if (value != nullptr)
     {
-        encode_struct(encoder, *value);
+        EncodeStruct(encoder, *value);
     }
 }
 
 template <typename T>
-void encode_struct_array(ParameterEncoder* encoder, const T* value, size_t len)
+void EncodeStructArray(ParameterEncoder* encoder, const T* value, size_t len)
 {
     encoder->EncodeStructArrayPreamble(value, len);
     if ((value != nullptr) && (len > 0))
     {
         for (size_t i = 0; i < len; ++i)
         {
-            encode_struct(encoder, value[i]);
+            EncodeStruct(encoder, value[i]);
         }
     }
 }

--- a/framework/generated/generated_decode_pnext_struct.cpp
+++ b/framework/generated/generated_decode_pnext_struct.cpp
@@ -31,7 +31,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-size_t decode_pnext_struct(const uint8_t* parameter_buffer, size_t buffer_size,  std::unique_ptr<PNextNode>* pNext)
+size_t DecodePNextStruct(const uint8_t* parameter_buffer, size_t buffer_size,  std::unique_ptr<PNextNode>* pNext)
 {
     assert(pNext != nullptr);
 

--- a/framework/generated/generated_encode_pnext_struct.cpp
+++ b/framework/generated/generated_encode_pnext_struct.cpp
@@ -36,7 +36,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-void encode_pnext_struct(ParameterEncoder* encoder, const void* value)
+void EncodePNextStruct(ParameterEncoder* encoder, const void* value)
 {
     assert(encoder != nullptr);
 
@@ -60,478 +60,478 @@ void encode_pnext_struct(ParameterEncoder* encoder, const void* value)
             }
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceSubgroupProperties*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceSubgroupProperties*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDevice16BitStorageFeatures*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDevice16BitStorageFeatures*>(value));
             break;
         case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkMemoryDedicatedRequirements*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkMemoryDedicatedRequirements*>(value));
             break;
         case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkMemoryDedicatedAllocateInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkMemoryDedicatedAllocateInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkMemoryAllocateFlagsInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkMemoryAllocateFlagsInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_RENDER_PASS_BEGIN_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDeviceGroupRenderPassBeginInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDeviceGroupRenderPassBeginInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_COMMAND_BUFFER_BEGIN_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDeviceGroupCommandBufferBeginInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDeviceGroupCommandBufferBeginInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_SUBMIT_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDeviceGroupSubmitInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDeviceGroupSubmitInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_BIND_SPARSE_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDeviceGroupBindSparseInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDeviceGroupBindSparseInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_DEVICE_GROUP_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkBindBufferMemoryDeviceGroupInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkBindBufferMemoryDeviceGroupInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_DEVICE_GROUP_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkBindImageMemoryDeviceGroupInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkBindImageMemoryDeviceGroupInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDeviceGroupDeviceCreateInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDeviceGroupDeviceCreateInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceFeatures2*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceFeatures2*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_POINT_CLIPPING_PROPERTIES:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDevicePointClippingProperties*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDevicePointClippingProperties*>(value));
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkRenderPassInputAttachmentAspectCreateInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkRenderPassInputAttachmentAspectCreateInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkImageViewUsageCreateInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkImageViewUsageCreateInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPipelineTessellationDomainOriginStateCreateInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineTessellationDomainOriginStateCreateInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkRenderPassMultiviewCreateInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkRenderPassMultiviewCreateInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceMultiviewProperties*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceMultiviewProperties*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceVariablePointerFeatures*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceVariablePointerFeatures*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_PROPERTIES:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceProtectedMemoryProperties*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceProtectedMemoryProperties*>(value));
             break;
         case VK_STRUCTURE_TYPE_PROTECTED_SUBMIT_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkProtectedSubmitInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkProtectedSubmitInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkSamplerYcbcrConversionInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkSamplerYcbcrConversionInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_BIND_IMAGE_PLANE_MEMORY_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkBindImagePlaneMemoryInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkBindImagePlaneMemoryInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_IMAGE_PLANE_MEMORY_REQUIREMENTS_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkImagePlaneMemoryRequirementsInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkImagePlaneMemoryRequirementsInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(value));
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkSamplerYcbcrConversionImageFormatProperties*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkSamplerYcbcrConversionImageFormatProperties*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceExternalImageFormatInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceExternalImageFormatInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkExternalImageFormatProperties*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkExternalImageFormatProperties*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceIDProperties*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceIDProperties*>(value));
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkExternalMemoryImageCreateInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkExternalMemoryImageCreateInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkExternalMemoryBufferCreateInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkExternalMemoryBufferCreateInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkExportMemoryAllocateInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkExportMemoryAllocateInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkExportFenceCreateInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkExportFenceCreateInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkExportSemaphoreCreateInfo*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkExportSemaphoreCreateInfo*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceMaintenance3Properties*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceMaintenance3Properties*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceShaderDrawParameterFeatures*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceShaderDrawParameterFeatures*>(value));
             break;
         case VK_STRUCTURE_TYPE_IMAGE_SWAPCHAIN_CREATE_INFO_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkImageSwapchainCreateInfoKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkImageSwapchainCreateInfoKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkBindImageMemorySwapchainInfoKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkBindImageMemorySwapchainInfoKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_INFO_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDeviceGroupPresentInfoKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDeviceGroupPresentInfoKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_SWAPCHAIN_CREATE_INFO_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDeviceGroupSwapchainCreateInfoKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDeviceGroupSwapchainCreateInfoKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_DISPLAY_PRESENT_INFO_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDisplayPresentInfoKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDisplayPresentInfoKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkImportMemoryWin32HandleInfoKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkImportMemoryWin32HandleInfoKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkExportMemoryWin32HandleInfoKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkExportMemoryWin32HandleInfoKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkImportMemoryFdInfoKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkImportMemoryFdInfoKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkWin32KeyedMutexAcquireReleaseInfoKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkWin32KeyedMutexAcquireReleaseInfoKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkExportSemaphoreWin32HandleInfoKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkExportSemaphoreWin32HandleInfoKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkD3D12FenceSubmitInfoKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkD3D12FenceSubmitInfoKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDevicePushDescriptorPropertiesKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDevicePushDescriptorPropertiesKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceFloat16Int8FeaturesKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceFloat16Int8FeaturesKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPresentRegionsKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPresentRegionsKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkSharedPresentSurfaceCapabilitiesKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkSharedPresentSurfaceCapabilitiesKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_EXPORT_FENCE_WIN32_HANDLE_INFO_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkExportFenceWin32HandleInfoKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkExportFenceWin32HandleInfoKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkImageFormatListCreateInfoKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkImageFormatListCreateInfoKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDevice8BitStorageFeaturesKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDevice8BitStorageFeaturesKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64FeaturesKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64FeaturesKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceDriverPropertiesKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceDriverPropertiesKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceFloatControlsPropertiesKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceFloatControlsPropertiesKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkSubpassDescriptionDepthStencilResolveKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkSubpassDescriptionDepthStencilResolveKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceDepthStencilResolvePropertiesKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceDepthStencilResolvePropertiesKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES_KHR:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR*>(value));
             break;
         case VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDebugReportCallbackCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDebugReportCallbackCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPipelineRasterizationStateRasterizationOrderAMD*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineRasterizationStateRasterizationOrderAMD*>(value));
             break;
         case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDedicatedAllocationImageCreateInfoNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDedicatedAllocationImageCreateInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDedicatedAllocationBufferCreateInfoNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDedicatedAllocationBufferCreateInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDedicatedAllocationMemoryAllocateInfoNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDedicatedAllocationMemoryAllocateInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceTransformFeedbackPropertiesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceTransformFeedbackPropertiesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPipelineRasterizationStateStreamCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineRasterizationStateStreamCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkTextureLODGatherFormatPropertiesAMD*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkTextureLODGatherFormatPropertiesAMD*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkExternalMemoryImageCreateInfoNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkExternalMemoryImageCreateInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkExportMemoryAllocateInfoNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkExportMemoryAllocateInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkImportMemoryWin32HandleInfoNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkImportMemoryWin32HandleInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkExportMemoryWin32HandleInfoNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkExportMemoryWin32HandleInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkWin32KeyedMutexAcquireReleaseInfoNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkWin32KeyedMutexAcquireReleaseInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkValidationFlagsEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkValidationFlagsEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_IMAGE_VIEW_ASTC_DECODE_MODE_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkImageViewASTCDecodeModeEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkImageViewASTCDecodeModeEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_CONDITIONAL_RENDERING_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkCommandBufferInheritanceConditionalRenderingInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkCommandBufferInheritanceConditionalRenderingInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_W_SCALING_STATE_CREATE_INFO_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPipelineViewportWScalingStateCreateInfoNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineViewportWScalingStateCreateInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_COUNTER_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkSwapchainCounterCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkSwapchainCounterCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPresentTimesInfoGOOGLE*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPresentTimesInfoGOOGLE*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX*>(value));
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPipelineViewportSwizzleStateCreateInfoNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineViewportSwizzleStateCreateInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceDiscardRectanglePropertiesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceDiscardRectanglePropertiesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPipelineDiscardRectangleStateCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineDiscardRectangleStateCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceConservativeRasterizationPropertiesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceConservativeRasterizationPropertiesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPipelineRasterizationConservativeStateCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineRasterizationConservativeStateCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDebugUtilsMessengerCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDebugUtilsMessengerCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkAndroidHardwareBufferUsageANDROID*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkAndroidHardwareBufferUsageANDROID*>(value));
             break;
         case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkAndroidHardwareBufferFormatPropertiesANDROID*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkAndroidHardwareBufferFormatPropertiesANDROID*>(value));
             break;
         case VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkImportAndroidHardwareBufferInfoANDROID*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkImportAndroidHardwareBufferInfoANDROID*>(value));
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkExternalFormatANDROID*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkExternalFormatANDROID*>(value));
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkSamplerReductionModeCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkSamplerReductionModeCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeaturesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeaturesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockPropertiesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockPropertiesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkWriteDescriptorSetInlineUniformBlockEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkWriteDescriptorSetInlineUniformBlockEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDescriptorPoolInlineUniformBlockCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDescriptorPoolInlineUniformBlockCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkSampleLocationsInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkSampleLocationsInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_SAMPLE_LOCATIONS_BEGIN_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkRenderPassSampleLocationsBeginInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkRenderPassSampleLocationsBeginInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_SAMPLE_LOCATIONS_STATE_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPipelineSampleLocationsStateCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineSampleLocationsStateCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceSampleLocationsPropertiesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceSampleLocationsPropertiesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPipelineColorBlendAdvancedStateCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineColorBlendAdvancedStateCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_TO_COLOR_STATE_CREATE_INFO_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPipelineCoverageToColorStateCreateInfoNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineCoverageToColorStateCreateInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_MODULATION_STATE_CREATE_INFO_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPipelineCoverageModulationStateCreateInfoNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineCoverageModulationStateCreateInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDrmFormatModifierPropertiesListEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDrmFormatModifierPropertiesListEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_DRM_FORMAT_MODIFIER_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceImageDrmFormatModifierInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceImageDrmFormatModifierInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkImageDrmFormatModifierListCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkImageDrmFormatModifierListCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_EXPLICIT_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkImageDrmFormatModifierExplicitCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkImageDrmFormatModifierExplicitCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkShaderModuleValidationCacheCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkShaderModuleValidationCacheCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDescriptorSetLayoutBindingFlagsCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDescriptorSetLayoutBindingFlagsCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeaturesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeaturesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingPropertiesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingPropertiesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDescriptorSetVariableDescriptorCountAllocateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDescriptorSetVariableDescriptorCountAllocateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDescriptorSetVariableDescriptorCountLayoutSupportEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDescriptorSetVariableDescriptorCountLayoutSupportEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SHADING_RATE_IMAGE_STATE_CREATE_INFO_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPipelineViewportShadingRateImageStateCreateInfoNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineViewportShadingRateImageStateCreateInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_FEATURES_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_PROPERTIES_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceShadingRateImagePropertiesNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceShadingRateImagePropertiesNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_COARSE_SAMPLE_ORDER_STATE_CREATE_INFO_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPipelineViewportCoarseSampleOrderStateCreateInfoNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineViewportCoarseSampleOrderStateCreateInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkWriteDescriptorSetAccelerationStructureNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkWriteDescriptorSetAccelerationStructureNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PROPERTIES_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceRayTracingPropertiesNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceRayTracingPropertiesNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_REPRESENTATIVE_FRAGMENT_TEST_STATE_CREATE_INFO_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPipelineRepresentativeFragmentTestStateCreateInfoNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineRepresentativeFragmentTestStateCreateInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDeviceQueueGlobalPriorityCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDeviceQueueGlobalPriorityCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_HOST_POINTER_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkImportMemoryHostPointerInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkImportMemoryHostPointerInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceExternalMemoryHostPropertiesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceExternalMemoryHostPropertiesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_AMD:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceShaderCorePropertiesAMD*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceShaderCorePropertiesAMD*>(value));
             break;
         case VK_STRUCTURE_TYPE_DEVICE_MEMORY_OVERALLOCATION_CREATE_INFO_AMD:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkDeviceMemoryOverallocationCreateInfoAMD*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkDeviceMemoryOverallocationCreateInfoAMD*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPipelineVertexInputDivisorStateCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineVertexInputDivisorStateCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceMeshShaderPropertiesNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceMeshShaderPropertiesNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_EXCLUSIVE_SCISSOR_STATE_CREATE_INFO_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPipelineViewportExclusiveScissorStateCreateInfoNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineViewportExclusiveScissorStateCreateInfoNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_NV:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkQueueFamilyCheckpointPropertiesNV*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkQueueFamilyCheckpointPropertiesNV*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDevicePCIBusInfoPropertiesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDevicePCIBusInfoPropertiesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapPropertiesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapPropertiesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkRenderPassFragmentDensityMapCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkRenderPassFragmentDensityMapCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeaturesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeaturesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceMemoryBudgetPropertiesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceMemoryBudgetPropertiesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkMemoryPriorityAllocateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkMemoryPriorityAllocateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_ADDRESS_FEATURES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkPhysicalDeviceBufferAddressFeaturesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceBufferAddressFeaturesEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkBufferDeviceAddressCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkBufferDeviceAddressCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_IMAGE_STENCIL_USAGE_CREATE_INFO_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkImageStencilUsageCreateInfoEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkImageStencilUsageCreateInfoEXT*>(value));
             break;
         case VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT:
-            encode_struct_ptr(encoder, reinterpret_cast<const VkValidationFeaturesEXT*>(value));
+            EncodeStructPtr(encoder, reinterpret_cast<const VkValidationFeaturesEXT*>(value));
             break;
         }
     }

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -46,8 +46,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(
     auto encoder = encode::TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateInstance);
     if (encoder)
     {
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pInstance);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -68,7 +68,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyInstance(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(instance);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -113,7 +113,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pFeatures);
+        EncodeStructPtr(encoder, pFeatures);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -134,7 +134,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties(
     {
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeEnumValue(format);
-        encode_struct_ptr(encoder, pFormatProperties);
+        EncodeStructPtr(encoder, pFormatProperties);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -163,7 +163,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties(
         encoder->EncodeEnumValue(tiling);
         encoder->EncodeFlagsValue(usage);
         encoder->EncodeFlagsValue(flags);
-        encode_struct_ptr(encoder, pImageFormatProperties);
+        EncodeStructPtr(encoder, pImageFormatProperties);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -185,7 +185,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pProperties);
+        EncodeStructPtr(encoder, pProperties);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -206,7 +206,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties(
     {
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeUInt32Ptr(pQueueFamilyPropertyCount);
-        encode_struct_array(encoder, pQueueFamilyProperties, (pQueueFamilyPropertyCount != nullptr) ? (*pQueueFamilyPropertyCount) : 0);
+        EncodeStructArray(encoder, pQueueFamilyProperties, (pQueueFamilyPropertyCount != nullptr) ? (*pQueueFamilyPropertyCount) : 0);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -225,7 +225,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pMemoryProperties);
+        EncodeStructPtr(encoder, pMemoryProperties);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -246,8 +246,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pDevice);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -268,7 +268,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDevice(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -315,7 +315,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit(
     {
         encoder->EncodeHandleIdValue(queue);
         encoder->EncodeUInt32Value(submitCount);
-        encode_struct_array(encoder, pSubmits, submitCount);
+        EncodeStructArray(encoder, pSubmits, submitCount);
         encoder->EncodeHandleIdValue(fence);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -380,8 +380,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateMemory(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pAllocateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pMemory);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -404,7 +404,7 @@ VKAPI_ATTR void VKAPI_CALL FreeMemory(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(memory);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -476,7 +476,7 @@ VKAPI_ATTR VkResult VKAPI_CALL FlushMappedMemoryRanges(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeUInt32Value(memoryRangeCount);
-        encode_struct_array(encoder, pMemoryRanges, memoryRangeCount);
+        EncodeStructArray(encoder, pMemoryRanges, memoryRangeCount);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -500,7 +500,7 @@ VKAPI_ATTR VkResult VKAPI_CALL InvalidateMappedMemoryRanges(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeUInt32Value(memoryRangeCount);
-        encode_struct_array(encoder, pMemoryRanges, memoryRangeCount);
+        EncodeStructArray(encoder, pMemoryRanges, memoryRangeCount);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -597,7 +597,7 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(buffer);
-        encode_struct_ptr(encoder, pMemoryRequirements);
+        EncodeStructPtr(encoder, pMemoryRequirements);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -618,7 +618,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(image);
-        encode_struct_ptr(encoder, pMemoryRequirements);
+        EncodeStructPtr(encoder, pMemoryRequirements);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -641,7 +641,7 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements(
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(image);
         encoder->EncodeUInt32Ptr(pSparseMemoryRequirementCount);
-        encode_struct_array(encoder, pSparseMemoryRequirements, (pSparseMemoryRequirementCount != nullptr) ? (*pSparseMemoryRequirementCount) : 0);
+        EncodeStructArray(encoder, pSparseMemoryRequirements, (pSparseMemoryRequirementCount != nullptr) ? (*pSparseMemoryRequirementCount) : 0);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -672,7 +672,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceSparseImageFormatProperties(
         encoder->EncodeFlagsValue(usage);
         encoder->EncodeEnumValue(tiling);
         encoder->EncodeUInt32Ptr(pPropertyCount);
-        encode_struct_array(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
+        EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -694,7 +694,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueBindSparse(
     {
         encoder->EncodeHandleIdValue(queue);
         encoder->EncodeUInt32Value(bindInfoCount);
-        encode_struct_array(encoder, pBindInfo, bindInfoCount);
+        EncodeStructArray(encoder, pBindInfo, bindInfoCount);
         encoder->EncodeHandleIdValue(fence);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -719,8 +719,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFence(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pFence);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -743,7 +743,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyFence(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(fence);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -840,8 +840,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSemaphore(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSemaphore);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -864,7 +864,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySemaphore(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(semaphore);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -887,8 +887,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateEvent(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pEvent);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -911,7 +911,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyEvent(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(event);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1000,8 +1000,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateQueryPool(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pQueryPool);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1024,7 +1024,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyQueryPool(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(queryPool);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1081,8 +1081,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBuffer(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pBuffer);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1105,7 +1105,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyBuffer(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(buffer);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1128,8 +1128,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBufferView(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pView);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1152,7 +1152,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyBufferView(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(bufferView);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1175,8 +1175,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImage(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pImage);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1199,7 +1199,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyImage(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(image);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1223,8 +1223,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageSubresourceLayout(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(image);
-        encode_struct_ptr(encoder, pSubresource);
-        encode_struct_ptr(encoder, pLayout);
+        EncodeStructPtr(encoder, pSubresource);
+        EncodeStructPtr(encoder, pLayout);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1245,8 +1245,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImageView(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pView);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1269,7 +1269,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyImageView(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(imageView);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1292,8 +1292,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pShaderModule);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1316,7 +1316,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderModule(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(shaderModule);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1339,8 +1339,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineCache(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pPipelineCache);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1363,7 +1363,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineCache(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(pipelineCache);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1442,8 +1442,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(pipelineCache);
         encoder->EncodeUInt32Value(createInfoCount);
-        encode_struct_array(encoder, pCreateInfos, createInfoCount);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructArray(encoder, pCreateInfos, createInfoCount);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1472,8 +1472,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(pipelineCache);
         encoder->EncodeUInt32Value(createInfoCount);
-        encode_struct_array(encoder, pCreateInfos, createInfoCount);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructArray(encoder, pCreateInfos, createInfoCount);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1496,7 +1496,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipeline(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(pipeline);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1519,8 +1519,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pPipelineLayout);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1543,7 +1543,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyPipelineLayout(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(pipelineLayout);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1566,8 +1566,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSampler(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSampler);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1590,7 +1590,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySampler(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(sampler);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1613,8 +1613,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorSetLayout(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSetLayout);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1637,7 +1637,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorSetLayout(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(descriptorSetLayout);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1660,8 +1660,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorPool(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pDescriptorPool);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1684,7 +1684,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorPool(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(descriptorPool);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1730,7 +1730,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pAllocateInfo);
+        EncodeStructPtr(encoder, pAllocateInfo);
         encoder->EncodeHandleIdArray(pDescriptorSets, pAllocateInfo->descriptorSetCount);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1781,9 +1781,9 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSets(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeUInt32Value(descriptorWriteCount);
-        encode_struct_array(encoder, pDescriptorWrites, descriptorWriteCount);
+        EncodeStructArray(encoder, pDescriptorWrites, descriptorWriteCount);
         encoder->EncodeUInt32Value(descriptorCopyCount);
-        encode_struct_array(encoder, pDescriptorCopies, descriptorCopyCount);
+        EncodeStructArray(encoder, pDescriptorCopies, descriptorCopyCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1806,8 +1806,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFramebuffer(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pFramebuffer);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1830,7 +1830,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyFramebuffer(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(framebuffer);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1853,8 +1853,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pRenderPass);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1877,7 +1877,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyRenderPass(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(renderPass);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1900,7 +1900,7 @@ VKAPI_ATTR void VKAPI_CALL GetRenderAreaGranularity(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(renderPass);
-        encode_struct_ptr(encoder, pGranularity);
+        EncodeStructPtr(encoder, pGranularity);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1921,8 +1921,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateCommandPool(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pCommandPool);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -1945,7 +1945,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyCommandPool(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(commandPool);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -1991,7 +1991,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateCommandBuffers(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pAllocateInfo);
+        EncodeStructPtr(encoder, pAllocateInfo);
         encoder->EncodeHandleIdArray(pCommandBuffers, pAllocateInfo->commandBufferCount);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -2037,7 +2037,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
-        encode_struct_ptr(encoder, pBeginInfo);
+        EncodeStructPtr(encoder, pBeginInfo);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -2124,7 +2124,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewport(
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeUInt32Value(firstViewport);
         encoder->EncodeUInt32Value(viewportCount);
-        encode_struct_array(encoder, pViewports, viewportCount);
+        EncodeStructArray(encoder, pViewports, viewportCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -2147,7 +2147,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetScissor(
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeUInt32Value(firstScissor);
         encoder->EncodeUInt32Value(scissorCount);
-        encode_struct_array(encoder, pScissors, scissorCount);
+        EncodeStructArray(encoder, pScissors, scissorCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -2542,7 +2542,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer(
         encoder->EncodeHandleIdValue(srcBuffer);
         encoder->EncodeHandleIdValue(dstBuffer);
         encoder->EncodeUInt32Value(regionCount);
-        encode_struct_array(encoder, pRegions, regionCount);
+        EncodeStructArray(encoder, pRegions, regionCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -2571,7 +2571,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage(
         encoder->EncodeHandleIdValue(dstImage);
         encoder->EncodeEnumValue(dstImageLayout);
         encoder->EncodeUInt32Value(regionCount);
-        encode_struct_array(encoder, pRegions, regionCount);
+        EncodeStructArray(encoder, pRegions, regionCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -2601,7 +2601,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage(
         encoder->EncodeHandleIdValue(dstImage);
         encoder->EncodeEnumValue(dstImageLayout);
         encoder->EncodeUInt32Value(regionCount);
-        encode_struct_array(encoder, pRegions, regionCount);
+        EncodeStructArray(encoder, pRegions, regionCount);
         encoder->EncodeEnumValue(filter);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -2629,7 +2629,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage(
         encoder->EncodeHandleIdValue(dstImage);
         encoder->EncodeEnumValue(dstImageLayout);
         encoder->EncodeUInt32Value(regionCount);
-        encode_struct_array(encoder, pRegions, regionCount);
+        EncodeStructArray(encoder, pRegions, regionCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -2656,7 +2656,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer(
         encoder->EncodeEnumValue(srcImageLayout);
         encoder->EncodeHandleIdValue(dstBuffer);
         encoder->EncodeUInt32Value(regionCount);
-        encode_struct_array(encoder, pRegions, regionCount);
+        EncodeStructArray(encoder, pRegions, regionCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -2731,9 +2731,9 @@ VKAPI_ATTR void VKAPI_CALL CmdClearColorImage(
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeHandleIdValue(image);
         encoder->EncodeEnumValue(imageLayout);
-        encode_struct_ptr(encoder, pColor);
+        EncodeStructPtr(encoder, pColor);
         encoder->EncodeUInt32Value(rangeCount);
-        encode_struct_array(encoder, pRanges, rangeCount);
+        EncodeStructArray(encoder, pRanges, rangeCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -2758,9 +2758,9 @@ VKAPI_ATTR void VKAPI_CALL CmdClearDepthStencilImage(
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeHandleIdValue(image);
         encoder->EncodeEnumValue(imageLayout);
-        encode_struct_ptr(encoder, pDepthStencil);
+        EncodeStructPtr(encoder, pDepthStencil);
         encoder->EncodeUInt32Value(rangeCount);
-        encode_struct_array(encoder, pRanges, rangeCount);
+        EncodeStructArray(encoder, pRanges, rangeCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -2783,9 +2783,9 @@ VKAPI_ATTR void VKAPI_CALL CmdClearAttachments(
     {
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeUInt32Value(attachmentCount);
-        encode_struct_array(encoder, pAttachments, attachmentCount);
+        EncodeStructArray(encoder, pAttachments, attachmentCount);
         encoder->EncodeUInt32Value(rectCount);
-        encode_struct_array(encoder, pRects, rectCount);
+        EncodeStructArray(encoder, pRects, rectCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -2814,7 +2814,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage(
         encoder->EncodeHandleIdValue(dstImage);
         encoder->EncodeEnumValue(dstImageLayout);
         encoder->EncodeUInt32Value(regionCount);
-        encode_struct_array(encoder, pRegions, regionCount);
+        EncodeStructArray(encoder, pRegions, regionCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -2889,11 +2889,11 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents(
         encoder->EncodeFlagsValue(srcStageMask);
         encoder->EncodeFlagsValue(dstStageMask);
         encoder->EncodeUInt32Value(memoryBarrierCount);
-        encode_struct_array(encoder, pMemoryBarriers, memoryBarrierCount);
+        EncodeStructArray(encoder, pMemoryBarriers, memoryBarrierCount);
         encoder->EncodeUInt32Value(bufferMemoryBarrierCount);
-        encode_struct_array(encoder, pBufferMemoryBarriers, bufferMemoryBarrierCount);
+        EncodeStructArray(encoder, pBufferMemoryBarriers, bufferMemoryBarrierCount);
         encoder->EncodeUInt32Value(imageMemoryBarrierCount);
-        encode_struct_array(encoder, pImageMemoryBarriers, imageMemoryBarrierCount);
+        EncodeStructArray(encoder, pImageMemoryBarriers, imageMemoryBarrierCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -2924,11 +2924,11 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier(
         encoder->EncodeFlagsValue(dstStageMask);
         encoder->EncodeFlagsValue(dependencyFlags);
         encoder->EncodeUInt32Value(memoryBarrierCount);
-        encode_struct_array(encoder, pMemoryBarriers, memoryBarrierCount);
+        EncodeStructArray(encoder, pMemoryBarriers, memoryBarrierCount);
         encoder->EncodeUInt32Value(bufferMemoryBarrierCount);
-        encode_struct_array(encoder, pBufferMemoryBarriers, bufferMemoryBarrierCount);
+        EncodeStructArray(encoder, pBufferMemoryBarriers, bufferMemoryBarrierCount);
         encoder->EncodeUInt32Value(imageMemoryBarrierCount);
-        encode_struct_array(encoder, pImageMemoryBarriers, imageMemoryBarrierCount);
+        EncodeStructArray(encoder, pImageMemoryBarriers, imageMemoryBarrierCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3096,7 +3096,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
-        encode_struct_ptr(encoder, pRenderPassBegin);
+        EncodeStructPtr(encoder, pRenderPassBegin);
         encoder->EncodeEnumValue(contents);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -3177,7 +3177,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeUInt32Value(bindInfoCount);
-        encode_struct_array(encoder, pBindInfos, bindInfoCount);
+        EncodeStructArray(encoder, pBindInfos, bindInfoCount);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -3201,7 +3201,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory2(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeUInt32Value(bindInfoCount);
-        encode_struct_array(encoder, pBindInfos, bindInfoCount);
+        EncodeStructArray(encoder, pBindInfos, bindInfoCount);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -3298,7 +3298,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroups(
     {
         encoder->EncodeHandleIdValue(instance);
         encoder->EncodeUInt32Ptr(pPhysicalDeviceGroupCount);
-        encode_struct_array(encoder, pPhysicalDeviceGroupProperties, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0);
+        EncodeStructArray(encoder, pPhysicalDeviceGroupProperties, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -3321,8 +3321,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements2(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pInfo);
-        encode_struct_ptr(encoder, pMemoryRequirements);
+        EncodeStructPtr(encoder, pInfo);
+        EncodeStructPtr(encoder, pMemoryRequirements);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3342,8 +3342,8 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements2(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pInfo);
-        encode_struct_ptr(encoder, pMemoryRequirements);
+        EncodeStructPtr(encoder, pInfo);
+        EncodeStructPtr(encoder, pMemoryRequirements);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3364,9 +3364,9 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements2(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pInfo);
+        EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt32Ptr(pSparseMemoryRequirementCount);
-        encode_struct_array(encoder, pSparseMemoryRequirements, (pSparseMemoryRequirementCount != nullptr) ? (*pSparseMemoryRequirementCount) : 0);
+        EncodeStructArray(encoder, pSparseMemoryRequirements, (pSparseMemoryRequirementCount != nullptr) ? (*pSparseMemoryRequirementCount) : 0);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3385,7 +3385,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures2(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pFeatures);
+        EncodeStructPtr(encoder, pFeatures);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3404,7 +3404,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pProperties);
+        EncodeStructPtr(encoder, pProperties);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3425,7 +3425,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2(
     {
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeEnumValue(format);
-        encode_struct_ptr(encoder, pFormatProperties);
+        EncodeStructPtr(encoder, pFormatProperties);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3445,8 +3445,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pImageFormatInfo);
-        encode_struct_ptr(encoder, pImageFormatProperties);
+        EncodeStructPtr(encoder, pImageFormatInfo);
+        EncodeStructPtr(encoder, pImageFormatProperties);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -3470,7 +3470,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties2(
     {
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeUInt32Ptr(pQueueFamilyPropertyCount);
-        encode_struct_array(encoder, pQueueFamilyProperties, (pQueueFamilyPropertyCount != nullptr) ? (*pQueueFamilyPropertyCount) : 0);
+        EncodeStructArray(encoder, pQueueFamilyProperties, (pQueueFamilyPropertyCount != nullptr) ? (*pQueueFamilyPropertyCount) : 0);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3489,7 +3489,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties2(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pMemoryProperties);
+        EncodeStructPtr(encoder, pMemoryProperties);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3510,9 +3510,9 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceSparseImageFormatProperties2(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pFormatInfo);
+        EncodeStructPtr(encoder, pFormatInfo);
         encoder->EncodeUInt32Ptr(pPropertyCount);
-        encode_struct_array(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
+        EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3553,7 +3553,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceQueue2(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pQueueInfo);
+        EncodeStructPtr(encoder, pQueueInfo);
         encoder->EncodeHandleIdPtr(pQueue);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -3575,8 +3575,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversion(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pYcbcrConversion);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -3599,7 +3599,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversion(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(ycbcrConversion);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3622,8 +3622,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplate(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pDescriptorUpdateTemplate);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -3646,7 +3646,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplate(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(descriptorUpdateTemplate);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3668,8 +3668,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferProperties(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pExternalBufferInfo);
-        encode_struct_ptr(encoder, pExternalBufferProperties);
+        EncodeStructPtr(encoder, pExternalBufferInfo);
+        EncodeStructPtr(encoder, pExternalBufferProperties);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3689,8 +3689,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalFenceProperties(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pExternalFenceInfo);
-        encode_struct_ptr(encoder, pExternalFenceProperties);
+        EncodeStructPtr(encoder, pExternalFenceInfo);
+        EncodeStructPtr(encoder, pExternalFenceProperties);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3710,8 +3710,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalSemaphoreProperties(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pExternalSemaphoreInfo);
-        encode_struct_ptr(encoder, pExternalSemaphoreProperties);
+        EncodeStructPtr(encoder, pExternalSemaphoreInfo);
+        EncodeStructPtr(encoder, pExternalSemaphoreProperties);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3731,8 +3731,8 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutSupport(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pSupport);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pSupport);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3751,7 +3751,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySurfaceKHR(
     {
         encoder->EncodeHandleIdValue(instance);
         encoder->EncodeHandleIdValue(surface);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3800,7 +3800,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilitiesKHR(
     {
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeHandleIdValue(surface);
-        encode_struct_ptr(encoder, pSurfaceCapabilities);
+        EncodeStructPtr(encoder, pSurfaceCapabilities);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -3826,7 +3826,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceFormatsKHR(
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeHandleIdValue(surface);
         encoder->EncodeUInt32Ptr(pSurfaceFormatCount);
-        encode_struct_array(encoder, pSurfaceFormats, (pSurfaceFormatCount != nullptr) ? (*pSurfaceFormatCount) : 0);
+        EncodeStructArray(encoder, pSurfaceFormats, (pSurfaceFormatCount != nullptr) ? (*pSurfaceFormatCount) : 0);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -3876,8 +3876,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSwapchainKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSwapchain);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -3900,7 +3900,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySwapchainKHR(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(swapchain);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -3977,7 +3977,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(queue);
-        encode_struct_ptr(encoder, pPresentInfo);
+        EncodeStructPtr(encoder, pPresentInfo);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -3999,7 +3999,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeviceGroupPresentCapabilitiesKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pDeviceGroupPresentCapabilities);
+        EncodeStructPtr(encoder, pDeviceGroupPresentCapabilities);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -4049,7 +4049,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDevicePresentRectanglesKHR(
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeHandleIdValue(surface);
         encoder->EncodeUInt32Ptr(pRectCount);
-        encode_struct_array(encoder, pRects, (pRectCount != nullptr) ? (*pRectCount) : 0);
+        EncodeStructArray(encoder, pRects, (pRectCount != nullptr) ? (*pRectCount) : 0);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -4072,7 +4072,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireNextImage2KHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pAcquireInfo);
+        EncodeStructPtr(encoder, pAcquireInfo);
         encoder->EncodeUInt32Ptr(pImageIndex);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -4097,7 +4097,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPropertiesKHR(
     {
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeUInt32Ptr(pPropertyCount);
-        encode_struct_array(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
+        EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -4121,7 +4121,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlanePropertiesKHR(
     {
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeUInt32Ptr(pPropertyCount);
-        encode_struct_array(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
+        EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -4173,7 +4173,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModePropertiesKHR(
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeHandleIdValue(display);
         encoder->EncodeUInt32Ptr(pPropertyCount);
-        encode_struct_array(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
+        EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -4199,8 +4199,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayModeKHR(
     {
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeHandleIdValue(display);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pMode);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -4227,7 +4227,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneCapabilitiesKHR(
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeHandleIdValue(mode);
         encoder->EncodeUInt32Value(planeIndex);
-        encode_struct_ptr(encoder, pCapabilities);
+        EncodeStructPtr(encoder, pCapabilities);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -4251,8 +4251,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayPlaneSurfaceKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(instance);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -4279,8 +4279,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSharedSwapchainsKHR(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeUInt32Value(swapchainCount);
-        encode_struct_array(encoder, pCreateInfos, swapchainCount);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructArray(encoder, pCreateInfos, swapchainCount);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdArray(pSwapchains, swapchainCount);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -4305,8 +4305,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXlibSurfaceKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(instance);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -4357,8 +4357,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXcbSurfaceKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(instance);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -4409,8 +4409,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWaylandSurfaceKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(instance);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -4459,8 +4459,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAndroidSurfaceKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(instance);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -4485,8 +4485,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWin32SurfaceKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(instance);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -4531,7 +4531,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFeatures2KHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pFeatures);
+        EncodeStructPtr(encoder, pFeatures);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -4550,7 +4550,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceProperties2KHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pProperties);
+        EncodeStructPtr(encoder, pProperties);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -4571,7 +4571,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceFormatProperties2KHR(
     {
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeEnumValue(format);
-        encode_struct_ptr(encoder, pFormatProperties);
+        EncodeStructPtr(encoder, pFormatProperties);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -4591,8 +4591,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceImageFormatProperties2KHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pImageFormatInfo);
-        encode_struct_ptr(encoder, pImageFormatProperties);
+        EncodeStructPtr(encoder, pImageFormatInfo);
+        EncodeStructPtr(encoder, pImageFormatProperties);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -4616,7 +4616,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties2KHR(
     {
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeUInt32Ptr(pQueueFamilyPropertyCount);
-        encode_struct_array(encoder, pQueueFamilyProperties, (pQueueFamilyPropertyCount != nullptr) ? (*pQueueFamilyPropertyCount) : 0);
+        EncodeStructArray(encoder, pQueueFamilyProperties, (pQueueFamilyPropertyCount != nullptr) ? (*pQueueFamilyPropertyCount) : 0);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -4635,7 +4635,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMemoryProperties2KHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pMemoryProperties);
+        EncodeStructPtr(encoder, pMemoryProperties);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -4656,9 +4656,9 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceSparseImageFormatProperties2KHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pFormatInfo);
+        EncodeStructPtr(encoder, pFormatInfo);
         encoder->EncodeUInt32Ptr(pPropertyCount);
-        encode_struct_array(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
+        EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -4773,7 +4773,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDeviceGroupsKHR(
     {
         encoder->EncodeHandleIdValue(instance);
         encoder->EncodeUInt32Ptr(pPhysicalDeviceGroupCount);
-        encode_struct_array(encoder, pPhysicalDeviceGroupProperties, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0);
+        EncodeStructArray(encoder, pPhysicalDeviceGroupProperties, (pPhysicalDeviceGroupCount != nullptr) ? (*pPhysicalDeviceGroupCount) : 0);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -4796,8 +4796,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalBufferPropertiesKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pExternalBufferInfo);
-        encode_struct_ptr(encoder, pExternalBufferProperties);
+        EncodeStructPtr(encoder, pExternalBufferInfo);
+        EncodeStructPtr(encoder, pExternalBufferProperties);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -4817,7 +4817,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandleKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pGetWin32HandleInfo);
+        EncodeStructPtr(encoder, pGetWin32HandleInfo);
         encoder->EncodeVoidPtrPtr(pHandle);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -4844,7 +4844,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryWin32HandlePropertiesKHR(
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeEnumValue(handleType);
         encoder->EncodeVoidPtr(handle);
-        encode_struct_ptr(encoder, pMemoryWin32HandleProperties);
+        EncodeStructPtr(encoder, pMemoryWin32HandleProperties);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -4867,7 +4867,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pGetFdInfo);
+        EncodeStructPtr(encoder, pGetFdInfo);
         encoder->EncodeInt32Ptr(pFd);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -4894,7 +4894,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryFdPropertiesKHR(
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeEnumValue(handleType);
         encoder->EncodeInt32Value(fd);
-        encode_struct_ptr(encoder, pMemoryFdProperties);
+        EncodeStructPtr(encoder, pMemoryFdProperties);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -4917,8 +4917,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalSemaphorePropertiesKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pExternalSemaphoreInfo);
-        encode_struct_ptr(encoder, pExternalSemaphoreProperties);
+        EncodeStructPtr(encoder, pExternalSemaphoreInfo);
+        EncodeStructPtr(encoder, pExternalSemaphoreProperties);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -4937,7 +4937,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreWin32HandleKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pImportSemaphoreWin32HandleInfo);
+        EncodeStructPtr(encoder, pImportSemaphoreWin32HandleInfo);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -4960,7 +4960,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreWin32HandleKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pGetWin32HandleInfo);
+        EncodeStructPtr(encoder, pGetWin32HandleInfo);
         encoder->EncodeVoidPtrPtr(pHandle);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -4983,7 +4983,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportSemaphoreFdKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pImportSemaphoreFdInfo);
+        EncodeStructPtr(encoder, pImportSemaphoreFdInfo);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -5006,7 +5006,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSemaphoreFdKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pGetFdInfo);
+        EncodeStructPtr(encoder, pGetFdInfo);
         encoder->EncodeInt32Ptr(pFd);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -5035,7 +5035,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetKHR(
         encoder->EncodeHandleIdValue(layout);
         encoder->EncodeUInt32Value(set);
         encoder->EncodeUInt32Value(descriptorWriteCount);
-        encode_struct_array(encoder, pDescriptorWrites, descriptorWriteCount);
+        EncodeStructArray(encoder, pDescriptorWrites, descriptorWriteCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -5058,8 +5058,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplateKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pDescriptorUpdateTemplate);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -5082,7 +5082,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDescriptorUpdateTemplateKHR(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(descriptorUpdateTemplate);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -5105,8 +5105,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pRenderPass);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -5128,8 +5128,8 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass2KHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
-        encode_struct_ptr(encoder, pRenderPassBegin);
-        encode_struct_ptr(encoder, pSubpassBeginInfo);
+        EncodeStructPtr(encoder, pRenderPassBegin);
+        EncodeStructPtr(encoder, pSubpassBeginInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -5149,8 +5149,8 @@ VKAPI_ATTR void VKAPI_CALL CmdNextSubpass2KHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
-        encode_struct_ptr(encoder, pSubpassBeginInfo);
-        encode_struct_ptr(encoder, pSubpassEndInfo);
+        EncodeStructPtr(encoder, pSubpassBeginInfo);
+        EncodeStructPtr(encoder, pSubpassEndInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -5169,7 +5169,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass2KHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
-        encode_struct_ptr(encoder, pSubpassEndInfo);
+        EncodeStructPtr(encoder, pSubpassEndInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -5213,8 +5213,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceExternalFencePropertiesKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pExternalFenceInfo);
-        encode_struct_ptr(encoder, pExternalFenceProperties);
+        EncodeStructPtr(encoder, pExternalFenceInfo);
+        EncodeStructPtr(encoder, pExternalFenceProperties);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -5233,7 +5233,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportFenceWin32HandleKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pImportFenceWin32HandleInfo);
+        EncodeStructPtr(encoder, pImportFenceWin32HandleInfo);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -5256,7 +5256,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceWin32HandleKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pGetWin32HandleInfo);
+        EncodeStructPtr(encoder, pGetWin32HandleInfo);
         encoder->EncodeVoidPtrPtr(pHandle);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -5279,7 +5279,7 @@ VKAPI_ATTR VkResult VKAPI_CALL ImportFenceFdKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pImportFenceFdInfo);
+        EncodeStructPtr(encoder, pImportFenceFdInfo);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -5302,7 +5302,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetFenceFdKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pGetFdInfo);
+        EncodeStructPtr(encoder, pGetFdInfo);
         encoder->EncodeInt32Ptr(pFd);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -5326,8 +5326,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2KHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pSurfaceInfo);
-        encode_struct_ptr(encoder, pSurfaceCapabilities);
+        EncodeStructPtr(encoder, pSurfaceInfo);
+        EncodeStructPtr(encoder, pSurfaceCapabilities);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -5351,9 +5351,9 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceFormats2KHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pSurfaceInfo);
+        EncodeStructPtr(encoder, pSurfaceInfo);
         encoder->EncodeUInt32Ptr(pSurfaceFormatCount);
-        encode_struct_array(encoder, pSurfaceFormats, (pSurfaceFormatCount != nullptr) ? (*pSurfaceFormatCount) : 0);
+        EncodeStructArray(encoder, pSurfaceFormats, (pSurfaceFormatCount != nullptr) ? (*pSurfaceFormatCount) : 0);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -5377,7 +5377,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayProperties2KHR(
     {
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeUInt32Ptr(pPropertyCount);
-        encode_struct_array(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
+        EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -5401,7 +5401,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlaneProperties2KHR(
     {
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeUInt32Ptr(pPropertyCount);
-        encode_struct_array(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
+        EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -5427,7 +5427,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModeProperties2KHR(
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeHandleIdValue(display);
         encoder->EncodeUInt32Ptr(pPropertyCount);
-        encode_struct_array(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
+        EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -5450,8 +5450,8 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneCapabilities2KHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pDisplayPlaneInfo);
-        encode_struct_ptr(encoder, pCapabilities);
+        EncodeStructPtr(encoder, pDisplayPlaneInfo);
+        EncodeStructPtr(encoder, pCapabilities);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -5474,8 +5474,8 @@ VKAPI_ATTR void VKAPI_CALL GetImageMemoryRequirements2KHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pInfo);
-        encode_struct_ptr(encoder, pMemoryRequirements);
+        EncodeStructPtr(encoder, pInfo);
+        EncodeStructPtr(encoder, pMemoryRequirements);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -5495,8 +5495,8 @@ VKAPI_ATTR void VKAPI_CALL GetBufferMemoryRequirements2KHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pInfo);
-        encode_struct_ptr(encoder, pMemoryRequirements);
+        EncodeStructPtr(encoder, pInfo);
+        EncodeStructPtr(encoder, pMemoryRequirements);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -5517,9 +5517,9 @@ VKAPI_ATTR void VKAPI_CALL GetImageSparseMemoryRequirements2KHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pInfo);
+        EncodeStructPtr(encoder, pInfo);
         encoder->EncodeUInt32Ptr(pSparseMemoryRequirementCount);
-        encode_struct_array(encoder, pSparseMemoryRequirements, (pSparseMemoryRequirementCount != nullptr) ? (*pSparseMemoryRequirementCount) : 0);
+        EncodeStructArray(encoder, pSparseMemoryRequirements, (pSparseMemoryRequirementCount != nullptr) ? (*pSparseMemoryRequirementCount) : 0);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -5540,8 +5540,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversionKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pYcbcrConversion);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -5564,7 +5564,7 @@ VKAPI_ATTR void VKAPI_CALL DestroySamplerYcbcrConversionKHR(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(ycbcrConversion);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -5587,7 +5587,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindBufferMemory2KHR(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeUInt32Value(bindInfoCount);
-        encode_struct_array(encoder, pBindInfos, bindInfoCount);
+        EncodeStructArray(encoder, pBindInfos, bindInfoCount);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -5611,7 +5611,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindImageMemory2KHR(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeUInt32Value(bindInfoCount);
-        encode_struct_array(encoder, pBindInfos, bindInfoCount);
+        EncodeStructArray(encoder, pBindInfos, bindInfoCount);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -5634,8 +5634,8 @@ VKAPI_ATTR void VKAPI_CALL GetDescriptorSetLayoutSupportKHR(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pSupport);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pSupport);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -5714,8 +5714,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugReportCallbackEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(instance);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pCallback);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -5738,7 +5738,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugReportCallbackEXT(
     {
         encoder->EncodeHandleIdValue(instance);
         encoder->EncodeHandleIdValue(callback);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -5790,7 +5790,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectTagEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pTagInfo);
+        EncodeStructPtr(encoder, pTagInfo);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -5812,7 +5812,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pNameInfo);
+        EncodeStructPtr(encoder, pNameInfo);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -5832,7 +5832,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerBeginEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
-        encode_struct_ptr(encoder, pMarkerInfo);
+        EncodeStructPtr(encoder, pMarkerInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -5868,7 +5868,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDebugMarkerInsertEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
-        encode_struct_ptr(encoder, pMarkerInfo);
+        EncodeStructPtr(encoder, pMarkerInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -6143,7 +6143,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceExternalImageFormatPropertiesNV(
         encoder->EncodeFlagsValue(usage);
         encoder->EncodeFlagsValue(flags);
         encoder->EncodeFlagsValue(externalHandleType);
-        encode_struct_ptr(encoder, pExternalImageFormatProperties);
+        EncodeStructPtr(encoder, pExternalImageFormatProperties);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -6193,8 +6193,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateViSurfaceNN(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(instance);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -6215,7 +6215,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginConditionalRenderingEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
-        encode_struct_ptr(encoder, pConditionalRenderingBegin);
+        EncodeStructPtr(encoder, pConditionalRenderingBegin);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -6251,7 +6251,7 @@ VKAPI_ATTR void VKAPI_CALL CmdProcessCommandsNVX(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
-        encode_struct_ptr(encoder, pProcessCommandsInfo);
+        EncodeStructPtr(encoder, pProcessCommandsInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -6270,7 +6270,7 @@ VKAPI_ATTR void VKAPI_CALL CmdReserveSpaceForCommandsNVX(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
-        encode_struct_ptr(encoder, pReserveSpaceInfo);
+        EncodeStructPtr(encoder, pReserveSpaceInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -6293,8 +6293,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIndirectCommandsLayoutNVX(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pIndirectCommandsLayout);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -6317,7 +6317,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyIndirectCommandsLayoutNVX(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(indirectCommandsLayout);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -6340,8 +6340,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateObjectTableNVX(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pObjectTable);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -6364,7 +6364,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyObjectTableNVX(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(objectTable);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -6414,8 +6414,8 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceGeneratedCommandsPropertiesNVX(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(physicalDevice);
-        encode_struct_ptr(encoder, pFeatures);
-        encode_struct_ptr(encoder, pLimits);
+        EncodeStructPtr(encoder, pFeatures);
+        EncodeStructPtr(encoder, pLimits);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -6436,7 +6436,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportWScalingNV(
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeUInt32Value(firstViewport);
         encoder->EncodeUInt32Value(viewportCount);
-        encode_struct_array(encoder, pViewportWScalings, viewportCount);
+        EncodeStructArray(encoder, pViewportWScalings, viewportCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -6531,7 +6531,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceSurfaceCapabilities2EXT(
     {
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeHandleIdValue(surface);
-        encode_struct_ptr(encoder, pSurfaceCapabilities);
+        EncodeStructPtr(encoder, pSurfaceCapabilities);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -6555,7 +6555,7 @@ VKAPI_ATTR VkResult VKAPI_CALL DisplayPowerControlEXT(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(display);
-        encode_struct_ptr(encoder, pDisplayPowerInfo);
+        EncodeStructPtr(encoder, pDisplayPowerInfo);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -6579,8 +6579,8 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDeviceEventEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pDeviceEventInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pDeviceEventInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pFence);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -6607,8 +6607,8 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDisplayEventEXT(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(display);
-        encode_struct_ptr(encoder, pDisplayEventInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pDisplayEventInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pFence);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -6659,7 +6659,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRefreshCycleDurationGOOGLE(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(swapchain);
-        encode_struct_ptr(encoder, pDisplayTimingProperties);
+        EncodeStructPtr(encoder, pDisplayTimingProperties);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -6685,7 +6685,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPastPresentationTimingGOOGLE(
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(swapchain);
         encoder->EncodeUInt32Ptr(pPresentationTimingCount);
-        encode_struct_array(encoder, pPresentationTimings, (pPresentationTimingCount != nullptr) ? (*pPresentationTimingCount) : 0);
+        EncodeStructArray(encoder, pPresentationTimings, (pPresentationTimingCount != nullptr) ? (*pPresentationTimingCount) : 0);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -6709,7 +6709,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleEXT(
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeUInt32Value(firstDiscardRectangle);
         encoder->EncodeUInt32Value(discardRectangleCount);
-        encode_struct_array(encoder, pDiscardRectangles, discardRectangleCount);
+        EncodeStructArray(encoder, pDiscardRectangles, discardRectangleCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -6732,7 +6732,7 @@ VKAPI_ATTR void VKAPI_CALL SetHdrMetadataEXT(
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeUInt32Value(swapchainCount);
         encoder->EncodeHandleIdArray(pSwapchains, swapchainCount);
-        encode_struct_array(encoder, pMetadata, swapchainCount);
+        EncodeStructArray(encoder, pMetadata, swapchainCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -6755,8 +6755,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIOSSurfaceMVK(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(instance);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -6781,8 +6781,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMacOSSurfaceMVK(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(instance);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -6805,7 +6805,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectNameEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pNameInfo);
+        EncodeStructPtr(encoder, pNameInfo);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -6827,7 +6827,7 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectTagEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pTagInfo);
+        EncodeStructPtr(encoder, pTagInfo);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -6847,7 +6847,7 @@ VKAPI_ATTR void VKAPI_CALL QueueBeginDebugUtilsLabelEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(queue);
-        encode_struct_ptr(encoder, pLabelInfo);
+        EncodeStructPtr(encoder, pLabelInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -6883,7 +6883,7 @@ VKAPI_ATTR void VKAPI_CALL QueueInsertDebugUtilsLabelEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(queue);
-        encode_struct_ptr(encoder, pLabelInfo);
+        EncodeStructPtr(encoder, pLabelInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -6902,7 +6902,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginDebugUtilsLabelEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
-        encode_struct_ptr(encoder, pLabelInfo);
+        EncodeStructPtr(encoder, pLabelInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -6938,7 +6938,7 @@ VKAPI_ATTR void VKAPI_CALL CmdInsertDebugUtilsLabelEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
-        encode_struct_ptr(encoder, pLabelInfo);
+        EncodeStructPtr(encoder, pLabelInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -6961,8 +6961,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugUtilsMessengerEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(instance);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pMessenger);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -6985,7 +6985,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyDebugUtilsMessengerEXT(
     {
         encoder->EncodeHandleIdValue(instance);
         encoder->EncodeHandleIdValue(messenger);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -7008,7 +7008,7 @@ VKAPI_ATTR void VKAPI_CALL SubmitDebugUtilsMessageEXT(
         encoder->EncodeHandleIdValue(instance);
         encoder->EncodeEnumValue(messageSeverity);
         encoder->EncodeFlagsValue(messageTypes);
-        encode_struct_ptr(encoder, pCallbackData);
+        EncodeStructPtr(encoder, pCallbackData);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -7031,7 +7031,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetAndroidHardwareBufferPropertiesANDROID(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeVoidPtr(buffer);
-        encode_struct_ptr(encoder, pProperties);
+        EncodeStructPtr(encoder, pProperties);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -7054,7 +7054,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryAndroidHardwareBufferANDROID(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pInfo);
+        EncodeStructPtr(encoder, pInfo);
         encoder->EncodeVoidPtrPtr(pBuffer);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -7075,7 +7075,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetSampleLocationsEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
-        encode_struct_ptr(encoder, pSampleLocationsInfo);
+        EncodeStructPtr(encoder, pSampleLocationsInfo);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -7098,7 +7098,7 @@ VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMultisamplePropertiesEXT(
     {
         encoder->EncodeHandleIdValue(physicalDevice);
         encoder->EncodeEnumValue(samples);
-        encode_struct_ptr(encoder, pMultisampleProperties);
+        EncodeStructPtr(encoder, pMultisampleProperties);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -7119,7 +7119,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetImageDrmFormatModifierPropertiesEXT(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(image);
-        encode_struct_ptr(encoder, pProperties);
+        EncodeStructPtr(encoder, pProperties);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -7143,8 +7143,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateValidationCacheEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pValidationCache);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -7167,7 +7167,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyValidationCacheEXT(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(validationCache);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -7263,7 +7263,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetViewportShadingRatePaletteNV(
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeUInt32Value(firstViewport);
         encoder->EncodeUInt32Value(viewportCount);
-        encode_struct_array(encoder, pShadingRatePalettes, viewportCount);
+        EncodeStructArray(encoder, pShadingRatePalettes, viewportCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -7286,7 +7286,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetCoarseSampleOrderNV(
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeEnumValue(sampleOrderType);
         encoder->EncodeUInt32Value(customSampleOrderCount);
-        encode_struct_array(encoder, pCustomSampleOrders, customSampleOrderCount);
+        EncodeStructArray(encoder, pCustomSampleOrders, customSampleOrderCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -7309,8 +7309,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureNV(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pAccelerationStructure);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -7333,7 +7333,7 @@ VKAPI_ATTR void VKAPI_CALL DestroyAccelerationStructureNV(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(accelerationStructure);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pAllocator);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -7355,8 +7355,8 @@ VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureMemoryRequirementsNV(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pInfo);
-        encode_struct_ptr(encoder, pMemoryRequirements);
+        EncodeStructPtr(encoder, pInfo);
+        EncodeStructPtr(encoder, pMemoryRequirements);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -7377,7 +7377,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BindAccelerationStructureMemoryNV(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeUInt32Value(bindInfoCount);
-        encode_struct_array(encoder, pBindInfos, bindInfoCount);
+        EncodeStructArray(encoder, pBindInfos, bindInfoCount);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -7404,7 +7404,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructureNV(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(commandBuffer);
-        encode_struct_ptr(encoder, pInfo);
+        EncodeStructPtr(encoder, pInfo);
         encoder->EncodeHandleIdValue(instanceData);
         encoder->EncodeVkDeviceSizeValue(instanceOffset);
         encoder->EncodeVkBool32Value(update);
@@ -7506,8 +7506,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(pipelineCache);
         encoder->EncodeUInt32Value(createInfoCount);
-        encode_struct_array(encoder, pCreateInfos, createInfoCount);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructArray(encoder, pCreateInfos, createInfoCount);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -7641,7 +7641,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetMemoryHostPointerPropertiesEXT(
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeEnumValue(handleType);
         encoder->EncodeVoidPtr(pHostPointer);
-        encode_struct_ptr(encoder, pMemoryHostPointerProperties);
+        EncodeStructPtr(encoder, pMemoryHostPointerProperties);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
@@ -7716,7 +7716,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetCalibratedTimestampsEXT(
     {
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeUInt32Value(timestampCount);
-        encode_struct_array(encoder, pTimestampInfos, timestampCount);
+        EncodeStructArray(encoder, pTimestampInfos, timestampCount);
         encoder->EncodeUInt64Array(pTimestamps, timestampCount);
         encoder->EncodeUInt64Ptr(pMaxDeviation);
         encoder->EncodeEnumValue(result);
@@ -7817,7 +7817,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetExclusiveScissorNV(
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeUInt32Value(firstExclusiveScissor);
         encoder->EncodeUInt32Value(exclusiveScissorCount);
-        encode_struct_array(encoder, pExclusiveScissors, exclusiveScissorCount);
+        EncodeStructArray(encoder, pExclusiveScissors, exclusiveScissorCount);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -7859,7 +7859,7 @@ VKAPI_ATTR void VKAPI_CALL GetQueueCheckpointDataNV(
     {
         encoder->EncodeHandleIdValue(queue);
         encoder->EncodeUInt32Ptr(pCheckpointDataCount);
-        encode_struct_array(encoder, pCheckpointData, (pCheckpointDataCount != nullptr) ? (*pCheckpointDataCount) : 0);
+        EncodeStructArray(encoder, pCheckpointData, (pCheckpointDataCount != nullptr) ? (*pCheckpointDataCount) : 0);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }
 
@@ -7880,8 +7880,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(instance);
-        encode_struct_ptr(encoder, pCreateInfo);
-        encode_struct_ptr(encoder, pAllocator);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
@@ -7904,7 +7904,7 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressEXT(
     if (encoder)
     {
         encoder->EncodeHandleIdValue(device);
-        encode_struct_ptr(encoder, pInfo);
+        EncodeStructPtr(encoder, pInfo);
         encoder->EncodeVkDeviceAddressValue(result);
         encode::TraceManager::Get()->EndApiCallTrace(encoder);
     }

--- a/framework/generated/generated_vulkan_struct_decoders.cpp
+++ b/framework/generated/generated_vulkan_struct_decoders.cpp
@@ -27,9 +27,9 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-size_t decode_pnext_struct(const uint8_t* buffer, size_t buffer_size, std::unique_ptr<PNextNode>* pNext);
+size_t DecodePNextStruct(const uint8_t* buffer, size_t buffer_size, std::unique_ptr<PNextNode>* pNext);
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkApplicationInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkApplicationInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -37,7 +37,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkApplic
     VkApplicationInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += wrapper->pApplicationName.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pApplicationName = wrapper->pApplicationName.GetPointer();
@@ -50,7 +50,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkApplic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkInstanceCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkInstanceCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -58,7 +58,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkInstan
     VkInstanceCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += wrapper->pApplicationInfo.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -73,7 +73,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkInstan
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAllocationCallbacks* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAllocationCallbacks* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -96,7 +96,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAlloca
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFeatures* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFeatures* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -162,7 +162,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFormatProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFormatProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -176,7 +176,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFormat
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtent3D* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtent3D* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -190,7 +190,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtent
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageFormatProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageFormatProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -198,7 +198,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageF
     VkImageFormatProperties* value = wrapper->value;
 
     wrapper->maxExtent.value = &(value->maxExtent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxExtent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxExtent));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxMipLevels));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxArrayLayers));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleCounts));
@@ -207,7 +207,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageF
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceLimits* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceLimits* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -330,7 +330,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSparseProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSparseProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -346,7 +346,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -363,14 +363,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     wrapper->pipelineCacheUUID.SetExternalMemory(value->pipelineCacheUUID, VK_UUID_SIZE);
     bytes_read += wrapper->pipelineCacheUUID.DecodeUInt8((buffer + bytes_read), (buffer_size - bytes_read));
     wrapper->limits.value = &(value->limits);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->limits));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->limits));
     wrapper->sparseProperties.value = &(value->sparseProperties);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->sparseProperties));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->sparseProperties));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkQueueFamilyProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkQueueFamilyProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -381,12 +381,12 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkQueueF
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->queueCount));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->timestampValidBits));
     wrapper->minImageTransferGranularity.value = &(value->minImageTransferGranularity);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->minImageTransferGranularity));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->minImageTransferGranularity));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryType* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryType* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -399,7 +399,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryHeap* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryHeap* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -412,7 +412,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -429,7 +429,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceQueueCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceQueueCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -437,7 +437,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     VkDeviceQueueCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->queueFamilyIndex));
@@ -448,7 +448,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -456,7 +456,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     VkDeviceCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->queueCreateInfoCount));
@@ -474,7 +474,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtensionProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtensionProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -488,7 +488,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtens
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkLayerProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkLayerProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -505,7 +505,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkLayerP
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubmitInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubmitInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -513,7 +513,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubmit
     VkSubmitInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->waitSemaphoreCount));
     bytes_read += wrapper->pWaitSemaphores.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -530,7 +530,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubmit
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryAllocateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryAllocateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -538,7 +538,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     VkMemoryAllocateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->allocationSize));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->memoryTypeIndex));
@@ -546,7 +546,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMappedMemoryRange* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMappedMemoryRange* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -554,7 +554,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMapped
     VkMappedMemoryRange* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->memory));
     value->memory = VK_NULL_HANDLE;
@@ -564,7 +564,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMapped
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryRequirements* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryRequirements* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -578,7 +578,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseImageFormatProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseImageFormatProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -587,13 +587,13 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparse
 
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->aspectMask));
     wrapper->imageGranularity.value = &(value->imageGranularity);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageGranularity));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageGranularity));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseImageMemoryRequirements* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseImageMemoryRequirements* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -601,7 +601,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparse
     VkSparseImageMemoryRequirements* value = wrapper->value;
 
     wrapper->formatProperties.value = &(value->formatProperties);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->formatProperties));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->formatProperties));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageMipTailFirstLod));
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageMipTailSize));
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageMipTailOffset));
@@ -610,7 +610,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparse
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseMemoryBind* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseMemoryBind* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -627,7 +627,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparse
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseBufferMemoryBindInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseBufferMemoryBindInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -643,7 +643,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparse
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseImageOpaqueMemoryBindInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseImageOpaqueMemoryBindInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -659,7 +659,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparse
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageSubresource* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageSubresource* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -673,7 +673,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageS
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkOffset3D* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkOffset3D* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -687,7 +687,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkOffset
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseImageMemoryBind* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseImageMemoryBind* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -695,11 +695,11 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparse
     VkSparseImageMemoryBind* value = wrapper->value;
 
     wrapper->subresource.value = &(value->subresource);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->subresource));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->subresource));
     wrapper->offset.value = &(value->offset);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->offset));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->offset));
     wrapper->extent.value = &(value->extent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->extent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->extent));
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->memory));
     value->memory = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->memoryOffset));
@@ -708,7 +708,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparse
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseImageMemoryBindInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseImageMemoryBindInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -724,7 +724,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparse
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindSparseInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindSparseInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -732,7 +732,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindSp
     VkBindSparseInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->waitSemaphoreCount));
     bytes_read += wrapper->pWaitSemaphores.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -753,7 +753,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindSp
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFenceCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFenceCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -761,14 +761,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFenceC
     VkFenceCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSemaphoreCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSemaphoreCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -776,14 +776,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSemaph
     VkSemaphoreCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkEventCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkEventCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -791,14 +791,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkEventC
     VkEventCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkQueryPoolCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkQueryPoolCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -806,7 +806,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkQueryP
     VkQueryPoolCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->queryType));
@@ -816,7 +816,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkQueryP
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -824,7 +824,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBuffer
     VkBufferCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->size));
@@ -837,7 +837,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBuffer
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferViewCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferViewCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -845,7 +845,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBuffer
     VkBufferViewCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->buffer));
@@ -857,7 +857,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBuffer
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -865,13 +865,13 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageC
     VkImageCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageType));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->format));
     wrapper->extent.value = &(value->extent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->extent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->extent));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->mipLevels));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->arrayLayers));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->samples));
@@ -886,7 +886,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageC
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubresourceLayout* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubresourceLayout* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -902,7 +902,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubres
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkComponentMapping* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkComponentMapping* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -917,7 +917,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCompon
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageSubresourceRange* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageSubresourceRange* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -933,7 +933,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageS
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageViewCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageViewCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -941,7 +941,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageV
     VkImageViewCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->image));
@@ -949,14 +949,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageV
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->viewType));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->format));
     wrapper->components.value = &(value->components);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->components));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->components));
     wrapper->subresourceRange.value = &(value->subresourceRange);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->subresourceRange));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->subresourceRange));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShaderModuleCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShaderModuleCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -964,7 +964,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShader
     VkShaderModuleCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeSizeTValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->codeSize));
@@ -974,7 +974,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShader
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineCacheCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineCacheCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -982,7 +982,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineCacheCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeSizeTValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->initialDataSize));
@@ -992,7 +992,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSpecializationMapEntry* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSpecializationMapEntry* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1006,7 +1006,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSpecia
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSpecializationInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSpecializationInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1023,7 +1023,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSpecia
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineShaderStageCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineShaderStageCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1031,7 +1031,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineShaderStageCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->stage));
@@ -1045,7 +1045,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkVertexInputBindingDescription* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkVertexInputBindingDescription* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1059,7 +1059,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkVertex
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkVertexInputAttributeDescription* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkVertexInputAttributeDescription* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1074,7 +1074,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkVertex
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineVertexInputStateCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineVertexInputStateCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1082,7 +1082,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineVertexInputStateCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->vertexBindingDescriptionCount));
@@ -1095,7 +1095,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineInputAssemblyStateCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineInputAssemblyStateCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1103,7 +1103,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineInputAssemblyStateCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->topology));
@@ -1112,7 +1112,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineTessellationStateCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineTessellationStateCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1120,7 +1120,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineTessellationStateCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->patchControlPoints));
@@ -1128,7 +1128,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkViewport* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkViewport* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1145,7 +1145,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkViewpo
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkOffset2D* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkOffset2D* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1158,7 +1158,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkOffset
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtent2D* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtent2D* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1171,7 +1171,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtent
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRect2D* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRect2D* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1179,14 +1179,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRect2D
     VkRect2D* value = wrapper->value;
 
     wrapper->offset.value = &(value->offset);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->offset));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->offset));
     wrapper->extent.value = &(value->extent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->extent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->extent));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineViewportStateCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineViewportStateCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1194,7 +1194,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineViewportStateCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->viewportCount));
@@ -1207,7 +1207,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineRasterizationStateCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineRasterizationStateCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1215,7 +1215,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineRasterizationStateCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->depthClampEnable));
@@ -1232,7 +1232,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineMultisampleStateCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineMultisampleStateCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1240,7 +1240,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineMultisampleStateCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->rasterizationSamples));
@@ -1254,7 +1254,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkStencilOpState* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkStencilOpState* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1272,7 +1272,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkStenci
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineDepthStencilStateCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineDepthStencilStateCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1280,7 +1280,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineDepthStencilStateCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->depthTestEnable));
@@ -1289,16 +1289,16 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->depthBoundsTestEnable));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->stencilTestEnable));
     wrapper->front.value = &(value->front);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->front));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->front));
     wrapper->back.value = &(value->back);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->back));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->back));
     bytes_read += ValueDecoder::DecodeFloatValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->minDepthBounds));
     bytes_read += ValueDecoder::DecodeFloatValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxDepthBounds));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineColorBlendAttachmentState* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineColorBlendAttachmentState* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1317,7 +1317,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineColorBlendStateCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineColorBlendStateCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1325,7 +1325,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineColorBlendStateCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->logicOpEnable));
@@ -1339,7 +1339,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineDynamicStateCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineDynamicStateCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1347,7 +1347,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineDynamicStateCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->dynamicStateCount));
@@ -1357,7 +1357,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGraphicsPipelineCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGraphicsPipelineCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1365,7 +1365,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGraphi
     VkGraphicsPipelineCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->stageCount));
@@ -1401,7 +1401,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGraphi
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkComputePipelineCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkComputePipelineCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1409,11 +1409,11 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkComput
     VkComputePipelineCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     wrapper->stage.value = &(value->stage);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->stage));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->stage));
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->layout));
     value->layout = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->basePipelineHandle));
@@ -1423,7 +1423,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkComput
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPushConstantRange* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPushConstantRange* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1437,7 +1437,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPushCo
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineLayoutCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineLayoutCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1445,7 +1445,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineLayoutCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->setLayoutCount));
@@ -1458,7 +1458,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSamplerCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSamplerCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1466,7 +1466,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSample
     VkSamplerCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->magFilter));
@@ -1488,7 +1488,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSample
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorSetLayoutBinding* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorSetLayoutBinding* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1505,7 +1505,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorSetLayoutCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorSetLayoutCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1513,7 +1513,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     VkDescriptorSetLayoutCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->bindingCount));
@@ -1523,7 +1523,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorPoolSize* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorPoolSize* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1536,7 +1536,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorPoolCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorPoolCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1544,7 +1544,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     VkDescriptorPoolCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxSets));
@@ -1555,7 +1555,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorSetAllocateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorSetAllocateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1563,7 +1563,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     VkDescriptorSetAllocateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->descriptorPool));
     value->descriptorPool = VK_NULL_HANDLE;
@@ -1574,7 +1574,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorImageInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorImageInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1590,7 +1590,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorBufferInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorBufferInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1605,7 +1605,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWriteDescriptorSet* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWriteDescriptorSet* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1613,7 +1613,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWriteD
     VkWriteDescriptorSet* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dstSet));
     value->dstSet = VK_NULL_HANDLE;
@@ -1631,7 +1631,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWriteD
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCopyDescriptorSet* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCopyDescriptorSet* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1639,7 +1639,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCopyDe
     VkCopyDescriptorSet* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->srcSet));
     value->srcSet = VK_NULL_HANDLE;
@@ -1654,7 +1654,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCopyDe
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFramebufferCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFramebufferCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1662,7 +1662,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFrameb
     VkFramebufferCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->renderPass));
@@ -1677,7 +1677,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFrameb
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttachmentDescription* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttachmentDescription* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1697,7 +1697,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttach
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttachmentReference* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttachmentReference* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1710,7 +1710,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttach
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpassDescription* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpassDescription* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1736,7 +1736,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpas
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpassDependency* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpassDependency* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1754,7 +1754,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpas
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderPassCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderPassCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1762,7 +1762,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRender
     VkRenderPassCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->attachmentCount));
@@ -1778,7 +1778,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRender
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCommandPoolCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCommandPoolCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1786,7 +1786,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkComman
     VkCommandPoolCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->queueFamilyIndex));
@@ -1794,7 +1794,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkComman
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCommandBufferAllocateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCommandBufferAllocateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1802,7 +1802,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkComman
     VkCommandBufferAllocateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->commandPool));
     value->commandPool = VK_NULL_HANDLE;
@@ -1812,7 +1812,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkComman
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCommandBufferInheritanceInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCommandBufferInheritanceInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1820,7 +1820,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkComman
     VkCommandBufferInheritanceInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->renderPass));
     value->renderPass = VK_NULL_HANDLE;
@@ -1834,7 +1834,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkComman
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCommandBufferBeginInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCommandBufferBeginInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1842,7 +1842,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkComman
     VkCommandBufferBeginInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += wrapper->pInheritanceInfo.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -1851,7 +1851,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkComman
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferCopy* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferCopy* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1865,7 +1865,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBuffer
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageSubresourceLayers* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageSubresourceLayers* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1880,7 +1880,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageS
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageCopy* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageCopy* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1888,20 +1888,20 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageC
     VkImageCopy* value = wrapper->value;
 
     wrapper->srcSubresource.value = &(value->srcSubresource);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->srcSubresource));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->srcSubresource));
     wrapper->srcOffset.value = &(value->srcOffset);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->srcOffset));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->srcOffset));
     wrapper->dstSubresource.value = &(value->dstSubresource);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dstSubresource));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dstSubresource));
     wrapper->dstOffset.value = &(value->dstOffset);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dstOffset));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dstOffset));
     wrapper->extent.value = &(value->extent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->extent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->extent));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageBlit* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageBlit* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1909,18 +1909,18 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageB
     VkImageBlit* value = wrapper->value;
 
     wrapper->srcSubresource.value = &(value->srcSubresource);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->srcSubresource));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->srcSubresource));
     wrapper->srcOffsets.SetExternalMemory(value->srcOffsets, 2);
     bytes_read += wrapper->srcOffsets.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     wrapper->dstSubresource.value = &(value->dstSubresource);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dstSubresource));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dstSubresource));
     wrapper->dstOffsets.SetExternalMemory(value->dstOffsets, 2);
     bytes_read += wrapper->dstOffsets.Decode((buffer + bytes_read), (buffer_size - bytes_read));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferImageCopy* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferImageCopy* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1931,16 +1931,16 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBuffer
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->bufferRowLength));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->bufferImageHeight));
     wrapper->imageSubresource.value = &(value->imageSubresource);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageSubresource));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageSubresource));
     wrapper->imageOffset.value = &(value->imageOffset);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageOffset));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageOffset));
     wrapper->imageExtent.value = &(value->imageExtent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageExtent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageExtent));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearDepthStencilValue* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearDepthStencilValue* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1953,7 +1953,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearD
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearAttachment* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearAttachment* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1963,12 +1963,12 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearA
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->aspectMask));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->colorAttachment));
     wrapper->clearValue.value = &(value->clearValue);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->clearValue));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->clearValue));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearRect* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearRect* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1976,14 +1976,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearR
     VkClearRect* value = wrapper->value;
 
     wrapper->rect.value = &(value->rect);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->rect));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->rect));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->baseArrayLayer));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->layerCount));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageResolve* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageResolve* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -1991,20 +1991,20 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageR
     VkImageResolve* value = wrapper->value;
 
     wrapper->srcSubresource.value = &(value->srcSubresource);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->srcSubresource));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->srcSubresource));
     wrapper->srcOffset.value = &(value->srcOffset);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->srcOffset));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->srcOffset));
     wrapper->dstSubresource.value = &(value->dstSubresource);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dstSubresource));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dstSubresource));
     wrapper->dstOffset.value = &(value->dstOffset);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dstOffset));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dstOffset));
     wrapper->extent.value = &(value->extent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->extent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->extent));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryBarrier* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryBarrier* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2012,7 +2012,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     VkMemoryBarrier* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->srcAccessMask));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->dstAccessMask));
@@ -2020,7 +2020,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferMemoryBarrier* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferMemoryBarrier* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2028,7 +2028,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBuffer
     VkBufferMemoryBarrier* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->srcAccessMask));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->dstAccessMask));
@@ -2042,7 +2042,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBuffer
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageMemoryBarrier* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageMemoryBarrier* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2050,7 +2050,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageM
     VkImageMemoryBarrier* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->srcAccessMask));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->dstAccessMask));
@@ -2061,12 +2061,12 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageM
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->image));
     value->image = VK_NULL_HANDLE;
     wrapper->subresourceRange.value = &(value->subresourceRange);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->subresourceRange));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->subresourceRange));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderPassBeginInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderPassBeginInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2074,14 +2074,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRender
     VkRenderPassBeginInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->renderPass));
     value->renderPass = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->framebuffer));
     value->framebuffer = VK_NULL_HANDLE;
     wrapper->renderArea.value = &(value->renderArea);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->renderArea));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->renderArea));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->clearValueCount));
     bytes_read += wrapper->pClearValues.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pClearValues = wrapper->pClearValues.GetPointer();
@@ -2089,7 +2089,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRender
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispatchIndirectCommand* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispatchIndirectCommand* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2103,7 +2103,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispat
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrawIndexedIndirectCommand* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrawIndexedIndirectCommand* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2119,7 +2119,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrawIn
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrawIndirectCommand* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrawIndirectCommand* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2134,7 +2134,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrawIn
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSubgroupProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSubgroupProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2142,7 +2142,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceSubgroupProperties* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->subgroupSize));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->supportedStages));
@@ -2152,7 +2152,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindBufferMemoryInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindBufferMemoryInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2160,7 +2160,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindBu
     VkBindBufferMemoryInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->buffer));
     value->buffer = VK_NULL_HANDLE;
@@ -2171,7 +2171,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindBu
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindImageMemoryInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindImageMemoryInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2179,7 +2179,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindIm
     VkBindImageMemoryInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->image));
     value->image = VK_NULL_HANDLE;
@@ -2190,7 +2190,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindIm
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDevice16BitStorageFeatures* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDevice16BitStorageFeatures* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2198,7 +2198,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDevice16BitStorageFeatures* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->storageBuffer16BitAccess));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->uniformAndStorageBuffer16BitAccess));
@@ -2208,7 +2208,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryDedicatedRequirements* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryDedicatedRequirements* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2216,7 +2216,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     VkMemoryDedicatedRequirements* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->prefersDedicatedAllocation));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->requiresDedicatedAllocation));
@@ -2224,7 +2224,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryDedicatedAllocateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryDedicatedAllocateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2232,7 +2232,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     VkMemoryDedicatedAllocateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->image));
     value->image = VK_NULL_HANDLE;
@@ -2242,7 +2242,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryAllocateFlagsInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryAllocateFlagsInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2250,7 +2250,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     VkMemoryAllocateFlagsInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->deviceMask));
@@ -2258,7 +2258,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGroupRenderPassBeginInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGroupRenderPassBeginInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2266,7 +2266,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     VkDeviceGroupRenderPassBeginInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->deviceMask));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->deviceRenderAreaCount));
@@ -2276,7 +2276,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGroupCommandBufferBeginInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGroupCommandBufferBeginInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2284,14 +2284,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     VkDeviceGroupCommandBufferBeginInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->deviceMask));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGroupSubmitInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGroupSubmitInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2299,7 +2299,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     VkDeviceGroupSubmitInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->waitSemaphoreCount));
     bytes_read += wrapper->pWaitSemaphoreDeviceIndices.DecodeUInt32((buffer + bytes_read), (buffer_size - bytes_read));
@@ -2314,7 +2314,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGroupBindSparseInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGroupBindSparseInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2322,7 +2322,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     VkDeviceGroupBindSparseInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->resourceDeviceIndex));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->memoryDeviceIndex));
@@ -2330,7 +2330,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindBufferMemoryDeviceGroupInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindBufferMemoryDeviceGroupInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2338,7 +2338,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindBu
     VkBindBufferMemoryDeviceGroupInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->deviceIndexCount));
     bytes_read += wrapper->pDeviceIndices.DecodeUInt32((buffer + bytes_read), (buffer_size - bytes_read));
@@ -2347,7 +2347,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindBu
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindImageMemoryDeviceGroupInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindImageMemoryDeviceGroupInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2355,7 +2355,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindIm
     VkBindImageMemoryDeviceGroupInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->deviceIndexCount));
     bytes_read += wrapper->pDeviceIndices.DecodeUInt32((buffer + bytes_read), (buffer_size - bytes_read));
@@ -2367,7 +2367,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindIm
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceGroupProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceGroupProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2375,7 +2375,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceGroupProperties* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->physicalDeviceCount));
     wrapper->physicalDevices.SetExternalMemory(value->physicalDevices, VK_MAX_DEVICE_GROUP_SIZE);
@@ -2385,7 +2385,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGroupDeviceCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGroupDeviceCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2393,7 +2393,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     VkDeviceGroupDeviceCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->physicalDeviceCount));
     bytes_read += wrapper->pPhysicalDevices.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -2402,7 +2402,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferMemoryRequirementsInfo2* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferMemoryRequirementsInfo2* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2410,7 +2410,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBuffer
     VkBufferMemoryRequirementsInfo2* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->buffer));
     value->buffer = VK_NULL_HANDLE;
@@ -2418,7 +2418,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBuffer
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageMemoryRequirementsInfo2* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageMemoryRequirementsInfo2* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2426,7 +2426,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageM
     VkImageMemoryRequirementsInfo2* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->image));
     value->image = VK_NULL_HANDLE;
@@ -2434,7 +2434,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageM
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageSparseMemoryRequirementsInfo2* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageSparseMemoryRequirementsInfo2* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2442,7 +2442,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageS
     VkImageSparseMemoryRequirementsInfo2* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->image));
     value->image = VK_NULL_HANDLE;
@@ -2450,7 +2450,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageS
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryRequirements2* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryRequirements2* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2458,15 +2458,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     VkMemoryRequirements2* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->memoryRequirements.value = &(value->memoryRequirements);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->memoryRequirements));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->memoryRequirements));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseImageMemoryRequirements2* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseImageMemoryRequirements2* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2474,15 +2474,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparse
     VkSparseImageMemoryRequirements2* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->memoryRequirements.value = &(value->memoryRequirements);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->memoryRequirements));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->memoryRequirements));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFeatures2* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFeatures2* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2490,15 +2490,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceFeatures2* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->features.value = &(value->features);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->features));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->features));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceProperties2* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceProperties2* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2506,15 +2506,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceProperties2* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->properties.value = &(value->properties);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->properties));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->properties));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFormatProperties2* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFormatProperties2* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2522,15 +2522,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFormat
     VkFormatProperties2* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->formatProperties.value = &(value->formatProperties);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->formatProperties));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->formatProperties));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageFormatProperties2* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageFormatProperties2* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2538,15 +2538,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageF
     VkImageFormatProperties2* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->imageFormatProperties.value = &(value->imageFormatProperties);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageFormatProperties));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageFormatProperties));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceImageFormatInfo2* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceImageFormatInfo2* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2554,7 +2554,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceImageFormatInfo2* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->format));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->type));
@@ -2565,7 +2565,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkQueueFamilyProperties2* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkQueueFamilyProperties2* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2573,15 +2573,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkQueueF
     VkQueueFamilyProperties2* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->queueFamilyProperties.value = &(value->queueFamilyProperties);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->queueFamilyProperties));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->queueFamilyProperties));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryProperties2* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryProperties2* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2589,15 +2589,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceMemoryProperties2* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->memoryProperties.value = &(value->memoryProperties);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->memoryProperties));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->memoryProperties));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseImageFormatProperties2* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseImageFormatProperties2* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2605,15 +2605,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparse
     VkSparseImageFormatProperties2* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->properties.value = &(value->properties);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->properties));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->properties));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSparseImageFormatInfo2* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSparseImageFormatInfo2* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2621,7 +2621,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceSparseImageFormatInfo2* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->format));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->type));
@@ -2632,7 +2632,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDevicePointClippingProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDevicePointClippingProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2640,14 +2640,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDevicePointClippingProperties* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->pointClippingBehavior));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkInputAttachmentAspectReference* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkInputAttachmentAspectReference* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2661,7 +2661,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkInputA
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderPassInputAttachmentAspectCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderPassInputAttachmentAspectCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2669,7 +2669,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRender
     VkRenderPassInputAttachmentAspectCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->aspectReferenceCount));
     bytes_read += wrapper->pAspectReferences.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -2678,7 +2678,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRender
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageViewUsageCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageViewUsageCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2686,14 +2686,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageV
     VkImageViewUsageCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->usage));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineTessellationDomainOriginStateCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineTessellationDomainOriginStateCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2701,14 +2701,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineTessellationDomainOriginStateCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->domainOrigin));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderPassMultiviewCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderPassMultiviewCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2716,7 +2716,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRender
     VkRenderPassMultiviewCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->subpassCount));
     bytes_read += wrapper->pViewMasks.DecodeUInt32((buffer + bytes_read), (buffer_size - bytes_read));
@@ -2731,7 +2731,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRender
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMultiviewFeatures* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMultiviewFeatures* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2739,7 +2739,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceMultiviewFeatures* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->multiview));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->multiviewGeometryShader));
@@ -2748,7 +2748,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMultiviewProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMultiviewProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2756,7 +2756,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceMultiviewProperties* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxMultiviewViewCount));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxMultiviewInstanceIndex));
@@ -2764,7 +2764,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceVariablePointerFeatures* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceVariablePointerFeatures* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2772,7 +2772,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceVariablePointerFeatures* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->variablePointersStorageBuffer));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->variablePointers));
@@ -2780,7 +2780,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceProtectedMemoryFeatures* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceProtectedMemoryFeatures* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2788,14 +2788,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceProtectedMemoryFeatures* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->protectedMemory));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceProtectedMemoryProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceProtectedMemoryProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2803,14 +2803,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceProtectedMemoryProperties* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->protectedNoFault));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceQueueInfo2* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceQueueInfo2* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2818,7 +2818,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     VkDeviceQueueInfo2* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->queueFamilyIndex));
@@ -2827,7 +2827,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkProtectedSubmitInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkProtectedSubmitInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2835,14 +2835,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkProtec
     VkProtectedSubmitInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->protectedSubmit));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSamplerYcbcrConversionCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSamplerYcbcrConversionCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2850,13 +2850,13 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSample
     VkSamplerYcbcrConversionCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->format));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->ycbcrModel));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->ycbcrRange));
     wrapper->components.value = &(value->components);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->components));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->components));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->xChromaOffset));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->yChromaOffset));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->chromaFilter));
@@ -2865,7 +2865,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSample
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSamplerYcbcrConversionInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSamplerYcbcrConversionInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2873,7 +2873,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSample
     VkSamplerYcbcrConversionInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->conversion));
     value->conversion = VK_NULL_HANDLE;
@@ -2881,7 +2881,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSample
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindImagePlaneMemoryInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindImagePlaneMemoryInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2889,14 +2889,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindIm
     VkBindImagePlaneMemoryInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->planeAspect));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImagePlaneMemoryRequirementsInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImagePlaneMemoryRequirementsInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2904,14 +2904,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageP
     VkImagePlaneMemoryRequirementsInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->planeAspect));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSamplerYcbcrConversionFeatures* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSamplerYcbcrConversionFeatures* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2919,14 +2919,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceSamplerYcbcrConversionFeatures* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->samplerYcbcrConversion));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSamplerYcbcrConversionImageFormatProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSamplerYcbcrConversionImageFormatProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2934,14 +2934,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSample
     VkSamplerYcbcrConversionImageFormatProperties* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->combinedImageSamplerDescriptorCount));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorUpdateTemplateEntry* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorUpdateTemplateEntry* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2958,7 +2958,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorUpdateTemplateCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorUpdateTemplateCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2966,7 +2966,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     VkDescriptorUpdateTemplateCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->descriptorUpdateEntryCount));
@@ -2983,7 +2983,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalMemoryProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalMemoryProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -2997,7 +2997,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtern
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalImageFormatInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalImageFormatInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3005,14 +3005,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceExternalImageFormatInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->handleType));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalImageFormatProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalImageFormatProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3020,15 +3020,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtern
     VkExternalImageFormatProperties* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->externalMemoryProperties.value = &(value->externalMemoryProperties);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->externalMemoryProperties));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->externalMemoryProperties));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalBufferInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalBufferInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3036,7 +3036,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceExternalBufferInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->usage));
@@ -3045,7 +3045,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalBufferProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalBufferProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3053,15 +3053,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtern
     VkExternalBufferProperties* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->externalMemoryProperties.value = &(value->externalMemoryProperties);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->externalMemoryProperties));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->externalMemoryProperties));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceIDProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceIDProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3069,7 +3069,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceIDProperties* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->deviceUUID.SetExternalMemory(value->deviceUUID, VK_UUID_SIZE);
     bytes_read += wrapper->deviceUUID.DecodeUInt8((buffer + bytes_read), (buffer_size - bytes_read));
@@ -3083,7 +3083,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalMemoryImageCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalMemoryImageCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3091,14 +3091,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtern
     VkExternalMemoryImageCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->handleTypes));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalMemoryBufferCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalMemoryBufferCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3106,14 +3106,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtern
     VkExternalMemoryBufferCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->handleTypes));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportMemoryAllocateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportMemoryAllocateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3121,14 +3121,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExport
     VkExportMemoryAllocateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->handleTypes));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalFenceInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalFenceInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3136,14 +3136,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceExternalFenceInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->handleType));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalFenceProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalFenceProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3151,7 +3151,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtern
     VkExternalFenceProperties* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->exportFromImportedHandleTypes));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->compatibleHandleTypes));
@@ -3160,7 +3160,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtern
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportFenceCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportFenceCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3168,14 +3168,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExport
     VkExportFenceCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->handleTypes));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportSemaphoreCreateInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportSemaphoreCreateInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3183,14 +3183,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExport
     VkExportSemaphoreCreateInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->handleTypes));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalSemaphoreInfo* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalSemaphoreInfo* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3198,14 +3198,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceExternalSemaphoreInfo* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->handleType));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalSemaphoreProperties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalSemaphoreProperties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3213,7 +3213,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtern
     VkExternalSemaphoreProperties* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->exportFromImportedHandleTypes));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->compatibleHandleTypes));
@@ -3222,7 +3222,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtern
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMaintenance3Properties* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMaintenance3Properties* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3230,7 +3230,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceMaintenance3Properties* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxPerSetDescriptors));
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxMemoryAllocationSize));
@@ -3238,7 +3238,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorSetLayoutSupport* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorSetLayoutSupport* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3246,14 +3246,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     VkDescriptorSetLayoutSupport* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->supported));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShaderDrawParameterFeatures* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShaderDrawParameterFeatures* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3261,14 +3261,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceShaderDrawParameterFeatures* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shaderDrawParameters));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfaceCapabilitiesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfaceCapabilitiesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3278,11 +3278,11 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfac
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->minImageCount));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxImageCount));
     wrapper->currentExtent.value = &(value->currentExtent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->currentExtent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->currentExtent));
     wrapper->minImageExtent.value = &(value->minImageExtent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->minImageExtent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->minImageExtent));
     wrapper->maxImageExtent.value = &(value->maxImageExtent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxImageExtent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxImageExtent));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxImageArrayLayers));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->supportedTransforms));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->currentTransform));
@@ -3292,7 +3292,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfac
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfaceFormatKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfaceFormatKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3305,7 +3305,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfac
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSwapchainCreateInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSwapchainCreateInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3313,7 +3313,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSwapch
     VkSwapchainCreateInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->surface));
@@ -3322,7 +3322,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSwapch
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageFormat));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageColorSpace));
     wrapper->imageExtent.value = &(value->imageExtent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageExtent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageExtent));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageArrayLayers));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageUsage));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageSharingMode));
@@ -3339,7 +3339,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSwapch
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresentInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresentInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3347,7 +3347,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresen
     VkPresentInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->waitSemaphoreCount));
     bytes_read += wrapper->pWaitSemaphores.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -3363,7 +3363,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresen
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageSwapchainCreateInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageSwapchainCreateInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3371,7 +3371,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageS
     VkImageSwapchainCreateInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->swapchain));
     value->swapchain = VK_NULL_HANDLE;
@@ -3379,7 +3379,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageS
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindImageMemorySwapchainInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindImageMemorySwapchainInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3387,7 +3387,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindIm
     VkBindImageMemorySwapchainInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->swapchain));
     value->swapchain = VK_NULL_HANDLE;
@@ -3396,7 +3396,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindIm
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAcquireNextImageInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAcquireNextImageInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3404,7 +3404,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAcquir
     VkAcquireNextImageInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->swapchain));
     value->swapchain = VK_NULL_HANDLE;
@@ -3418,7 +3418,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAcquir
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGroupPresentCapabilitiesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGroupPresentCapabilitiesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3426,7 +3426,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     VkDeviceGroupPresentCapabilitiesKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->presentMask.SetExternalMemory(value->presentMask, VK_MAX_DEVICE_GROUP_SIZE);
     bytes_read += wrapper->presentMask.DecodeUInt32((buffer + bytes_read), (buffer_size - bytes_read));
@@ -3435,7 +3435,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGroupPresentInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGroupPresentInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3443,7 +3443,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     VkDeviceGroupPresentInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->swapchainCount));
     bytes_read += wrapper->pDeviceMasks.DecodeUInt32((buffer + bytes_read), (buffer_size - bytes_read));
@@ -3453,7 +3453,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGroupSwapchainCreateInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGroupSwapchainCreateInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3461,14 +3461,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     VkDeviceGroupSwapchainCreateInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->modes));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayPropertiesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayPropertiesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3480,9 +3480,9 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     bytes_read += wrapper->displayName.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->displayName = wrapper->displayName.GetPointer();
     wrapper->physicalDimensions.value = &(value->physicalDimensions);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->physicalDimensions));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->physicalDimensions));
     wrapper->physicalResolution.value = &(value->physicalResolution);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->physicalResolution));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->physicalResolution));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->supportedTransforms));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->planeReorderPossible));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->persistentContent));
@@ -3490,7 +3490,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayModeParametersKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayModeParametersKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3498,13 +3498,13 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     VkDisplayModeParametersKHR* value = wrapper->value;
 
     wrapper->visibleRegion.value = &(value->visibleRegion);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->visibleRegion));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->visibleRegion));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->refreshRate));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayModePropertiesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayModePropertiesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3514,12 +3514,12 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->displayMode));
     value->displayMode = VK_NULL_HANDLE;
     wrapper->parameters.value = &(value->parameters);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->parameters));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->parameters));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayModeCreateInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayModeCreateInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3527,16 +3527,16 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     VkDisplayModeCreateInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     wrapper->parameters.value = &(value->parameters);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->parameters));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->parameters));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayPlaneCapabilitiesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayPlaneCapabilitiesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3545,26 +3545,26 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
 
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->supportedAlpha));
     wrapper->minSrcPosition.value = &(value->minSrcPosition);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->minSrcPosition));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->minSrcPosition));
     wrapper->maxSrcPosition.value = &(value->maxSrcPosition);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxSrcPosition));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxSrcPosition));
     wrapper->minSrcExtent.value = &(value->minSrcExtent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->minSrcExtent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->minSrcExtent));
     wrapper->maxSrcExtent.value = &(value->maxSrcExtent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxSrcExtent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxSrcExtent));
     wrapper->minDstPosition.value = &(value->minDstPosition);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->minDstPosition));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->minDstPosition));
     wrapper->maxDstPosition.value = &(value->maxDstPosition);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxDstPosition));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxDstPosition));
     wrapper->minDstExtent.value = &(value->minDstExtent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->minDstExtent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->minDstExtent));
     wrapper->maxDstExtent.value = &(value->maxDstExtent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxDstExtent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxDstExtent));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayPlanePropertiesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayPlanePropertiesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3578,7 +3578,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplaySurfaceCreateInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplaySurfaceCreateInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3586,7 +3586,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     VkDisplaySurfaceCreateInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->displayMode));
@@ -3597,12 +3597,12 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     bytes_read += ValueDecoder::DecodeFloatValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->globalAlpha));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->alphaMode));
     wrapper->imageExtent.value = &(value->imageExtent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageExtent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageExtent));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayPresentInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayPresentInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3610,18 +3610,18 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     VkDisplayPresentInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->srcRect.value = &(value->srcRect);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->srcRect));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->srcRect));
     wrapper->dstRect.value = &(value->dstRect);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dstRect));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dstRect));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->persistent));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkXlibSurfaceCreateInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkXlibSurfaceCreateInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3629,7 +3629,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkXlibSu
     VkXlibSurfaceCreateInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dpy));
@@ -3639,7 +3639,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkXlibSu
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkXcbSurfaceCreateInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkXcbSurfaceCreateInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3647,7 +3647,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkXcbSur
     VkXcbSurfaceCreateInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->connection));
@@ -3657,7 +3657,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkXcbSur
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWaylandSurfaceCreateInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWaylandSurfaceCreateInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3665,7 +3665,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWaylan
     VkWaylandSurfaceCreateInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->display));
@@ -3676,7 +3676,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWaylan
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAndroidSurfaceCreateInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAndroidSurfaceCreateInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3684,7 +3684,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAndroi
     VkAndroidSurfaceCreateInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->window));
@@ -3693,7 +3693,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAndroi
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWin32SurfaceCreateInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWin32SurfaceCreateInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3701,7 +3701,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWin32S
     VkWin32SurfaceCreateInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->hinstance));
@@ -3712,7 +3712,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWin32S
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportMemoryWin32HandleInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportMemoryWin32HandleInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3720,7 +3720,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     VkImportMemoryWin32HandleInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->handleType));
     bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->handle));
@@ -3731,7 +3731,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportMemoryWin32HandleInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportMemoryWin32HandleInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3739,7 +3739,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExport
     VkExportMemoryWin32HandleInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += wrapper->pAttributes.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAttributes = wrapper->pAttributes.GetPointer();
@@ -3750,7 +3750,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExport
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryWin32HandlePropertiesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryWin32HandlePropertiesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3758,14 +3758,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     VkMemoryWin32HandlePropertiesKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->memoryTypeBits));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryGetWin32HandleInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryGetWin32HandleInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3773,7 +3773,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     VkMemoryGetWin32HandleInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->memory));
     value->memory = VK_NULL_HANDLE;
@@ -3782,7 +3782,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportMemoryFdInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportMemoryFdInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3790,7 +3790,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     VkImportMemoryFdInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->handleType));
     bytes_read += ValueDecoder::DecodeInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->fd));
@@ -3798,7 +3798,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryFdPropertiesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryFdPropertiesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3806,14 +3806,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     VkMemoryFdPropertiesKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->memoryTypeBits));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryGetFdInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryGetFdInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3821,7 +3821,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     VkMemoryGetFdInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->memory));
     value->memory = VK_NULL_HANDLE;
@@ -3830,7 +3830,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3838,7 +3838,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWin32K
     VkWin32KeyedMutexAcquireReleaseInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->acquireCount));
     bytes_read += wrapper->pAcquireSyncs.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -3856,7 +3856,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWin32K
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportSemaphoreWin32HandleInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportSemaphoreWin32HandleInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3864,7 +3864,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     VkImportSemaphoreWin32HandleInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->semaphore));
     value->semaphore = VK_NULL_HANDLE;
@@ -3878,7 +3878,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportSemaphoreWin32HandleInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportSemaphoreWin32HandleInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3886,7 +3886,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExport
     VkExportSemaphoreWin32HandleInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += wrapper->pAttributes.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAttributes = wrapper->pAttributes.GetPointer();
@@ -3897,7 +3897,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExport
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkD3D12FenceSubmitInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkD3D12FenceSubmitInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3905,7 +3905,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkD3D12F
     VkD3D12FenceSubmitInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->waitSemaphoreValuesCount));
     bytes_read += wrapper->pWaitSemaphoreValues.DecodeUInt64((buffer + bytes_read), (buffer_size - bytes_read));
@@ -3917,7 +3917,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkD3D12F
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSemaphoreGetWin32HandleInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSemaphoreGetWin32HandleInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3925,7 +3925,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSemaph
     VkSemaphoreGetWin32HandleInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->semaphore));
     value->semaphore = VK_NULL_HANDLE;
@@ -3934,7 +3934,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSemaph
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportSemaphoreFdInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportSemaphoreFdInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3942,7 +3942,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     VkImportSemaphoreFdInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->semaphore));
     value->semaphore = VK_NULL_HANDLE;
@@ -3953,7 +3953,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSemaphoreGetFdInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSemaphoreGetFdInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3961,7 +3961,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSemaph
     VkSemaphoreGetFdInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->semaphore));
     value->semaphore = VK_NULL_HANDLE;
@@ -3970,7 +3970,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSemaph
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDevicePushDescriptorPropertiesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDevicePushDescriptorPropertiesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3978,14 +3978,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDevicePushDescriptorPropertiesKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxPushDescriptors));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFloat16Int8FeaturesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFloat16Int8FeaturesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -3993,7 +3993,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceFloat16Int8FeaturesKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shaderFloat16));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shaderInt8));
@@ -4001,7 +4001,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRectLayerKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRectLayerKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4009,15 +4009,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRectLa
     VkRectLayerKHR* value = wrapper->value;
 
     wrapper->offset.value = &(value->offset);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->offset));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->offset));
     wrapper->extent.value = &(value->extent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->extent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->extent));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->layer));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresentRegionKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresentRegionKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4031,7 +4031,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresen
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresentRegionsKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresentRegionsKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4039,7 +4039,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresen
     VkPresentRegionsKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->swapchainCount));
     bytes_read += wrapper->pRegions.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -4048,7 +4048,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresen
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttachmentDescription2KHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttachmentDescription2KHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4056,7 +4056,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttach
     VkAttachmentDescription2KHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->format));
@@ -4071,7 +4071,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttach
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttachmentReference2KHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttachmentReference2KHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4079,7 +4079,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttach
     VkAttachmentReference2KHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->attachment));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->layout));
@@ -4088,7 +4088,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttach
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpassDescription2KHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpassDescription2KHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4096,7 +4096,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpas
     VkSubpassDescription2KHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->pipelineBindPoint));
@@ -4118,7 +4118,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpas
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpassDependency2KHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpassDependency2KHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4126,7 +4126,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpas
     VkSubpassDependency2KHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->srcSubpass));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->dstSubpass));
@@ -4140,7 +4140,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpas
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderPassCreateInfo2KHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderPassCreateInfo2KHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4148,7 +4148,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRender
     VkRenderPassCreateInfo2KHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->attachmentCount));
@@ -4167,7 +4167,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRender
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpassBeginInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpassBeginInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4175,14 +4175,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpas
     VkSubpassBeginInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->contents));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpassEndInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpassEndInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4190,13 +4190,13 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpas
     VkSubpassEndInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSharedPresentSurfaceCapabilitiesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSharedPresentSurfaceCapabilitiesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4204,14 +4204,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShared
     VkSharedPresentSurfaceCapabilitiesKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sharedPresentSupportedUsageFlags));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportFenceWin32HandleInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportFenceWin32HandleInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4219,7 +4219,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     VkImportFenceWin32HandleInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->fence));
     value->fence = VK_NULL_HANDLE;
@@ -4233,7 +4233,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportFenceWin32HandleInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportFenceWin32HandleInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4241,7 +4241,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExport
     VkExportFenceWin32HandleInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += wrapper->pAttributes.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAttributes = wrapper->pAttributes.GetPointer();
@@ -4252,7 +4252,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExport
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFenceGetWin32HandleInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFenceGetWin32HandleInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4260,7 +4260,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFenceG
     VkFenceGetWin32HandleInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->fence));
     value->fence = VK_NULL_HANDLE;
@@ -4269,7 +4269,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFenceG
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportFenceFdInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportFenceFdInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4277,7 +4277,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     VkImportFenceFdInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->fence));
     value->fence = VK_NULL_HANDLE;
@@ -4288,7 +4288,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFenceGetFdInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFenceGetFdInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4296,7 +4296,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFenceG
     VkFenceGetFdInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->fence));
     value->fence = VK_NULL_HANDLE;
@@ -4305,7 +4305,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFenceG
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSurfaceInfo2KHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSurfaceInfo2KHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4313,7 +4313,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceSurfaceInfo2KHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->surface));
     value->surface = VK_NULL_HANDLE;
@@ -4321,7 +4321,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfaceCapabilities2KHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfaceCapabilities2KHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4329,15 +4329,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfac
     VkSurfaceCapabilities2KHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->surfaceCapabilities.value = &(value->surfaceCapabilities);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->surfaceCapabilities));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->surfaceCapabilities));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfaceFormat2KHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfaceFormat2KHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4345,15 +4345,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfac
     VkSurfaceFormat2KHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->surfaceFormat.value = &(value->surfaceFormat);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->surfaceFormat));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->surfaceFormat));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayProperties2KHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayProperties2KHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4361,15 +4361,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     VkDisplayProperties2KHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->displayProperties.value = &(value->displayProperties);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->displayProperties));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->displayProperties));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayPlaneProperties2KHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayPlaneProperties2KHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4377,15 +4377,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     VkDisplayPlaneProperties2KHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->displayPlaneProperties.value = &(value->displayPlaneProperties);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->displayPlaneProperties));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->displayPlaneProperties));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayModeProperties2KHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayModeProperties2KHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4393,15 +4393,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     VkDisplayModeProperties2KHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->displayModeProperties.value = &(value->displayModeProperties);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->displayModeProperties));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->displayModeProperties));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayPlaneInfo2KHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayPlaneInfo2KHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4409,7 +4409,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     VkDisplayPlaneInfo2KHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->mode));
     value->mode = VK_NULL_HANDLE;
@@ -4418,7 +4418,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayPlaneCapabilities2KHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayPlaneCapabilities2KHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4426,15 +4426,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     VkDisplayPlaneCapabilities2KHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->capabilities.value = &(value->capabilities);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->capabilities));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->capabilities));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageFormatListCreateInfoKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageFormatListCreateInfoKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4442,7 +4442,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageF
     VkImageFormatListCreateInfoKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->viewFormatCount));
     bytes_read += wrapper->pViewFormats.DecodeEnum((buffer + bytes_read), (buffer_size - bytes_read));
@@ -4451,7 +4451,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageF
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDevice8BitStorageFeaturesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDevice8BitStorageFeaturesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4459,7 +4459,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDevice8BitStorageFeaturesKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->storageBuffer8BitAccess));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->uniformAndStorageBuffer8BitAccess));
@@ -4468,7 +4468,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShaderAtomicInt64FeaturesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShaderAtomicInt64FeaturesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4476,7 +4476,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceShaderAtomicInt64FeaturesKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shaderBufferInt64Atomics));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shaderSharedInt64Atomics));
@@ -4484,7 +4484,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkConformanceVersionKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkConformanceVersionKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4499,7 +4499,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkConfor
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDriverPropertiesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDriverPropertiesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4507,7 +4507,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceDriverPropertiesKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->driverID));
     wrapper->driverName.SetExternalMemory(value->driverName, VK_MAX_DRIVER_NAME_SIZE_KHR);
@@ -4515,12 +4515,12 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     wrapper->driverInfo.SetExternalMemory(value->driverInfo, VK_MAX_DRIVER_INFO_SIZE_KHR);
     bytes_read += wrapper->driverInfo.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     wrapper->conformanceVersion.value = &(value->conformanceVersion);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->conformanceVersion));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->conformanceVersion));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFloatControlsPropertiesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFloatControlsPropertiesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4528,7 +4528,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceFloatControlsPropertiesKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->separateDenormSettings));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->separateRoundingModeSettings));
@@ -4551,7 +4551,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpassDescriptionDepthStencilResolveKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpassDescriptionDepthStencilResolveKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4559,7 +4559,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpas
     VkSubpassDescriptionDepthStencilResolveKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->depthResolveMode));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->stencilResolveMode));
@@ -4569,7 +4569,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpas
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDepthStencilResolvePropertiesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDepthStencilResolvePropertiesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4577,7 +4577,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceDepthStencilResolvePropertiesKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->supportedDepthResolveModes));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->supportedStencilResolveModes));
@@ -4587,7 +4587,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceVulkanMemoryModelFeaturesKHR* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceVulkanMemoryModelFeaturesKHR* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4595,7 +4595,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceVulkanMemoryModelFeaturesKHR* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->vulkanMemoryModel));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->vulkanMemoryModelDeviceScope));
@@ -4603,7 +4603,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugReportCallbackCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugReportCallbackCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4611,7 +4611,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugR
     VkDebugReportCallbackCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pfnCallback));
@@ -4622,7 +4622,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugR
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineRasterizationStateRasterizationOrderAMD* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineRasterizationStateRasterizationOrderAMD* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4630,14 +4630,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineRasterizationStateRasterizationOrderAMD* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->rasterizationOrder));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugMarkerObjectNameInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugMarkerObjectNameInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4645,7 +4645,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugM
     VkDebugMarkerObjectNameInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->objectType));
     bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->object));
@@ -4655,7 +4655,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugM
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugMarkerObjectTagInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugMarkerObjectTagInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4663,7 +4663,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugM
     VkDebugMarkerObjectTagInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->objectType));
     bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->object));
@@ -4675,7 +4675,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugM
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugMarkerMarkerInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugMarkerMarkerInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4683,7 +4683,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugM
     VkDebugMarkerMarkerInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += wrapper->pMarkerName.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pMarkerName = wrapper->pMarkerName.GetPointer();
@@ -4693,7 +4693,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugM
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDedicatedAllocationImageCreateInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDedicatedAllocationImageCreateInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4701,14 +4701,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDedica
     VkDedicatedAllocationImageCreateInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->dedicatedAllocation));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDedicatedAllocationBufferCreateInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDedicatedAllocationBufferCreateInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4716,14 +4716,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDedica
     VkDedicatedAllocationBufferCreateInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->dedicatedAllocation));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDedicatedAllocationMemoryAllocateInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDedicatedAllocationMemoryAllocateInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4731,7 +4731,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDedica
     VkDedicatedAllocationMemoryAllocateInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->image));
     value->image = VK_NULL_HANDLE;
@@ -4741,7 +4741,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDedica
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceTransformFeedbackFeaturesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceTransformFeedbackFeaturesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4749,7 +4749,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceTransformFeedbackFeaturesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->transformFeedback));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->geometryStreams));
@@ -4757,7 +4757,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4765,7 +4765,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceTransformFeedbackPropertiesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxTransformFeedbackStreams));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxTransformFeedbackBuffers));
@@ -4781,7 +4781,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4789,7 +4789,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineRasterizationStateStreamCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->rasterizationStream));
@@ -4797,7 +4797,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkTextureLODGatherFormatPropertiesAMD* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkTextureLODGatherFormatPropertiesAMD* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4805,14 +4805,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkTextur
     VkTextureLODGatherFormatPropertiesAMD* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->supportsTextureGatherLODBiasAMD));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShaderResourceUsageAMD* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShaderResourceUsageAMD* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4828,7 +4828,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShader
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShaderStatisticsInfoAMD* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShaderStatisticsInfoAMD* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4837,7 +4837,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShader
 
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->shaderStageMask));
     wrapper->resourceUsage.value = &(value->resourceUsage);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->resourceUsage));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->resourceUsage));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->numPhysicalVgprs));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->numPhysicalSgprs));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->numAvailableVgprs));
@@ -4848,7 +4848,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShader
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceCornerSampledImageFeaturesNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceCornerSampledImageFeaturesNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4856,14 +4856,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceCornerSampledImageFeaturesNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->cornerSampledImage));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalImageFormatPropertiesNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalImageFormatPropertiesNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4871,7 +4871,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtern
     VkExternalImageFormatPropertiesNV* value = wrapper->value;
 
     wrapper->imageFormatProperties.value = &(value->imageFormatProperties);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageFormatProperties));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageFormatProperties));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->externalMemoryFeatures));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->exportFromImportedHandleTypes));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->compatibleHandleTypes));
@@ -4879,7 +4879,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtern
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalMemoryImageCreateInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalMemoryImageCreateInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4887,14 +4887,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtern
     VkExternalMemoryImageCreateInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->handleTypes));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportMemoryAllocateInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportMemoryAllocateInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4902,14 +4902,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExport
     VkExportMemoryAllocateInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->handleTypes));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportMemoryWin32HandleInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportMemoryWin32HandleInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4917,7 +4917,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     VkImportMemoryWin32HandleInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->handleType));
     bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->handle));
@@ -4926,7 +4926,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportMemoryWin32HandleInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportMemoryWin32HandleInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4934,7 +4934,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExport
     VkExportMemoryWin32HandleInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += wrapper->pAttributes.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAttributes = wrapper->pAttributes.GetPointer();
@@ -4943,7 +4943,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExport
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4951,7 +4951,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWin32K
     VkWin32KeyedMutexAcquireReleaseInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->acquireCount));
     bytes_read += wrapper->pAcquireSyncs.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -4969,7 +4969,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWin32K
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkValidationFlagsEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkValidationFlagsEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4977,7 +4977,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkValida
     VkValidationFlagsEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->disabledValidationCheckCount));
     bytes_read += wrapper->pDisabledValidationChecks.DecodeEnum((buffer + bytes_read), (buffer_size - bytes_read));
@@ -4986,7 +4986,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkValida
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkViSurfaceCreateInfoNN* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkViSurfaceCreateInfoNN* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -4994,7 +4994,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkViSurf
     VkViSurfaceCreateInfoNN* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->window));
@@ -5003,7 +5003,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkViSurf
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageViewASTCDecodeModeEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageViewASTCDecodeModeEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5011,14 +5011,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageV
     VkImageViewASTCDecodeModeEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->decodeMode));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceASTCDecodeFeaturesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceASTCDecodeFeaturesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5026,14 +5026,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceASTCDecodeFeaturesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->decodeModeSharedExponent));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkConditionalRenderingBeginInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkConditionalRenderingBeginInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5041,7 +5041,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCondit
     VkConditionalRenderingBeginInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->buffer));
     value->buffer = VK_NULL_HANDLE;
@@ -5051,7 +5051,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCondit
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceConditionalRenderingFeaturesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceConditionalRenderingFeaturesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5059,7 +5059,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceConditionalRenderingFeaturesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->conditionalRendering));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->inheritedConditionalRendering));
@@ -5067,7 +5067,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCommandBufferInheritanceConditionalRenderingInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCommandBufferInheritanceConditionalRenderingInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5075,14 +5075,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkComman
     VkCommandBufferInheritanceConditionalRenderingInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->conditionalRenderingEnable));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGeneratedCommandsFeaturesNVX* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGeneratedCommandsFeaturesNVX* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5090,14 +5090,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     VkDeviceGeneratedCommandsFeaturesNVX* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->computeBindingPointSupport));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGeneratedCommandsLimitsNVX* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceGeneratedCommandsLimitsNVX* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5105,7 +5105,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     VkDeviceGeneratedCommandsLimitsNVX* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxIndirectCommandsLayoutTokenCount));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxObjectEntryCounts));
@@ -5116,7 +5116,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkIndirectCommandsTokenNVX* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkIndirectCommandsTokenNVX* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5131,7 +5131,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkIndire
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkIndirectCommandsLayoutTokenNVX* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkIndirectCommandsLayoutTokenNVX* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5146,7 +5146,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkIndire
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkIndirectCommandsLayoutCreateInfoNVX* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkIndirectCommandsLayoutCreateInfoNVX* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5154,7 +5154,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkIndire
     VkIndirectCommandsLayoutCreateInfoNVX* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->pipelineBindPoint));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
@@ -5165,7 +5165,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkIndire
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCmdProcessCommandsInfoNVX* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCmdProcessCommandsInfoNVX* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5173,7 +5173,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCmdPro
     VkCmdProcessCommandsInfoNVX* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->objectTable));
     value->objectTable = VK_NULL_HANDLE;
@@ -5195,7 +5195,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCmdPro
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCmdReserveSpaceForCommandsInfoNVX* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCmdReserveSpaceForCommandsInfoNVX* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5203,7 +5203,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCmdRes
     VkCmdReserveSpaceForCommandsInfoNVX* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->objectTable));
     value->objectTable = VK_NULL_HANDLE;
@@ -5214,7 +5214,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCmdRes
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObjectTableCreateInfoNVX* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObjectTableCreateInfoNVX* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5222,7 +5222,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObject
     VkObjectTableCreateInfoNVX* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->objectCount));
     bytes_read += wrapper->pObjectEntryTypes.DecodeEnum((buffer + bytes_read), (buffer_size - bytes_read));
@@ -5240,7 +5240,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObject
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObjectTablePipelineEntryNVX* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObjectTablePipelineEntryNVX* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5255,7 +5255,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObject
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObjectTableDescriptorSetEntryNVX* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObjectTableDescriptorSetEntryNVX* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5272,7 +5272,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObject
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObjectTableVertexBufferEntryNVX* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObjectTableVertexBufferEntryNVX* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5287,7 +5287,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObject
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObjectTableIndexBufferEntryNVX* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObjectTableIndexBufferEntryNVX* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5303,7 +5303,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObject
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObjectTablePushConstantEntryNVX* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObjectTablePushConstantEntryNVX* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5319,7 +5319,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkObject
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkViewportWScalingNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkViewportWScalingNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5332,7 +5332,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkViewpo
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineViewportWScalingStateCreateInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineViewportWScalingStateCreateInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5340,7 +5340,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineViewportWScalingStateCreateInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->viewportWScalingEnable));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->viewportCount));
@@ -5350,7 +5350,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfaceCapabilities2EXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfaceCapabilities2EXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5358,16 +5358,16 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfac
     VkSurfaceCapabilities2EXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->minImageCount));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxImageCount));
     wrapper->currentExtent.value = &(value->currentExtent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->currentExtent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->currentExtent));
     wrapper->minImageExtent.value = &(value->minImageExtent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->minImageExtent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->minImageExtent));
     wrapper->maxImageExtent.value = &(value->maxImageExtent);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxImageExtent));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxImageExtent));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxImageArrayLayers));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->supportedTransforms));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->currentTransform));
@@ -5378,7 +5378,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurfac
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayPowerInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayPowerInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5386,14 +5386,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     VkDisplayPowerInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->powerState));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceEventInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceEventInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5401,14 +5401,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     VkDeviceEventInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->deviceEvent));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayEventInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplayEventInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5416,14 +5416,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDispla
     VkDisplayEventInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->displayEvent));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSwapchainCounterCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSwapchainCounterCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5431,14 +5431,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSwapch
     VkSwapchainCounterCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->surfaceCounters));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRefreshCycleDurationGOOGLE* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRefreshCycleDurationGOOGLE* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5450,7 +5450,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRefres
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPastPresentationTimingGOOGLE* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPastPresentationTimingGOOGLE* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5466,7 +5466,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPastPr
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresentTimeGOOGLE* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresentTimeGOOGLE* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5479,7 +5479,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresen
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresentTimesInfoGOOGLE* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresentTimesInfoGOOGLE* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5487,7 +5487,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresen
     VkPresentTimesInfoGOOGLE* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->swapchainCount));
     bytes_read += wrapper->pTimes.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -5496,7 +5496,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresen
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5504,14 +5504,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->perViewPositionAllComponents));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkViewportSwizzleNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkViewportSwizzleNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5526,7 +5526,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkViewpo
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineViewportSwizzleStateCreateInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineViewportSwizzleStateCreateInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5534,7 +5534,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineViewportSwizzleStateCreateInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->viewportCount));
@@ -5544,7 +5544,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDiscardRectanglePropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDiscardRectanglePropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5552,14 +5552,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceDiscardRectanglePropertiesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxDiscardRectangles));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5567,7 +5567,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineDiscardRectangleStateCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->discardRectangleMode));
@@ -5578,7 +5578,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5586,7 +5586,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceConservativeRasterizationPropertiesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFloatValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->primitiveOverestimationSize));
     bytes_read += ValueDecoder::DecodeFloatValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxExtraPrimitiveOverestimationSize));
@@ -5601,7 +5601,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5609,7 +5609,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineRasterizationConservativeStateCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->conservativeRasterizationMode));
@@ -5618,7 +5618,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkXYColorEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkXYColorEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5631,7 +5631,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkXYColo
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkHdrMetadataEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkHdrMetadataEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5639,16 +5639,16 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkHdrMet
     VkHdrMetadataEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->displayPrimaryRed.value = &(value->displayPrimaryRed);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->displayPrimaryRed));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->displayPrimaryRed));
     wrapper->displayPrimaryGreen.value = &(value->displayPrimaryGreen);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->displayPrimaryGreen));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->displayPrimaryGreen));
     wrapper->displayPrimaryBlue.value = &(value->displayPrimaryBlue);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->displayPrimaryBlue));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->displayPrimaryBlue));
     wrapper->whitePoint.value = &(value->whitePoint);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->whitePoint));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->whitePoint));
     bytes_read += ValueDecoder::DecodeFloatValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxLuminance));
     bytes_read += ValueDecoder::DecodeFloatValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->minLuminance));
     bytes_read += ValueDecoder::DecodeFloatValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxContentLightLevel));
@@ -5657,7 +5657,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkHdrMet
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkIOSSurfaceCreateInfoMVK* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkIOSSurfaceCreateInfoMVK* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5665,7 +5665,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkIOSSur
     VkIOSSurfaceCreateInfoMVK* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pView));
@@ -5674,7 +5674,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkIOSSur
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMacOSSurfaceCreateInfoMVK* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMacOSSurfaceCreateInfoMVK* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5682,7 +5682,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMacOSS
     VkMacOSSurfaceCreateInfoMVK* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pView));
@@ -5691,7 +5691,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMacOSS
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugUtilsObjectNameInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugUtilsObjectNameInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5699,7 +5699,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugU
     VkDebugUtilsObjectNameInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->objectType));
     bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->objectHandle));
@@ -5709,7 +5709,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugU
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugUtilsObjectTagInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugUtilsObjectTagInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5717,7 +5717,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugU
     VkDebugUtilsObjectTagInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->objectType));
     bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->objectHandle));
@@ -5729,7 +5729,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugU
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugUtilsLabelEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugUtilsLabelEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5737,7 +5737,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugU
     VkDebugUtilsLabelEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += wrapper->pLabelName.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pLabelName = wrapper->pLabelName.GetPointer();
@@ -5747,7 +5747,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugU
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugUtilsMessengerCallbackDataEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugUtilsMessengerCallbackDataEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5755,7 +5755,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugU
     VkDebugUtilsMessengerCallbackDataEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += wrapper->pMessageIdName.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -5776,7 +5776,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugU
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugUtilsMessengerCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugUtilsMessengerCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5784,7 +5784,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugU
     VkDebugUtilsMessengerCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->messageSeverity));
@@ -5797,7 +5797,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugU
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAndroidHardwareBufferUsageANDROID* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAndroidHardwareBufferUsageANDROID* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5805,14 +5805,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAndroi
     VkAndroidHardwareBufferUsageANDROID* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->androidHardwareBufferUsage));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAndroidHardwareBufferPropertiesANDROID* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAndroidHardwareBufferPropertiesANDROID* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5820,7 +5820,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAndroi
     VkAndroidHardwareBufferPropertiesANDROID* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->allocationSize));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->memoryTypeBits));
@@ -5828,7 +5828,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAndroi
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAndroidHardwareBufferFormatPropertiesANDROID* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAndroidHardwareBufferFormatPropertiesANDROID* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5836,13 +5836,13 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAndroi
     VkAndroidHardwareBufferFormatPropertiesANDROID* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->format));
     bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->externalFormat));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->formatFeatures));
     wrapper->samplerYcbcrConversionComponents.value = &(value->samplerYcbcrConversionComponents);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->samplerYcbcrConversionComponents));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->samplerYcbcrConversionComponents));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->suggestedYcbcrModel));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->suggestedYcbcrRange));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->suggestedXChromaOffset));
@@ -5851,7 +5851,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAndroi
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportAndroidHardwareBufferInfoANDROID* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportAndroidHardwareBufferInfoANDROID* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5859,7 +5859,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     VkImportAndroidHardwareBufferInfoANDROID* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->buffer));
     value->buffer = nullptr;
@@ -5867,7 +5867,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5875,7 +5875,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     VkMemoryGetAndroidHardwareBufferInfoANDROID* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->memory));
     value->memory = VK_NULL_HANDLE;
@@ -5883,7 +5883,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalFormatANDROID* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExternalFormatANDROID* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5891,14 +5891,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtern
     VkExternalFormatANDROID* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->externalFormat));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSamplerReductionModeCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSamplerReductionModeCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5906,14 +5906,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSample
     VkSamplerReductionModeCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->reductionMode));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5921,7 +5921,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->filterMinmaxSingleComponentFormats));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->filterMinmaxImageComponentMapping));
@@ -5929,7 +5929,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceInlineUniformBlockFeaturesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceInlineUniformBlockFeaturesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5937,7 +5937,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceInlineUniformBlockFeaturesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->inlineUniformBlock));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->descriptorBindingInlineUniformBlockUpdateAfterBind));
@@ -5945,7 +5945,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceInlineUniformBlockPropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceInlineUniformBlockPropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5953,7 +5953,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceInlineUniformBlockPropertiesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxInlineUniformBlockSize));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxPerStageDescriptorInlineUniformBlocks));
@@ -5964,7 +5964,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWriteDescriptorSetInlineUniformBlockEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWriteDescriptorSetInlineUniformBlockEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5972,7 +5972,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWriteD
     VkWriteDescriptorSetInlineUniformBlockEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->dataSize));
     bytes_read += wrapper->pData.DecodeVoid((buffer + bytes_read), (buffer_size - bytes_read));
@@ -5981,7 +5981,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWriteD
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorPoolInlineUniformBlockCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorPoolInlineUniformBlockCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -5989,14 +5989,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     VkDescriptorPoolInlineUniformBlockCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxInlineUniformBlockBindings));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSampleLocationEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSampleLocationEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6009,7 +6009,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSample
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSampleLocationsInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSampleLocationsInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6017,11 +6017,11 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSample
     VkSampleLocationsInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleLocationsPerPixel));
     wrapper->sampleLocationGridSize.value = &(value->sampleLocationGridSize);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->sampleLocationGridSize));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->sampleLocationGridSize));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleLocationsCount));
     bytes_read += wrapper->pSampleLocations.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pSampleLocations = wrapper->pSampleLocations.GetPointer();
@@ -6029,7 +6029,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSample
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttachmentSampleLocationsEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttachmentSampleLocationsEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6038,12 +6038,12 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttach
 
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->attachmentIndex));
     wrapper->sampleLocationsInfo.value = &(value->sampleLocationsInfo);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->sampleLocationsInfo));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->sampleLocationsInfo));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpassSampleLocationsEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpassSampleLocationsEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6052,12 +6052,12 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpas
 
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->subpassIndex));
     wrapper->sampleLocationsInfo.value = &(value->sampleLocationsInfo);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->sampleLocationsInfo));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->sampleLocationsInfo));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderPassSampleLocationsBeginInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderPassSampleLocationsBeginInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6065,7 +6065,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRender
     VkRenderPassSampleLocationsBeginInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->attachmentInitialSampleLocationsCount));
     bytes_read += wrapper->pAttachmentInitialSampleLocations.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -6077,7 +6077,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRender
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineSampleLocationsStateCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineSampleLocationsStateCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6085,16 +6085,16 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineSampleLocationsStateCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleLocationsEnable));
     wrapper->sampleLocationsInfo.value = &(value->sampleLocationsInfo);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->sampleLocationsInfo));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->sampleLocationsInfo));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSampleLocationsPropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSampleLocationsPropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6102,11 +6102,11 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceSampleLocationsPropertiesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleLocationSampleCounts));
     wrapper->maxSampleLocationGridSize.value = &(value->maxSampleLocationGridSize);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxSampleLocationGridSize));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxSampleLocationGridSize));
     wrapper->sampleLocationCoordinateRange.SetExternalMemory(value->sampleLocationCoordinateRange, 2);
     bytes_read += wrapper->sampleLocationCoordinateRange.DecodeFloat((buffer + bytes_read), (buffer_size - bytes_read));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleLocationSubPixelBits));
@@ -6115,7 +6115,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMultisamplePropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMultisamplePropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6123,15 +6123,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMultis
     VkMultisamplePropertiesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->maxSampleLocationGridSize.value = &(value->maxSampleLocationGridSize);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxSampleLocationGridSize));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxSampleLocationGridSize));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6139,14 +6139,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->advancedBlendCoherentOperations));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6154,7 +6154,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->advancedBlendMaxColorAttachments));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->advancedBlendIndependentBlend));
@@ -6166,7 +6166,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineColorBlendAdvancedStateCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineColorBlendAdvancedStateCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6174,7 +6174,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineColorBlendAdvancedStateCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->srcPremultiplied));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->dstPremultiplied));
@@ -6183,7 +6183,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineCoverageToColorStateCreateInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineCoverageToColorStateCreateInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6191,7 +6191,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineCoverageToColorStateCreateInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->coverageToColorEnable));
@@ -6200,7 +6200,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineCoverageModulationStateCreateInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineCoverageModulationStateCreateInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6208,7 +6208,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineCoverageModulationStateCreateInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->coverageModulationMode));
@@ -6220,7 +6220,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrmFormatModifierPropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrmFormatModifierPropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6234,7 +6234,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrmFor
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrmFormatModifierPropertiesListEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrmFormatModifierPropertiesListEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6242,7 +6242,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrmFor
     VkDrmFormatModifierPropertiesListEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->drmFormatModifierCount));
     bytes_read += wrapper->pDrmFormatModifierProperties.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -6251,7 +6251,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrmFor
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceImageDrmFormatModifierInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceImageDrmFormatModifierInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6259,7 +6259,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceImageDrmFormatModifierInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->drmFormatModifier));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sharingMode));
@@ -6270,7 +6270,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageDrmFormatModifierListCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageDrmFormatModifierListCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6278,7 +6278,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageD
     VkImageDrmFormatModifierListCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->drmFormatModifierCount));
     bytes_read += wrapper->pDrmFormatModifiers.DecodeUInt64((buffer + bytes_read), (buffer_size - bytes_read));
@@ -6287,7 +6287,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageD
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageDrmFormatModifierExplicitCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageDrmFormatModifierExplicitCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6295,7 +6295,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageD
     VkImageDrmFormatModifierExplicitCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->drmFormatModifier));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->drmFormatModifierPlaneCount));
@@ -6305,7 +6305,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageD
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageDrmFormatModifierPropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageDrmFormatModifierPropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6313,14 +6313,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageD
     VkImageDrmFormatModifierPropertiesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->drmFormatModifier));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkValidationCacheCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkValidationCacheCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6328,7 +6328,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkValida
     VkValidationCacheCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeSizeTValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->initialDataSize));
@@ -6338,7 +6338,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkValida
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShaderModuleValidationCacheCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShaderModuleValidationCacheCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6346,7 +6346,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShader
     VkShaderModuleValidationCacheCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->validationCache));
     value->validationCache = VK_NULL_HANDLE;
@@ -6354,7 +6354,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShader
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorSetLayoutBindingFlagsCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorSetLayoutBindingFlagsCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6362,7 +6362,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     VkDescriptorSetLayoutBindingFlagsCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->bindingCount));
     bytes_read += wrapper->pBindingFlags.DecodeFlags((buffer + bytes_read), (buffer_size - bytes_read));
@@ -6371,7 +6371,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDescriptorIndexingFeaturesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDescriptorIndexingFeaturesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6379,7 +6379,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceDescriptorIndexingFeaturesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shaderInputAttachmentArrayDynamicIndexing));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shaderUniformTexelBufferArrayDynamicIndexing));
@@ -6405,7 +6405,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDescriptorIndexingPropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDescriptorIndexingPropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6413,7 +6413,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceDescriptorIndexingPropertiesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxUpdateAfterBindDescriptorsInAllPools));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shaderUniformBufferArrayNonUniformIndexingNative));
@@ -6442,7 +6442,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorSetVariableDescriptorCountAllocateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorSetVariableDescriptorCountAllocateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6450,7 +6450,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     VkDescriptorSetVariableDescriptorCountAllocateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->descriptorSetCount));
     bytes_read += wrapper->pDescriptorCounts.DecodeUInt32((buffer + bytes_read), (buffer_size - bytes_read));
@@ -6459,7 +6459,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorSetVariableDescriptorCountLayoutSupportEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescriptorSetVariableDescriptorCountLayoutSupportEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6467,14 +6467,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescri
     VkDescriptorSetVariableDescriptorCountLayoutSupportEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxVariableDescriptorCount));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShadingRatePaletteNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShadingRatePaletteNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6488,7 +6488,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShadin
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineViewportShadingRateImageStateCreateInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineViewportShadingRateImageStateCreateInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6496,7 +6496,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineViewportShadingRateImageStateCreateInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shadingRateImageEnable));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->viewportCount));
@@ -6506,7 +6506,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShadingRateImageFeaturesNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShadingRateImageFeaturesNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6514,7 +6514,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceShadingRateImageFeaturesNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shadingRateImage));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shadingRateCoarseSampleOrder));
@@ -6522,7 +6522,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShadingRateImagePropertiesNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShadingRateImagePropertiesNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6530,17 +6530,17 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceShadingRateImagePropertiesNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->shadingRateTexelSize.value = &(value->shadingRateTexelSize);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->shadingRateTexelSize));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->shadingRateTexelSize));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shadingRatePaletteSize));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shadingRateMaxCoarseSamples));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCoarseSampleLocationNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCoarseSampleLocationNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6554,7 +6554,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCoarse
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCoarseSampleOrderCustomNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCoarseSampleOrderCustomNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6570,7 +6570,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCoarse
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6578,7 +6578,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineViewportCoarseSampleOrderStateCreateInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleOrderType));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->customSampleOrderCount));
@@ -6588,7 +6588,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRayTracingShaderGroupCreateInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRayTracingShaderGroupCreateInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6596,7 +6596,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRayTra
     VkRayTracingShaderGroupCreateInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->type));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->generalShader));
@@ -6607,7 +6607,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRayTra
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRayTracingPipelineCreateInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRayTracingPipelineCreateInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6615,7 +6615,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRayTra
     VkRayTracingPipelineCreateInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->stageCount));
@@ -6634,7 +6634,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRayTra
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGeometryTrianglesNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGeometryTrianglesNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6642,7 +6642,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGeomet
     VkGeometryTrianglesNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->vertexData));
     value->vertexData = VK_NULL_HANDLE;
@@ -6662,7 +6662,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGeomet
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGeometryAABBNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGeometryAABBNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6670,7 +6670,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGeomet
     VkGeometryAABBNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->aabbData));
     value->aabbData = VK_NULL_HANDLE;
@@ -6681,7 +6681,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGeomet
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGeometryDataNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGeometryDataNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6689,14 +6689,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGeomet
     VkGeometryDataNV* value = wrapper->value;
 
     wrapper->triangles.value = &(value->triangles);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->triangles));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->triangles));
     wrapper->aabbs.value = &(value->aabbs);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->aabbs));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->aabbs));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGeometryNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGeometryNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6704,17 +6704,17 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGeomet
     VkGeometryNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->geometryType));
     wrapper->geometry.value = &(value->geometry);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->geometry));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->geometry));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAccelerationStructureInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAccelerationStructureInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6722,7 +6722,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAccele
     VkAccelerationStructureInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->type));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
@@ -6734,7 +6734,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAccele
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAccelerationStructureCreateInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAccelerationStructureCreateInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6742,16 +6742,16 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAccele
     VkAccelerationStructureCreateInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->compactedSize));
     wrapper->info.value = &(value->info);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->info));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->info));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindAccelerationStructureMemoryInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindAccelerationStructureMemoryInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6759,7 +6759,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindAc
     VkBindAccelerationStructureMemoryInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->accelerationStructure));
     value->accelerationStructure = VK_NULL_HANDLE;
@@ -6773,7 +6773,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindAc
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWriteDescriptorSetAccelerationStructureNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWriteDescriptorSetAccelerationStructureNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6781,7 +6781,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWriteD
     VkWriteDescriptorSetAccelerationStructureNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->accelerationStructureCount));
     bytes_read += wrapper->pAccelerationStructures.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -6790,7 +6790,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWriteD
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAccelerationStructureMemoryRequirementsInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAccelerationStructureMemoryRequirementsInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6798,7 +6798,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAccele
     VkAccelerationStructureMemoryRequirementsInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->type));
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->accelerationStructure));
@@ -6807,7 +6807,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAccele
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceRayTracingPropertiesNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceRayTracingPropertiesNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6815,7 +6815,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceRayTracingPropertiesNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shaderGroupHandleSize));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxRecursionDepth));
@@ -6829,7 +6829,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6837,14 +6837,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->representativeFragmentTest));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6852,14 +6852,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineRepresentativeFragmentTestStateCreateInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->representativeFragmentTestEnable));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6867,14 +6867,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     VkDeviceQueueGlobalPriorityCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->globalPriority));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportMemoryHostPointerInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImportMemoryHostPointerInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6882,7 +6882,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     VkImportMemoryHostPointerInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->handleType));
     bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pHostPointer));
@@ -6891,7 +6891,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImport
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryHostPointerPropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryHostPointerPropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6899,14 +6899,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     VkMemoryHostPointerPropertiesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->memoryTypeBits));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalMemoryHostPropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalMemoryHostPropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6914,14 +6914,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceExternalMemoryHostPropertiesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->minImportedHostPointerAlignment));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCalibratedTimestampInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCalibratedTimestampInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6929,14 +6929,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCalibr
     VkCalibratedTimestampInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->timeDomain));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShaderCorePropertiesAMD* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShaderCorePropertiesAMD* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6944,7 +6944,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceShaderCorePropertiesAMD* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shaderEngineCount));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shaderArraysPerEngineCount));
@@ -6964,7 +6964,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceMemoryOverallocationCreateInfoAMD* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceMemoryOverallocationCreateInfoAMD* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6972,14 +6972,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDevice
     VkDeviceMemoryOverallocationCreateInfoAMD* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->overallocationBehavior));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -6987,14 +6987,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxVertexAttribDivisor));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkVertexInputBindingDivisorDescriptionEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkVertexInputBindingDivisorDescriptionEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7007,7 +7007,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkVertex
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineVertexInputDivisorStateCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineVertexInputDivisorStateCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7015,7 +7015,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineVertexInputDivisorStateCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->vertexBindingDivisorCount));
     bytes_read += wrapper->pVertexBindingDivisors.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -7024,7 +7024,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7032,7 +7032,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->vertexAttributeInstanceRateDivisor));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->vertexAttributeInstanceRateZeroDivisor));
@@ -7040,7 +7040,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7048,7 +7048,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceComputeShaderDerivativesFeaturesNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->computeDerivativeGroupQuads));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->computeDerivativeGroupLinear));
@@ -7056,7 +7056,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMeshShaderFeaturesNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMeshShaderFeaturesNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7064,7 +7064,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceMeshShaderFeaturesNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->taskShader));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->meshShader));
@@ -7072,7 +7072,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMeshShaderPropertiesNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMeshShaderPropertiesNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7080,7 +7080,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceMeshShaderPropertiesNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxDrawMeshTasksCount));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxTaskWorkGroupInvocations));
@@ -7101,7 +7101,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrawMeshTasksIndirectCommandNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrawMeshTasksIndirectCommandNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7114,7 +7114,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrawMe
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7122,14 +7122,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->fragmentShaderBarycentric));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShaderImageFootprintFeaturesNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShaderImageFootprintFeaturesNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7137,14 +7137,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceShaderImageFootprintFeaturesNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageFootprint));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineViewportExclusiveScissorStateCreateInfoNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineViewportExclusiveScissorStateCreateInfoNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7152,7 +7152,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     VkPipelineViewportExclusiveScissorStateCreateInfoNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->exclusiveScissorCount));
     bytes_read += wrapper->pExclusiveScissors.Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -7161,7 +7161,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipeli
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExclusiveScissorFeaturesNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExclusiveScissorFeaturesNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7169,14 +7169,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceExclusiveScissorFeaturesNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->exclusiveScissor));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkQueueFamilyCheckpointPropertiesNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkQueueFamilyCheckpointPropertiesNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7184,14 +7184,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkQueueF
     VkQueueFamilyCheckpointPropertiesNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->checkpointExecutionStageMask));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCheckpointDataNV* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCheckpointDataNV* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7199,7 +7199,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCheckp
     VkCheckpointDataNV* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->stage));
     bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pCheckpointMarker));
@@ -7208,7 +7208,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCheckp
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDevicePCIBusInfoPropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDevicePCIBusInfoPropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7216,7 +7216,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDevicePCIBusInfoPropertiesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->pciDomain));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->pciBus));
@@ -7226,7 +7226,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7234,7 +7234,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageP
     VkImagePipeSurfaceCreateInfoFUCHSIA* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->imagePipeHandle));
@@ -7242,7 +7242,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageP
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7250,7 +7250,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceFragmentDensityMapFeaturesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->fragmentDensityMap));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->fragmentDensityMapDynamic));
@@ -7259,7 +7259,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7267,18 +7267,18 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceFragmentDensityMapPropertiesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->minFragmentDensityTexelSize.value = &(value->minFragmentDensityTexelSize);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->minFragmentDensityTexelSize));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->minFragmentDensityTexelSize));
     wrapper->maxFragmentDensityTexelSize.value = &(value->maxFragmentDensityTexelSize);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxFragmentDensityTexelSize));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->maxFragmentDensityTexelSize));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->fragmentDensityInvocations));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7286,15 +7286,15 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRender
     VkRenderPassFragmentDensityMapCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->fragmentDensityMapAttachment.value = &(value->fragmentDensityMapAttachment);
-    bytes_read += decode_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->fragmentDensityMapAttachment));
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->fragmentDensityMapAttachment));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceScalarBlockLayoutFeaturesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceScalarBlockLayoutFeaturesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7302,14 +7302,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceScalarBlockLayoutFeaturesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->scalarBlockLayout));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryBudgetPropertiesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryBudgetPropertiesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7317,7 +7317,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceMemoryBudgetPropertiesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     wrapper->heapBudget.SetExternalMemory(value->heapBudget, VK_MAX_MEMORY_HEAPS);
     bytes_read += wrapper->heapBudget.DecodeVkDeviceSize((buffer + bytes_read), (buffer_size - bytes_read));
@@ -7327,7 +7327,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryPriorityFeaturesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryPriorityFeaturesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7335,14 +7335,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceMemoryPriorityFeaturesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->memoryPriority));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryPriorityAllocateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryPriorityAllocateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7350,14 +7350,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemory
     VkMemoryPriorityAllocateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFloatValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->priority));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceBufferAddressFeaturesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceBufferAddressFeaturesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7365,7 +7365,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     VkPhysicalDeviceBufferAddressFeaturesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->bufferDeviceAddress));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->bufferDeviceAddressCaptureReplay));
@@ -7374,7 +7374,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysic
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferDeviceAddressInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferDeviceAddressInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7382,7 +7382,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBuffer
     VkBufferDeviceAddressInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->buffer));
     value->buffer = VK_NULL_HANDLE;
@@ -7390,7 +7390,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBuffer
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferDeviceAddressCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferDeviceAddressCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7398,14 +7398,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBuffer
     VkBufferDeviceAddressCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->deviceAddress));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageStencilUsageCreateInfoEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageStencilUsageCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7413,14 +7413,14 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageS
     VkImageStencilUsageCreateInfoEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->stencilUsage));
 
     return bytes_read;
 }
 
-size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkValidationFeaturesEXT* wrapper)
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkValidationFeaturesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
 
@@ -7428,7 +7428,7 @@ size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_VkValida
     VkValidationFeaturesEXT* value = wrapper->value;
 
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
-    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->enabledValidationFeatureCount));
     bytes_read += wrapper->pEnabledValidationFeatures.DecodeEnum((buffer + bytes_read), (buffer_size - bytes_read));

--- a/framework/generated/generated_vulkan_struct_decoders_forward.h
+++ b/framework/generated/generated_vulkan_struct_decoders_forward.h
@@ -138,111 +138,111 @@ struct Decoded_VkDispatchIndirectCommand;
 struct Decoded_VkDrawIndexedIndirectCommand;
 struct Decoded_VkDrawIndirectCommand;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkApplicationInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkInstanceCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAllocationCallbacks* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFeatures* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkFormatProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExtent3D* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageFormatProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceLimits* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSparseProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkQueueFamilyProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryType* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryHeap* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceQueueCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExtensionProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkLayerProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubmitInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryAllocateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMappedMemoryRange* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryRequirements* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseImageFormatProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseImageMemoryRequirements* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseMemoryBind* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseBufferMemoryBindInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseImageOpaqueMemoryBindInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageSubresource* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkOffset3D* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseImageMemoryBind* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseImageMemoryBindInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindSparseInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkFenceCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSemaphoreCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkEventCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkQueryPoolCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBufferCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBufferViewCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubresourceLayout* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkComponentMapping* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageSubresourceRange* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageViewCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkShaderModuleCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineCacheCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSpecializationMapEntry* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSpecializationInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineShaderStageCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkVertexInputBindingDescription* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkVertexInputAttributeDescription* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineVertexInputStateCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineInputAssemblyStateCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineTessellationStateCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkViewport* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkOffset2D* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExtent2D* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRect2D* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineViewportStateCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineRasterizationStateCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineMultisampleStateCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkStencilOpState* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineDepthStencilStateCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineColorBlendAttachmentState* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineColorBlendStateCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineDynamicStateCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkGraphicsPipelineCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkComputePipelineCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPushConstantRange* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineLayoutCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSamplerCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorSetLayoutBinding* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorSetLayoutCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorPoolSize* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorPoolCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorSetAllocateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorImageInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorBufferInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkWriteDescriptorSet* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCopyDescriptorSet* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkFramebufferCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAttachmentDescription* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAttachmentReference* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubpassDescription* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubpassDependency* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRenderPassCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCommandPoolCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCommandBufferAllocateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCommandBufferInheritanceInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCommandBufferBeginInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBufferCopy* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageSubresourceLayers* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageCopy* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageBlit* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBufferImageCopy* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkClearDepthStencilValue* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkClearAttachment* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkClearRect* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageResolve* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryBarrier* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBufferMemoryBarrier* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageMemoryBarrier* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRenderPassBeginInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDispatchIndirectCommand* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDrawIndexedIndirectCommand* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDrawIndirectCommand* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkApplicationInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkInstanceCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAllocationCallbacks* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFeatures* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkFormatProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExtent3D* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageFormatProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceLimits* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSparseProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkQueueFamilyProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryType* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryHeap* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceQueueCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExtensionProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkLayerProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubmitInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryAllocateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMappedMemoryRange* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryRequirements* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseImageFormatProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseImageMemoryRequirements* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseMemoryBind* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseBufferMemoryBindInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseImageOpaqueMemoryBindInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageSubresource* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkOffset3D* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseImageMemoryBind* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseImageMemoryBindInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindSparseInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkFenceCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSemaphoreCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkEventCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkQueryPoolCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBufferCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBufferViewCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubresourceLayout* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkComponentMapping* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageSubresourceRange* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageViewCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkShaderModuleCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineCacheCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSpecializationMapEntry* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSpecializationInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineShaderStageCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkVertexInputBindingDescription* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkVertexInputAttributeDescription* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineVertexInputStateCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineInputAssemblyStateCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineTessellationStateCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkViewport* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkOffset2D* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExtent2D* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRect2D* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineViewportStateCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineRasterizationStateCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineMultisampleStateCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkStencilOpState* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineDepthStencilStateCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineColorBlendAttachmentState* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineColorBlendStateCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineDynamicStateCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkGraphicsPipelineCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkComputePipelineCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPushConstantRange* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineLayoutCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSamplerCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorSetLayoutBinding* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorSetLayoutCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorPoolSize* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorPoolCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorSetAllocateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorImageInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorBufferInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkWriteDescriptorSet* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCopyDescriptorSet* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkFramebufferCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAttachmentDescription* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAttachmentReference* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubpassDescription* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubpassDependency* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRenderPassCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCommandPoolCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCommandBufferAllocateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCommandBufferInheritanceInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCommandBufferBeginInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBufferCopy* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageSubresourceLayers* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageCopy* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageBlit* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBufferImageCopy* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkClearDepthStencilValue* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkClearAttachment* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkClearRect* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageResolve* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryBarrier* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBufferMemoryBarrier* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageMemoryBarrier* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRenderPassBeginInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDispatchIndirectCommand* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDrawIndexedIndirectCommand* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDrawIndirectCommand* wrapper);
 
 struct Decoded_VkPhysicalDeviceSubgroupProperties;
 struct Decoded_VkBindBufferMemoryInfo;
@@ -313,80 +313,80 @@ struct Decoded_VkPhysicalDeviceMaintenance3Properties;
 struct Decoded_VkDescriptorSetLayoutSupport;
 struct Decoded_VkPhysicalDeviceShaderDrawParameterFeatures;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSubgroupProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindBufferMemoryInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindImageMemoryInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDevice16BitStorageFeatures* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryDedicatedRequirements* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryDedicatedAllocateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryAllocateFlagsInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGroupRenderPassBeginInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGroupCommandBufferBeginInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGroupSubmitInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGroupBindSparseInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindBufferMemoryDeviceGroupInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindImageMemoryDeviceGroupInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceGroupProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGroupDeviceCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBufferMemoryRequirementsInfo2* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageMemoryRequirementsInfo2* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageSparseMemoryRequirementsInfo2* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryRequirements2* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseImageMemoryRequirements2* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFeatures2* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceProperties2* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkFormatProperties2* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageFormatProperties2* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceImageFormatInfo2* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkQueueFamilyProperties2* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryProperties2* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseImageFormatProperties2* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSparseImageFormatInfo2* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDevicePointClippingProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkInputAttachmentAspectReference* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRenderPassInputAttachmentAspectCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageViewUsageCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineTessellationDomainOriginStateCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRenderPassMultiviewCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMultiviewFeatures* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMultiviewProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceVariablePointerFeatures* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceProtectedMemoryFeatures* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceProtectedMemoryProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceQueueInfo2* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkProtectedSubmitInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSamplerYcbcrConversionCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSamplerYcbcrConversionInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindImagePlaneMemoryInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImagePlaneMemoryRequirementsInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSamplerYcbcrConversionFeatures* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSamplerYcbcrConversionImageFormatProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorUpdateTemplateEntry* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorUpdateTemplateCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalMemoryProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalImageFormatInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalImageFormatProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalBufferInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalBufferProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceIDProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalMemoryImageCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalMemoryBufferCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExportMemoryAllocateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalFenceInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalFenceProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExportFenceCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExportSemaphoreCreateInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalSemaphoreInfo* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalSemaphoreProperties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMaintenance3Properties* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorSetLayoutSupport* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShaderDrawParameterFeatures* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSubgroupProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindBufferMemoryInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindImageMemoryInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDevice16BitStorageFeatures* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryDedicatedRequirements* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryDedicatedAllocateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryAllocateFlagsInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGroupRenderPassBeginInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGroupCommandBufferBeginInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGroupSubmitInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGroupBindSparseInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindBufferMemoryDeviceGroupInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindImageMemoryDeviceGroupInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceGroupProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGroupDeviceCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBufferMemoryRequirementsInfo2* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageMemoryRequirementsInfo2* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageSparseMemoryRequirementsInfo2* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryRequirements2* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseImageMemoryRequirements2* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFeatures2* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceProperties2* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkFormatProperties2* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageFormatProperties2* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceImageFormatInfo2* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkQueueFamilyProperties2* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryProperties2* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSparseImageFormatProperties2* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSparseImageFormatInfo2* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDevicePointClippingProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkInputAttachmentAspectReference* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRenderPassInputAttachmentAspectCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageViewUsageCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineTessellationDomainOriginStateCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRenderPassMultiviewCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMultiviewFeatures* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMultiviewProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceVariablePointerFeatures* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceProtectedMemoryFeatures* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceProtectedMemoryProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceQueueInfo2* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkProtectedSubmitInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSamplerYcbcrConversionCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSamplerYcbcrConversionInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindImagePlaneMemoryInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImagePlaneMemoryRequirementsInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSamplerYcbcrConversionFeatures* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSamplerYcbcrConversionImageFormatProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorUpdateTemplateEntry* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorUpdateTemplateCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalMemoryProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalImageFormatInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalImageFormatProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalBufferInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalBufferProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceIDProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalMemoryImageCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalMemoryBufferCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExportMemoryAllocateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalFenceInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalFenceProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExportFenceCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExportSemaphoreCreateInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalSemaphoreInfo* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalSemaphoreProperties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMaintenance3Properties* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorSetLayoutSupport* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShaderDrawParameterFeatures* wrapper);
 
 struct Decoded_VkSurfaceCapabilitiesKHR;
 struct Decoded_VkSurfaceFormatKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSurfaceCapabilitiesKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSurfaceFormatKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSurfaceCapabilitiesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSurfaceFormatKHR* wrapper);
 
 struct Decoded_VkSwapchainCreateInfoKHR;
 struct Decoded_VkPresentInfoKHR;
@@ -397,14 +397,14 @@ struct Decoded_VkDeviceGroupPresentCapabilitiesKHR;
 struct Decoded_VkDeviceGroupPresentInfoKHR;
 struct Decoded_VkDeviceGroupSwapchainCreateInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSwapchainCreateInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPresentInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageSwapchainCreateInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindImageMemorySwapchainInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAcquireNextImageInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGroupPresentCapabilitiesKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGroupPresentInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGroupSwapchainCreateInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSwapchainCreateInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPresentInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageSwapchainCreateInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindImageMemorySwapchainInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAcquireNextImageInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGroupPresentCapabilitiesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGroupPresentInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGroupSwapchainCreateInfoKHR* wrapper);
 
 struct Decoded_VkDisplayPropertiesKHR;
 struct Decoded_VkDisplayModeParametersKHR;
@@ -414,91 +414,91 @@ struct Decoded_VkDisplayPlaneCapabilitiesKHR;
 struct Decoded_VkDisplayPlanePropertiesKHR;
 struct Decoded_VkDisplaySurfaceCreateInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayPropertiesKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayModeParametersKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayModePropertiesKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayModeCreateInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayPlaneCapabilitiesKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayPlanePropertiesKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplaySurfaceCreateInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayPropertiesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayModeParametersKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayModePropertiesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayModeCreateInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayPlaneCapabilitiesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayPlanePropertiesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplaySurfaceCreateInfoKHR* wrapper);
 
 struct Decoded_VkDisplayPresentInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayPresentInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayPresentInfoKHR* wrapper);
 
 struct Decoded_VkXlibSurfaceCreateInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkXlibSurfaceCreateInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkXlibSurfaceCreateInfoKHR* wrapper);
 
 struct Decoded_VkXcbSurfaceCreateInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkXcbSurfaceCreateInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkXcbSurfaceCreateInfoKHR* wrapper);
 
 struct Decoded_VkWaylandSurfaceCreateInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkWaylandSurfaceCreateInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkWaylandSurfaceCreateInfoKHR* wrapper);
 
 struct Decoded_VkAndroidSurfaceCreateInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAndroidSurfaceCreateInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAndroidSurfaceCreateInfoKHR* wrapper);
 
 struct Decoded_VkWin32SurfaceCreateInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkWin32SurfaceCreateInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkWin32SurfaceCreateInfoKHR* wrapper);
 
 struct Decoded_VkImportMemoryWin32HandleInfoKHR;
 struct Decoded_VkExportMemoryWin32HandleInfoKHR;
 struct Decoded_VkMemoryWin32HandlePropertiesKHR;
 struct Decoded_VkMemoryGetWin32HandleInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportMemoryWin32HandleInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExportMemoryWin32HandleInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryWin32HandlePropertiesKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryGetWin32HandleInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportMemoryWin32HandleInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExportMemoryWin32HandleInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryWin32HandlePropertiesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryGetWin32HandleInfoKHR* wrapper);
 
 struct Decoded_VkImportMemoryFdInfoKHR;
 struct Decoded_VkMemoryFdPropertiesKHR;
 struct Decoded_VkMemoryGetFdInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportMemoryFdInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryFdPropertiesKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryGetFdInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportMemoryFdInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryFdPropertiesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryGetFdInfoKHR* wrapper);
 
 struct Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR* wrapper);
 
 struct Decoded_VkImportSemaphoreWin32HandleInfoKHR;
 struct Decoded_VkExportSemaphoreWin32HandleInfoKHR;
 struct Decoded_VkD3D12FenceSubmitInfoKHR;
 struct Decoded_VkSemaphoreGetWin32HandleInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportSemaphoreWin32HandleInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExportSemaphoreWin32HandleInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkD3D12FenceSubmitInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSemaphoreGetWin32HandleInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportSemaphoreWin32HandleInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExportSemaphoreWin32HandleInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkD3D12FenceSubmitInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSemaphoreGetWin32HandleInfoKHR* wrapper);
 
 struct Decoded_VkImportSemaphoreFdInfoKHR;
 struct Decoded_VkSemaphoreGetFdInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportSemaphoreFdInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSemaphoreGetFdInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportSemaphoreFdInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSemaphoreGetFdInfoKHR* wrapper);
 
 struct Decoded_VkPhysicalDevicePushDescriptorPropertiesKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDevicePushDescriptorPropertiesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDevicePushDescriptorPropertiesKHR* wrapper);
 
 struct Decoded_VkPhysicalDeviceFloat16Int8FeaturesKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFloat16Int8FeaturesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFloat16Int8FeaturesKHR* wrapper);
 
 struct Decoded_VkRectLayerKHR;
 struct Decoded_VkPresentRegionKHR;
 struct Decoded_VkPresentRegionsKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRectLayerKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPresentRegionKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPresentRegionsKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRectLayerKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPresentRegionKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPresentRegionsKHR* wrapper);
 
 struct Decoded_VkAttachmentDescription2KHR;
 struct Decoded_VkAttachmentReference2KHR;
@@ -508,39 +508,39 @@ struct Decoded_VkRenderPassCreateInfo2KHR;
 struct Decoded_VkSubpassBeginInfoKHR;
 struct Decoded_VkSubpassEndInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAttachmentDescription2KHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAttachmentReference2KHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubpassDescription2KHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubpassDependency2KHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRenderPassCreateInfo2KHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubpassBeginInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubpassEndInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAttachmentDescription2KHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAttachmentReference2KHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubpassDescription2KHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubpassDependency2KHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRenderPassCreateInfo2KHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubpassBeginInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubpassEndInfoKHR* wrapper);
 
 struct Decoded_VkSharedPresentSurfaceCapabilitiesKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSharedPresentSurfaceCapabilitiesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSharedPresentSurfaceCapabilitiesKHR* wrapper);
 
 struct Decoded_VkImportFenceWin32HandleInfoKHR;
 struct Decoded_VkExportFenceWin32HandleInfoKHR;
 struct Decoded_VkFenceGetWin32HandleInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportFenceWin32HandleInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExportFenceWin32HandleInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkFenceGetWin32HandleInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportFenceWin32HandleInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExportFenceWin32HandleInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkFenceGetWin32HandleInfoKHR* wrapper);
 
 struct Decoded_VkImportFenceFdInfoKHR;
 struct Decoded_VkFenceGetFdInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportFenceFdInfoKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkFenceGetFdInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportFenceFdInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkFenceGetFdInfoKHR* wrapper);
 
 struct Decoded_VkPhysicalDeviceSurfaceInfo2KHR;
 struct Decoded_VkSurfaceCapabilities2KHR;
 struct Decoded_VkSurfaceFormat2KHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSurfaceInfo2KHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSurfaceCapabilities2KHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSurfaceFormat2KHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSurfaceInfo2KHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSurfaceCapabilities2KHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSurfaceFormat2KHR* wrapper);
 
 struct Decoded_VkDisplayProperties2KHR;
 struct Decoded_VkDisplayPlaneProperties2KHR;
@@ -548,131 +548,131 @@ struct Decoded_VkDisplayModeProperties2KHR;
 struct Decoded_VkDisplayPlaneInfo2KHR;
 struct Decoded_VkDisplayPlaneCapabilities2KHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayProperties2KHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayPlaneProperties2KHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayModeProperties2KHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayPlaneInfo2KHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayPlaneCapabilities2KHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayProperties2KHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayPlaneProperties2KHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayModeProperties2KHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayPlaneInfo2KHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayPlaneCapabilities2KHR* wrapper);
 
 struct Decoded_VkImageFormatListCreateInfoKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageFormatListCreateInfoKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageFormatListCreateInfoKHR* wrapper);
 
 struct Decoded_VkPhysicalDevice8BitStorageFeaturesKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDevice8BitStorageFeaturesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDevice8BitStorageFeaturesKHR* wrapper);
 
 struct Decoded_VkPhysicalDeviceShaderAtomicInt64FeaturesKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShaderAtomicInt64FeaturesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShaderAtomicInt64FeaturesKHR* wrapper);
 
 struct Decoded_VkConformanceVersionKHR;
 struct Decoded_VkPhysicalDeviceDriverPropertiesKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkConformanceVersionKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDriverPropertiesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkConformanceVersionKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDriverPropertiesKHR* wrapper);
 
 struct Decoded_VkPhysicalDeviceFloatControlsPropertiesKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFloatControlsPropertiesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFloatControlsPropertiesKHR* wrapper);
 
 struct Decoded_VkSubpassDescriptionDepthStencilResolveKHR;
 struct Decoded_VkPhysicalDeviceDepthStencilResolvePropertiesKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubpassDescriptionDepthStencilResolveKHR* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDepthStencilResolvePropertiesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubpassDescriptionDepthStencilResolveKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDepthStencilResolvePropertiesKHR* wrapper);
 
 struct Decoded_VkPhysicalDeviceVulkanMemoryModelFeaturesKHR;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceVulkanMemoryModelFeaturesKHR* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceVulkanMemoryModelFeaturesKHR* wrapper);
 
 struct Decoded_VkDebugReportCallbackCreateInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugReportCallbackCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugReportCallbackCreateInfoEXT* wrapper);
 
 struct Decoded_VkPipelineRasterizationStateRasterizationOrderAMD;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineRasterizationStateRasterizationOrderAMD* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineRasterizationStateRasterizationOrderAMD* wrapper);
 
 struct Decoded_VkDebugMarkerObjectNameInfoEXT;
 struct Decoded_VkDebugMarkerObjectTagInfoEXT;
 struct Decoded_VkDebugMarkerMarkerInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugMarkerObjectNameInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugMarkerObjectTagInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugMarkerMarkerInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugMarkerObjectNameInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugMarkerObjectTagInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugMarkerMarkerInfoEXT* wrapper);
 
 struct Decoded_VkDedicatedAllocationImageCreateInfoNV;
 struct Decoded_VkDedicatedAllocationBufferCreateInfoNV;
 struct Decoded_VkDedicatedAllocationMemoryAllocateInfoNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDedicatedAllocationImageCreateInfoNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDedicatedAllocationBufferCreateInfoNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDedicatedAllocationMemoryAllocateInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDedicatedAllocationImageCreateInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDedicatedAllocationBufferCreateInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDedicatedAllocationMemoryAllocateInfoNV* wrapper);
 
 struct Decoded_VkPhysicalDeviceTransformFeedbackFeaturesEXT;
 struct Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT;
 struct Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceTransformFeedbackFeaturesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceTransformFeedbackFeaturesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT* wrapper);
 
 struct Decoded_VkTextureLODGatherFormatPropertiesAMD;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkTextureLODGatherFormatPropertiesAMD* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkTextureLODGatherFormatPropertiesAMD* wrapper);
 
 struct Decoded_VkShaderResourceUsageAMD;
 struct Decoded_VkShaderStatisticsInfoAMD;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkShaderResourceUsageAMD* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkShaderStatisticsInfoAMD* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkShaderResourceUsageAMD* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkShaderStatisticsInfoAMD* wrapper);
 
 struct Decoded_VkPhysicalDeviceCornerSampledImageFeaturesNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceCornerSampledImageFeaturesNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceCornerSampledImageFeaturesNV* wrapper);
 
 struct Decoded_VkExternalImageFormatPropertiesNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalImageFormatPropertiesNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalImageFormatPropertiesNV* wrapper);
 
 struct Decoded_VkExternalMemoryImageCreateInfoNV;
 struct Decoded_VkExportMemoryAllocateInfoNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalMemoryImageCreateInfoNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExportMemoryAllocateInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalMemoryImageCreateInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExportMemoryAllocateInfoNV* wrapper);
 
 struct Decoded_VkImportMemoryWin32HandleInfoNV;
 struct Decoded_VkExportMemoryWin32HandleInfoNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportMemoryWin32HandleInfoNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExportMemoryWin32HandleInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportMemoryWin32HandleInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExportMemoryWin32HandleInfoNV* wrapper);
 
 struct Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV* wrapper);
 
 struct Decoded_VkValidationFlagsEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkValidationFlagsEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkValidationFlagsEXT* wrapper);
 
 struct Decoded_VkViSurfaceCreateInfoNN;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkViSurfaceCreateInfoNN* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkViSurfaceCreateInfoNN* wrapper);
 
 struct Decoded_VkImageViewASTCDecodeModeEXT;
 struct Decoded_VkPhysicalDeviceASTCDecodeFeaturesEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageViewASTCDecodeModeEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceASTCDecodeFeaturesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageViewASTCDecodeModeEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceASTCDecodeFeaturesEXT* wrapper);
 
 struct Decoded_VkConditionalRenderingBeginInfoEXT;
 struct Decoded_VkPhysicalDeviceConditionalRenderingFeaturesEXT;
 struct Decoded_VkCommandBufferInheritanceConditionalRenderingInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkConditionalRenderingBeginInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceConditionalRenderingFeaturesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCommandBufferInheritanceConditionalRenderingInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkConditionalRenderingBeginInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceConditionalRenderingFeaturesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCommandBufferInheritanceConditionalRenderingInfoEXT* wrapper);
 
 struct Decoded_VkDeviceGeneratedCommandsFeaturesNVX;
 struct Decoded_VkDeviceGeneratedCommandsLimitsNVX;
@@ -688,85 +688,85 @@ struct Decoded_VkObjectTableVertexBufferEntryNVX;
 struct Decoded_VkObjectTableIndexBufferEntryNVX;
 struct Decoded_VkObjectTablePushConstantEntryNVX;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGeneratedCommandsFeaturesNVX* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGeneratedCommandsLimitsNVX* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkIndirectCommandsTokenNVX* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkIndirectCommandsLayoutTokenNVX* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkIndirectCommandsLayoutCreateInfoNVX* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCmdProcessCommandsInfoNVX* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCmdReserveSpaceForCommandsInfoNVX* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkObjectTableCreateInfoNVX* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkObjectTablePipelineEntryNVX* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkObjectTableDescriptorSetEntryNVX* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkObjectTableVertexBufferEntryNVX* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkObjectTableIndexBufferEntryNVX* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkObjectTablePushConstantEntryNVX* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGeneratedCommandsFeaturesNVX* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceGeneratedCommandsLimitsNVX* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkIndirectCommandsTokenNVX* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkIndirectCommandsLayoutTokenNVX* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkIndirectCommandsLayoutCreateInfoNVX* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCmdProcessCommandsInfoNVX* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCmdReserveSpaceForCommandsInfoNVX* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkObjectTableCreateInfoNVX* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkObjectTablePipelineEntryNVX* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkObjectTableDescriptorSetEntryNVX* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkObjectTableVertexBufferEntryNVX* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkObjectTableIndexBufferEntryNVX* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkObjectTablePushConstantEntryNVX* wrapper);
 
 struct Decoded_VkViewportWScalingNV;
 struct Decoded_VkPipelineViewportWScalingStateCreateInfoNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkViewportWScalingNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineViewportWScalingStateCreateInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkViewportWScalingNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineViewportWScalingStateCreateInfoNV* wrapper);
 
 struct Decoded_VkSurfaceCapabilities2EXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSurfaceCapabilities2EXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSurfaceCapabilities2EXT* wrapper);
 
 struct Decoded_VkDisplayPowerInfoEXT;
 struct Decoded_VkDeviceEventInfoEXT;
 struct Decoded_VkDisplayEventInfoEXT;
 struct Decoded_VkSwapchainCounterCreateInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayPowerInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceEventInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayEventInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSwapchainCounterCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayPowerInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceEventInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDisplayEventInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSwapchainCounterCreateInfoEXT* wrapper);
 
 struct Decoded_VkRefreshCycleDurationGOOGLE;
 struct Decoded_VkPastPresentationTimingGOOGLE;
 struct Decoded_VkPresentTimeGOOGLE;
 struct Decoded_VkPresentTimesInfoGOOGLE;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRefreshCycleDurationGOOGLE* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPastPresentationTimingGOOGLE* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPresentTimeGOOGLE* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPresentTimesInfoGOOGLE* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRefreshCycleDurationGOOGLE* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPastPresentationTimingGOOGLE* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPresentTimeGOOGLE* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPresentTimesInfoGOOGLE* wrapper);
 
 struct Decoded_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX* wrapper);
 
 struct Decoded_VkViewportSwizzleNV;
 struct Decoded_VkPipelineViewportSwizzleStateCreateInfoNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkViewportSwizzleNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineViewportSwizzleStateCreateInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkViewportSwizzleNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineViewportSwizzleStateCreateInfoNV* wrapper);
 
 struct Decoded_VkPhysicalDeviceDiscardRectanglePropertiesEXT;
 struct Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDiscardRectanglePropertiesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDiscardRectanglePropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT* wrapper);
 
 struct Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT;
 struct Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT* wrapper);
 
 struct Decoded_VkXYColorEXT;
 struct Decoded_VkHdrMetadataEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkXYColorEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkHdrMetadataEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkXYColorEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkHdrMetadataEXT* wrapper);
 
 struct Decoded_VkIOSSurfaceCreateInfoMVK;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkIOSSurfaceCreateInfoMVK* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkIOSSurfaceCreateInfoMVK* wrapper);
 
 struct Decoded_VkMacOSSurfaceCreateInfoMVK;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMacOSSurfaceCreateInfoMVK* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMacOSSurfaceCreateInfoMVK* wrapper);
 
 struct Decoded_VkDebugUtilsObjectNameInfoEXT;
 struct Decoded_VkDebugUtilsObjectTagInfoEXT;
@@ -774,11 +774,11 @@ struct Decoded_VkDebugUtilsLabelEXT;
 struct Decoded_VkDebugUtilsMessengerCallbackDataEXT;
 struct Decoded_VkDebugUtilsMessengerCreateInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugUtilsObjectNameInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugUtilsObjectTagInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugUtilsLabelEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugUtilsMessengerCallbackDataEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugUtilsMessengerCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugUtilsObjectNameInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugUtilsObjectTagInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugUtilsLabelEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugUtilsMessengerCallbackDataEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDebugUtilsMessengerCreateInfoEXT* wrapper);
 
 struct Decoded_VkAndroidHardwareBufferUsageANDROID;
 struct Decoded_VkAndroidHardwareBufferPropertiesANDROID;
@@ -787,28 +787,28 @@ struct Decoded_VkImportAndroidHardwareBufferInfoANDROID;
 struct Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID;
 struct Decoded_VkExternalFormatANDROID;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAndroidHardwareBufferUsageANDROID* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAndroidHardwareBufferPropertiesANDROID* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAndroidHardwareBufferFormatPropertiesANDROID* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportAndroidHardwareBufferInfoANDROID* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalFormatANDROID* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAndroidHardwareBufferUsageANDROID* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAndroidHardwareBufferPropertiesANDROID* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAndroidHardwareBufferFormatPropertiesANDROID* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportAndroidHardwareBufferInfoANDROID* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkExternalFormatANDROID* wrapper);
 
 struct Decoded_VkSamplerReductionModeCreateInfoEXT;
 struct Decoded_VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSamplerReductionModeCreateInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSamplerReductionModeCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT* wrapper);
 
 struct Decoded_VkPhysicalDeviceInlineUniformBlockFeaturesEXT;
 struct Decoded_VkPhysicalDeviceInlineUniformBlockPropertiesEXT;
 struct Decoded_VkWriteDescriptorSetInlineUniformBlockEXT;
 struct Decoded_VkDescriptorPoolInlineUniformBlockCreateInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceInlineUniformBlockFeaturesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceInlineUniformBlockPropertiesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkWriteDescriptorSetInlineUniformBlockEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorPoolInlineUniformBlockCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceInlineUniformBlockFeaturesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceInlineUniformBlockPropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkWriteDescriptorSetInlineUniformBlockEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorPoolInlineUniformBlockCreateInfoEXT* wrapper);
 
 struct Decoded_VkSampleLocationEXT;
 struct Decoded_VkSampleLocationsInfoEXT;
@@ -819,30 +819,30 @@ struct Decoded_VkPipelineSampleLocationsStateCreateInfoEXT;
 struct Decoded_VkPhysicalDeviceSampleLocationsPropertiesEXT;
 struct Decoded_VkMultisamplePropertiesEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSampleLocationEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSampleLocationsInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAttachmentSampleLocationsEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubpassSampleLocationsEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRenderPassSampleLocationsBeginInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineSampleLocationsStateCreateInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSampleLocationsPropertiesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMultisamplePropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSampleLocationEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSampleLocationsInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAttachmentSampleLocationsEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkSubpassSampleLocationsEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRenderPassSampleLocationsBeginInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineSampleLocationsStateCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceSampleLocationsPropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMultisamplePropertiesEXT* wrapper);
 
 struct Decoded_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT;
 struct Decoded_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT;
 struct Decoded_VkPipelineColorBlendAdvancedStateCreateInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineColorBlendAdvancedStateCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineColorBlendAdvancedStateCreateInfoEXT* wrapper);
 
 struct Decoded_VkPipelineCoverageToColorStateCreateInfoNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineCoverageToColorStateCreateInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineCoverageToColorStateCreateInfoNV* wrapper);
 
 struct Decoded_VkPipelineCoverageModulationStateCreateInfoNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineCoverageModulationStateCreateInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineCoverageModulationStateCreateInfoNV* wrapper);
 
 struct Decoded_VkDrmFormatModifierPropertiesEXT;
 struct Decoded_VkDrmFormatModifierPropertiesListEXT;
@@ -851,18 +851,18 @@ struct Decoded_VkImageDrmFormatModifierListCreateInfoEXT;
 struct Decoded_VkImageDrmFormatModifierExplicitCreateInfoEXT;
 struct Decoded_VkImageDrmFormatModifierPropertiesEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDrmFormatModifierPropertiesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDrmFormatModifierPropertiesListEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceImageDrmFormatModifierInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageDrmFormatModifierListCreateInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageDrmFormatModifierExplicitCreateInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageDrmFormatModifierPropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDrmFormatModifierPropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDrmFormatModifierPropertiesListEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceImageDrmFormatModifierInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageDrmFormatModifierListCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageDrmFormatModifierExplicitCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageDrmFormatModifierPropertiesEXT* wrapper);
 
 struct Decoded_VkValidationCacheCreateInfoEXT;
 struct Decoded_VkShaderModuleValidationCacheCreateInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkValidationCacheCreateInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkShaderModuleValidationCacheCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkValidationCacheCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkShaderModuleValidationCacheCreateInfoEXT* wrapper);
 
 struct Decoded_VkDescriptorSetLayoutBindingFlagsCreateInfoEXT;
 struct Decoded_VkPhysicalDeviceDescriptorIndexingFeaturesEXT;
@@ -870,11 +870,11 @@ struct Decoded_VkPhysicalDeviceDescriptorIndexingPropertiesEXT;
 struct Decoded_VkDescriptorSetVariableDescriptorCountAllocateInfoEXT;
 struct Decoded_VkDescriptorSetVariableDescriptorCountLayoutSupportEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorSetLayoutBindingFlagsCreateInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDescriptorIndexingFeaturesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDescriptorIndexingPropertiesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorSetVariableDescriptorCountAllocateInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorSetVariableDescriptorCountLayoutSupportEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorSetLayoutBindingFlagsCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDescriptorIndexingFeaturesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDescriptorIndexingPropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorSetVariableDescriptorCountAllocateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDescriptorSetVariableDescriptorCountLayoutSupportEXT* wrapper);
 
 struct Decoded_VkShadingRatePaletteNV;
 struct Decoded_VkPipelineViewportShadingRateImageStateCreateInfoNV;
@@ -884,13 +884,13 @@ struct Decoded_VkCoarseSampleLocationNV;
 struct Decoded_VkCoarseSampleOrderCustomNV;
 struct Decoded_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkShadingRatePaletteNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineViewportShadingRateImageStateCreateInfoNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShadingRateImageFeaturesNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShadingRateImagePropertiesNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCoarseSampleLocationNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCoarseSampleOrderCustomNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkShadingRatePaletteNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineViewportShadingRateImageStateCreateInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShadingRateImageFeaturesNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShadingRateImagePropertiesNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCoarseSampleLocationNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCoarseSampleOrderCustomNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV* wrapper);
 
 struct Decoded_VkRayTracingShaderGroupCreateInfoNV;
 struct Decoded_VkRayTracingPipelineCreateInfoNV;
@@ -905,136 +905,136 @@ struct Decoded_VkWriteDescriptorSetAccelerationStructureNV;
 struct Decoded_VkAccelerationStructureMemoryRequirementsInfoNV;
 struct Decoded_VkPhysicalDeviceRayTracingPropertiesNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRayTracingShaderGroupCreateInfoNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRayTracingPipelineCreateInfoNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkGeometryTrianglesNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkGeometryAABBNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkGeometryDataNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkGeometryNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAccelerationStructureInfoNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAccelerationStructureCreateInfoNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindAccelerationStructureMemoryInfoNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkWriteDescriptorSetAccelerationStructureNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAccelerationStructureMemoryRequirementsInfoNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceRayTracingPropertiesNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRayTracingShaderGroupCreateInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRayTracingPipelineCreateInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkGeometryTrianglesNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkGeometryAABBNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkGeometryDataNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkGeometryNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAccelerationStructureInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAccelerationStructureCreateInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBindAccelerationStructureMemoryInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkWriteDescriptorSetAccelerationStructureNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkAccelerationStructureMemoryRequirementsInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceRayTracingPropertiesNV* wrapper);
 
 struct Decoded_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV;
 struct Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV* wrapper);
 
 struct Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT* wrapper);
 
 struct Decoded_VkImportMemoryHostPointerInfoEXT;
 struct Decoded_VkMemoryHostPointerPropertiesEXT;
 struct Decoded_VkPhysicalDeviceExternalMemoryHostPropertiesEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportMemoryHostPointerInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryHostPointerPropertiesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalMemoryHostPropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImportMemoryHostPointerInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryHostPointerPropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExternalMemoryHostPropertiesEXT* wrapper);
 
 struct Decoded_VkCalibratedTimestampInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCalibratedTimestampInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCalibratedTimestampInfoEXT* wrapper);
 
 struct Decoded_VkPhysicalDeviceShaderCorePropertiesAMD;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShaderCorePropertiesAMD* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShaderCorePropertiesAMD* wrapper);
 
 struct Decoded_VkDeviceMemoryOverallocationCreateInfoAMD;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceMemoryOverallocationCreateInfoAMD* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceMemoryOverallocationCreateInfoAMD* wrapper);
 
 struct Decoded_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT;
 struct Decoded_VkVertexInputBindingDivisorDescriptionEXT;
 struct Decoded_VkPipelineVertexInputDivisorStateCreateInfoEXT;
 struct Decoded_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkVertexInputBindingDivisorDescriptionEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineVertexInputDivisorStateCreateInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkVertexInputBindingDivisorDescriptionEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineVertexInputDivisorStateCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT* wrapper);
 
 struct Decoded_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV* wrapper);
 
 struct Decoded_VkPhysicalDeviceMeshShaderFeaturesNV;
 struct Decoded_VkPhysicalDeviceMeshShaderPropertiesNV;
 struct Decoded_VkDrawMeshTasksIndirectCommandNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMeshShaderFeaturesNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMeshShaderPropertiesNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDrawMeshTasksIndirectCommandNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMeshShaderFeaturesNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMeshShaderPropertiesNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDrawMeshTasksIndirectCommandNV* wrapper);
 
 struct Decoded_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV* wrapper);
 
 struct Decoded_VkPhysicalDeviceShaderImageFootprintFeaturesNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShaderImageFootprintFeaturesNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceShaderImageFootprintFeaturesNV* wrapper);
 
 struct Decoded_VkPipelineViewportExclusiveScissorStateCreateInfoNV;
 struct Decoded_VkPhysicalDeviceExclusiveScissorFeaturesNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineViewportExclusiveScissorStateCreateInfoNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExclusiveScissorFeaturesNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineViewportExclusiveScissorStateCreateInfoNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceExclusiveScissorFeaturesNV* wrapper);
 
 struct Decoded_VkQueueFamilyCheckpointPropertiesNV;
 struct Decoded_VkCheckpointDataNV;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkQueueFamilyCheckpointPropertiesNV* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCheckpointDataNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkQueueFamilyCheckpointPropertiesNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCheckpointDataNV* wrapper);
 
 struct Decoded_VkPhysicalDevicePCIBusInfoPropertiesEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDevicePCIBusInfoPropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDevicePCIBusInfoPropertiesEXT* wrapper);
 
 struct Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA* wrapper);
 
 struct Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT;
 struct Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT;
 struct Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT* wrapper);
 
 struct Decoded_VkPhysicalDeviceScalarBlockLayoutFeaturesEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceScalarBlockLayoutFeaturesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceScalarBlockLayoutFeaturesEXT* wrapper);
 
 struct Decoded_VkPhysicalDeviceMemoryBudgetPropertiesEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryBudgetPropertiesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryBudgetPropertiesEXT* wrapper);
 
 struct Decoded_VkPhysicalDeviceMemoryPriorityFeaturesEXT;
 struct Decoded_VkMemoryPriorityAllocateInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryPriorityFeaturesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryPriorityAllocateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryPriorityFeaturesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryPriorityAllocateInfoEXT* wrapper);
 
 struct Decoded_VkPhysicalDeviceBufferAddressFeaturesEXT;
 struct Decoded_VkBufferDeviceAddressInfoEXT;
 struct Decoded_VkBufferDeviceAddressCreateInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceBufferAddressFeaturesEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBufferDeviceAddressInfoEXT* wrapper);
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBufferDeviceAddressCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceBufferAddressFeaturesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBufferDeviceAddressInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkBufferDeviceAddressCreateInfoEXT* wrapper);
 
 struct Decoded_VkImageStencilUsageCreateInfoEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageStencilUsageCreateInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageStencilUsageCreateInfoEXT* wrapper);
 
 struct Decoded_VkValidationFeaturesEXT;
 
-size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkValidationFeaturesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkValidationFeaturesEXT* wrapper);
 
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/generated_vulkan_struct_encoders.cpp
+++ b/framework/generated/generated_vulkan_struct_encoders.cpp
@@ -32,10 +32,10 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-void encode_struct(ParameterEncoder* encoder, const VkApplicationInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkApplicationInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeString(value.pApplicationName);
     encoder->EncodeUInt32Value(value.applicationVersion);
     encoder->EncodeString(value.pEngineName);
@@ -43,19 +43,19 @@ void encode_struct(ParameterEncoder* encoder, const VkApplicationInfo& value)
     encoder->EncodeUInt32Value(value.apiVersion);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkInstanceCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkInstanceCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encode_struct_ptr(encoder, value.pApplicationInfo);
+    EncodeStructPtr(encoder, value.pApplicationInfo);
     encoder->EncodeUInt32Value(value.enabledLayerCount);
     encoder->EncodeStringArray(value.ppEnabledLayerNames, value.enabledLayerCount);
     encoder->EncodeUInt32Value(value.enabledExtensionCount);
     encoder->EncodeStringArray(value.ppEnabledExtensionNames, value.enabledExtensionCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkAllocationCallbacks& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkAllocationCallbacks& value)
 {
     encoder->EncodeVoidPtr(value.pUserData);
     encoder->EncodeFunctionPtr(value.pfnAllocation);
@@ -65,7 +65,7 @@ void encode_struct(ParameterEncoder* encoder, const VkAllocationCallbacks& value
     encoder->EncodeFunctionPtr(value.pfnInternalFree);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceFeatures& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFeatures& value)
 {
     encoder->EncodeVkBool32Value(value.robustBufferAccess);
     encoder->EncodeVkBool32Value(value.fullDrawIndexUint32);
@@ -124,30 +124,30 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceFeatures& va
     encoder->EncodeVkBool32Value(value.inheritedQueries);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkFormatProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkFormatProperties& value)
 {
     encoder->EncodeFlagsValue(value.linearTilingFeatures);
     encoder->EncodeFlagsValue(value.optimalTilingFeatures);
     encoder->EncodeFlagsValue(value.bufferFeatures);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExtent3D& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExtent3D& value)
 {
     encoder->EncodeUInt32Value(value.width);
     encoder->EncodeUInt32Value(value.height);
     encoder->EncodeUInt32Value(value.depth);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageFormatProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageFormatProperties& value)
 {
-    encode_struct(encoder, value.maxExtent);
+    EncodeStruct(encoder, value.maxExtent);
     encoder->EncodeUInt32Value(value.maxMipLevels);
     encoder->EncodeUInt32Value(value.maxArrayLayers);
     encoder->EncodeFlagsValue(value.sampleCounts);
     encoder->EncodeVkDeviceSizeValue(value.maxResourceSize);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceLimits& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceLimits& value)
 {
     encoder->EncodeUInt32Value(value.maxImageDimension1D);
     encoder->EncodeUInt32Value(value.maxImageDimension2D);
@@ -257,7 +257,7 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceLimits& valu
     encoder->EncodeVkDeviceSizeValue(value.nonCoherentAtomSize);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSparseProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSparseProperties& value)
 {
     encoder->EncodeVkBool32Value(value.residencyStandard2DBlockShape);
     encoder->EncodeVkBool32Value(value.residencyStandard2DMultisampleBlockShape);
@@ -266,7 +266,7 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSparseProper
     encoder->EncodeVkBool32Value(value.residencyNonResidentStrict);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceProperties& value)
 {
     encoder->EncodeUInt32Value(value.apiVersion);
     encoder->EncodeUInt32Value(value.driverVersion);
@@ -275,69 +275,69 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceProperties& 
     encoder->EncodeEnumValue(value.deviceType);
     encoder->EncodeString(value.deviceName);
     encoder->EncodeUInt8Array(value.pipelineCacheUUID, VK_UUID_SIZE);
-    encode_struct(encoder, value.limits);
-    encode_struct(encoder, value.sparseProperties);
+    EncodeStruct(encoder, value.limits);
+    EncodeStruct(encoder, value.sparseProperties);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkQueueFamilyProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkQueueFamilyProperties& value)
 {
     encoder->EncodeFlagsValue(value.queueFlags);
     encoder->EncodeUInt32Value(value.queueCount);
     encoder->EncodeUInt32Value(value.timestampValidBits);
-    encode_struct(encoder, value.minImageTransferGranularity);
+    EncodeStruct(encoder, value.minImageTransferGranularity);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMemoryType& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryType& value)
 {
     encoder->EncodeFlagsValue(value.propertyFlags);
     encoder->EncodeUInt32Value(value.heapIndex);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMemoryHeap& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryHeap& value)
 {
     encoder->EncodeVkDeviceSizeValue(value.size);
     encoder->EncodeFlagsValue(value.flags);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryProperties& value)
 {
     encoder->EncodeUInt32Value(value.memoryTypeCount);
-    encode_struct_array(encoder, value.memoryTypes, value.memoryTypeCount);
+    EncodeStructArray(encoder, value.memoryTypes, value.memoryTypeCount);
     encoder->EncodeUInt32Value(value.memoryHeapCount);
-    encode_struct_array(encoder, value.memoryHeaps, value.memoryHeapCount);
+    EncodeStructArray(encoder, value.memoryHeaps, value.memoryHeapCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDeviceQueueCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceQueueCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.queueFamilyIndex);
     encoder->EncodeUInt32Value(value.queueCount);
     encoder->EncodeFloatArray(value.pQueuePriorities, value.queueCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDeviceCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.queueCreateInfoCount);
-    encode_struct_array(encoder, value.pQueueCreateInfos, value.queueCreateInfoCount);
+    EncodeStructArray(encoder, value.pQueueCreateInfos, value.queueCreateInfoCount);
     encoder->EncodeUInt32Value(value.enabledLayerCount);
     encoder->EncodeStringArray(value.ppEnabledLayerNames, value.enabledLayerCount);
     encoder->EncodeUInt32Value(value.enabledExtensionCount);
     encoder->EncodeStringArray(value.ppEnabledExtensionNames, value.enabledExtensionCount);
-    encode_struct_ptr(encoder, value.pEnabledFeatures);
+    EncodeStructPtr(encoder, value.pEnabledFeatures);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExtensionProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExtensionProperties& value)
 {
     encoder->EncodeString(value.extensionName);
     encoder->EncodeUInt32Value(value.specVersion);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkLayerProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkLayerProperties& value)
 {
     encoder->EncodeString(value.layerName);
     encoder->EncodeUInt32Value(value.specVersion);
@@ -345,10 +345,10 @@ void encode_struct(ParameterEncoder* encoder, const VkLayerProperties& value)
     encoder->EncodeString(value.description);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSubmitInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSubmitInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.waitSemaphoreCount);
     encoder->EncodeHandleIdArray(value.pWaitSemaphores, value.waitSemaphoreCount);
     encoder->EncodeFlagsArray(value.pWaitDstStageMask, value.waitSemaphoreCount);
@@ -358,47 +358,47 @@ void encode_struct(ParameterEncoder* encoder, const VkSubmitInfo& value)
     encoder->EncodeHandleIdArray(value.pSignalSemaphores, value.signalSemaphoreCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMemoryAllocateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryAllocateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkDeviceSizeValue(value.allocationSize);
     encoder->EncodeUInt32Value(value.memoryTypeIndex);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMappedMemoryRange& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMappedMemoryRange& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.size);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMemoryRequirements& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryRequirements& value)
 {
     encoder->EncodeVkDeviceSizeValue(value.size);
     encoder->EncodeVkDeviceSizeValue(value.alignment);
     encoder->EncodeUInt32Value(value.memoryTypeBits);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSparseImageFormatProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageFormatProperties& value)
 {
     encoder->EncodeFlagsValue(value.aspectMask);
-    encode_struct(encoder, value.imageGranularity);
+    EncodeStruct(encoder, value.imageGranularity);
     encoder->EncodeFlagsValue(value.flags);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSparseImageMemoryRequirements& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageMemoryRequirements& value)
 {
-    encode_struct(encoder, value.formatProperties);
+    EncodeStruct(encoder, value.formatProperties);
     encoder->EncodeUInt32Value(value.imageMipTailFirstLod);
     encoder->EncodeVkDeviceSizeValue(value.imageMipTailSize);
     encoder->EncodeVkDeviceSizeValue(value.imageMipTailOffset);
     encoder->EncodeVkDeviceSizeValue(value.imageMipTailStride);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSparseMemoryBind& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseMemoryBind& value)
 {
     encoder->EncodeVkDeviceSizeValue(value.resourceOffset);
     encoder->EncodeVkDeviceSizeValue(value.size);
@@ -407,102 +407,102 @@ void encode_struct(ParameterEncoder* encoder, const VkSparseMemoryBind& value)
     encoder->EncodeFlagsValue(value.flags);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSparseBufferMemoryBindInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseBufferMemoryBindInfo& value)
 {
     encoder->EncodeHandleIdValue(value.buffer);
     encoder->EncodeUInt32Value(value.bindCount);
-    encode_struct_array(encoder, value.pBinds, value.bindCount);
+    EncodeStructArray(encoder, value.pBinds, value.bindCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSparseImageOpaqueMemoryBindInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageOpaqueMemoryBindInfo& value)
 {
     encoder->EncodeHandleIdValue(value.image);
     encoder->EncodeUInt32Value(value.bindCount);
-    encode_struct_array(encoder, value.pBinds, value.bindCount);
+    EncodeStructArray(encoder, value.pBinds, value.bindCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageSubresource& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageSubresource& value)
 {
     encoder->EncodeFlagsValue(value.aspectMask);
     encoder->EncodeUInt32Value(value.mipLevel);
     encoder->EncodeUInt32Value(value.arrayLayer);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkOffset3D& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkOffset3D& value)
 {
     encoder->EncodeInt32Value(value.x);
     encoder->EncodeInt32Value(value.y);
     encoder->EncodeInt32Value(value.z);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSparseImageMemoryBind& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageMemoryBind& value)
 {
-    encode_struct(encoder, value.subresource);
-    encode_struct(encoder, value.offset);
-    encode_struct(encoder, value.extent);
+    EncodeStruct(encoder, value.subresource);
+    EncodeStruct(encoder, value.offset);
+    EncodeStruct(encoder, value.extent);
     encoder->EncodeHandleIdValue(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.memoryOffset);
     encoder->EncodeFlagsValue(value.flags);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSparseImageMemoryBindInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageMemoryBindInfo& value)
 {
     encoder->EncodeHandleIdValue(value.image);
     encoder->EncodeUInt32Value(value.bindCount);
-    encode_struct_array(encoder, value.pBinds, value.bindCount);
+    EncodeStructArray(encoder, value.pBinds, value.bindCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkBindSparseInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkBindSparseInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.waitSemaphoreCount);
     encoder->EncodeHandleIdArray(value.pWaitSemaphores, value.waitSemaphoreCount);
     encoder->EncodeUInt32Value(value.bufferBindCount);
-    encode_struct_array(encoder, value.pBufferBinds, value.bufferBindCount);
+    EncodeStructArray(encoder, value.pBufferBinds, value.bufferBindCount);
     encoder->EncodeUInt32Value(value.imageOpaqueBindCount);
-    encode_struct_array(encoder, value.pImageOpaqueBinds, value.imageOpaqueBindCount);
+    EncodeStructArray(encoder, value.pImageOpaqueBinds, value.imageOpaqueBindCount);
     encoder->EncodeUInt32Value(value.imageBindCount);
-    encode_struct_array(encoder, value.pImageBinds, value.imageBindCount);
+    EncodeStructArray(encoder, value.pImageBinds, value.imageBindCount);
     encoder->EncodeUInt32Value(value.signalSemaphoreCount);
     encoder->EncodeHandleIdArray(value.pSignalSemaphores, value.signalSemaphoreCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkFenceCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkFenceCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSemaphoreCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkEventCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkEventCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkQueryPoolCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkQueryPoolCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.queryType);
     encoder->EncodeUInt32Value(value.queryCount);
     encoder->EncodeFlagsValue(value.pipelineStatistics);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkBufferCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkBufferCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVkDeviceSizeValue(value.size);
     encoder->EncodeFlagsValue(value.usage);
@@ -511,10 +511,10 @@ void encode_struct(ParameterEncoder* encoder, const VkBufferCreateInfo& value)
     encoder->EncodeUInt32Array(value.pQueueFamilyIndices, value.queueFamilyIndexCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkBufferViewCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkBufferViewCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeHandleIdValue(value.buffer);
     encoder->EncodeEnumValue(value.format);
@@ -522,14 +522,14 @@ void encode_struct(ParameterEncoder* encoder, const VkBufferViewCreateInfo& valu
     encoder->EncodeVkDeviceSizeValue(value.range);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.imageType);
     encoder->EncodeEnumValue(value.format);
-    encode_struct(encoder, value.extent);
+    EncodeStruct(encoder, value.extent);
     encoder->EncodeUInt32Value(value.mipLevels);
     encoder->EncodeUInt32Value(value.arrayLayers);
     encoder->EncodeEnumValue(value.samples);
@@ -541,7 +541,7 @@ void encode_struct(ParameterEncoder* encoder, const VkImageCreateInfo& value)
     encoder->EncodeEnumValue(value.initialLayout);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSubresourceLayout& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSubresourceLayout& value)
 {
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.size);
@@ -550,7 +550,7 @@ void encode_struct(ParameterEncoder* encoder, const VkSubresourceLayout& value)
     encoder->EncodeVkDeviceSizeValue(value.depthPitch);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkComponentMapping& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkComponentMapping& value)
 {
     encoder->EncodeEnumValue(value.r);
     encoder->EncodeEnumValue(value.g);
@@ -558,7 +558,7 @@ void encode_struct(ParameterEncoder* encoder, const VkComponentMapping& value)
     encoder->EncodeEnumValue(value.a);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageSubresourceRange& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageSubresourceRange& value)
 {
     encoder->EncodeFlagsValue(value.aspectMask);
     encoder->EncodeUInt32Value(value.baseMipLevel);
@@ -567,70 +567,70 @@ void encode_struct(ParameterEncoder* encoder, const VkImageSubresourceRange& val
     encoder->EncodeUInt32Value(value.layerCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageViewCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageViewCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeHandleIdValue(value.image);
     encoder->EncodeEnumValue(value.viewType);
     encoder->EncodeEnumValue(value.format);
-    encode_struct(encoder, value.components);
-    encode_struct(encoder, value.subresourceRange);
+    EncodeStruct(encoder, value.components);
+    EncodeStruct(encoder, value.subresourceRange);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkShaderModuleCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkShaderModuleCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeSizeTValue(value.codeSize);
     encoder->EncodeUInt32Array(value.pCode, value.codeSize / 4);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineCacheCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineCacheCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeSizeTValue(value.initialDataSize);
     encoder->EncodeVoidArray(value.pInitialData, value.initialDataSize);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSpecializationMapEntry& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSpecializationMapEntry& value)
 {
     encoder->EncodeUInt32Value(value.constantID);
     encoder->EncodeUInt32Value(value.offset);
     encoder->EncodeSizeTValue(value.size);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSpecializationInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSpecializationInfo& value)
 {
     encoder->EncodeUInt32Value(value.mapEntryCount);
-    encode_struct_array(encoder, value.pMapEntries, value.mapEntryCount);
+    EncodeStructArray(encoder, value.pMapEntries, value.mapEntryCount);
     encoder->EncodeSizeTValue(value.dataSize);
     encoder->EncodeVoidArray(value.pData, value.dataSize);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineShaderStageCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineShaderStageCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.stage);
     encoder->EncodeHandleIdValue(value.module);
     encoder->EncodeString(value.pName);
-    encode_struct_ptr(encoder, value.pSpecializationInfo);
+    EncodeStructPtr(encoder, value.pSpecializationInfo);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkVertexInputBindingDescription& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkVertexInputBindingDescription& value)
 {
     encoder->EncodeUInt32Value(value.binding);
     encoder->EncodeUInt32Value(value.stride);
     encoder->EncodeEnumValue(value.inputRate);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkVertexInputAttributeDescription& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkVertexInputAttributeDescription& value)
 {
     encoder->EncodeUInt32Value(value.location);
     encoder->EncodeUInt32Value(value.binding);
@@ -638,35 +638,35 @@ void encode_struct(ParameterEncoder* encoder, const VkVertexInputAttributeDescri
     encoder->EncodeUInt32Value(value.offset);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineVertexInputStateCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineVertexInputStateCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.vertexBindingDescriptionCount);
-    encode_struct_array(encoder, value.pVertexBindingDescriptions, value.vertexBindingDescriptionCount);
+    EncodeStructArray(encoder, value.pVertexBindingDescriptions, value.vertexBindingDescriptionCount);
     encoder->EncodeUInt32Value(value.vertexAttributeDescriptionCount);
-    encode_struct_array(encoder, value.pVertexAttributeDescriptions, value.vertexAttributeDescriptionCount);
+    EncodeStructArray(encoder, value.pVertexAttributeDescriptions, value.vertexAttributeDescriptionCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineInputAssemblyStateCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineInputAssemblyStateCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.topology);
     encoder->EncodeVkBool32Value(value.primitiveRestartEnable);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineTessellationStateCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineTessellationStateCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.patchControlPoints);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkViewport& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkViewport& value)
 {
     encoder->EncodeFloatValue(value.x);
     encoder->EncodeFloatValue(value.y);
@@ -676,39 +676,39 @@ void encode_struct(ParameterEncoder* encoder, const VkViewport& value)
     encoder->EncodeFloatValue(value.maxDepth);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkOffset2D& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkOffset2D& value)
 {
     encoder->EncodeInt32Value(value.x);
     encoder->EncodeInt32Value(value.y);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExtent2D& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExtent2D& value)
 {
     encoder->EncodeUInt32Value(value.width);
     encoder->EncodeUInt32Value(value.height);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkRect2D& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkRect2D& value)
 {
-    encode_struct(encoder, value.offset);
-    encode_struct(encoder, value.extent);
+    EncodeStruct(encoder, value.offset);
+    EncodeStruct(encoder, value.extent);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineViewportStateCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineViewportStateCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.viewportCount);
-    encode_struct_array(encoder, value.pViewports, value.viewportCount);
+    EncodeStructArray(encoder, value.pViewports, value.viewportCount);
     encoder->EncodeUInt32Value(value.scissorCount);
-    encode_struct_array(encoder, value.pScissors, value.scissorCount);
+    EncodeStructArray(encoder, value.pScissors, value.scissorCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineRasterizationStateCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRasterizationStateCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVkBool32Value(value.depthClampEnable);
     encoder->EncodeVkBool32Value(value.rasterizerDiscardEnable);
@@ -722,10 +722,10 @@ void encode_struct(ParameterEncoder* encoder, const VkPipelineRasterizationState
     encoder->EncodeFloatValue(value.lineWidth);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineMultisampleStateCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineMultisampleStateCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.rasterizationSamples);
     encoder->EncodeVkBool32Value(value.sampleShadingEnable);
@@ -735,7 +735,7 @@ void encode_struct(ParameterEncoder* encoder, const VkPipelineMultisampleStateCr
     encoder->EncodeVkBool32Value(value.alphaToOneEnable);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkStencilOpState& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkStencilOpState& value)
 {
     encoder->EncodeEnumValue(value.failOp);
     encoder->EncodeEnumValue(value.passOp);
@@ -746,23 +746,23 @@ void encode_struct(ParameterEncoder* encoder, const VkStencilOpState& value)
     encoder->EncodeUInt32Value(value.reference);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineDepthStencilStateCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineDepthStencilStateCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVkBool32Value(value.depthTestEnable);
     encoder->EncodeVkBool32Value(value.depthWriteEnable);
     encoder->EncodeEnumValue(value.depthCompareOp);
     encoder->EncodeVkBool32Value(value.depthBoundsTestEnable);
     encoder->EncodeVkBool32Value(value.stencilTestEnable);
-    encode_struct(encoder, value.front);
-    encode_struct(encoder, value.back);
+    EncodeStruct(encoder, value.front);
+    EncodeStruct(encoder, value.back);
     encoder->EncodeFloatValue(value.minDepthBounds);
     encoder->EncodeFloatValue(value.maxDepthBounds);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineColorBlendAttachmentState& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineColorBlendAttachmentState& value)
 {
     encoder->EncodeVkBool32Value(value.blendEnable);
     encoder->EncodeEnumValue(value.srcColorBlendFactor);
@@ -774,43 +774,43 @@ void encode_struct(ParameterEncoder* encoder, const VkPipelineColorBlendAttachme
     encoder->EncodeFlagsValue(value.colorWriteMask);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineColorBlendStateCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineColorBlendStateCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVkBool32Value(value.logicOpEnable);
     encoder->EncodeEnumValue(value.logicOp);
     encoder->EncodeUInt32Value(value.attachmentCount);
-    encode_struct_array(encoder, value.pAttachments, value.attachmentCount);
+    EncodeStructArray(encoder, value.pAttachments, value.attachmentCount);
     encoder->EncodeFloatArray(value.blendConstants, 4);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineDynamicStateCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineDynamicStateCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.dynamicStateCount);
     encoder->EncodeEnumArray(value.pDynamicStates, value.dynamicStateCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkGraphicsPipelineCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkGraphicsPipelineCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.stageCount);
-    encode_struct_array(encoder, value.pStages, value.stageCount);
-    encode_struct_ptr(encoder, value.pVertexInputState);
-    encode_struct_ptr(encoder, value.pInputAssemblyState);
-    encode_struct_ptr(encoder, value.pTessellationState);
-    encode_struct_ptr(encoder, value.pViewportState);
-    encode_struct_ptr(encoder, value.pRasterizationState);
-    encode_struct_ptr(encoder, value.pMultisampleState);
-    encode_struct_ptr(encoder, value.pDepthStencilState);
-    encode_struct_ptr(encoder, value.pColorBlendState);
-    encode_struct_ptr(encoder, value.pDynamicState);
+    EncodeStructArray(encoder, value.pStages, value.stageCount);
+    EncodeStructPtr(encoder, value.pVertexInputState);
+    EncodeStructPtr(encoder, value.pInputAssemblyState);
+    EncodeStructPtr(encoder, value.pTessellationState);
+    EncodeStructPtr(encoder, value.pViewportState);
+    EncodeStructPtr(encoder, value.pRasterizationState);
+    EncodeStructPtr(encoder, value.pMultisampleState);
+    EncodeStructPtr(encoder, value.pDepthStencilState);
+    EncodeStructPtr(encoder, value.pColorBlendState);
+    EncodeStructPtr(encoder, value.pDynamicState);
     encoder->EncodeHandleIdValue(value.layout);
     encoder->EncodeHandleIdValue(value.renderPass);
     encoder->EncodeUInt32Value(value.subpass);
@@ -818,39 +818,39 @@ void encode_struct(ParameterEncoder* encoder, const VkGraphicsPipelineCreateInfo
     encoder->EncodeInt32Value(value.basePipelineIndex);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkComputePipelineCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkComputePipelineCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encode_struct(encoder, value.stage);
+    EncodeStruct(encoder, value.stage);
     encoder->EncodeHandleIdValue(value.layout);
     encoder->EncodeHandleIdValue(value.basePipelineHandle);
     encoder->EncodeInt32Value(value.basePipelineIndex);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPushConstantRange& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPushConstantRange& value)
 {
     encoder->EncodeFlagsValue(value.stageFlags);
     encoder->EncodeUInt32Value(value.offset);
     encoder->EncodeUInt32Value(value.size);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineLayoutCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineLayoutCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.setLayoutCount);
     encoder->EncodeHandleIdArray(value.pSetLayouts, value.setLayoutCount);
     encoder->EncodeUInt32Value(value.pushConstantRangeCount);
-    encode_struct_array(encoder, value.pPushConstantRanges, value.pushConstantRangeCount);
+    EncodeStructArray(encoder, value.pPushConstantRanges, value.pushConstantRangeCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSamplerCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSamplerCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.magFilter);
     encoder->EncodeEnumValue(value.minFilter);
@@ -869,7 +869,7 @@ void encode_struct(ParameterEncoder* encoder, const VkSamplerCreateInfo& value)
     encoder->EncodeVkBool32Value(value.unnormalizedCoordinates);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorSetLayoutBinding& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetLayoutBinding& value)
 {
     encoder->EncodeUInt32Value(value.binding);
     encoder->EncodeEnumValue(value.descriptorType);
@@ -878,72 +878,72 @@ void encode_struct(ParameterEncoder* encoder, const VkDescriptorSetLayoutBinding
     encoder->EncodeHandleIdArray(value.pImmutableSamplers, value.descriptorCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorSetLayoutCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetLayoutCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.bindingCount);
-    encode_struct_array(encoder, value.pBindings, value.bindingCount);
+    EncodeStructArray(encoder, value.pBindings, value.bindingCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorPoolSize& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorPoolSize& value)
 {
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeUInt32Value(value.descriptorCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorPoolCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorPoolCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.maxSets);
     encoder->EncodeUInt32Value(value.poolSizeCount);
-    encode_struct_array(encoder, value.pPoolSizes, value.poolSizeCount);
+    EncodeStructArray(encoder, value.pPoolSizes, value.poolSizeCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorSetAllocateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetAllocateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.descriptorPool);
     encoder->EncodeUInt32Value(value.descriptorSetCount);
     encoder->EncodeHandleIdArray(value.pSetLayouts, value.descriptorSetCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorImageInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorImageInfo& value)
 {
     encoder->EncodeHandleIdValue(value.sampler);
     encoder->EncodeHandleIdValue(value.imageView);
     encoder->EncodeEnumValue(value.imageLayout);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorBufferInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorBufferInfo& value)
 {
     encoder->EncodeHandleIdValue(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeVkDeviceSizeValue(value.range);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkWriteDescriptorSet& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSet& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.dstSet);
     encoder->EncodeUInt32Value(value.dstBinding);
     encoder->EncodeUInt32Value(value.dstArrayElement);
     encoder->EncodeUInt32Value(value.descriptorCount);
     encoder->EncodeEnumValue(value.descriptorType);
-    encode_struct_array(encoder, value.pImageInfo, value.descriptorCount);
-    encode_struct_array(encoder, value.pBufferInfo, value.descriptorCount);
+    EncodeStructArray(encoder, value.pImageInfo, value.descriptorCount);
+    EncodeStructArray(encoder, value.pBufferInfo, value.descriptorCount);
     encoder->EncodeHandleIdArray(value.pTexelBufferView, value.descriptorCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkCopyDescriptorSet& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkCopyDescriptorSet& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.srcSet);
     encoder->EncodeUInt32Value(value.srcBinding);
     encoder->EncodeUInt32Value(value.srcArrayElement);
@@ -953,10 +953,10 @@ void encode_struct(ParameterEncoder* encoder, const VkCopyDescriptorSet& value)
     encoder->EncodeUInt32Value(value.descriptorCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkFramebufferCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkFramebufferCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeHandleIdValue(value.renderPass);
     encoder->EncodeUInt32Value(value.attachmentCount);
@@ -966,7 +966,7 @@ void encode_struct(ParameterEncoder* encoder, const VkFramebufferCreateInfo& val
     encoder->EncodeUInt32Value(value.layers);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkAttachmentDescription& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkAttachmentDescription& value)
 {
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.format);
@@ -979,27 +979,27 @@ void encode_struct(ParameterEncoder* encoder, const VkAttachmentDescription& val
     encoder->EncodeEnumValue(value.finalLayout);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkAttachmentReference& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkAttachmentReference& value)
 {
     encoder->EncodeUInt32Value(value.attachment);
     encoder->EncodeEnumValue(value.layout);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSubpassDescription& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSubpassDescription& value)
 {
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.pipelineBindPoint);
     encoder->EncodeUInt32Value(value.inputAttachmentCount);
-    encode_struct_array(encoder, value.pInputAttachments, value.inputAttachmentCount);
+    EncodeStructArray(encoder, value.pInputAttachments, value.inputAttachmentCount);
     encoder->EncodeUInt32Value(value.colorAttachmentCount);
-    encode_struct_array(encoder, value.pColorAttachments, value.colorAttachmentCount);
-    encode_struct_array(encoder, value.pResolveAttachments, value.colorAttachmentCount);
-    encode_struct_ptr(encoder, value.pDepthStencilAttachment);
+    EncodeStructArray(encoder, value.pColorAttachments, value.colorAttachmentCount);
+    EncodeStructArray(encoder, value.pResolveAttachments, value.colorAttachmentCount);
+    EncodeStructPtr(encoder, value.pDepthStencilAttachment);
     encoder->EncodeUInt32Value(value.preserveAttachmentCount);
     encoder->EncodeUInt32Array(value.pPreserveAttachments, value.preserveAttachmentCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSubpassDependency& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSubpassDependency& value)
 {
     encoder->EncodeUInt32Value(value.srcSubpass);
     encoder->EncodeUInt32Value(value.dstSubpass);
@@ -1010,40 +1010,40 @@ void encode_struct(ParameterEncoder* encoder, const VkSubpassDependency& value)
     encoder->EncodeFlagsValue(value.dependencyFlags);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkRenderPassCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.attachmentCount);
-    encode_struct_array(encoder, value.pAttachments, value.attachmentCount);
+    EncodeStructArray(encoder, value.pAttachments, value.attachmentCount);
     encoder->EncodeUInt32Value(value.subpassCount);
-    encode_struct_array(encoder, value.pSubpasses, value.subpassCount);
+    EncodeStructArray(encoder, value.pSubpasses, value.subpassCount);
     encoder->EncodeUInt32Value(value.dependencyCount);
-    encode_struct_array(encoder, value.pDependencies, value.dependencyCount);
+    EncodeStructArray(encoder, value.pDependencies, value.dependencyCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkCommandPoolCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkCommandPoolCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.queueFamilyIndex);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkCommandBufferAllocateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkCommandBufferAllocateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.commandPool);
     encoder->EncodeEnumValue(value.level);
     encoder->EncodeUInt32Value(value.commandBufferCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkCommandBufferInheritanceInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkCommandBufferInheritanceInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.renderPass);
     encoder->EncodeUInt32Value(value.subpass);
     encoder->EncodeHandleIdValue(value.framebuffer);
@@ -1052,22 +1052,22 @@ void encode_struct(ParameterEncoder* encoder, const VkCommandBufferInheritanceIn
     encoder->EncodeFlagsValue(value.pipelineStatistics);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkCommandBufferBeginInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkCommandBufferBeginInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encode_struct_ptr(encoder, value.pInheritanceInfo);
+    EncodeStructPtr(encoder, value.pInheritanceInfo);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkBufferCopy& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkBufferCopy& value)
 {
     encoder->EncodeVkDeviceSizeValue(value.srcOffset);
     encoder->EncodeVkDeviceSizeValue(value.dstOffset);
     encoder->EncodeVkDeviceSizeValue(value.size);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageSubresourceLayers& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageSubresourceLayers& value)
 {
     encoder->EncodeFlagsValue(value.aspectMask);
     encoder->EncodeUInt32Value(value.mipLevel);
@@ -1075,74 +1075,74 @@ void encode_struct(ParameterEncoder* encoder, const VkImageSubresourceLayers& va
     encoder->EncodeUInt32Value(value.layerCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageCopy& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageCopy& value)
 {
-    encode_struct(encoder, value.srcSubresource);
-    encode_struct(encoder, value.srcOffset);
-    encode_struct(encoder, value.dstSubresource);
-    encode_struct(encoder, value.dstOffset);
-    encode_struct(encoder, value.extent);
+    EncodeStruct(encoder, value.srcSubresource);
+    EncodeStruct(encoder, value.srcOffset);
+    EncodeStruct(encoder, value.dstSubresource);
+    EncodeStruct(encoder, value.dstOffset);
+    EncodeStruct(encoder, value.extent);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageBlit& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageBlit& value)
 {
-    encode_struct(encoder, value.srcSubresource);
-    encode_struct_array(encoder, value.srcOffsets, 2);
-    encode_struct(encoder, value.dstSubresource);
-    encode_struct_array(encoder, value.dstOffsets, 2);
+    EncodeStruct(encoder, value.srcSubresource);
+    EncodeStructArray(encoder, value.srcOffsets, 2);
+    EncodeStruct(encoder, value.dstSubresource);
+    EncodeStructArray(encoder, value.dstOffsets, 2);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkBufferImageCopy& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkBufferImageCopy& value)
 {
     encoder->EncodeVkDeviceSizeValue(value.bufferOffset);
     encoder->EncodeUInt32Value(value.bufferRowLength);
     encoder->EncodeUInt32Value(value.bufferImageHeight);
-    encode_struct(encoder, value.imageSubresource);
-    encode_struct(encoder, value.imageOffset);
-    encode_struct(encoder, value.imageExtent);
+    EncodeStruct(encoder, value.imageSubresource);
+    EncodeStruct(encoder, value.imageOffset);
+    EncodeStruct(encoder, value.imageExtent);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkClearDepthStencilValue& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkClearDepthStencilValue& value)
 {
     encoder->EncodeFloatValue(value.depth);
     encoder->EncodeUInt32Value(value.stencil);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkClearAttachment& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkClearAttachment& value)
 {
     encoder->EncodeFlagsValue(value.aspectMask);
     encoder->EncodeUInt32Value(value.colorAttachment);
-    encode_struct(encoder, value.clearValue);
+    EncodeStruct(encoder, value.clearValue);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkClearRect& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkClearRect& value)
 {
-    encode_struct(encoder, value.rect);
+    EncodeStruct(encoder, value.rect);
     encoder->EncodeUInt32Value(value.baseArrayLayer);
     encoder->EncodeUInt32Value(value.layerCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageResolve& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageResolve& value)
 {
-    encode_struct(encoder, value.srcSubresource);
-    encode_struct(encoder, value.srcOffset);
-    encode_struct(encoder, value.dstSubresource);
-    encode_struct(encoder, value.dstOffset);
-    encode_struct(encoder, value.extent);
+    EncodeStruct(encoder, value.srcSubresource);
+    EncodeStruct(encoder, value.srcOffset);
+    EncodeStruct(encoder, value.dstSubresource);
+    EncodeStruct(encoder, value.dstOffset);
+    EncodeStruct(encoder, value.extent);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMemoryBarrier& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryBarrier& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.srcAccessMask);
     encoder->EncodeFlagsValue(value.dstAccessMask);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkBufferMemoryBarrier& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkBufferMemoryBarrier& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.srcAccessMask);
     encoder->EncodeFlagsValue(value.dstAccessMask);
     encoder->EncodeUInt32Value(value.srcQueueFamilyIndex);
@@ -1152,10 +1152,10 @@ void encode_struct(ParameterEncoder* encoder, const VkBufferMemoryBarrier& value
     encoder->EncodeVkDeviceSizeValue(value.size);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageMemoryBarrier& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageMemoryBarrier& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.srcAccessMask);
     encoder->EncodeFlagsValue(value.dstAccessMask);
     encoder->EncodeEnumValue(value.oldLayout);
@@ -1163,28 +1163,28 @@ void encode_struct(ParameterEncoder* encoder, const VkImageMemoryBarrier& value)
     encoder->EncodeUInt32Value(value.srcQueueFamilyIndex);
     encoder->EncodeUInt32Value(value.dstQueueFamilyIndex);
     encoder->EncodeHandleIdValue(value.image);
-    encode_struct(encoder, value.subresourceRange);
+    EncodeStruct(encoder, value.subresourceRange);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkRenderPassBeginInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassBeginInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.renderPass);
     encoder->EncodeHandleIdValue(value.framebuffer);
-    encode_struct(encoder, value.renderArea);
+    EncodeStruct(encoder, value.renderArea);
     encoder->EncodeUInt32Value(value.clearValueCount);
-    encode_struct_array(encoder, value.pClearValues, value.clearValueCount);
+    EncodeStructArray(encoder, value.pClearValues, value.clearValueCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDispatchIndirectCommand& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDispatchIndirectCommand& value)
 {
     encoder->EncodeUInt32Value(value.x);
     encoder->EncodeUInt32Value(value.y);
     encoder->EncodeUInt32Value(value.z);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDrawIndexedIndirectCommand& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDrawIndexedIndirectCommand& value)
 {
     encoder->EncodeUInt32Value(value.indexCount);
     encoder->EncodeUInt32Value(value.instanceCount);
@@ -1193,7 +1193,7 @@ void encode_struct(ParameterEncoder* encoder, const VkDrawIndexedIndirectCommand
     encoder->EncodeUInt32Value(value.firstInstance);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDrawIndirectCommand& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDrawIndirectCommand& value)
 {
     encoder->EncodeUInt32Value(value.vertexCount);
     encoder->EncodeUInt32Value(value.instanceCount);
@@ -1201,88 +1201,88 @@ void encode_struct(ParameterEncoder* encoder, const VkDrawIndirectCommand& value
     encoder->EncodeUInt32Value(value.firstInstance);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSubgroupProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSubgroupProperties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.subgroupSize);
     encoder->EncodeFlagsValue(value.supportedStages);
     encoder->EncodeFlagsValue(value.supportedOperations);
     encoder->EncodeVkBool32Value(value.quadOperationsInAllStages);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkBindBufferMemoryInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkBindBufferMemoryInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.buffer);
     encoder->EncodeHandleIdValue(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.memoryOffset);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkBindImageMemoryInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkBindImageMemoryInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.image);
     encoder->EncodeHandleIdValue(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.memoryOffset);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDevice16BitStorageFeatures& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDevice16BitStorageFeatures& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.storageBuffer16BitAccess);
     encoder->EncodeVkBool32Value(value.uniformAndStorageBuffer16BitAccess);
     encoder->EncodeVkBool32Value(value.storagePushConstant16);
     encoder->EncodeVkBool32Value(value.storageInputOutput16);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMemoryDedicatedRequirements& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryDedicatedRequirements& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.prefersDedicatedAllocation);
     encoder->EncodeVkBool32Value(value.requiresDedicatedAllocation);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMemoryDedicatedAllocateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryDedicatedAllocateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.image);
     encoder->EncodeHandleIdValue(value.buffer);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMemoryAllocateFlagsInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryAllocateFlagsInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.deviceMask);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupRenderPassBeginInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupRenderPassBeginInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.deviceMask);
     encoder->EncodeUInt32Value(value.deviceRenderAreaCount);
-    encode_struct_array(encoder, value.pDeviceRenderAreas, value.deviceRenderAreaCount);
+    EncodeStructArray(encoder, value.pDeviceRenderAreas, value.deviceRenderAreaCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupCommandBufferBeginInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupCommandBufferBeginInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.deviceMask);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupSubmitInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupSubmitInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.waitSemaphoreCount);
     encoder->EncodeUInt32Array(value.pWaitSemaphoreDeviceIndices, value.waitSemaphoreCount);
     encoder->EncodeUInt32Value(value.commandBufferCount);
@@ -1291,116 +1291,116 @@ void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupSubmitInfo& val
     encoder->EncodeUInt32Array(value.pSignalSemaphoreDeviceIndices, value.signalSemaphoreCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupBindSparseInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupBindSparseInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.resourceDeviceIndex);
     encoder->EncodeUInt32Value(value.memoryDeviceIndex);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkBindBufferMemoryDeviceGroupInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkBindBufferMemoryDeviceGroupInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.deviceIndexCount);
     encoder->EncodeUInt32Array(value.pDeviceIndices, value.deviceIndexCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkBindImageMemoryDeviceGroupInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkBindImageMemoryDeviceGroupInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.deviceIndexCount);
     encoder->EncodeUInt32Array(value.pDeviceIndices, value.deviceIndexCount);
     encoder->EncodeUInt32Value(value.splitInstanceBindRegionCount);
-    encode_struct_array(encoder, value.pSplitInstanceBindRegions, value.splitInstanceBindRegionCount);
+    EncodeStructArray(encoder, value.pSplitInstanceBindRegions, value.splitInstanceBindRegionCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceGroupProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceGroupProperties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.physicalDeviceCount);
     encoder->EncodeHandleIdArray(value.physicalDevices, value.physicalDeviceCount);
     encoder->EncodeVkBool32Value(value.subsetAllocation);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupDeviceCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupDeviceCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.physicalDeviceCount);
     encoder->EncodeHandleIdArray(value.pPhysicalDevices, value.physicalDeviceCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkBufferMemoryRequirementsInfo2& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkBufferMemoryRequirementsInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.buffer);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageMemoryRequirementsInfo2& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageMemoryRequirementsInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.image);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageSparseMemoryRequirementsInfo2& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageSparseMemoryRequirementsInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.image);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMemoryRequirements2& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryRequirements2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.memoryRequirements);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.memoryRequirements);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSparseImageMemoryRequirements2& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageMemoryRequirements2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.memoryRequirements);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.memoryRequirements);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceFeatures2& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFeatures2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.features);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.features);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceProperties2& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceProperties2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.properties);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.properties);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkFormatProperties2& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkFormatProperties2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.formatProperties);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.formatProperties);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageFormatProperties2& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageFormatProperties2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.imageFormatProperties);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.imageFormatProperties);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceImageFormatInfo2& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceImageFormatInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.format);
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeEnumValue(value.tiling);
@@ -1408,31 +1408,31 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceImageFormatI
     encoder->EncodeFlagsValue(value.flags);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkQueueFamilyProperties2& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkQueueFamilyProperties2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.queueFamilyProperties);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.queueFamilyProperties);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryProperties2& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryProperties2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.memoryProperties);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.memoryProperties);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSparseImageFormatProperties2& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageFormatProperties2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.properties);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.properties);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSparseImageFormatInfo2& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSparseImageFormatInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.format);
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeEnumValue(value.samples);
@@ -1440,46 +1440,46 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSparseImageF
     encoder->EncodeEnumValue(value.tiling);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDevicePointClippingProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDevicePointClippingProperties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.pointClippingBehavior);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkInputAttachmentAspectReference& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkInputAttachmentAspectReference& value)
 {
     encoder->EncodeUInt32Value(value.subpass);
     encoder->EncodeUInt32Value(value.inputAttachmentIndex);
     encoder->EncodeFlagsValue(value.aspectMask);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkRenderPassInputAttachmentAspectCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassInputAttachmentAspectCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.aspectReferenceCount);
-    encode_struct_array(encoder, value.pAspectReferences, value.aspectReferenceCount);
+    EncodeStructArray(encoder, value.pAspectReferences, value.aspectReferenceCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageViewUsageCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageViewUsageCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.usage);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineTessellationDomainOriginStateCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineTessellationDomainOriginStateCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.domainOrigin);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkRenderPassMultiviewCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassMultiviewCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.subpassCount);
     encoder->EncodeUInt32Array(value.pViewMasks, value.subpassCount);
     encoder->EncodeUInt32Value(value.dependencyCount);
@@ -1488,111 +1488,111 @@ void encode_struct(ParameterEncoder* encoder, const VkRenderPassMultiviewCreateI
     encoder->EncodeUInt32Array(value.pCorrelationMasks, value.correlationMaskCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMultiviewFeatures& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMultiviewFeatures& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.multiview);
     encoder->EncodeVkBool32Value(value.multiviewGeometryShader);
     encoder->EncodeVkBool32Value(value.multiviewTessellationShader);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMultiviewProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMultiviewProperties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.maxMultiviewViewCount);
     encoder->EncodeUInt32Value(value.maxMultiviewInstanceIndex);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceVariablePointerFeatures& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceVariablePointerFeatures& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.variablePointersStorageBuffer);
     encoder->EncodeVkBool32Value(value.variablePointers);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceProtectedMemoryFeatures& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceProtectedMemoryFeatures& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.protectedMemory);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceProtectedMemoryProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceProtectedMemoryProperties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.protectedNoFault);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDeviceQueueInfo2& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceQueueInfo2& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.queueFamilyIndex);
     encoder->EncodeUInt32Value(value.queueIndex);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkProtectedSubmitInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkProtectedSubmitInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.protectedSubmit);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSamplerYcbcrConversionCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSamplerYcbcrConversionCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.format);
     encoder->EncodeEnumValue(value.ycbcrModel);
     encoder->EncodeEnumValue(value.ycbcrRange);
-    encode_struct(encoder, value.components);
+    EncodeStruct(encoder, value.components);
     encoder->EncodeEnumValue(value.xChromaOffset);
     encoder->EncodeEnumValue(value.yChromaOffset);
     encoder->EncodeEnumValue(value.chromaFilter);
     encoder->EncodeVkBool32Value(value.forceExplicitReconstruction);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSamplerYcbcrConversionInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSamplerYcbcrConversionInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.conversion);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkBindImagePlaneMemoryInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkBindImagePlaneMemoryInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.planeAspect);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImagePlaneMemoryRequirementsInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImagePlaneMemoryRequirementsInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.planeAspect);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSamplerYcbcrConversionFeatures& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSamplerYcbcrConversionFeatures& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.samplerYcbcrConversion);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSamplerYcbcrConversionImageFormatProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSamplerYcbcrConversionImageFormatProperties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.combinedImageSamplerDescriptorCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorUpdateTemplateEntry& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorUpdateTemplateEntry& value)
 {
     encoder->EncodeUInt32Value(value.dstBinding);
     encoder->EncodeUInt32Value(value.dstArrayElement);
@@ -1602,13 +1602,13 @@ void encode_struct(ParameterEncoder* encoder, const VkDescriptorUpdateTemplateEn
     encoder->EncodeSizeTValue(value.stride);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorUpdateTemplateCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorUpdateTemplateCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.descriptorUpdateEntryCount);
-    encode_struct_array(encoder, value.pDescriptorUpdateEntries, value.descriptorUpdateEntryCount);
+    EncodeStructArray(encoder, value.pDescriptorUpdateEntries, value.descriptorUpdateEntryCount);
     encoder->EncodeEnumValue(value.templateType);
     encoder->EncodeHandleIdValue(value.descriptorSetLayout);
     encoder->EncodeEnumValue(value.pipelineBindPoint);
@@ -1616,47 +1616,47 @@ void encode_struct(ParameterEncoder* encoder, const VkDescriptorUpdateTemplateCr
     encoder->EncodeUInt32Value(value.set);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExternalMemoryProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalMemoryProperties& value)
 {
     encoder->EncodeFlagsValue(value.externalMemoryFeatures);
     encoder->EncodeFlagsValue(value.exportFromImportedHandleTypes);
     encoder->EncodeFlagsValue(value.compatibleHandleTypes);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalImageFormatInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalImageFormatInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.handleType);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExternalImageFormatProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalImageFormatProperties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.externalMemoryProperties);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.externalMemoryProperties);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalBufferInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalBufferInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeFlagsValue(value.usage);
     encoder->EncodeEnumValue(value.handleType);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExternalBufferProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalBufferProperties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.externalMemoryProperties);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.externalMemoryProperties);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceIDProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceIDProperties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt8Array(value.deviceUUID, VK_UUID_SIZE);
     encoder->EncodeUInt8Array(value.driverUUID, VK_UUID_SIZE);
     encoder->EncodeUInt8Array(value.deviceLUID, VK_LUID_SIZE);
@@ -1664,102 +1664,102 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceIDProperties
     encoder->EncodeVkBool32Value(value.deviceLUIDValid);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExternalMemoryImageCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalMemoryImageCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.handleTypes);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExternalMemoryBufferCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalMemoryBufferCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.handleTypes);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExportMemoryAllocateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExportMemoryAllocateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.handleTypes);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalFenceInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalFenceInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.handleType);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExternalFenceProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalFenceProperties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.exportFromImportedHandleTypes);
     encoder->EncodeFlagsValue(value.compatibleHandleTypes);
     encoder->EncodeFlagsValue(value.externalFenceFeatures);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExportFenceCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExportFenceCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.handleTypes);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExportSemaphoreCreateInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExportSemaphoreCreateInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.handleTypes);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalSemaphoreInfo& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalSemaphoreInfo& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.handleType);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExternalSemaphoreProperties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalSemaphoreProperties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.exportFromImportedHandleTypes);
     encoder->EncodeFlagsValue(value.compatibleHandleTypes);
     encoder->EncodeFlagsValue(value.externalSemaphoreFeatures);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMaintenance3Properties& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMaintenance3Properties& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.maxPerSetDescriptors);
     encoder->EncodeVkDeviceSizeValue(value.maxMemoryAllocationSize);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorSetLayoutSupport& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetLayoutSupport& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.supported);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderDrawParameterFeatures& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderDrawParameterFeatures& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.shaderDrawParameters);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSurfaceCapabilitiesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSurfaceCapabilitiesKHR& value)
 {
     encoder->EncodeUInt32Value(value.minImageCount);
     encoder->EncodeUInt32Value(value.maxImageCount);
-    encode_struct(encoder, value.currentExtent);
-    encode_struct(encoder, value.minImageExtent);
-    encode_struct(encoder, value.maxImageExtent);
+    EncodeStruct(encoder, value.currentExtent);
+    EncodeStruct(encoder, value.minImageExtent);
+    EncodeStruct(encoder, value.maxImageExtent);
     encoder->EncodeUInt32Value(value.maxImageArrayLayers);
     encoder->EncodeFlagsValue(value.supportedTransforms);
     encoder->EncodeEnumValue(value.currentTransform);
@@ -1767,22 +1767,22 @@ void encode_struct(ParameterEncoder* encoder, const VkSurfaceCapabilitiesKHR& va
     encoder->EncodeFlagsValue(value.supportedUsageFlags);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSurfaceFormatKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSurfaceFormatKHR& value)
 {
     encoder->EncodeEnumValue(value.format);
     encoder->EncodeEnumValue(value.colorSpace);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSwapchainCreateInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSwapchainCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeHandleIdValue(value.surface);
     encoder->EncodeUInt32Value(value.minImageCount);
     encoder->EncodeEnumValue(value.imageFormat);
     encoder->EncodeEnumValue(value.imageColorSpace);
-    encode_struct(encoder, value.imageExtent);
+    EncodeStruct(encoder, value.imageExtent);
     encoder->EncodeUInt32Value(value.imageArrayLayers);
     encoder->EncodeFlagsValue(value.imageUsage);
     encoder->EncodeEnumValue(value.imageSharingMode);
@@ -1795,10 +1795,10 @@ void encode_struct(ParameterEncoder* encoder, const VkSwapchainCreateInfoKHR& va
     encoder->EncodeHandleIdValue(value.oldSwapchain);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPresentInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPresentInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.waitSemaphoreCount);
     encoder->EncodeHandleIdArray(value.pWaitSemaphores, value.waitSemaphoreCount);
     encoder->EncodeUInt32Value(value.swapchainCount);
@@ -1807,25 +1807,25 @@ void encode_struct(ParameterEncoder* encoder, const VkPresentInfoKHR& value)
     encoder->EncodeEnumArray(value.pResults, value.swapchainCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageSwapchainCreateInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageSwapchainCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.swapchain);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkBindImageMemorySwapchainInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkBindImageMemorySwapchainInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.swapchain);
     encoder->EncodeUInt32Value(value.imageIndex);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkAcquireNextImageInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkAcquireNextImageInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.swapchain);
     encoder->EncodeUInt64Value(value.timeout);
     encoder->EncodeHandleIdValue(value.semaphore);
@@ -1833,84 +1833,84 @@ void encode_struct(ParameterEncoder* encoder, const VkAcquireNextImageInfoKHR& v
     encoder->EncodeUInt32Value(value.deviceMask);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupPresentCapabilitiesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupPresentCapabilitiesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Array(value.presentMask, VK_MAX_DEVICE_GROUP_SIZE);
     encoder->EncodeFlagsValue(value.modes);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupPresentInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupPresentInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.swapchainCount);
     encoder->EncodeUInt32Array(value.pDeviceMasks, value.swapchainCount);
     encoder->EncodeEnumValue(value.mode);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupSwapchainCreateInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupSwapchainCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.modes);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDisplayPropertiesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPropertiesKHR& value)
 {
     encoder->EncodeHandleIdValue(value.display);
     encoder->EncodeString(value.displayName);
-    encode_struct(encoder, value.physicalDimensions);
-    encode_struct(encoder, value.physicalResolution);
+    EncodeStruct(encoder, value.physicalDimensions);
+    EncodeStruct(encoder, value.physicalResolution);
     encoder->EncodeFlagsValue(value.supportedTransforms);
     encoder->EncodeVkBool32Value(value.planeReorderPossible);
     encoder->EncodeVkBool32Value(value.persistentContent);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDisplayModeParametersKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayModeParametersKHR& value)
 {
-    encode_struct(encoder, value.visibleRegion);
+    EncodeStruct(encoder, value.visibleRegion);
     encoder->EncodeUInt32Value(value.refreshRate);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDisplayModePropertiesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayModePropertiesKHR& value)
 {
     encoder->EncodeHandleIdValue(value.displayMode);
-    encode_struct(encoder, value.parameters);
+    EncodeStruct(encoder, value.parameters);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDisplayModeCreateInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayModeCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
-    encode_struct(encoder, value.parameters);
+    EncodeStruct(encoder, value.parameters);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDisplayPlaneCapabilitiesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlaneCapabilitiesKHR& value)
 {
     encoder->EncodeFlagsValue(value.supportedAlpha);
-    encode_struct(encoder, value.minSrcPosition);
-    encode_struct(encoder, value.maxSrcPosition);
-    encode_struct(encoder, value.minSrcExtent);
-    encode_struct(encoder, value.maxSrcExtent);
-    encode_struct(encoder, value.minDstPosition);
-    encode_struct(encoder, value.maxDstPosition);
-    encode_struct(encoder, value.minDstExtent);
-    encode_struct(encoder, value.maxDstExtent);
+    EncodeStruct(encoder, value.minSrcPosition);
+    EncodeStruct(encoder, value.maxSrcPosition);
+    EncodeStruct(encoder, value.minSrcExtent);
+    EncodeStruct(encoder, value.maxSrcExtent);
+    EncodeStruct(encoder, value.minDstPosition);
+    EncodeStruct(encoder, value.maxDstPosition);
+    EncodeStruct(encoder, value.minDstExtent);
+    EncodeStruct(encoder, value.maxDstExtent);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDisplayPlanePropertiesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlanePropertiesKHR& value)
 {
     encoder->EncodeHandleIdValue(value.currentDisplay);
     encoder->EncodeUInt32Value(value.currentStackIndex);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDisplaySurfaceCreateInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplaySurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeHandleIdValue(value.displayMode);
     encoder->EncodeUInt32Value(value.planeIndex);
@@ -1918,122 +1918,122 @@ void encode_struct(ParameterEncoder* encoder, const VkDisplaySurfaceCreateInfoKH
     encoder->EncodeEnumValue(value.transform);
     encoder->EncodeFloatValue(value.globalAlpha);
     encoder->EncodeEnumValue(value.alphaMode);
-    encode_struct(encoder, value.imageExtent);
+    EncodeStruct(encoder, value.imageExtent);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDisplayPresentInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPresentInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.srcRect);
-    encode_struct(encoder, value.dstRect);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.srcRect);
+    EncodeStruct(encoder, value.dstRect);
     encoder->EncodeVkBool32Value(value.persistent);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkXlibSurfaceCreateInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkXlibSurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.dpy);
     encoder->EncodeSizeTValue(value.window);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkXcbSurfaceCreateInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkXcbSurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.connection);
     encoder->EncodeUInt32Value(value.window);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkWaylandSurfaceCreateInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkWaylandSurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.display);
     encoder->EncodeVoidPtr(value.surface);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkAndroidSurfaceCreateInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkAndroidSurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.window);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkWin32SurfaceCreateInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkWin32SurfaceCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.hinstance);
     encoder->EncodeVoidPtr(value.hwnd);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImportMemoryWin32HandleInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImportMemoryWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.handleType);
     encoder->EncodeVoidPtr(value.handle);
     encoder->EncodeWString(value.name);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExportMemoryWin32HandleInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExportMemoryWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct_ptr(encoder, value.pAttributes);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStructPtr(encoder, value.pAttributes);
     encoder->EncodeUInt32Value(value.dwAccess);
     encoder->EncodeWString(value.name);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMemoryWin32HandlePropertiesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryWin32HandlePropertiesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.memoryTypeBits);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMemoryGetWin32HandleInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.memory);
     encoder->EncodeEnumValue(value.handleType);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImportMemoryFdInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImportMemoryFdInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.handleType);
     encoder->EncodeInt32Value(value.fd);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMemoryFdPropertiesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryFdPropertiesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.memoryTypeBits);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMemoryGetFdInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetFdInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.memory);
     encoder->EncodeEnumValue(value.handleType);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireReleaseInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireReleaseInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.acquireCount);
     encoder->EncodeHandleIdArray(value.pAcquireSyncs, value.acquireCount);
     encoder->EncodeUInt64Array(value.pAcquireKeys, value.acquireCount);
@@ -2043,10 +2043,10 @@ void encode_struct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireRele
     encoder->EncodeUInt64Array(value.pReleaseKeys, value.releaseCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImportSemaphoreWin32HandleInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImportSemaphoreWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.semaphore);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
@@ -2054,91 +2054,91 @@ void encode_struct(ParameterEncoder* encoder, const VkImportSemaphoreWin32Handle
     encoder->EncodeWString(value.name);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExportSemaphoreWin32HandleInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExportSemaphoreWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct_ptr(encoder, value.pAttributes);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStructPtr(encoder, value.pAttributes);
     encoder->EncodeUInt32Value(value.dwAccess);
     encoder->EncodeWString(value.name);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkD3D12FenceSubmitInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkD3D12FenceSubmitInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.waitSemaphoreValuesCount);
     encoder->EncodeUInt64Array(value.pWaitSemaphoreValues, value.waitSemaphoreValuesCount);
     encoder->EncodeUInt32Value(value.signalSemaphoreValuesCount);
     encoder->EncodeUInt64Array(value.pSignalSemaphoreValues, value.signalSemaphoreValuesCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSemaphoreGetWin32HandleInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreGetWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.semaphore);
     encoder->EncodeEnumValue(value.handleType);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImportSemaphoreFdInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImportSemaphoreFdInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.semaphore);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
     encoder->EncodeInt32Value(value.fd);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSemaphoreGetFdInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreGetFdInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.semaphore);
     encoder->EncodeEnumValue(value.handleType);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDevicePushDescriptorPropertiesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDevicePushDescriptorPropertiesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.maxPushDescriptors);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceFloat16Int8FeaturesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFloat16Int8FeaturesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.shaderFloat16);
     encoder->EncodeVkBool32Value(value.shaderInt8);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkRectLayerKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkRectLayerKHR& value)
 {
-    encode_struct(encoder, value.offset);
-    encode_struct(encoder, value.extent);
+    EncodeStruct(encoder, value.offset);
+    EncodeStruct(encoder, value.extent);
     encoder->EncodeUInt32Value(value.layer);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPresentRegionKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPresentRegionKHR& value)
 {
     encoder->EncodeUInt32Value(value.rectangleCount);
-    encode_struct_array(encoder, value.pRectangles, value.rectangleCount);
+    EncodeStructArray(encoder, value.pRectangles, value.rectangleCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPresentRegionsKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPresentRegionsKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.swapchainCount);
-    encode_struct_array(encoder, value.pRegions, value.swapchainCount);
+    EncodeStructArray(encoder, value.pRegions, value.swapchainCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkAttachmentDescription2KHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkAttachmentDescription2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.format);
     encoder->EncodeEnumValue(value.samples);
@@ -2150,36 +2150,36 @@ void encode_struct(ParameterEncoder* encoder, const VkAttachmentDescription2KHR&
     encoder->EncodeEnumValue(value.finalLayout);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkAttachmentReference2KHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkAttachmentReference2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.attachment);
     encoder->EncodeEnumValue(value.layout);
     encoder->EncodeFlagsValue(value.aspectMask);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSubpassDescription2KHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSubpassDescription2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.pipelineBindPoint);
     encoder->EncodeUInt32Value(value.viewMask);
     encoder->EncodeUInt32Value(value.inputAttachmentCount);
-    encode_struct_array(encoder, value.pInputAttachments, value.inputAttachmentCount);
+    EncodeStructArray(encoder, value.pInputAttachments, value.inputAttachmentCount);
     encoder->EncodeUInt32Value(value.colorAttachmentCount);
-    encode_struct_array(encoder, value.pColorAttachments, value.colorAttachmentCount);
-    encode_struct_array(encoder, value.pResolveAttachments, value.colorAttachmentCount);
-    encode_struct_ptr(encoder, value.pDepthStencilAttachment);
+    EncodeStructArray(encoder, value.pColorAttachments, value.colorAttachmentCount);
+    EncodeStructArray(encoder, value.pResolveAttachments, value.colorAttachmentCount);
+    EncodeStructPtr(encoder, value.pDepthStencilAttachment);
     encoder->EncodeUInt32Value(value.preserveAttachmentCount);
     encoder->EncodeUInt32Array(value.pPreserveAttachments, value.preserveAttachmentCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSubpassDependency2KHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSubpassDependency2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.srcSubpass);
     encoder->EncodeUInt32Value(value.dstSubpass);
     encoder->EncodeFlagsValue(value.srcStageMask);
@@ -2190,45 +2190,45 @@ void encode_struct(ParameterEncoder* encoder, const VkSubpassDependency2KHR& val
     encoder->EncodeInt32Value(value.viewOffset);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkRenderPassCreateInfo2KHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassCreateInfo2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.attachmentCount);
-    encode_struct_array(encoder, value.pAttachments, value.attachmentCount);
+    EncodeStructArray(encoder, value.pAttachments, value.attachmentCount);
     encoder->EncodeUInt32Value(value.subpassCount);
-    encode_struct_array(encoder, value.pSubpasses, value.subpassCount);
+    EncodeStructArray(encoder, value.pSubpasses, value.subpassCount);
     encoder->EncodeUInt32Value(value.dependencyCount);
-    encode_struct_array(encoder, value.pDependencies, value.dependencyCount);
+    EncodeStructArray(encoder, value.pDependencies, value.dependencyCount);
     encoder->EncodeUInt32Value(value.correlatedViewMaskCount);
     encoder->EncodeUInt32Array(value.pCorrelatedViewMasks, value.correlatedViewMaskCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSubpassBeginInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSubpassBeginInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.contents);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSubpassEndInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSubpassEndInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSharedPresentSurfaceCapabilitiesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSharedPresentSurfaceCapabilitiesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.sharedPresentSupportedUsageFlags);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImportFenceWin32HandleInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImportFenceWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.fence);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
@@ -2236,124 +2236,124 @@ void encode_struct(ParameterEncoder* encoder, const VkImportFenceWin32HandleInfo
     encoder->EncodeWString(value.name);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExportFenceWin32HandleInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExportFenceWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct_ptr(encoder, value.pAttributes);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStructPtr(encoder, value.pAttributes);
     encoder->EncodeUInt32Value(value.dwAccess);
     encoder->EncodeWString(value.name);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkFenceGetWin32HandleInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkFenceGetWin32HandleInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.fence);
     encoder->EncodeEnumValue(value.handleType);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImportFenceFdInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImportFenceFdInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.fence);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.handleType);
     encoder->EncodeInt32Value(value.fd);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkFenceGetFdInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkFenceGetFdInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.fence);
     encoder->EncodeEnumValue(value.handleType);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSurfaceInfo2KHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSurfaceInfo2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.surface);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSurfaceCapabilities2KHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSurfaceCapabilities2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.surfaceCapabilities);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.surfaceCapabilities);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSurfaceFormat2KHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSurfaceFormat2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.surfaceFormat);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.surfaceFormat);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDisplayProperties2KHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayProperties2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.displayProperties);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.displayProperties);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDisplayPlaneProperties2KHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlaneProperties2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.displayPlaneProperties);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.displayPlaneProperties);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDisplayModeProperties2KHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayModeProperties2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.displayModeProperties);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.displayModeProperties);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDisplayPlaneInfo2KHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlaneInfo2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.mode);
     encoder->EncodeUInt32Value(value.planeIndex);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDisplayPlaneCapabilities2KHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlaneCapabilities2KHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.capabilities);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.capabilities);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageFormatListCreateInfoKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageFormatListCreateInfoKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.viewFormatCount);
     encoder->EncodeEnumArray(value.pViewFormats, value.viewFormatCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDevice8BitStorageFeaturesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDevice8BitStorageFeaturesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.storageBuffer8BitAccess);
     encoder->EncodeVkBool32Value(value.uniformAndStorageBuffer8BitAccess);
     encoder->EncodeVkBool32Value(value.storagePushConstant8);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderAtomicInt64FeaturesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderAtomicInt64FeaturesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.shaderBufferInt64Atomics);
     encoder->EncodeVkBool32Value(value.shaderSharedInt64Atomics);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkConformanceVersionKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkConformanceVersionKHR& value)
 {
     encoder->EncodeUInt8Value(value.major);
     encoder->EncodeUInt8Value(value.minor);
@@ -2361,20 +2361,20 @@ void encode_struct(ParameterEncoder* encoder, const VkConformanceVersionKHR& val
     encoder->EncodeUInt8Value(value.patch);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceDriverPropertiesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDriverPropertiesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.driverID);
     encoder->EncodeString(value.driverName);
     encoder->EncodeString(value.driverInfo);
-    encode_struct(encoder, value.conformanceVersion);
+    EncodeStruct(encoder, value.conformanceVersion);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceFloatControlsPropertiesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFloatControlsPropertiesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.separateDenormSettings);
     encoder->EncodeVkBool32Value(value.separateRoundingModeSettings);
     encoder->EncodeVkBool32Value(value.shaderSignedZeroInfNanPreserveFloat16);
@@ -2394,62 +2394,62 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceFloatControl
     encoder->EncodeVkBool32Value(value.shaderRoundingModeRTZFloat64);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSubpassDescriptionDepthStencilResolveKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSubpassDescriptionDepthStencilResolveKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.depthResolveMode);
     encoder->EncodeEnumValue(value.stencilResolveMode);
-    encode_struct_ptr(encoder, value.pDepthStencilResolveAttachment);
+    EncodeStructPtr(encoder, value.pDepthStencilResolveAttachment);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceDepthStencilResolvePropertiesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDepthStencilResolvePropertiesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.supportedDepthResolveModes);
     encoder->EncodeFlagsValue(value.supportedStencilResolveModes);
     encoder->EncodeVkBool32Value(value.independentResolveNone);
     encoder->EncodeVkBool32Value(value.independentResolve);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.vulkanMemoryModel);
     encoder->EncodeVkBool32Value(value.vulkanMemoryModelDeviceScope);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDebugReportCallbackCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugReportCallbackCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeFunctionPtr(value.pfnCallback);
     encoder->EncodeVoidPtr(value.pUserData);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineRasterizationStateRasterizationOrderAMD& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRasterizationStateRasterizationOrderAMD& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.rasterizationOrder);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDebugMarkerObjectNameInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugMarkerObjectNameInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.objectType);
     encoder->EncodeUInt64Value(value.object);
     encoder->EncodeString(value.pObjectName);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDebugMarkerObjectTagInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugMarkerObjectTagInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.objectType);
     encoder->EncodeUInt64Value(value.object);
     encoder->EncodeUInt64Value(value.tagName);
@@ -2457,48 +2457,48 @@ void encode_struct(ParameterEncoder* encoder, const VkDebugMarkerObjectTagInfoEX
     encoder->EncodeVoidArray(value.pTag, value.tagSize);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDebugMarkerMarkerInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugMarkerMarkerInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeString(value.pMarkerName);
     encoder->EncodeFloatArray(value.color, 4);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDedicatedAllocationImageCreateInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDedicatedAllocationImageCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.dedicatedAllocation);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDedicatedAllocationBufferCreateInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDedicatedAllocationBufferCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.dedicatedAllocation);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDedicatedAllocationMemoryAllocateInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDedicatedAllocationMemoryAllocateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.image);
     encoder->EncodeHandleIdValue(value.buffer);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceTransformFeedbackFeaturesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceTransformFeedbackFeaturesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.transformFeedback);
     encoder->EncodeVkBool32Value(value.geometryStreams);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceTransformFeedbackPropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceTransformFeedbackPropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.maxTransformFeedbackStreams);
     encoder->EncodeUInt32Value(value.maxTransformFeedbackBuffers);
     encoder->EncodeVkDeviceSizeValue(value.maxTransformFeedbackBufferSize);
@@ -2511,22 +2511,22 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceTransformFee
     encoder->EncodeVkBool32Value(value.transformFeedbackDraw);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineRasterizationStateStreamCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRasterizationStateStreamCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.rasterizationStream);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkTextureLODGatherFormatPropertiesAMD& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkTextureLODGatherFormatPropertiesAMD& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.supportsTextureGatherLODBiasAMD);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkShaderResourceUsageAMD& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkShaderResourceUsageAMD& value)
 {
     encoder->EncodeUInt32Value(value.numUsedVgprs);
     encoder->EncodeUInt32Value(value.numUsedSgprs);
@@ -2535,10 +2535,10 @@ void encode_struct(ParameterEncoder* encoder, const VkShaderResourceUsageAMD& va
     encoder->EncodeSizeTValue(value.scratchMemUsageInBytes);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkShaderStatisticsInfoAMD& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkShaderStatisticsInfoAMD& value)
 {
     encoder->EncodeFlagsValue(value.shaderStageMask);
-    encode_struct(encoder, value.resourceUsage);
+    EncodeStruct(encoder, value.resourceUsage);
     encoder->EncodeUInt32Value(value.numPhysicalVgprs);
     encoder->EncodeUInt32Value(value.numPhysicalSgprs);
     encoder->EncodeUInt32Value(value.numAvailableVgprs);
@@ -2546,55 +2546,55 @@ void encode_struct(ParameterEncoder* encoder, const VkShaderStatisticsInfoAMD& v
     encoder->EncodeUInt32Array(value.computeWorkGroupSize, 3);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceCornerSampledImageFeaturesNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceCornerSampledImageFeaturesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.cornerSampledImage);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExternalImageFormatPropertiesNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalImageFormatPropertiesNV& value)
 {
-    encode_struct(encoder, value.imageFormatProperties);
+    EncodeStruct(encoder, value.imageFormatProperties);
     encoder->EncodeFlagsValue(value.externalMemoryFeatures);
     encoder->EncodeFlagsValue(value.exportFromImportedHandleTypes);
     encoder->EncodeFlagsValue(value.compatibleHandleTypes);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExternalMemoryImageCreateInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalMemoryImageCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.handleTypes);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExportMemoryAllocateInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExportMemoryAllocateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.handleTypes);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImportMemoryWin32HandleInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImportMemoryWin32HandleInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.handleType);
     encoder->EncodeVoidPtr(value.handle);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExportMemoryWin32HandleInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExportMemoryWin32HandleInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct_ptr(encoder, value.pAttributes);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStructPtr(encoder, value.pAttributes);
     encoder->EncodeUInt32Value(value.dwAccess);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireReleaseInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireReleaseInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.acquireCount);
     encoder->EncodeHandleIdArray(value.pAcquireSyncs, value.acquireCount);
     encoder->EncodeUInt64Array(value.pAcquireKeys, value.acquireCount);
@@ -2604,71 +2604,71 @@ void encode_struct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireRele
     encoder->EncodeUInt64Array(value.pReleaseKeys, value.releaseCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkValidationFlagsEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkValidationFlagsEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.disabledValidationCheckCount);
     encoder->EncodeEnumArray(value.pDisabledValidationChecks, value.disabledValidationCheckCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkViSurfaceCreateInfoNN& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkViSurfaceCreateInfoNN& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.window);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageViewASTCDecodeModeEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageViewASTCDecodeModeEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.decodeMode);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceASTCDecodeFeaturesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceASTCDecodeFeaturesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.decodeModeSharedExponent);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkConditionalRenderingBeginInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkConditionalRenderingBeginInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
     encoder->EncodeFlagsValue(value.flags);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceConditionalRenderingFeaturesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceConditionalRenderingFeaturesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.conditionalRendering);
     encoder->EncodeVkBool32Value(value.inheritedConditionalRendering);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkCommandBufferInheritanceConditionalRenderingInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkCommandBufferInheritanceConditionalRenderingInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.conditionalRenderingEnable);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGeneratedCommandsFeaturesNVX& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGeneratedCommandsFeaturesNVX& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.computeBindingPointSupport);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGeneratedCommandsLimitsNVX& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGeneratedCommandsLimitsNVX& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.maxIndirectCommandsLayoutTokenCount);
     encoder->EncodeUInt32Value(value.maxObjectEntryCounts);
     encoder->EncodeUInt32Value(value.minSequenceCountBufferOffsetAlignment);
@@ -2676,14 +2676,14 @@ void encode_struct(ParameterEncoder* encoder, const VkDeviceGeneratedCommandsLim
     encoder->EncodeUInt32Value(value.minCommandsTokenBufferOffsetAlignment);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkIndirectCommandsTokenNVX& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkIndirectCommandsTokenNVX& value)
 {
     encoder->EncodeEnumValue(value.tokenType);
     encoder->EncodeHandleIdValue(value.buffer);
     encoder->EncodeVkDeviceSizeValue(value.offset);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkIndirectCommandsLayoutTokenNVX& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkIndirectCommandsLayoutTokenNVX& value)
 {
     encoder->EncodeEnumValue(value.tokenType);
     encoder->EncodeUInt32Value(value.bindingUnit);
@@ -2691,24 +2691,24 @@ void encode_struct(ParameterEncoder* encoder, const VkIndirectCommandsLayoutToke
     encoder->EncodeUInt32Value(value.divisor);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkIndirectCommandsLayoutCreateInfoNVX& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkIndirectCommandsLayoutCreateInfoNVX& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.pipelineBindPoint);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.tokenCount);
-    encode_struct_array(encoder, value.pTokens, value.tokenCount);
+    EncodeStructArray(encoder, value.pTokens, value.tokenCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkCmdProcessCommandsInfoNVX& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkCmdProcessCommandsInfoNVX& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.objectTable);
     encoder->EncodeHandleIdValue(value.indirectCommandsLayout);
     encoder->EncodeUInt32Value(value.indirectCommandsTokenCount);
-    encode_struct_array(encoder, value.pIndirectCommandsTokens, value.indirectCommandsTokenCount);
+    EncodeStructArray(encoder, value.pIndirectCommandsTokens, value.indirectCommandsTokenCount);
     encoder->EncodeUInt32Value(value.maxSequencesCount);
     encoder->EncodeHandleIdValue(value.targetCommandBuffer);
     encoder->EncodeHandleIdValue(value.sequencesCountBuffer);
@@ -2717,19 +2717,19 @@ void encode_struct(ParameterEncoder* encoder, const VkCmdProcessCommandsInfoNVX&
     encoder->EncodeVkDeviceSizeValue(value.sequencesIndexOffset);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkCmdReserveSpaceForCommandsInfoNVX& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkCmdReserveSpaceForCommandsInfoNVX& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.objectTable);
     encoder->EncodeHandleIdValue(value.indirectCommandsLayout);
     encoder->EncodeUInt32Value(value.maxSequencesCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkObjectTableCreateInfoNVX& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkObjectTableCreateInfoNVX& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.objectCount);
     encoder->EncodeEnumArray(value.pObjectEntryTypes, value.objectCount);
     encoder->EncodeUInt32Array(value.pObjectEntryCounts, value.objectCount);
@@ -2741,14 +2741,14 @@ void encode_struct(ParameterEncoder* encoder, const VkObjectTableCreateInfoNVX& 
     encoder->EncodeUInt32Value(value.maxPipelineLayouts);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkObjectTablePipelineEntryNVX& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkObjectTablePipelineEntryNVX& value)
 {
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeHandleIdValue(value.pipeline);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkObjectTableDescriptorSetEntryNVX& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkObjectTableDescriptorSetEntryNVX& value)
 {
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeFlagsValue(value.flags);
@@ -2756,14 +2756,14 @@ void encode_struct(ParameterEncoder* encoder, const VkObjectTableDescriptorSetEn
     encoder->EncodeHandleIdValue(value.descriptorSet);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkObjectTableVertexBufferEntryNVX& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkObjectTableVertexBufferEntryNVX& value)
 {
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeHandleIdValue(value.buffer);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkObjectTableIndexBufferEntryNVX& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkObjectTableIndexBufferEntryNVX& value)
 {
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeFlagsValue(value.flags);
@@ -2771,7 +2771,7 @@ void encode_struct(ParameterEncoder* encoder, const VkObjectTableIndexBufferEntr
     encoder->EncodeEnumValue(value.indexType);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkObjectTablePushConstantEntryNVX& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkObjectTablePushConstantEntryNVX& value)
 {
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeFlagsValue(value.flags);
@@ -2779,30 +2779,30 @@ void encode_struct(ParameterEncoder* encoder, const VkObjectTablePushConstantEnt
     encoder->EncodeFlagsValue(value.stageFlags);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkViewportWScalingNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkViewportWScalingNV& value)
 {
     encoder->EncodeFloatValue(value.xcoeff);
     encoder->EncodeFloatValue(value.ycoeff);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineViewportWScalingStateCreateInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineViewportWScalingStateCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.viewportWScalingEnable);
     encoder->EncodeUInt32Value(value.viewportCount);
-    encode_struct_array(encoder, value.pViewportWScalings, value.viewportCount);
+    EncodeStructArray(encoder, value.pViewportWScalings, value.viewportCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSurfaceCapabilities2EXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSurfaceCapabilities2EXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.minImageCount);
     encoder->EncodeUInt32Value(value.maxImageCount);
-    encode_struct(encoder, value.currentExtent);
-    encode_struct(encoder, value.minImageExtent);
-    encode_struct(encoder, value.maxImageExtent);
+    EncodeStruct(encoder, value.currentExtent);
+    EncodeStruct(encoder, value.minImageExtent);
+    EncodeStruct(encoder, value.maxImageExtent);
     encoder->EncodeUInt32Value(value.maxImageArrayLayers);
     encoder->EncodeFlagsValue(value.supportedTransforms);
     encoder->EncodeEnumValue(value.currentTransform);
@@ -2811,40 +2811,40 @@ void encode_struct(ParameterEncoder* encoder, const VkSurfaceCapabilities2EXT& v
     encoder->EncodeFlagsValue(value.supportedSurfaceCounters);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDisplayPowerInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPowerInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.powerState);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDeviceEventInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceEventInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.deviceEvent);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDisplayEventInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayEventInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.displayEvent);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSwapchainCounterCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSwapchainCounterCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.surfaceCounters);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkRefreshCycleDurationGOOGLE& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkRefreshCycleDurationGOOGLE& value)
 {
     encoder->EncodeUInt64Value(value.refreshDuration);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPastPresentationTimingGOOGLE& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPastPresentationTimingGOOGLE& value)
 {
     encoder->EncodeUInt32Value(value.presentID);
     encoder->EncodeUInt64Value(value.desiredPresentTime);
@@ -2853,28 +2853,28 @@ void encode_struct(ParameterEncoder* encoder, const VkPastPresentationTimingGOOG
     encoder->EncodeUInt64Value(value.presentMargin);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPresentTimeGOOGLE& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPresentTimeGOOGLE& value)
 {
     encoder->EncodeUInt32Value(value.presentID);
     encoder->EncodeUInt64Value(value.desiredPresentTime);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPresentTimesInfoGOOGLE& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPresentTimesInfoGOOGLE& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.swapchainCount);
-    encode_struct_array(encoder, value.pTimes, value.swapchainCount);
+    EncodeStructArray(encoder, value.pTimes, value.swapchainCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.perViewPositionAllComponents);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkViewportSwizzleNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkViewportSwizzleNV& value)
 {
     encoder->EncodeEnumValue(value.x);
     encoder->EncodeEnumValue(value.y);
@@ -2882,36 +2882,36 @@ void encode_struct(ParameterEncoder* encoder, const VkViewportSwizzleNV& value)
     encoder->EncodeEnumValue(value.w);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineViewportSwizzleStateCreateInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineViewportSwizzleStateCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.viewportCount);
-    encode_struct_array(encoder, value.pViewportSwizzles, value.viewportCount);
+    EncodeStructArray(encoder, value.pViewportSwizzles, value.viewportCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceDiscardRectanglePropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDiscardRectanglePropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.maxDiscardRectangles);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineDiscardRectangleStateCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineDiscardRectangleStateCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.discardRectangleMode);
     encoder->EncodeUInt32Value(value.discardRectangleCount);
-    encode_struct_array(encoder, value.pDiscardRectangles, value.discardRectangleCount);
+    EncodeStructArray(encoder, value.pDiscardRectangles, value.discardRectangleCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceConservativeRasterizationPropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceConservativeRasterizationPropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFloatValue(value.primitiveOverestimationSize);
     encoder->EncodeFloatValue(value.maxExtraPrimitiveOverestimationSize);
     encoder->EncodeFloatValue(value.extraPrimitiveOverestimationSizeGranularity);
@@ -2923,64 +2923,64 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceConservative
     encoder->EncodeVkBool32Value(value.conservativeRasterizationPostDepthCoverage);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineRasterizationConservativeStateCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRasterizationConservativeStateCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.conservativeRasterizationMode);
     encoder->EncodeFloatValue(value.extraPrimitiveOverestimationSize);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkXYColorEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkXYColorEXT& value)
 {
     encoder->EncodeFloatValue(value.x);
     encoder->EncodeFloatValue(value.y);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkHdrMetadataEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkHdrMetadataEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.displayPrimaryRed);
-    encode_struct(encoder, value.displayPrimaryGreen);
-    encode_struct(encoder, value.displayPrimaryBlue);
-    encode_struct(encoder, value.whitePoint);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.displayPrimaryRed);
+    EncodeStruct(encoder, value.displayPrimaryGreen);
+    EncodeStruct(encoder, value.displayPrimaryBlue);
+    EncodeStruct(encoder, value.whitePoint);
     encoder->EncodeFloatValue(value.maxLuminance);
     encoder->EncodeFloatValue(value.minLuminance);
     encoder->EncodeFloatValue(value.maxContentLightLevel);
     encoder->EncodeFloatValue(value.maxFrameAverageLightLevel);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkIOSSurfaceCreateInfoMVK& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkIOSSurfaceCreateInfoMVK& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.pView);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMacOSSurfaceCreateInfoMVK& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMacOSSurfaceCreateInfoMVK& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVoidPtr(value.pView);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsObjectNameInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsObjectNameInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.objectType);
     encoder->EncodeUInt64Value(value.objectHandle);
     encoder->EncodeString(value.pObjectName);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsObjectTagInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsObjectTagInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.objectType);
     encoder->EncodeUInt64Value(value.objectHandle);
     encoder->EncodeUInt64Value(value.tagName);
@@ -2988,34 +2988,34 @@ void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsObjectTagInfoEXT
     encoder->EncodeVoidArray(value.pTag, value.tagSize);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsLabelEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsLabelEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeString(value.pLabelName);
     encoder->EncodeFloatArray(value.color, 4);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsMessengerCallbackDataEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsMessengerCallbackDataEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeString(value.pMessageIdName);
     encoder->EncodeInt32Value(value.messageIdNumber);
     encoder->EncodeString(value.pMessage);
     encoder->EncodeUInt32Value(value.queueLabelCount);
-    encode_struct_array(encoder, value.pQueueLabels, value.queueLabelCount);
+    EncodeStructArray(encoder, value.pQueueLabels, value.queueLabelCount);
     encoder->EncodeUInt32Value(value.cmdBufLabelCount);
-    encode_struct_array(encoder, value.pCmdBufLabels, value.cmdBufLabelCount);
+    EncodeStructArray(encoder, value.pCmdBufLabels, value.cmdBufLabelCount);
     encoder->EncodeUInt32Value(value.objectCount);
-    encode_struct_array(encoder, value.pObjects, value.objectCount);
+    EncodeStructArray(encoder, value.pObjects, value.objectCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsMessengerCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsMessengerCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeFlagsValue(value.messageSeverity);
     encoder->EncodeFlagsValue(value.messageType);
@@ -3023,83 +3023,83 @@ void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsMessengerCreateI
     encoder->EncodeVoidPtr(value.pUserData);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkAndroidHardwareBufferUsageANDROID& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkAndroidHardwareBufferUsageANDROID& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt64Value(value.androidHardwareBufferUsage);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkAndroidHardwareBufferPropertiesANDROID& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkAndroidHardwareBufferPropertiesANDROID& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkDeviceSizeValue(value.allocationSize);
     encoder->EncodeUInt32Value(value.memoryTypeBits);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkAndroidHardwareBufferFormatPropertiesANDROID& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkAndroidHardwareBufferFormatPropertiesANDROID& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.format);
     encoder->EncodeUInt64Value(value.externalFormat);
     encoder->EncodeFlagsValue(value.formatFeatures);
-    encode_struct(encoder, value.samplerYcbcrConversionComponents);
+    EncodeStruct(encoder, value.samplerYcbcrConversionComponents);
     encoder->EncodeEnumValue(value.suggestedYcbcrModel);
     encoder->EncodeEnumValue(value.suggestedYcbcrRange);
     encoder->EncodeEnumValue(value.suggestedXChromaOffset);
     encoder->EncodeEnumValue(value.suggestedYChromaOffset);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImportAndroidHardwareBufferInfoANDROID& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImportAndroidHardwareBufferInfoANDROID& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVoidPtr(value.buffer);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMemoryGetAndroidHardwareBufferInfoANDROID& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetAndroidHardwareBufferInfoANDROID& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.memory);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkExternalFormatANDROID& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalFormatANDROID& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt64Value(value.externalFormat);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSamplerReductionModeCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSamplerReductionModeCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.reductionMode);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.filterMinmaxSingleComponentFormats);
     encoder->EncodeVkBool32Value(value.filterMinmaxImageComponentMapping);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceInlineUniformBlockFeaturesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceInlineUniformBlockFeaturesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.inlineUniformBlock);
     encoder->EncodeVkBool32Value(value.descriptorBindingInlineUniformBlockUpdateAfterBind);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceInlineUniformBlockPropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceInlineUniformBlockPropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.maxInlineUniformBlockSize);
     encoder->EncodeUInt32Value(value.maxPerStageDescriptorInlineUniformBlocks);
     encoder->EncodeUInt32Value(value.maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks);
@@ -3107,96 +3107,96 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceInlineUnifor
     encoder->EncodeUInt32Value(value.maxDescriptorSetUpdateAfterBindInlineUniformBlocks);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkWriteDescriptorSetInlineUniformBlockEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSetInlineUniformBlockEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.dataSize);
     encoder->EncodeVoidArray(value.pData, value.dataSize);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorPoolInlineUniformBlockCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorPoolInlineUniformBlockCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.maxInlineUniformBlockBindings);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSampleLocationEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSampleLocationEXT& value)
 {
     encoder->EncodeFloatValue(value.x);
     encoder->EncodeFloatValue(value.y);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSampleLocationsInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSampleLocationsInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.sampleLocationsPerPixel);
-    encode_struct(encoder, value.sampleLocationGridSize);
+    EncodeStruct(encoder, value.sampleLocationGridSize);
     encoder->EncodeUInt32Value(value.sampleLocationsCount);
-    encode_struct_array(encoder, value.pSampleLocations, value.sampleLocationsCount);
+    EncodeStructArray(encoder, value.pSampleLocations, value.sampleLocationsCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkAttachmentSampleLocationsEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkAttachmentSampleLocationsEXT& value)
 {
     encoder->EncodeUInt32Value(value.attachmentIndex);
-    encode_struct(encoder, value.sampleLocationsInfo);
+    EncodeStruct(encoder, value.sampleLocationsInfo);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkSubpassSampleLocationsEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkSubpassSampleLocationsEXT& value)
 {
     encoder->EncodeUInt32Value(value.subpassIndex);
-    encode_struct(encoder, value.sampleLocationsInfo);
+    EncodeStruct(encoder, value.sampleLocationsInfo);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkRenderPassSampleLocationsBeginInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassSampleLocationsBeginInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.attachmentInitialSampleLocationsCount);
-    encode_struct_array(encoder, value.pAttachmentInitialSampleLocations, value.attachmentInitialSampleLocationsCount);
+    EncodeStructArray(encoder, value.pAttachmentInitialSampleLocations, value.attachmentInitialSampleLocationsCount);
     encoder->EncodeUInt32Value(value.postSubpassSampleLocationsCount);
-    encode_struct_array(encoder, value.pPostSubpassSampleLocations, value.postSubpassSampleLocationsCount);
+    EncodeStructArray(encoder, value.pPostSubpassSampleLocations, value.postSubpassSampleLocationsCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineSampleLocationsStateCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineSampleLocationsStateCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.sampleLocationsEnable);
-    encode_struct(encoder, value.sampleLocationsInfo);
+    EncodeStruct(encoder, value.sampleLocationsInfo);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSampleLocationsPropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSampleLocationsPropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.sampleLocationSampleCounts);
-    encode_struct(encoder, value.maxSampleLocationGridSize);
+    EncodeStruct(encoder, value.maxSampleLocationGridSize);
     encoder->EncodeFloatArray(value.sampleLocationCoordinateRange, 2);
     encoder->EncodeUInt32Value(value.sampleLocationSubPixelBits);
     encoder->EncodeVkBool32Value(value.variableSampleLocations);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMultisamplePropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMultisamplePropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.maxSampleLocationGridSize);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.maxSampleLocationGridSize);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.advancedBlendCoherentOperations);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.advancedBlendMaxColorAttachments);
     encoder->EncodeVkBool32Value(value.advancedBlendIndependentBlend);
     encoder->EncodeVkBool32Value(value.advancedBlendNonPremultipliedSrcColor);
@@ -3205,28 +3205,28 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceBlendOperati
     encoder->EncodeVkBool32Value(value.advancedBlendAllOperations);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineColorBlendAdvancedStateCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineColorBlendAdvancedStateCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.srcPremultiplied);
     encoder->EncodeVkBool32Value(value.dstPremultiplied);
     encoder->EncodeEnumValue(value.blendOverlap);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineCoverageToColorStateCreateInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineCoverageToColorStateCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeVkBool32Value(value.coverageToColorEnable);
     encoder->EncodeUInt32Value(value.coverageToColorLocation);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineCoverageModulationStateCreateInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineCoverageModulationStateCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.coverageModulationMode);
     encoder->EncodeVkBool32Value(value.coverageModulationTableEnable);
@@ -3234,83 +3234,83 @@ void encode_struct(ParameterEncoder* encoder, const VkPipelineCoverageModulation
     encoder->EncodeFloatArray(value.pCoverageModulationTable, value.coverageModulationTableCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDrmFormatModifierPropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDrmFormatModifierPropertiesEXT& value)
 {
     encoder->EncodeUInt64Value(value.drmFormatModifier);
     encoder->EncodeUInt32Value(value.drmFormatModifierPlaneCount);
     encoder->EncodeFlagsValue(value.drmFormatModifierTilingFeatures);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDrmFormatModifierPropertiesListEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDrmFormatModifierPropertiesListEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.drmFormatModifierCount);
-    encode_struct_array(encoder, value.pDrmFormatModifierProperties, value.drmFormatModifierCount);
+    EncodeStructArray(encoder, value.pDrmFormatModifierProperties, value.drmFormatModifierCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceImageDrmFormatModifierInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceImageDrmFormatModifierInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt64Value(value.drmFormatModifier);
     encoder->EncodeEnumValue(value.sharingMode);
     encoder->EncodeUInt32Value(value.queueFamilyIndexCount);
     encoder->EncodeUInt32Array(value.pQueueFamilyIndices, value.queueFamilyIndexCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageDrmFormatModifierListCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageDrmFormatModifierListCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.drmFormatModifierCount);
     encoder->EncodeUInt64Array(value.pDrmFormatModifiers, value.drmFormatModifierCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageDrmFormatModifierExplicitCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageDrmFormatModifierExplicitCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt64Value(value.drmFormatModifier);
     encoder->EncodeUInt32Value(value.drmFormatModifierPlaneCount);
-    encode_struct_array(encoder, value.pPlaneLayouts, value.drmFormatModifierPlaneCount);
+    EncodeStructArray(encoder, value.pPlaneLayouts, value.drmFormatModifierPlaneCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageDrmFormatModifierPropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageDrmFormatModifierPropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt64Value(value.drmFormatModifier);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkValidationCacheCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkValidationCacheCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeSizeTValue(value.initialDataSize);
     encoder->EncodeVoidArray(value.pInitialData, value.initialDataSize);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkShaderModuleValidationCacheCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkShaderModuleValidationCacheCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.validationCache);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorSetLayoutBindingFlagsCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetLayoutBindingFlagsCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.bindingCount);
     encoder->EncodeFlagsArray(value.pBindingFlags, value.bindingCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceDescriptorIndexingFeaturesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDescriptorIndexingFeaturesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.shaderInputAttachmentArrayDynamicIndexing);
     encoder->EncodeVkBool32Value(value.shaderUniformTexelBufferArrayDynamicIndexing);
     encoder->EncodeVkBool32Value(value.shaderStorageTexelBufferArrayDynamicIndexing);
@@ -3333,10 +3333,10 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceDescriptorIn
     encoder->EncodeVkBool32Value(value.runtimeDescriptorArray);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceDescriptorIndexingPropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDescriptorIndexingPropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.maxUpdateAfterBindDescriptorsInAllPools);
     encoder->EncodeVkBool32Value(value.shaderUniformBufferArrayNonUniformIndexingNative);
     encoder->EncodeVkBool32Value(value.shaderSampledImageArrayNonUniformIndexingNative);
@@ -3362,81 +3362,81 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceDescriptorIn
     encoder->EncodeUInt32Value(value.maxDescriptorSetUpdateAfterBindInputAttachments);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorSetVariableDescriptorCountAllocateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetVariableDescriptorCountAllocateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.descriptorSetCount);
     encoder->EncodeUInt32Array(value.pDescriptorCounts, value.descriptorSetCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorSetVariableDescriptorCountLayoutSupportEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetVariableDescriptorCountLayoutSupportEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.maxVariableDescriptorCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkShadingRatePaletteNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkShadingRatePaletteNV& value)
 {
     encoder->EncodeUInt32Value(value.shadingRatePaletteEntryCount);
     encoder->EncodeEnumArray(value.pShadingRatePaletteEntries, value.shadingRatePaletteEntryCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineViewportShadingRateImageStateCreateInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineViewportShadingRateImageStateCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.shadingRateImageEnable);
     encoder->EncodeUInt32Value(value.viewportCount);
-    encode_struct_array(encoder, value.pShadingRatePalettes, value.viewportCount);
+    EncodeStructArray(encoder, value.pShadingRatePalettes, value.viewportCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceShadingRateImageFeaturesNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceShadingRateImageFeaturesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.shadingRateImage);
     encoder->EncodeVkBool32Value(value.shadingRateCoarseSampleOrder);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceShadingRateImagePropertiesNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceShadingRateImagePropertiesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.shadingRateTexelSize);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.shadingRateTexelSize);
     encoder->EncodeUInt32Value(value.shadingRatePaletteSize);
     encoder->EncodeUInt32Value(value.shadingRateMaxCoarseSamples);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkCoarseSampleLocationNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkCoarseSampleLocationNV& value)
 {
     encoder->EncodeUInt32Value(value.pixelX);
     encoder->EncodeUInt32Value(value.pixelY);
     encoder->EncodeUInt32Value(value.sample);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkCoarseSampleOrderCustomNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkCoarseSampleOrderCustomNV& value)
 {
     encoder->EncodeEnumValue(value.shadingRate);
     encoder->EncodeUInt32Value(value.sampleCount);
     encoder->EncodeUInt32Value(value.sampleLocationCount);
-    encode_struct_array(encoder, value.pSampleLocations, value.sampleLocationCount);
+    EncodeStructArray(encoder, value.pSampleLocations, value.sampleLocationCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineViewportCoarseSampleOrderStateCreateInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineViewportCoarseSampleOrderStateCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.sampleOrderType);
     encoder->EncodeUInt32Value(value.customSampleOrderCount);
-    encode_struct_array(encoder, value.pCustomSampleOrders, value.customSampleOrderCount);
+    EncodeStructArray(encoder, value.pCustomSampleOrders, value.customSampleOrderCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkRayTracingShaderGroupCreateInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkRayTracingShaderGroupCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeUInt32Value(value.generalShader);
     encoder->EncodeUInt32Value(value.closestHitShader);
@@ -3444,25 +3444,25 @@ void encode_struct(ParameterEncoder* encoder, const VkRayTracingShaderGroupCreat
     encoder->EncodeUInt32Value(value.intersectionShader);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkRayTracingPipelineCreateInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkRayTracingPipelineCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.stageCount);
-    encode_struct_array(encoder, value.pStages, value.stageCount);
+    EncodeStructArray(encoder, value.pStages, value.stageCount);
     encoder->EncodeUInt32Value(value.groupCount);
-    encode_struct_array(encoder, value.pGroups, value.groupCount);
+    EncodeStructArray(encoder, value.pGroups, value.groupCount);
     encoder->EncodeUInt32Value(value.maxRecursionDepth);
     encoder->EncodeHandleIdValue(value.layout);
     encoder->EncodeHandleIdValue(value.basePipelineHandle);
     encoder->EncodeInt32Value(value.basePipelineIndex);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkGeometryTrianglesNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkGeometryTrianglesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.vertexData);
     encoder->EncodeVkDeviceSizeValue(value.vertexOffset);
     encoder->EncodeUInt32Value(value.vertexCount);
@@ -3476,54 +3476,54 @@ void encode_struct(ParameterEncoder* encoder, const VkGeometryTrianglesNV& value
     encoder->EncodeVkDeviceSizeValue(value.transformOffset);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkGeometryAABBNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkGeometryAABBNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.aabbData);
     encoder->EncodeUInt32Value(value.numAABBs);
     encoder->EncodeUInt32Value(value.stride);
     encoder->EncodeVkDeviceSizeValue(value.offset);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkGeometryDataNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkGeometryDataNV& value)
 {
-    encode_struct(encoder, value.triangles);
-    encode_struct(encoder, value.aabbs);
+    EncodeStruct(encoder, value.triangles);
+    EncodeStruct(encoder, value.aabbs);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkGeometryNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkGeometryNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.geometryType);
-    encode_struct(encoder, value.geometry);
+    EncodeStruct(encoder, value.geometry);
     encoder->EncodeFlagsValue(value.flags);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkAccelerationStructureInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.instanceCount);
     encoder->EncodeUInt32Value(value.geometryCount);
-    encode_struct_array(encoder, value.pGeometries, value.geometryCount);
+    EncodeStructArray(encoder, value.pGeometries, value.geometryCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkAccelerationStructureCreateInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkDeviceSizeValue(value.compactedSize);
-    encode_struct(encoder, value.info);
+    EncodeStruct(encoder, value.info);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkBindAccelerationStructureMemoryInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkBindAccelerationStructureMemoryInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.accelerationStructure);
     encoder->EncodeHandleIdValue(value.memory);
     encoder->EncodeVkDeviceSizeValue(value.memoryOffset);
@@ -3531,26 +3531,26 @@ void encode_struct(ParameterEncoder* encoder, const VkBindAccelerationStructureM
     encoder->EncodeUInt32Array(value.pDeviceIndices, value.deviceIndexCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkWriteDescriptorSetAccelerationStructureNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSetAccelerationStructureNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.accelerationStructureCount);
     encoder->EncodeHandleIdArray(value.pAccelerationStructures, value.accelerationStructureCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkAccelerationStructureMemoryRequirementsInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureMemoryRequirementsInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.type);
     encoder->EncodeHandleIdValue(value.accelerationStructure);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceRayTracingPropertiesNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceRayTracingPropertiesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.shaderGroupHandleSize);
     encoder->EncodeUInt32Value(value.maxRecursionDepth);
     encoder->EncodeUInt32Value(value.maxShaderGroupStride);
@@ -3561,60 +3561,60 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceRayTracingPr
     encoder->EncodeUInt32Value(value.maxDescriptorSetAccelerationStructures);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.representativeFragmentTest);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineRepresentativeFragmentTestStateCreateInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRepresentativeFragmentTestStateCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.representativeFragmentTestEnable);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDeviceQueueGlobalPriorityCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceQueueGlobalPriorityCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.globalPriority);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImportMemoryHostPointerInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImportMemoryHostPointerInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.handleType);
     encoder->EncodeVoidPtr(value.pHostPointer);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMemoryHostPointerPropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryHostPointerPropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.memoryTypeBits);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalMemoryHostPropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalMemoryHostPropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkDeviceSizeValue(value.minImportedHostPointerAlignment);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkCalibratedTimestampInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkCalibratedTimestampInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.timeDomain);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderCorePropertiesAMD& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderCorePropertiesAMD& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.shaderEngineCount);
     encoder->EncodeUInt32Value(value.shaderArraysPerEngineCount);
     encoder->EncodeUInt32Value(value.computeUnitsPerShaderArray);
@@ -3631,62 +3631,62 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderCorePr
     encoder->EncodeUInt32Value(value.vgprAllocationGranularity);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDeviceMemoryOverallocationCreateInfoAMD& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceMemoryOverallocationCreateInfoAMD& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.overallocationBehavior);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.maxVertexAttribDivisor);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkVertexInputBindingDivisorDescriptionEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkVertexInputBindingDivisorDescriptionEXT& value)
 {
     encoder->EncodeUInt32Value(value.binding);
     encoder->EncodeUInt32Value(value.divisor);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineVertexInputDivisorStateCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineVertexInputDivisorStateCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.vertexBindingDivisorCount);
-    encode_struct_array(encoder, value.pVertexBindingDivisors, value.vertexBindingDivisorCount);
+    EncodeStructArray(encoder, value.pVertexBindingDivisors, value.vertexBindingDivisorCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.vertexAttributeInstanceRateDivisor);
     encoder->EncodeVkBool32Value(value.vertexAttributeInstanceRateZeroDivisor);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceComputeShaderDerivativesFeaturesNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceComputeShaderDerivativesFeaturesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.computeDerivativeGroupQuads);
     encoder->EncodeVkBool32Value(value.computeDerivativeGroupLinear);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMeshShaderFeaturesNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMeshShaderFeaturesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.taskShader);
     encoder->EncodeVkBool32Value(value.meshShader);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMeshShaderPropertiesNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMeshShaderPropertiesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.maxDrawMeshTasksCount);
     encoder->EncodeUInt32Value(value.maxTaskWorkGroupInvocations);
     encoder->EncodeUInt32Array(value.maxTaskWorkGroupSize, 3);
@@ -3702,162 +3702,162 @@ void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMeshShaderPr
     encoder->EncodeUInt32Value(value.meshOutputPerPrimitiveGranularity);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkDrawMeshTasksIndirectCommandNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkDrawMeshTasksIndirectCommandNV& value)
 {
     encoder->EncodeUInt32Value(value.taskCount);
     encoder->EncodeUInt32Value(value.firstTask);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.fragmentShaderBarycentric);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderImageFootprintFeaturesNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderImageFootprintFeaturesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.imageFootprint);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPipelineViewportExclusiveScissorStateCreateInfoNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineViewportExclusiveScissorStateCreateInfoNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.exclusiveScissorCount);
-    encode_struct_array(encoder, value.pExclusiveScissors, value.exclusiveScissorCount);
+    EncodeStructArray(encoder, value.pExclusiveScissors, value.exclusiveScissorCount);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceExclusiveScissorFeaturesNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceExclusiveScissorFeaturesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.exclusiveScissor);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkQueueFamilyCheckpointPropertiesNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkQueueFamilyCheckpointPropertiesNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.checkpointExecutionStageMask);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkCheckpointDataNV& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkCheckpointDataNV& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.stage);
     encoder->EncodeVoidPtr(value.pCheckpointMarker);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDevicePCIBusInfoPropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDevicePCIBusInfoPropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.pciDomain);
     encoder->EncodeUInt32Value(value.pciBus);
     encoder->EncodeUInt32Value(value.pciDevice);
     encoder->EncodeUInt32Value(value.pciFunction);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImagePipeSurfaceCreateInfoFUCHSIA& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImagePipeSurfaceCreateInfoFUCHSIA& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.imagePipeHandle);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentDensityMapFeaturesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentDensityMapFeaturesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.fragmentDensityMap);
     encoder->EncodeVkBool32Value(value.fragmentDensityMapDynamic);
     encoder->EncodeVkBool32Value(value.fragmentDensityMapNonSubsampledImages);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentDensityMapPropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentDensityMapPropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.minFragmentDensityTexelSize);
-    encode_struct(encoder, value.maxFragmentDensityTexelSize);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.minFragmentDensityTexelSize);
+    EncodeStruct(encoder, value.maxFragmentDensityTexelSize);
     encoder->EncodeVkBool32Value(value.fragmentDensityInvocations);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkRenderPassFragmentDensityMapCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassFragmentDensityMapCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
-    encode_struct(encoder, value.fragmentDensityMapAttachment);
+    EncodePNextStruct(encoder, value.pNext);
+    EncodeStruct(encoder, value.fragmentDensityMapAttachment);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceScalarBlockLayoutFeaturesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceScalarBlockLayoutFeaturesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.scalarBlockLayout);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryBudgetPropertiesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryBudgetPropertiesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkDeviceSizeArray(value.heapBudget, VK_MAX_MEMORY_HEAPS);
     encoder->EncodeVkDeviceSizeArray(value.heapUsage, VK_MAX_MEMORY_HEAPS);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryPriorityFeaturesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryPriorityFeaturesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.memoryPriority);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkMemoryPriorityAllocateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryPriorityAllocateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFloatValue(value.priority);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceBufferAddressFeaturesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceBufferAddressFeaturesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.bufferDeviceAddress);
     encoder->EncodeVkBool32Value(value.bufferDeviceAddressCaptureReplay);
     encoder->EncodeVkBool32Value(value.bufferDeviceAddressMultiDevice);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkBufferDeviceAddressInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkBufferDeviceAddressInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeHandleIdValue(value.buffer);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkBufferDeviceAddressCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkBufferDeviceAddressCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkDeviceSizeValue(value.deviceAddress);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkImageStencilUsageCreateInfoEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkImageStencilUsageCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.stencilUsage);
 }
 
-void encode_struct(ParameterEncoder* encoder, const VkValidationFeaturesEXT& value)
+void EncodeStruct(ParameterEncoder* encoder, const VkValidationFeaturesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
-    encode_pnext_struct(encoder, value.pNext);
+    EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeUInt32Value(value.enabledValidationFeatureCount);
     encoder->EncodeEnumArray(value.pEnabledValidationFeatures, value.enabledValidationFeatureCount);
     encoder->EncodeUInt32Value(value.disabledValidationFeatureCount);

--- a/framework/generated/generated_vulkan_struct_encoders.h
+++ b/framework/generated/generated_vulkan_struct_encoders.h
@@ -34,509 +34,509 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-void encode_pnext_struct(ParameterEncoder* encoder, const void* value);
-
-void encode_struct(ParameterEncoder* encoder, const VkApplicationInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkInstanceCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkAllocationCallbacks& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceFeatures& value);
-void encode_struct(ParameterEncoder* encoder, const VkFormatProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkExtent3D& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageFormatProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceLimits& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSparseProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkQueueFamilyProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkMemoryType& value);
-void encode_struct(ParameterEncoder* encoder, const VkMemoryHeap& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkDeviceQueueCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkDeviceCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkExtensionProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkLayerProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkSubmitInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkMemoryAllocateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkMappedMemoryRange& value);
-void encode_struct(ParameterEncoder* encoder, const VkMemoryRequirements& value);
-void encode_struct(ParameterEncoder* encoder, const VkSparseImageFormatProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkSparseImageMemoryRequirements& value);
-void encode_struct(ParameterEncoder* encoder, const VkSparseMemoryBind& value);
-void encode_struct(ParameterEncoder* encoder, const VkSparseBufferMemoryBindInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkSparseImageOpaqueMemoryBindInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageSubresource& value);
-void encode_struct(ParameterEncoder* encoder, const VkOffset3D& value);
-void encode_struct(ParameterEncoder* encoder, const VkSparseImageMemoryBind& value);
-void encode_struct(ParameterEncoder* encoder, const VkSparseImageMemoryBindInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkBindSparseInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkFenceCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkSemaphoreCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkEventCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkQueryPoolCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkBufferCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkBufferViewCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkSubresourceLayout& value);
-void encode_struct(ParameterEncoder* encoder, const VkComponentMapping& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageSubresourceRange& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageViewCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkShaderModuleCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineCacheCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkSpecializationMapEntry& value);
-void encode_struct(ParameterEncoder* encoder, const VkSpecializationInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineShaderStageCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkVertexInputBindingDescription& value);
-void encode_struct(ParameterEncoder* encoder, const VkVertexInputAttributeDescription& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineVertexInputStateCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineInputAssemblyStateCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineTessellationStateCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkViewport& value);
-void encode_struct(ParameterEncoder* encoder, const VkOffset2D& value);
-void encode_struct(ParameterEncoder* encoder, const VkExtent2D& value);
-void encode_struct(ParameterEncoder* encoder, const VkRect2D& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineViewportStateCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineRasterizationStateCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineMultisampleStateCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkStencilOpState& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineDepthStencilStateCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineColorBlendAttachmentState& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineColorBlendStateCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineDynamicStateCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkGraphicsPipelineCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkComputePipelineCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkPushConstantRange& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineLayoutCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkSamplerCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorSetLayoutBinding& value);
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorSetLayoutCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorPoolSize& value);
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorPoolCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorSetAllocateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorImageInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorBufferInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkWriteDescriptorSet& value);
-void encode_struct(ParameterEncoder* encoder, const VkCopyDescriptorSet& value);
-void encode_struct(ParameterEncoder* encoder, const VkFramebufferCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkAttachmentDescription& value);
-void encode_struct(ParameterEncoder* encoder, const VkAttachmentReference& value);
-void encode_struct(ParameterEncoder* encoder, const VkSubpassDescription& value);
-void encode_struct(ParameterEncoder* encoder, const VkSubpassDependency& value);
-void encode_struct(ParameterEncoder* encoder, const VkRenderPassCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkCommandPoolCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkCommandBufferAllocateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkCommandBufferInheritanceInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkCommandBufferBeginInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkBufferCopy& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageSubresourceLayers& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageCopy& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageBlit& value);
-void encode_struct(ParameterEncoder* encoder, const VkBufferImageCopy& value);
-void encode_struct(ParameterEncoder* encoder, const VkClearDepthStencilValue& value);
-void encode_struct(ParameterEncoder* encoder, const VkClearAttachment& value);
-void encode_struct(ParameterEncoder* encoder, const VkClearRect& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageResolve& value);
-void encode_struct(ParameterEncoder* encoder, const VkMemoryBarrier& value);
-void encode_struct(ParameterEncoder* encoder, const VkBufferMemoryBarrier& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageMemoryBarrier& value);
-void encode_struct(ParameterEncoder* encoder, const VkRenderPassBeginInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkDispatchIndirectCommand& value);
-void encode_struct(ParameterEncoder* encoder, const VkDrawIndexedIndirectCommand& value);
-void encode_struct(ParameterEncoder* encoder, const VkDrawIndirectCommand& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSubgroupProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkBindBufferMemoryInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkBindImageMemoryInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDevice16BitStorageFeatures& value);
-void encode_struct(ParameterEncoder* encoder, const VkMemoryDedicatedRequirements& value);
-void encode_struct(ParameterEncoder* encoder, const VkMemoryDedicatedAllocateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkMemoryAllocateFlagsInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupRenderPassBeginInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupCommandBufferBeginInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupSubmitInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupBindSparseInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkBindBufferMemoryDeviceGroupInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkBindImageMemoryDeviceGroupInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceGroupProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupDeviceCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkBufferMemoryRequirementsInfo2& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageMemoryRequirementsInfo2& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageSparseMemoryRequirementsInfo2& value);
-void encode_struct(ParameterEncoder* encoder, const VkMemoryRequirements2& value);
-void encode_struct(ParameterEncoder* encoder, const VkSparseImageMemoryRequirements2& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceFeatures2& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceProperties2& value);
-void encode_struct(ParameterEncoder* encoder, const VkFormatProperties2& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageFormatProperties2& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceImageFormatInfo2& value);
-void encode_struct(ParameterEncoder* encoder, const VkQueueFamilyProperties2& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryProperties2& value);
-void encode_struct(ParameterEncoder* encoder, const VkSparseImageFormatProperties2& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSparseImageFormatInfo2& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDevicePointClippingProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkInputAttachmentAspectReference& value);
-void encode_struct(ParameterEncoder* encoder, const VkRenderPassInputAttachmentAspectCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageViewUsageCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineTessellationDomainOriginStateCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkRenderPassMultiviewCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMultiviewFeatures& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMultiviewProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceVariablePointerFeatures& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceProtectedMemoryFeatures& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceProtectedMemoryProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkDeviceQueueInfo2& value);
-void encode_struct(ParameterEncoder* encoder, const VkProtectedSubmitInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkSamplerYcbcrConversionCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkSamplerYcbcrConversionInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkBindImagePlaneMemoryInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkImagePlaneMemoryRequirementsInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSamplerYcbcrConversionFeatures& value);
-void encode_struct(ParameterEncoder* encoder, const VkSamplerYcbcrConversionImageFormatProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorUpdateTemplateEntry& value);
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorUpdateTemplateCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkExternalMemoryProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalImageFormatInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkExternalImageFormatProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalBufferInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkExternalBufferProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceIDProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkExternalMemoryImageCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkExternalMemoryBufferCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkExportMemoryAllocateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalFenceInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkExternalFenceProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkExportFenceCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkExportSemaphoreCreateInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalSemaphoreInfo& value);
-void encode_struct(ParameterEncoder* encoder, const VkExternalSemaphoreProperties& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMaintenance3Properties& value);
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorSetLayoutSupport& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderDrawParameterFeatures& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkSurfaceCapabilitiesKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkSurfaceFormatKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkSwapchainCreateInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkPresentInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageSwapchainCreateInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkBindImageMemorySwapchainInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkAcquireNextImageInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupPresentCapabilitiesKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupPresentInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGroupSwapchainCreateInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkDisplayPropertiesKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkDisplayModeParametersKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkDisplayModePropertiesKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkDisplayModeCreateInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkDisplayPlaneCapabilitiesKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkDisplayPlanePropertiesKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkDisplaySurfaceCreateInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkDisplayPresentInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkXlibSurfaceCreateInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkXcbSurfaceCreateInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkWaylandSurfaceCreateInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkAndroidSurfaceCreateInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkWin32SurfaceCreateInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkImportMemoryWin32HandleInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkExportMemoryWin32HandleInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkMemoryWin32HandlePropertiesKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkMemoryGetWin32HandleInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkImportMemoryFdInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkMemoryFdPropertiesKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkMemoryGetFdInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireReleaseInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkImportSemaphoreWin32HandleInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkExportSemaphoreWin32HandleInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkD3D12FenceSubmitInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkSemaphoreGetWin32HandleInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkImportSemaphoreFdInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkSemaphoreGetFdInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDevicePushDescriptorPropertiesKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceFloat16Int8FeaturesKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkRectLayerKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkPresentRegionKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkPresentRegionsKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkAttachmentDescription2KHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkAttachmentReference2KHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkSubpassDescription2KHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkSubpassDependency2KHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkRenderPassCreateInfo2KHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkSubpassBeginInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkSubpassEndInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkSharedPresentSurfaceCapabilitiesKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkImportFenceWin32HandleInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkExportFenceWin32HandleInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkFenceGetWin32HandleInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkImportFenceFdInfoKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkFenceGetFdInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSurfaceInfo2KHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkSurfaceCapabilities2KHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkSurfaceFormat2KHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkDisplayProperties2KHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkDisplayPlaneProperties2KHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkDisplayModeProperties2KHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkDisplayPlaneInfo2KHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkDisplayPlaneCapabilities2KHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkImageFormatListCreateInfoKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDevice8BitStorageFeaturesKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderAtomicInt64FeaturesKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkConformanceVersionKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceDriverPropertiesKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceFloatControlsPropertiesKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkSubpassDescriptionDepthStencilResolveKHR& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceDepthStencilResolvePropertiesKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkDebugReportCallbackCreateInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPipelineRasterizationStateRasterizationOrderAMD& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkDebugMarkerObjectNameInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkDebugMarkerObjectTagInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkDebugMarkerMarkerInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkDedicatedAllocationImageCreateInfoNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkDedicatedAllocationBufferCreateInfoNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkDedicatedAllocationMemoryAllocateInfoNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceTransformFeedbackFeaturesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceTransformFeedbackPropertiesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineRasterizationStateStreamCreateInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkTextureLODGatherFormatPropertiesAMD& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkShaderResourceUsageAMD& value);
-void encode_struct(ParameterEncoder* encoder, const VkShaderStatisticsInfoAMD& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceCornerSampledImageFeaturesNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkExternalImageFormatPropertiesNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkExternalMemoryImageCreateInfoNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkExportMemoryAllocateInfoNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkImportMemoryWin32HandleInfoNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkExportMemoryWin32HandleInfoNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireReleaseInfoNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkValidationFlagsEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkViSurfaceCreateInfoNN& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkImageViewASTCDecodeModeEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceASTCDecodeFeaturesEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkConditionalRenderingBeginInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceConditionalRenderingFeaturesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkCommandBufferInheritanceConditionalRenderingInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGeneratedCommandsFeaturesNVX& value);
-void encode_struct(ParameterEncoder* encoder, const VkDeviceGeneratedCommandsLimitsNVX& value);
-void encode_struct(ParameterEncoder* encoder, const VkIndirectCommandsTokenNVX& value);
-void encode_struct(ParameterEncoder* encoder, const VkIndirectCommandsLayoutTokenNVX& value);
-void encode_struct(ParameterEncoder* encoder, const VkIndirectCommandsLayoutCreateInfoNVX& value);
-void encode_struct(ParameterEncoder* encoder, const VkCmdProcessCommandsInfoNVX& value);
-void encode_struct(ParameterEncoder* encoder, const VkCmdReserveSpaceForCommandsInfoNVX& value);
-void encode_struct(ParameterEncoder* encoder, const VkObjectTableCreateInfoNVX& value);
-void encode_struct(ParameterEncoder* encoder, const VkObjectTablePipelineEntryNVX& value);
-void encode_struct(ParameterEncoder* encoder, const VkObjectTableDescriptorSetEntryNVX& value);
-void encode_struct(ParameterEncoder* encoder, const VkObjectTableVertexBufferEntryNVX& value);
-void encode_struct(ParameterEncoder* encoder, const VkObjectTableIndexBufferEntryNVX& value);
-void encode_struct(ParameterEncoder* encoder, const VkObjectTablePushConstantEntryNVX& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkViewportWScalingNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineViewportWScalingStateCreateInfoNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkSurfaceCapabilities2EXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkDisplayPowerInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkDeviceEventInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkDisplayEventInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkSwapchainCounterCreateInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkRefreshCycleDurationGOOGLE& value);
-void encode_struct(ParameterEncoder* encoder, const VkPastPresentationTimingGOOGLE& value);
-void encode_struct(ParameterEncoder* encoder, const VkPresentTimeGOOGLE& value);
-void encode_struct(ParameterEncoder* encoder, const VkPresentTimesInfoGOOGLE& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkViewportSwizzleNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineViewportSwizzleStateCreateInfoNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceDiscardRectanglePropertiesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineDiscardRectangleStateCreateInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceConservativeRasterizationPropertiesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineRasterizationConservativeStateCreateInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkXYColorEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkHdrMetadataEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkIOSSurfaceCreateInfoMVK& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkMacOSSurfaceCreateInfoMVK& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsObjectNameInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsObjectTagInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsLabelEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsMessengerCallbackDataEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkDebugUtilsMessengerCreateInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkAndroidHardwareBufferUsageANDROID& value);
-void encode_struct(ParameterEncoder* encoder, const VkAndroidHardwareBufferPropertiesANDROID& value);
-void encode_struct(ParameterEncoder* encoder, const VkAndroidHardwareBufferFormatPropertiesANDROID& value);
-void encode_struct(ParameterEncoder* encoder, const VkImportAndroidHardwareBufferInfoANDROID& value);
-void encode_struct(ParameterEncoder* encoder, const VkMemoryGetAndroidHardwareBufferInfoANDROID& value);
-void encode_struct(ParameterEncoder* encoder, const VkExternalFormatANDROID& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkSamplerReductionModeCreateInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceInlineUniformBlockFeaturesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceInlineUniformBlockPropertiesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkWriteDescriptorSetInlineUniformBlockEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorPoolInlineUniformBlockCreateInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkSampleLocationEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkSampleLocationsInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkAttachmentSampleLocationsEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkSubpassSampleLocationsEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkRenderPassSampleLocationsBeginInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineSampleLocationsStateCreateInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceSampleLocationsPropertiesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkMultisamplePropertiesEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineColorBlendAdvancedStateCreateInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPipelineCoverageToColorStateCreateInfoNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPipelineCoverageModulationStateCreateInfoNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkDrmFormatModifierPropertiesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkDrmFormatModifierPropertiesListEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceImageDrmFormatModifierInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageDrmFormatModifierListCreateInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageDrmFormatModifierExplicitCreateInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkImageDrmFormatModifierPropertiesEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkValidationCacheCreateInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkShaderModuleValidationCacheCreateInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorSetLayoutBindingFlagsCreateInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceDescriptorIndexingFeaturesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceDescriptorIndexingPropertiesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorSetVariableDescriptorCountAllocateInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkDescriptorSetVariableDescriptorCountLayoutSupportEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkShadingRatePaletteNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineViewportShadingRateImageStateCreateInfoNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceShadingRateImageFeaturesNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceShadingRateImagePropertiesNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkCoarseSampleLocationNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkCoarseSampleOrderCustomNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineViewportCoarseSampleOrderStateCreateInfoNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkRayTracingShaderGroupCreateInfoNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkRayTracingPipelineCreateInfoNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkGeometryTrianglesNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkGeometryAABBNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkGeometryDataNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkGeometryNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkAccelerationStructureInfoNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkAccelerationStructureCreateInfoNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkBindAccelerationStructureMemoryInfoNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkWriteDescriptorSetAccelerationStructureNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkAccelerationStructureMemoryRequirementsInfoNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceRayTracingPropertiesNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineRepresentativeFragmentTestStateCreateInfoNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkDeviceQueueGlobalPriorityCreateInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkImportMemoryHostPointerInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkMemoryHostPointerPropertiesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalMemoryHostPropertiesEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkCalibratedTimestampInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderCorePropertiesAMD& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkDeviceMemoryOverallocationCreateInfoAMD& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkVertexInputBindingDivisorDescriptionEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPipelineVertexInputDivisorStateCreateInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceComputeShaderDerivativesFeaturesNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMeshShaderFeaturesNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMeshShaderPropertiesNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkDrawMeshTasksIndirectCommandNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderImageFootprintFeaturesNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPipelineViewportExclusiveScissorStateCreateInfoNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceExclusiveScissorFeaturesNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkQueueFamilyCheckpointPropertiesNV& value);
-void encode_struct(ParameterEncoder* encoder, const VkCheckpointDataNV& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDevicePCIBusInfoPropertiesEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkImagePipeSurfaceCreateInfoFUCHSIA& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentDensityMapFeaturesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentDensityMapPropertiesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkRenderPassFragmentDensityMapCreateInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceScalarBlockLayoutFeaturesEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryBudgetPropertiesEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryPriorityFeaturesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkMemoryPriorityAllocateInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkPhysicalDeviceBufferAddressFeaturesEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkBufferDeviceAddressInfoEXT& value);
-void encode_struct(ParameterEncoder* encoder, const VkBufferDeviceAddressCreateInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkImageStencilUsageCreateInfoEXT& value);
-
-void encode_struct(ParameterEncoder* encoder, const VkValidationFeaturesEXT& value);
+void EncodePNextStruct(ParameterEncoder* encoder, const void* value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkApplicationInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkInstanceCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkAllocationCallbacks& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFeatures& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkFormatProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExtent3D& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageFormatProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceLimits& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSparseProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkQueueFamilyProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryType& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryHeap& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceQueueCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExtensionProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkLayerProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSubmitInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryAllocateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMappedMemoryRange& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryRequirements& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageFormatProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageMemoryRequirements& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseMemoryBind& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseBufferMemoryBindInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageOpaqueMemoryBindInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageSubresource& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkOffset3D& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageMemoryBind& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageMemoryBindInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkBindSparseInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkFenceCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkEventCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkQueryPoolCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkBufferCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkBufferViewCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSubresourceLayout& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkComponentMapping& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageSubresourceRange& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageViewCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkShaderModuleCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineCacheCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSpecializationMapEntry& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSpecializationInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineShaderStageCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkVertexInputBindingDescription& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkVertexInputAttributeDescription& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineVertexInputStateCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineInputAssemblyStateCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineTessellationStateCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkViewport& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkOffset2D& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExtent2D& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkRect2D& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineViewportStateCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRasterizationStateCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineMultisampleStateCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkStencilOpState& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineDepthStencilStateCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineColorBlendAttachmentState& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineColorBlendStateCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineDynamicStateCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkGraphicsPipelineCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkComputePipelineCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPushConstantRange& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineLayoutCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSamplerCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetLayoutBinding& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetLayoutCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorPoolSize& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorPoolCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetAllocateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorImageInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorBufferInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSet& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkCopyDescriptorSet& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkFramebufferCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkAttachmentDescription& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkAttachmentReference& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSubpassDescription& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSubpassDependency& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkCommandPoolCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkCommandBufferAllocateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkCommandBufferInheritanceInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkCommandBufferBeginInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkBufferCopy& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageSubresourceLayers& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageCopy& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageBlit& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkBufferImageCopy& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkClearDepthStencilValue& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkClearAttachment& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkClearRect& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageResolve& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryBarrier& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkBufferMemoryBarrier& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageMemoryBarrier& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassBeginInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDispatchIndirectCommand& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDrawIndexedIndirectCommand& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDrawIndirectCommand& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSubgroupProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkBindBufferMemoryInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkBindImageMemoryInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDevice16BitStorageFeatures& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryDedicatedRequirements& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryDedicatedAllocateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryAllocateFlagsInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupRenderPassBeginInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupCommandBufferBeginInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupSubmitInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupBindSparseInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkBindBufferMemoryDeviceGroupInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkBindImageMemoryDeviceGroupInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceGroupProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupDeviceCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkBufferMemoryRequirementsInfo2& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageMemoryRequirementsInfo2& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageSparseMemoryRequirementsInfo2& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryRequirements2& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageMemoryRequirements2& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFeatures2& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceProperties2& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkFormatProperties2& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageFormatProperties2& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceImageFormatInfo2& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkQueueFamilyProperties2& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryProperties2& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSparseImageFormatProperties2& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSparseImageFormatInfo2& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDevicePointClippingProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkInputAttachmentAspectReference& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassInputAttachmentAspectCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageViewUsageCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineTessellationDomainOriginStateCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassMultiviewCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMultiviewFeatures& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMultiviewProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceVariablePointerFeatures& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceProtectedMemoryFeatures& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceProtectedMemoryProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceQueueInfo2& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkProtectedSubmitInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSamplerYcbcrConversionCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSamplerYcbcrConversionInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkBindImagePlaneMemoryInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImagePlaneMemoryRequirementsInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSamplerYcbcrConversionFeatures& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSamplerYcbcrConversionImageFormatProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorUpdateTemplateEntry& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorUpdateTemplateCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalMemoryProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalImageFormatInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalImageFormatProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalBufferInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalBufferProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceIDProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalMemoryImageCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalMemoryBufferCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExportMemoryAllocateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalFenceInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalFenceProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExportFenceCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExportSemaphoreCreateInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalSemaphoreInfo& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalSemaphoreProperties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMaintenance3Properties& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetLayoutSupport& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderDrawParameterFeatures& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkSurfaceCapabilitiesKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSurfaceFormatKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkSwapchainCreateInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPresentInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageSwapchainCreateInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkBindImageMemorySwapchainInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkAcquireNextImageInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupPresentCapabilitiesKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupPresentInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGroupSwapchainCreateInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPropertiesKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayModeParametersKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayModePropertiesKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayModeCreateInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlaneCapabilitiesKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlanePropertiesKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplaySurfaceCreateInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPresentInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkXlibSurfaceCreateInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkXcbSurfaceCreateInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkWaylandSurfaceCreateInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkAndroidSurfaceCreateInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkWin32SurfaceCreateInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkImportMemoryWin32HandleInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExportMemoryWin32HandleInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryWin32HandlePropertiesKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetWin32HandleInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkImportMemoryFdInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryFdPropertiesKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetFdInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireReleaseInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkImportSemaphoreWin32HandleInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExportSemaphoreWin32HandleInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkD3D12FenceSubmitInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreGetWin32HandleInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkImportSemaphoreFdInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSemaphoreGetFdInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDevicePushDescriptorPropertiesKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFloat16Int8FeaturesKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkRectLayerKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPresentRegionKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPresentRegionsKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkAttachmentDescription2KHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkAttachmentReference2KHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSubpassDescription2KHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSubpassDependency2KHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassCreateInfo2KHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSubpassBeginInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSubpassEndInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkSharedPresentSurfaceCapabilitiesKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkImportFenceWin32HandleInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExportFenceWin32HandleInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkFenceGetWin32HandleInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkImportFenceFdInfoKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkFenceGetFdInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSurfaceInfo2KHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSurfaceCapabilities2KHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSurfaceFormat2KHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayProperties2KHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlaneProperties2KHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayModeProperties2KHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlaneInfo2KHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPlaneCapabilities2KHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkImageFormatListCreateInfoKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDevice8BitStorageFeaturesKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderAtomicInt64FeaturesKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkConformanceVersionKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDriverPropertiesKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFloatControlsPropertiesKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkSubpassDescriptionDepthStencilResolveKHR& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDepthStencilResolvePropertiesKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceVulkanMemoryModelFeaturesKHR& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugReportCallbackCreateInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRasterizationStateRasterizationOrderAMD& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugMarkerObjectNameInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugMarkerObjectTagInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugMarkerMarkerInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkDedicatedAllocationImageCreateInfoNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDedicatedAllocationBufferCreateInfoNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDedicatedAllocationMemoryAllocateInfoNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceTransformFeedbackFeaturesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceTransformFeedbackPropertiesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRasterizationStateStreamCreateInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkTextureLODGatherFormatPropertiesAMD& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkShaderResourceUsageAMD& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkShaderStatisticsInfoAMD& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceCornerSampledImageFeaturesNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalImageFormatPropertiesNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalMemoryImageCreateInfoNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExportMemoryAllocateInfoNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkImportMemoryWin32HandleInfoNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExportMemoryWin32HandleInfoNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkWin32KeyedMutexAcquireReleaseInfoNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkValidationFlagsEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkViSurfaceCreateInfoNN& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkImageViewASTCDecodeModeEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceASTCDecodeFeaturesEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkConditionalRenderingBeginInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceConditionalRenderingFeaturesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkCommandBufferInheritanceConditionalRenderingInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGeneratedCommandsFeaturesNVX& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceGeneratedCommandsLimitsNVX& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkIndirectCommandsTokenNVX& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkIndirectCommandsLayoutTokenNVX& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkIndirectCommandsLayoutCreateInfoNVX& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkCmdProcessCommandsInfoNVX& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkCmdReserveSpaceForCommandsInfoNVX& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkObjectTableCreateInfoNVX& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkObjectTablePipelineEntryNVX& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkObjectTableDescriptorSetEntryNVX& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkObjectTableVertexBufferEntryNVX& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkObjectTableIndexBufferEntryNVX& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkObjectTablePushConstantEntryNVX& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkViewportWScalingNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineViewportWScalingStateCreateInfoNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkSurfaceCapabilities2EXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayPowerInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceEventInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDisplayEventInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSwapchainCounterCreateInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkRefreshCycleDurationGOOGLE& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPastPresentationTimingGOOGLE& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPresentTimeGOOGLE& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPresentTimesInfoGOOGLE& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkViewportSwizzleNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineViewportSwizzleStateCreateInfoNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDiscardRectanglePropertiesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineDiscardRectangleStateCreateInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceConservativeRasterizationPropertiesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRasterizationConservativeStateCreateInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkXYColorEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkHdrMetadataEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkIOSSurfaceCreateInfoMVK& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkMacOSSurfaceCreateInfoMVK& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsObjectNameInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsObjectTagInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsLabelEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsMessengerCallbackDataEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsMessengerCreateInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkAndroidHardwareBufferUsageANDROID& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkAndroidHardwareBufferPropertiesANDROID& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkAndroidHardwareBufferFormatPropertiesANDROID& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImportAndroidHardwareBufferInfoANDROID& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryGetAndroidHardwareBufferInfoANDROID& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkExternalFormatANDROID& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkSamplerReductionModeCreateInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceInlineUniformBlockFeaturesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceInlineUniformBlockPropertiesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSetInlineUniformBlockEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorPoolInlineUniformBlockCreateInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkSampleLocationEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSampleLocationsInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkAttachmentSampleLocationsEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkSubpassSampleLocationsEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassSampleLocationsBeginInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineSampleLocationsStateCreateInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceSampleLocationsPropertiesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMultisamplePropertiesEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineColorBlendAdvancedStateCreateInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineCoverageToColorStateCreateInfoNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineCoverageModulationStateCreateInfoNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkDrmFormatModifierPropertiesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDrmFormatModifierPropertiesListEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceImageDrmFormatModifierInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageDrmFormatModifierListCreateInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageDrmFormatModifierExplicitCreateInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkImageDrmFormatModifierPropertiesEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkValidationCacheCreateInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkShaderModuleValidationCacheCreateInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetLayoutBindingFlagsCreateInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDescriptorIndexingFeaturesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDescriptorIndexingPropertiesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetVariableDescriptorCountAllocateInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDescriptorSetVariableDescriptorCountLayoutSupportEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkShadingRatePaletteNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineViewportShadingRateImageStateCreateInfoNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceShadingRateImageFeaturesNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceShadingRateImagePropertiesNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkCoarseSampleLocationNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkCoarseSampleOrderCustomNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineViewportCoarseSampleOrderStateCreateInfoNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkRayTracingShaderGroupCreateInfoNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkRayTracingPipelineCreateInfoNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkGeometryTrianglesNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkGeometryAABBNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkGeometryDataNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkGeometryNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureInfoNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureCreateInfoNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkBindAccelerationStructureMemoryInfoNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkWriteDescriptorSetAccelerationStructureNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureMemoryRequirementsInfoNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceRayTracingPropertiesNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRepresentativeFragmentTestStateCreateInfoNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceQueueGlobalPriorityCreateInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkImportMemoryHostPointerInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryHostPointerPropertiesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceExternalMemoryHostPropertiesEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkCalibratedTimestampInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderCorePropertiesAMD& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkDeviceMemoryOverallocationCreateInfoAMD& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkVertexInputBindingDivisorDescriptionEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineVertexInputDivisorStateCreateInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceComputeShaderDerivativesFeaturesNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMeshShaderFeaturesNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMeshShaderPropertiesNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkDrawMeshTasksIndirectCommandNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceShaderImageFootprintFeaturesNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineViewportExclusiveScissorStateCreateInfoNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceExclusiveScissorFeaturesNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkQueueFamilyCheckpointPropertiesNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkCheckpointDataNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDevicePCIBusInfoPropertiesEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkImagePipeSurfaceCreateInfoFUCHSIA& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentDensityMapFeaturesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentDensityMapPropertiesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassFragmentDensityMapCreateInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceScalarBlockLayoutFeaturesEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryBudgetPropertiesEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryPriorityFeaturesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkMemoryPriorityAllocateInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceBufferAddressFeaturesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkBufferDeviceAddressInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkBufferDeviceAddressCreateInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkImageStencilUsageCreateInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkValidationFeaturesEXT& value);
 
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -704,7 +704,7 @@ class BaseGenerator(OutputGenerator):
         if self.isStruct(typeName):
             args = ['encoder'] + args
             isStruct = True
-            methodCall = 'encode_struct'
+            methodCall = 'EncodeStruct'
         else:
             if typeName in ['String', 'WString']:
                 isString = True
@@ -721,10 +721,7 @@ class BaseGenerator(OutputGenerator):
                 lengthName = self.parseLateXMath(value.arrayLength)
                 lengthExpr = value.altArrayLength
 
-            if isStruct:
-                methodCall += '_array'
-            else:
-                methodCall += 'Array'
+            methodCall += 'Array'
 
             # Build a list of parameter names and search for the array length value.
             lengthValue = None
@@ -744,7 +741,7 @@ class BaseGenerator(OutputGenerator):
                 args.append(lengthExpr)     # Length is a constant value, not a parameter
         elif isStruct:
             if value.isPointer:
-                methodCall += '_ptr'
+                methodCall += 'Ptr'
         elif not (isString or isFuncp):
             # Ignore string and function names, which do not use the Ptr/Value suffix
             if value.isPointer:

--- a/framework/generated/vulkan_generators/decode_pnext_struct_generator.py
+++ b/framework/generated/vulkan_generators/decode_pnext_struct_generator.py
@@ -62,7 +62,7 @@ class DecodePNextStructGenerator(BaseGenerator):
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)
         self.newline()
-        write('size_t decode_pnext_struct(const uint8_t* parameter_buffer, size_t buffer_size,  std::unique_ptr<PNextNode>* pNext)', file=self.outFile)
+        write('size_t DecodePNextStruct(const uint8_t* parameter_buffer, size_t buffer_size,  std::unique_ptr<PNextNode>* pNext)', file=self.outFile)
         write('{', file=self.outFile)
         write('    assert(pNext != nullptr);', file=self.outFile)
         self.newline()

--- a/framework/generated/vulkan_generators/encode_pnext_struct_generator.py
+++ b/framework/generated/vulkan_generators/encode_pnext_struct_generator.py
@@ -67,7 +67,7 @@ class EncodePNextStructGenerator(BaseGenerator):
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(encode)', file=self.outFile)
         self.newline()
-        write('void encode_pnext_struct(ParameterEncoder* encoder, const void* value)', file=self.outFile)
+        write('void EncodePNextStruct(ParameterEncoder* encoder, const void* value)', file=self.outFile)
         write('{', file=self.outFile)
         write('    assert(encoder != nullptr);', file=self.outFile)
         self.newline()
@@ -130,6 +130,6 @@ class EncodePNextStructGenerator(BaseGenerator):
     def generateFeature(self):
         for struct in self.sTypeValues:
             write('        case {}:'.format(self.sTypeValues[struct]), file=self.outFile)
-            write('            encode_struct_ptr(encoder, reinterpret_cast<const {}*>(value));'.format(struct), file=self.outFile)
+            write('            EncodeStructPtr(encoder, reinterpret_cast<const {}*>(value));'.format(struct), file=self.outFile)
             write('            break;', file=self.outFile)
         self.sTypeValues = dict()

--- a/framework/generated/vulkan_generators/vulkan_decoder_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_decoder_body_generator.py
@@ -189,7 +189,7 @@ class VulkanDecoderBodyGenerator(BaseGenerator):
                     body += '    bytes_read += {}.Decode{}({});\n'.format(value.name, typeName, bufferArgs)
         else:
             if isStruct:
-                body += '    bytes_read += decode_struct({}, &{});\n'.format(bufferArgs, value.name)
+                body += '    bytes_read += DecodeStruct({}, &{});\n'.format(bufferArgs, value.name)
             elif isFuncp:
                 body += '    bytes_read += ValueDecoder::DecodeAddress({}, &{});\n'.format(bufferArgs, value.name)
             else:

--- a/framework/generated/vulkan_generators/vulkan_struct_decoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_decoders_body_generator.py
@@ -55,7 +55,7 @@ class VulkanStructDecodersBodyGenerator(BaseGenerator):
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)
         self.newline()
-        write('size_t decode_pnext_struct(const uint8_t* buffer, size_t buffer_size, std::unique_ptr<PNextNode>* pNext);', file=self.outFile)
+        write('size_t DecodePNextStruct(const uint8_t* buffer, size_t buffer_size, std::unique_ptr<PNextNode>* pNext);', file=self.outFile)
 
     # Method override
     def endFile(self):
@@ -79,7 +79,7 @@ class VulkanStructDecodersBodyGenerator(BaseGenerator):
         first = True
         for struct in self.featureStructMembers:
             body = '' if first else '\n'
-            body += 'size_t decode_struct(const uint8_t* buffer, size_t buffer_size, Decoded_{}* wrapper)\n'.format(struct)
+            body += 'size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_{}* wrapper)\n'.format(struct)
             body += '{\n'
             body += '    assert((wrapper != nullptr) && (wrapper->value != nullptr));\n'
             body += '\n'
@@ -102,7 +102,7 @@ class VulkanStructDecodersBodyGenerator(BaseGenerator):
         for value in values:
             # pNext fields require special treatment and are not processed by type name
             if 'pNext' in value.name:
-                body += '    bytes_read += decode_pnext_struct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->{}));\n'.format(value.name)
+                body += '    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->{}));\n'.format(value.name)
                 body += '    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;\n'
             else:
                 body += self.makeDecodeInvocation(value)
@@ -160,7 +160,7 @@ class VulkanStructDecodersBodyGenerator(BaseGenerator):
         else:
             if isStruct:
                 body += '    wrapper->{name}.value = &(value->{name});\n'.format(name=value.name)
-                body += '    bytes_read += decode_struct({}, &(wrapper->{}));\n'.format(bufferArgs, value.name)
+                body += '    bytes_read += DecodeStruct({}, &(wrapper->{}));\n'.format(bufferArgs, value.name)
             elif isFuncp:
                 body += '    bytes_read += ValueDecoder::DecodeAddress({}, &(wrapper->{}));\n'.format(bufferArgs, value.name)
                 body += '    value->{} = nullptr;\n'.format(value.name)

--- a/framework/generated/vulkan_generators/vulkan_struct_decoders_forward_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_decoders_forward_generator.py
@@ -82,4 +82,4 @@ class VulkanStructDecodersForwardGenerator(BaseGenerator):
         self.newline()
 
         for struct in self.featureStructMembers:
-            write('size_t decode_struct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_{}* wrapper);'.format(struct), file=self.outFile)
+            write('size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_{}* wrapper);'.format(struct), file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_struct_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_encoders_body_generator.py
@@ -82,7 +82,7 @@ class VulkanStructEncodersBodyGenerator(BaseGenerator):
         first = True
         for struct in self.featureStructMembers:
             body = '' if first else '\n'
-            body += 'void encode_struct(ParameterEncoder* encoder, const {}& value)\n'.format(struct)
+            body += 'void EncodeStruct(ParameterEncoder* encoder, const {}& value)\n'.format(struct)
             body += '{\n'
             body += self.makeStructBody(self.featureStructMembers[struct], 'value.')
             body += '}'
@@ -99,7 +99,7 @@ class VulkanStructEncodersBodyGenerator(BaseGenerator):
         for value in values:
             # pNext fields require special treatment and are not processed by typename
             if 'pNext' in value.name:
-                body += '    encode_pnext_struct(encoder, {});\n'.format(prefix + value.name)
+                body += '    EncodePNextStruct(encoder, {});\n'.format(prefix + value.name)
             else:
                 methodCall = self.makeEncoderMethodCall(value, values, prefix)
                 body += '    {};\n'.format(methodCall)

--- a/framework/generated/vulkan_generators/vulkan_struct_encoders_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_encoders_header_generator.py
@@ -59,7 +59,7 @@ class VulkanStructEncodersHeaderGenerator(BaseGenerator):
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(encode)', file=self.outFile)
         self.newline()
-        write('void encode_pnext_struct(ParameterEncoder* encoder, const void* value);', file=self.outFile)
+        write('void EncodePNextStruct(ParameterEncoder* encoder, const void* value);', file=self.outFile)
 
     # Method override
     def endFile(self):
@@ -81,4 +81,4 @@ class VulkanStructEncodersHeaderGenerator(BaseGenerator):
     # Performs C++ code generation for the feature.
     def generateFeature(self):
         for struct in self.featureStructMembers:
-            write('void encode_struct(ParameterEncoder* encoder, const {}& value);'.format(struct), file=self.outFile)
+            write('void EncodeStruct(ParameterEncoder* encoder, const {}& value);'.format(struct), file=self.outFile)

--- a/layer/custom_vulkan_api_call_encoders.cpp
+++ b/layer/custom_vulkan_api_call_encoders.cpp
@@ -67,7 +67,7 @@ static void EncodeDescriptorUpdateTemplateInfo(encode::TraceManager*      manage
             {
                 size_t                       offset = entry_info.offset + (entry_info.stride * i);
                 const VkDescriptorImageInfo* entry  = reinterpret_cast<const VkDescriptorImageInfo*>(bytes + offset);
-                encode_struct(encoder, (*entry));
+                EncodeStruct(encoder, (*entry));
             }
         }
 
@@ -78,7 +78,7 @@ static void EncodeDescriptorUpdateTemplateInfo(encode::TraceManager*      manage
             {
                 size_t                        offset = entry_info.offset + (entry_info.stride * i);
                 const VkDescriptorBufferInfo* entry  = reinterpret_cast<const VkDescriptorBufferInfo*>(bytes + offset);
-                encode_struct(encoder, (*entry));
+                EncodeStruct(encoder, (*entry));
             }
         }
 
@@ -207,7 +207,7 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterObjectsNVX(VkDevice                      
         encoder->EncodeHandleIdValue(device);
         encoder->EncodeHandleIdValue(objectTable);
         encoder->EncodeUInt32Value(objectCount);
-        encode_struct_array(encoder, ppObjectTableEntries, objectCount);
+        EncodeStructArray(encoder, ppObjectTableEntries, objectCount);
         encoder->EncodeUInt32Array(pObjectIndices, objectCount);
         encoder->EncodeEnumValue(result);
         trace_manager->EndApiCallTrace(encoder);


### PR DESCRIPTION
Change the struct encode and decode function names from the
'encode_struct' style to the 'EncodeStruct' style for consistency with
other project function names.