### PR TITLE
compress: Fix print and log statements

### DIFF
--- a/framework/format/format_util.cpp
+++ b/framework/format/format_util.cpp
@@ -45,21 +45,27 @@ util::Compressor* CreateCompressor(CompressionType type)
 
     switch (type)
     {
-#ifdef ENABLE_LZ4_COMPRESSION
         case kLz4:
+#ifdef ENABLE_LZ4_COMPRESSION
             compressor = new util::Lz4Compressor();
-            break;
+#else
+            GFXRECON_LOG_ERROR("Failed to initialize compression module: LZ4 compression is disabled.");
+            assert(false);
 #endif // ENABLE_LZ4_COMPRESSION
-#ifdef ENABLE_ZLIB_COMPRESSION
-        case kZlib:
-            compressor = new util::ZlibCompressor();
             break;
+        case kZlib:
+#ifdef ENABLE_ZLIB_COMPRESSION
+            compressor = new util::ZlibCompressor();
+#else
+            GFXRECON_LOG_ERROR("Failed to initialize compression module: zlib compression is disabled.");
+            assert(false);
 #endif // ENABLE_ZLIB_COMPRESSION
+            break;
         case kNone:
             // Nothing to do here.
             break;
         default:
-            GFXRECON_LOG_ERROR("Unsupported compression format %d", type);
+            GFXRECON_LOG_ERROR("Failed to initialize compression module: Unrecognized compression type ID %d", type);
             assert(false);
             break;
     }

--- a/tools/compress/main.cpp
+++ b/tools/compress/main.cpp
@@ -143,7 +143,7 @@ int main(int argc, const char** argv)
                 GFXRECON_WRITE_CONSOLE("  Compressed Size [Compression: %5s] = %" PRIu64 " bytes",
                                        dst_compression_string.c_str(),
                                        bytes_written);
-                printf("  Percent Reduction                    = %.2f%%", percent_reduction);
+                GFXRECON_WRITE_CONSOLE("  Percent Reduction                    = %.2f%%", percent_reduction);
             }
             else
             {


### PR DESCRIPTION
When output resulted in a compression, we were not using the correct
GFXRECON_WRITE_CONSOLE macro to output the message.  We were using
a standard printf.  This resulted in no carraige return being
added.

Also, I noticed that both compress/main.cpp and format/format_util.cpp
had the same error message which caused me some confusing when
investigating it.  So I added more details to the format_util.cpp
error message.