### PR TITLE
Utility Code Cleanup

### DIFF
--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -29,6 +29,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
+// Default log level to use prior to loading settings.
 const util::Log::Severity kDefaultLogLevel = util::Log::Severity::kInfoSeverity;
 
 std::mutex                                     TraceManager::ThreadData::count_lock_;

--- a/framework/util/logging.h
+++ b/framework/util/logging.h
@@ -64,7 +64,7 @@ class Log
 
         // Constructor used for default initialization
         Settings() :
-            min_severity(kErrorSeverity), output_detailed_log_info(false), flush_after_write(false), use_indent(false),
+            min_severity(kInfoSeverity), output_detailed_log_info(false), flush_after_write(false), use_indent(false),
             indent(0), indent_spaces(std::string("   ")), break_on_error(false), write_to_file(false), create_new(true),
             leave_file_open(true), file_name(std::string("")), file_pointer(nullptr), write_to_console(true),
             output_errors_to_stderr(true), output_to_os_debug_string(false)
@@ -73,7 +73,7 @@ class Log
 
     static inline std::string SeverityToString(Severity severity);
     static void               Init(const util::Log::Settings& settings);
-    static void               Init(Severity    min_severity              = kErrorSeverity,
+    static void               Init(Severity    min_severity              = kInfoSeverity,
                                    const char* log_file_name             = nullptr,
                                    bool        leave_file_open           = true,
                                    bool        create_new_file_on_open   = true,

--- a/framework/util/platform.h
+++ b/framework/util/platform.h
@@ -356,6 +356,10 @@ inline int32_t FileVprintf(FILE* stream, const char* format, va_list vlist)
 
 inline int32_t LocalTime(tm* local_time, const time_t* timer)
 {
+#if defined(__ANDROID__) || defined(__USE_POSIX)
+    tm* result = localtime_r(timer, local_time);
+    return (result != nullptr) ? 0 : errno;
+#else
     if (local_time == nullptr)
     {
         return EINVAL;
@@ -371,10 +375,15 @@ inline int32_t LocalTime(tm* local_time, const time_t* timer)
     {
         return errno;
     }
+#endif
 }
 
 inline int32_t GMTime(tm* gm_time, const time_t* timer)
 {
+#if defined(__ANDROID__) || defined(__USE_POSIX)
+    tm* result = gmtime_r(timer, gm_time);
+    return (result != nullptr) ? 0 : errno;
+#else
     if (gm_time == nullptr)
     {
         return EINVAL;
@@ -390,6 +399,7 @@ inline int32_t GMTime(tm* gm_time, const time_t* timer)
     {
         return errno;
     }
+#endif
 }
 
 #endif // WIN32

--- a/framework/util/platform.h
+++ b/framework/util/platform.h
@@ -152,7 +152,7 @@ inline int64_t FileTell(FILE* stream)
 inline bool FileSeek(FILE* stream, int64_t offset, FileSeekOrigin origin)
 {
     int32_t result = _fseeki64(stream, offset, origin);
-    return (result == 0) ? true : false;
+    return (result == 0);
 }
 
 inline size_t FileWriteNoLock(const void* buffer, size_t element_size, size_t element_count, FILE* stream)
@@ -303,8 +303,21 @@ inline int32_t StringCopy(wchar_t* destination, size_t destination_size, const w
 
 inline int32_t FileOpen(FILE** stream, const char* filename, const char* mode)
 {
-    (*stream) = fopen(filename, mode);
-    return errno;
+    if (stream == nullptr)
+    {
+        return EINVAL;
+    }
+
+    FILE* result = fopen(filename, mode);
+    if (result != nullptr)
+    {
+        (*stream) = result;
+        return 0;
+    }
+    else
+    {
+        return errno;
+    }
 }
 
 inline int64_t FileTell(FILE* stream)
@@ -315,7 +328,7 @@ inline int64_t FileTell(FILE* stream)
 inline bool FileSeek(FILE* stream, int64_t offset, FileSeekOrigin origin)
 {
     int32_t result = fseeko(stream, offset, origin);
-    return (result == 0) ? true : false;
+    return (result == 0);
 }
 
 inline size_t FileWriteNoLock(const void* buffer, size_t element_size, size_t element_count, FILE* stream)
@@ -343,10 +356,15 @@ inline int32_t FileVprintf(FILE* stream, const char* format, va_list vlist)
 
 inline int32_t LocalTime(tm* local_time, const time_t* timer)
 {
+    if (local_time == nullptr)
+    {
+        return EINVAL;
+    }
+
     tm* result = localtime(timer);
     if (result != nullptr)
     {
-        memcpy(local_time, result, sizeof(tm));
+        (*local_time) = (*result);
         return 0;
     }
     else
@@ -357,10 +375,15 @@ inline int32_t LocalTime(tm* local_time, const time_t* timer)
 
 inline int32_t GMTime(tm* gm_time, const time_t* timer)
 {
+    if (gm_time == nullptr)
+    {
+        return EINVAL;
+    }
+
     tm* result = gmtime(timer);
     if (result != nullptr)
     {
-        memcpy(gm_time, result, sizeof(tm));
+        (*gm_time) = (*result);
         return 0;
     }
     else

--- a/tools/compress/main.cpp
+++ b/tools/compress/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, const char** argv)
     std::string                       input_filename;
     std::string                       output_filename;
 
-    gfxrecon::util::Log::Init(gfxrecon::util::Log::kInfoSeverity);
+    gfxrecon::util::Log::Init();
 
     gfxrecon::util::ArgumentParser arg_parser(argc, argv, "", "", 3);
 

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -47,7 +47,7 @@ void        PrintUsage(const char* exe_name);
 
 void android_main(struct android_app* app)
 {
-    gfxrecon::util::Log::Init(gfxrecon::util::Log::kInfoSeverity);
+    gfxrecon::util::Log::Init();
 
     std::string                    args = GetIntentExtra(app, kArgsExtentKey);
     gfxrecon::util::ArgumentParser arg_parser(false, args.c_str(), "", "", 0);

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -83,7 +83,7 @@ int main(int argc, const char** argv)
     int return_code = 0;
     std::string filename;
 
-    gfxrecon::util::Log::Init(gfxrecon::util::Log::kInfoSeverity);
+    gfxrecon::util::Log::Init();
 
     gfxrecon::util::ArgumentParser arg_parser(argc, argv, "", "", 1);
 

--- a/tools/toascii/main.cpp
+++ b/tools/toascii/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, const char** argv)
     gfxrecon::decode::FileProcessor file_processor;
     gfxrecon::util::ArgumentParser  arg_parser(argc, argv, "", "", 1);
 
-    gfxrecon::util::Log::Init(gfxrecon::util::Log::kInfoSeverity);
+    gfxrecon::util::Log::Init();
 
     if (arg_parser.IsInvalid() || (arg_parser.GetPositionalArgumentsCount() != 1))
     {


### PR DESCRIPTION
* Set default log level to info
* Add null checks to platform wrapper functions that dereference pointers
* FileOpen returns 0 on success instead of errno
* Convert some memcpy calls to assignments