### PR TITLE
Fail vkCreateInstance When Layer Initialization Fails

### DIFF
--- a/framework/encode/custom_encoder_commands.h
+++ b/framework/encode/custom_encoder_commands.h
@@ -47,12 +47,12 @@ struct CustomEncoderPostCall
 
 // Dispatch custom command to initialize capture at instance creation.
 template <>
-struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateInstance>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateInstance>
 {
     template <typename... Args>
-    static void Dispatch(TraceManager*, Args...)
+    static void Dispatch(TraceManager*, VkResult result, Args...)
     {
-        TraceManager::Create();
+        TraceManager::CheckCreateInstanceStatus(result);
     }
 };
 
@@ -63,7 +63,7 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyInstance>
     template <typename... Args>
     static void Dispatch(TraceManager*, Args...)
     {
-        TraceManager::Destroy();
+        TraceManager::DestroyInstance();
     }
 };
 

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2019 Valve Corporation
+** Copyright (c) 2018-2019 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -62,9 +62,20 @@ class TraceManager
     };
 
   public:
-    static void Create();
+    // Creates an instance if none exists, or increments a reference count if an instance already exists.  Intended to
+    // be called by the layer's vkCreateInstance function, before the driver's vkCreateInstance has been called, to
+    // initialize capture resources.
+    static bool CreateInstance();
 
-    static void Destroy();
+    // Called by the layer's vkCreateInstance function, after the driver's vkCreateInstance function has been called, to
+    // check for failure.  If vkCreateInstance failed, the reference count will be decremented and resources will be
+    // released as necessry.  Allows a failed vkCreateInstance call to be logged to the capture file while performing
+    // the appropriate resource cleanup.
+    static void CheckCreateInstanceStatus(VkResult result);
+
+    // Dectement the instance reference count, releasing reources when the count reaches zero.  Ignored if the count is
+    // already zero.
+    static void DestroyInstance();
 
     static TraceManager* Get() { return instance_; }
 


### PR DESCRIPTION
When layer initialization fails, the layer will skip the call to the next vkCreateInstance function in its call chain and return VK_ERROR_INITIALIZATION_FAILED.
- Moves layer initialization from a custom pre-call command to the layer's dispatch_CreateInstance function.
- Adds a CreateInstance post-call command to check the result of the vkCreateInstance call and handle failure.