### PR TITLE
Linux Timestamp Update

### DIFF
--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -34,15 +34,29 @@ target_include_directories(gfxrecon_util
 
 target_link_libraries(gfxrecon_util platform_specific)
 
+if (UNIX AND NOT APPLE)
+    # Check for clock_gettime in libc
+    check_library_exists(c clock_gettime "" HAVE_GETTIME)
+    if (NOT HAVE_GETTIME)
+        # If not in libc, check librt
+        check_library_exists(rt clock_gettime "" HAVE_GETTIME)
+        if (HAVE_GETTIME)
+            target_link_libraries(gfxrecon_util rt)
+        else()
+            message(WARNING "Function clock_gettime not found in either libc or librt")
+        endif()
+    endif()
+endif()
+
 if (TARGET LZ4::LZ4)
-target_compile_definitions(gfxrecon_util PUBLIC ENABLE_LZ4_COMPRESSION)
-target_link_libraries(gfxrecon_util LZ4::LZ4)
+    target_compile_definitions(gfxrecon_util PUBLIC ENABLE_LZ4_COMPRESSION)
+    target_link_libraries(gfxrecon_util LZ4::LZ4)
 endif()
 
 if (TARGET ZLIB::ZLIB)
-target_compile_definitions(gfxrecon_util
-                           PUBLIC
-                               ENABLE_ZLIB_COMPRESSION
-                               $<$<BOOL:${WIN32}>:ZLIB_WINAPI>)
-target_link_libraries(gfxrecon_util ZLIB::ZLIB)
+    target_compile_definitions(gfxrecon_util
+                               PUBLIC
+                                   ENABLE_ZLIB_COMPRESSION
+                                   $<$<BOOL:${WIN32}>:ZLIB_WINAPI>)
+    target_link_libraries(gfxrecon_util ZLIB::ZLIB)
 endif()

--- a/framework/util/date_time.h
+++ b/framework/util/date_time.h
@@ -38,6 +38,7 @@ GFXRECON_BEGIN_NAMESPACE(datetime)
 
 #if defined(WIN32)
 
+// Retrieve a timestamp, relative to an undefined reference point, suitable for computing time intervals.
 inline uint64_t GetTimestamp()
 {
     LARGE_INTEGER StartingTime;
@@ -55,10 +56,19 @@ inline uint64_t GetTimestamp()
 
 #else // !defined(WIN32)
 
+// Retrieve a timestamp, relative to an undefined reference point, suitable for computing time intervals.
 inline int64_t GetTimestamp()
 {
+#if defined(CLOCK_MONOTONIC_RAW)
+    const clockid_t clock_id = CLOCK_MONOTONIC_RAW;
+#elif defined(CLOCK_MONOTONIC)
+    const clockid_t clock_id = CLOCK_MONOTONIC;
+#else
+    const clockid_t clock_id = CLOCK_REALTIME;
+#endif
+
     timespec time;
-    clock_gettime(CLOCK_REALTIME, &time);
+    clock_gettime(clock_id, &time);
     int64_t timestamp = (1000000000 * static_cast<int64_t>(time.tv_sec)) + static_cast<int64_t>(time.tv_nsec);
     return timestamp;
 }


### PR DESCRIPTION
Updates to the timestamp generation code for Linux/Android.
- Use CLOCK_MONOTONIC_RAW or CLOCK_MONOTONIC instead of CLOCK_REALTIME with clock_gettime() when available.
- Update CMake to check for presence of clock_gettime in librt and add librt link target if necessary.