### PR TITLE
Fix gcc 5.4 compilation errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(GFXReconstruct)
 
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include("FindVulkanVersion")

--- a/framework/util/compressor.h
+++ b/framework/util/compressor.h
@@ -20,7 +20,8 @@
 
 #include "util/defines.h"
 
-#include <cinttypes>
+#include <cstddef>
+#include <cstdint>
 #include <vector>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)

--- a/framework/util/page_guard_manager.h
+++ b/framework/util/page_guard_manager.h
@@ -22,6 +22,7 @@
 #include "util/defines.h"
 #include "util/page_status_tracker.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <mutex>

--- a/framework/util/page_status_tracker.h
+++ b/framework/util/page_status_tracker.h
@@ -21,6 +21,7 @@
 
 #include "util/defines.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 


### PR DESCRIPTION
Minor changes to address build errors with gcc 5.4.0 on Ubuntu 16.04
systems:
- Add <stddef> includes for size_t
- Set CMAKE_CXX_STANDARD to ensure appropriate C++ version is enabled