### PR TITLE
Stop Replay on Error

### DIFF
--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -186,7 +186,7 @@ int main(int argc, const char** argv)
     }
     catch (std::runtime_error error)
     {
-        GFXRECON_WRITE_CONSOLE("Replay failed with error message: %s", error.what());
+        GFXRECON_WRITE_CONSOLE("Replay has encountered a fatal error and cannot continue: %s", error.what());
         return_code = -1;
     }
     catch (...)


### PR DESCRIPTION
Updates to replay error handling:
- Stop replay if an API call that succeeded on capture fails on replay.
- Remove warning messages for API calls that failed during capture.
  These are typically out of memory errors from descriptor allocations
  or out of date errors from window resize, which were handled by the
  captured application.