### PR TITLE
Fix Vulkan Decoder API Range

### DIFF
--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -49,8 +49,8 @@ class VulkanDecoderBase : public ApiDecoder
 
     virtual bool SupportsApiCall(format::ApiCallId call_id) override
     {
-        return ((call_id >= format::MakeApiCallId(format::ApiFamily_Vulkan, 0x1000)) &&
-                (call_id <= format::MakeApiCallId(format::ApiFamily_Vulkan, 0x114e)));
+        return ((call_id >= format::ApiCallId::ApiCall_vkCreateInstance) &&
+                (call_id < format::ApiCallId::ApiCall_VulkanLast));
     }
 
     virtual void DecodeFunctionCall(format::ApiCallId  call_id,

--- a/framework/format/api_call_id.h
+++ b/framework/format/api_call_id.h
@@ -392,6 +392,8 @@ enum ApiCallId : uint32_t
     ApiCall_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT                                        = MakeApiCallId(ApiFamily_Vulkan, 0x1155),
     ApiCall_vkGetCalibratedTimestampsEXT                                                          = MakeApiCallId(ApiFamily_Vulkan, 0x1156),
     ApiCall_vkGetBufferDeviceAddressEXT                                                           = MakeApiCallId(ApiFamily_Vulkan, 0x1157),
+
+    ApiCall_VulkanLast
     // clang-format on
 };
 


### PR DESCRIPTION
The range of supported API call IDs was not updated with the last header
update, and any API calls introduced with that update are not being
decoded during replay.  This is causing replay issues with titles that
use transform feedback.

This change adds a sentinel value to the end of the API call ID list,
which is now referened by the decoder in place of the specific API call
ID for the last item in the list.