### PR TITLE
Remove GetPhysicalDeviceProcAddr Layer Function

### DIFF
--- a/framework/generated/generated_layer_func_table.h
+++ b/framework/generated/generated_layer_func_table.h
@@ -376,9 +376,6 @@ const std::unordered_map<std::string, PFN_vkVoidFunction> func_table = {
     { "vkGetQueueCheckpointDataNV",                                                                          reinterpret_cast<PFN_vkVoidFunction>(encode::GetQueueCheckpointDataNV) },
     { "vkCreateImagePipeSurfaceFUCHSIA",                                                                     reinterpret_cast<PFN_vkVoidFunction>(encode::CreateImagePipeSurfaceFUCHSIA) },
     { "vkGetBufferDeviceAddressEXT",                                                                         reinterpret_cast<PFN_vkVoidFunction>(encode::GetBufferDeviceAddressEXT) },
-
-    // Special case handling of "vk_layerGetPhysicalDeviceProcAddr"
-    { "vk_layerGetPhysicalDeviceProcAddr",                                                                   reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceProcAddr) },
 };
 
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/vulkan_generators/layer_func_table_generator.py
+++ b/framework/generated/vulkan_generators/layer_func_table_generator.py
@@ -75,11 +75,6 @@ class LayerFuncTableGenerator(BaseGenerator):
 
     # Method override
     def endFile(self):
-        # Add the special-case internal loader/layer command 'vk_layerGetPhysicalDeviceProcAddr'
-        self.newline()
-        write('    // Special case handling of "vk_layerGetPhysicalDeviceProcAddr"', file=self.outFile)
-        align = 100 - len('vk_layerGetPhysicalDeviceProcAddr')
-        write('    { "vk_layerGetPhysicalDeviceProcAddr",%sreinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceProcAddr) },' % (' ' * align), file=self.outFile)
         write('};', file=self.outFile)
         self.newline()
         write('GFXRECON_END_NAMESPACE(gfxrecon)', file=self.outFile)


### PR DESCRIPTION
Remove the layer's vk_layerGetPhysicalDeviceProcAddr function.
This is an optional function from the layer loader interface, which
the layer does not use directly. All calls to this function result
in the layer calling down the chain, which is not working correctly
with some versions of the loader. Because the function is optional,
it has been removed to work around the existing issue.
