### PR TITLE
Update for header 1.1.102

### DIFF
--- a/framework/format/api_call_id.h
+++ b/framework/format/api_call_id.h
@@ -392,6 +392,9 @@ enum ApiCallId : uint32_t
     ApiCall_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT                                        = MakeApiCallId(ApiFamily_Vulkan, 0x1155),
     ApiCall_vkGetCalibratedTimestampsEXT                                                          = MakeApiCallId(ApiFamily_Vulkan, 0x1156),
     ApiCall_vkGetBufferDeviceAddressEXT                                                           = MakeApiCallId(ApiFamily_Vulkan, 0x1157),
+    ApiCall_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV                                      = MakeApiCallId(ApiFamily_Vulkan, 0x1158),
+    ApiCall_vkGetImageViewHandleNVX                                                               = MakeApiCallId(ApiFamily_Vulkan, 0x1159),
+    ApiCall_vkCreateMetalSurfaceEXT                                                               = MakeApiCallId(ApiFamily_Vulkan, 0x115a),
 
     ApiCall_VulkanLast
     // clang-format on

--- a/framework/format/platform_types.h
+++ b/framework/format/platform_types.h
@@ -284,6 +284,39 @@ static VKAPI_ATTR VkResult VKAPI_CALL vkCreateMacOSSurfaceMVK(VkInstance,
 }
 #endif // VK_USE_PLATFORM_MACOS_MVK
 
+#if !defined(VK_USE_PLATFORM_METAL_EXT)
+#define VK_EXT_METAL_SURFACE_EXTENSION_NAME "VK_EXT_metal_surface"
+
+typedef VkFlags VkMetalSurfaceCreateFlagsEXT;
+
+struct CAMetalLayer;
+
+struct VkMetalSurfaceCreateInfoEXT
+{
+    VkStructureType              sType;
+    const void*                  pNext;
+    VkMetalSurfaceCreateFlagsEXT flags;
+    const CAMetalLayer*          pLayer;
+};
+
+extern "C" {
+typedef VkResult(VKAPI_PTR* PFN_vkCreateMetalSurfaceEXT)(VkInstance                         instance,
+                                                         const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
+                                                         const VkAllocationCallbacks*       pAllocator,
+                                                         VkSurfaceKHR*                      pSurface);
+
+static VKAPI_ATTR VkResult VKAPI_CALL vkCreateMetalSurfaceEXT(VkInstance,
+                                                              const VkMetalSurfaceCreateInfoEXT*,
+                                                              const VkAllocationCallbacks*,
+                                                              VkSurfaceKHR*)
+{
+    GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkCreateMetalSurfaceEXT");
+    return VK_ERROR_EXTENSION_NOT_PRESENT;
+}
+}
+#endif // VK_USE_PLATFORM_METAL_EXT
+
+
 #if !defined(VK_USE_PLATFORM_MIR_KHR)
 #define VK_KHR_MIR_SURFACE_EXTENSION_NAME "VK_KHR_mir_surface"
 

--- a/framework/generated/generated_decode_pnext_struct.cpp
+++ b/framework/generated/generated_decode_pnext_struct.cpp
@@ -434,6 +434,14 @@ size_t DecodePNextStruct(const uint8_t* parameter_buffer, size_t buffer_size,  s
                 (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT:
+                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT>>();
+                bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
+                break;
+            case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_DEPTH_CLIP_STATE_CREATE_INFO_EXT:
+                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT>>();
+                bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
+                break;
             case VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT:
                 (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDebugUtilsMessengerCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
@@ -586,6 +594,14 @@ size_t DecodePNextStruct(const uint8_t* parameter_buffer, size_t buffer_size,  s
                 (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_IMAGE_FORMAT_INFO_EXT:
+                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT>>();
+                bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
+                break;
+            case VK_STRUCTURE_TYPE_FILTER_CUBIC_IMAGE_VIEW_IMAGE_FORMAT_PROPERTIES_EXT:
+                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT>>();
+                bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
+                break;
             case VK_STRUCTURE_TYPE_DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT:
                 (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
@@ -682,6 +698,10 @@ size_t DecodePNextStruct(const uint8_t* parameter_buffer, size_t buffer_size,  s
                 (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkMemoryPriorityAllocateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV:
+                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV>>();
+                bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
+                break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_ADDRESS_FEATURES_EXT:
                 (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceBufferAddressFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
@@ -696,6 +716,18 @@ size_t DecodePNextStruct(const uint8_t* parameter_buffer, size_t buffer_size,  s
                 break;
             case VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT:
                 (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkValidationFeaturesEXT>>();
+                bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
+                break;
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV:
+                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV>>();
+                bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
+                break;
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV:
+                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV>>();
+                bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
+                break;
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT:
+                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             }

--- a/framework/generated/generated_encode_pnext_struct.cpp
+++ b/framework/generated/generated_encode_pnext_struct.cpp
@@ -335,6 +335,12 @@ void EncodePNextStruct(ParameterEncoder* encoder, const void* value)
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT:
             EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineRasterizationConservativeStateCreateInfoEXT*>(value));
             break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT:
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(value));
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_DEPTH_CLIP_STATE_CREATE_INFO_EXT:
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineRasterizationDepthClipStateCreateInfoEXT*>(value));
+            break;
         case VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT:
             EncodeStructPtr(encoder, reinterpret_cast<const VkDebugUtilsMessengerCreateInfoEXT*>(value));
             break;
@@ -449,6 +455,12 @@ void EncodePNextStruct(ParameterEncoder* encoder, const void* value)
         case VK_STRUCTURE_TYPE_PIPELINE_REPRESENTATIVE_FRAGMENT_TEST_STATE_CREATE_INFO_NV:
             EncodeStructPtr(encoder, reinterpret_cast<const VkPipelineRepresentativeFragmentTestStateCreateInfoNV*>(value));
             break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_IMAGE_FORMAT_INFO_EXT:
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceImageViewImageFormatInfoEXT*>(value));
+            break;
+        case VK_STRUCTURE_TYPE_FILTER_CUBIC_IMAGE_VIEW_IMAGE_FORMAT_PROPERTIES_EXT:
+            EncodeStructPtr(encoder, reinterpret_cast<const VkFilterCubicImageViewImageFormatPropertiesEXT*>(value));
+            break;
         case VK_STRUCTURE_TYPE_DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT:
             EncodeStructPtr(encoder, reinterpret_cast<const VkDeviceQueueGlobalPriorityCreateInfoEXT*>(value));
             break;
@@ -521,6 +533,9 @@ void EncodePNextStruct(ParameterEncoder* encoder, const void* value)
         case VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT:
             EncodeStructPtr(encoder, reinterpret_cast<const VkMemoryPriorityAllocateInfoEXT*>(value));
             break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV:
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(value));
+            break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_ADDRESS_FEATURES_EXT:
             EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceBufferAddressFeaturesEXT*>(value));
             break;
@@ -532,6 +547,15 @@ void EncodePNextStruct(ParameterEncoder* encoder, const void* value)
             break;
         case VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT:
             EncodeStructPtr(encoder, reinterpret_cast<const VkValidationFeaturesEXT*>(value));
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV:
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(value));
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV:
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixPropertiesNV*>(value));
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT:
+            EncodeStructPtr(encoder, reinterpret_cast<const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(value));
             break;
         }
     }

--- a/framework/generated/generated_layer_func_table.h
+++ b/framework/generated/generated_layer_func_table.h
@@ -297,6 +297,7 @@ const std::unordered_map<std::string, PFN_vkVoidFunction> func_table = {
     { "vkCmdBeginQueryIndexedEXT",                                                                           reinterpret_cast<PFN_vkVoidFunction>(encode::CmdBeginQueryIndexedEXT) },
     { "vkCmdEndQueryIndexedEXT",                                                                             reinterpret_cast<PFN_vkVoidFunction>(encode::CmdEndQueryIndexedEXT) },
     { "vkCmdDrawIndirectByteCountEXT",                                                                       reinterpret_cast<PFN_vkVoidFunction>(encode::CmdDrawIndirectByteCountEXT) },
+    { "vkGetImageViewHandleNVX",                                                                             reinterpret_cast<PFN_vkVoidFunction>(encode::GetImageViewHandleNVX) },
     { "vkCmdDrawIndirectCountAMD",                                                                           reinterpret_cast<PFN_vkVoidFunction>(encode::CmdDrawIndirectCountAMD) },
     { "vkCmdDrawIndexedIndirectCountAMD",                                                                    reinterpret_cast<PFN_vkVoidFunction>(encode::CmdDrawIndexedIndirectCountAMD) },
     { "vkGetShaderInfoAMD",                                                                                  reinterpret_cast<PFN_vkVoidFunction>(encode::GetShaderInfoAMD) },
@@ -375,7 +376,9 @@ const std::unordered_map<std::string, PFN_vkVoidFunction> func_table = {
     { "vkCmdSetCheckpointNV",                                                                                reinterpret_cast<PFN_vkVoidFunction>(encode::CmdSetCheckpointNV) },
     { "vkGetQueueCheckpointDataNV",                                                                          reinterpret_cast<PFN_vkVoidFunction>(encode::GetQueueCheckpointDataNV) },
     { "vkCreateImagePipeSurfaceFUCHSIA",                                                                     reinterpret_cast<PFN_vkVoidFunction>(encode::CreateImagePipeSurfaceFUCHSIA) },
+    { "vkCreateMetalSurfaceEXT",                                                                             reinterpret_cast<PFN_vkVoidFunction>(encode::CreateMetalSurfaceEXT) },
     { "vkGetBufferDeviceAddressEXT",                                                                         reinterpret_cast<PFN_vkVoidFunction>(encode::GetBufferDeviceAddressEXT) },
+    { "vkGetPhysicalDeviceCooperativeMatrixPropertiesNV",                                                    reinterpret_cast<PFN_vkVoidFunction>(encode::GetPhysicalDeviceCooperativeMatrixPropertiesNV) },
 };
 
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -6031,6 +6031,28 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectByteCountEXT(
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdDrawIndirectByteCountEXT>::Dispatch(TraceManager::Get(), commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride);
 }
 
+VKAPI_ATTR uint32_t VKAPI_CALL GetImageViewHandleNVX(
+    VkDevice                                    device,
+    const VkImageViewHandleInfoNVX*             pInfo)
+{
+    CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetImageViewHandleNVX>::Dispatch(TraceManager::Get(), device, pInfo);
+
+    uint32_t result = TraceManager::Get()->GetDeviceTable(device)->GetImageViewHandleNVX(device, pInfo);
+
+    auto encoder = TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkGetImageViewHandleNVX);
+    if (encoder)
+    {
+        encoder->EncodeHandleIdValue(device);
+        EncodeStructPtr(encoder, pInfo);
+        encoder->EncodeUInt32Value(result);
+        TraceManager::Get()->EndApiCallTrace(encoder);
+    }
+
+    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetImageViewHandleNVX>::Dispatch(TraceManager::Get(), result, device, pInfo);
+
+    return result;
+}
+
 VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountAMD(
     VkCommandBuffer                             commandBuffer,
     VkBuffer                                    buffer,
@@ -7892,6 +7914,32 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(
     return result;
 }
 
+VKAPI_ATTR VkResult VKAPI_CALL CreateMetalSurfaceEXT(
+    VkInstance                                  instance,
+    const VkMetalSurfaceCreateInfoEXT*          pCreateInfo,
+    const VkAllocationCallbacks*                pAllocator,
+    VkSurfaceKHR*                               pSurface)
+{
+    CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateMetalSurfaceEXT>::Dispatch(TraceManager::Get(), instance, pCreateInfo, pAllocator, pSurface);
+
+    VkResult result = TraceManager::Get()->GetInstanceTable(instance)->CreateMetalSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface);
+
+    auto encoder = TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCreateMetalSurfaceEXT);
+    if (encoder)
+    {
+        encoder->EncodeHandleIdValue(instance);
+        EncodeStructPtr(encoder, pCreateInfo);
+        EncodeStructPtr(encoder, pAllocator);
+        encoder->EncodeHandleIdPtr(pSurface);
+        encoder->EncodeEnumValue(result);
+        TraceManager::Get()->EndApiCallTrace(encoder);
+    }
+
+    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateMetalSurfaceEXT>::Dispatch(TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
+
+    return result;
+}
+
 VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressEXT(
     VkDevice                                    device,
     const VkBufferDeviceAddressInfoEXT*         pInfo)
@@ -7910,6 +7958,30 @@ VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressEXT(
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetBufferDeviceAddressEXT>::Dispatch(TraceManager::Get(), result, device, pInfo);
+
+    return result;
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCooperativeMatrixPropertiesNV(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t*                                   pPropertyCount,
+    VkCooperativeMatrixPropertiesNV*            pProperties)
+{
+    CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV>::Dispatch(TraceManager::Get(), physicalDevice, pPropertyCount, pProperties);
+
+    VkResult result = TraceManager::Get()->GetInstanceTable(physicalDevice)->GetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties);
+
+    auto encoder = TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV);
+    if (encoder)
+    {
+        encoder->EncodeHandleIdValue(physicalDevice);
+        encoder->EncodeUInt32Ptr(pPropertyCount);
+        EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0);
+        encoder->EncodeEnumValue(result);
+        TraceManager::Get()->EndApiCallTrace(encoder);
+    }
+
+    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV>::Dispatch(TraceManager::Get(), result, physicalDevice, pPropertyCount, pProperties);
 
     return result;
 }

--- a/framework/generated/generated_vulkan_api_call_encoders.h
+++ b/framework/generated/generated_vulkan_api_call_encoders.h
@@ -1467,6 +1467,10 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectByteCountEXT(
     uint32_t                                    counterOffset,
     uint32_t                                    vertexStride);
 
+VKAPI_ATTR uint32_t VKAPI_CALL GetImageViewHandleNVX(
+    VkDevice                                    device,
+    const VkImageViewHandleInfoNVX*             pInfo);
+
 VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountAMD(
     VkCommandBuffer                             commandBuffer,
     VkBuffer                                    buffer,
@@ -1917,9 +1921,20 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(
     const VkAllocationCallbacks*                pAllocator,
     VkSurfaceKHR*                               pSurface);
 
+VKAPI_ATTR VkResult VKAPI_CALL CreateMetalSurfaceEXT(
+    VkInstance                                  instance,
+    const VkMetalSurfaceCreateInfoEXT*          pCreateInfo,
+    const VkAllocationCallbacks*                pAllocator,
+    VkSurfaceKHR*                               pSurface);
+
 VKAPI_ATTR VkDeviceAddress VKAPI_CALL GetBufferDeviceAddressEXT(
     VkDevice                                    device,
     const VkBufferDeviceAddressInfoEXT*         pInfo);
+
+VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCooperativeMatrixPropertiesNV(
+    VkPhysicalDevice                            physicalDevice,
+    uint32_t*                                   pPropertyCount,
+    VkCooperativeMatrixPropertiesNV*            pProperties);
 
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/generated_vulkan_ascii_consumer.cpp
+++ b/framework/generated/generated_vulkan_ascii_consumer.cpp
@@ -2338,6 +2338,14 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectByteCountEXT(
     fprintf(GetFile(), "%s\n", "vkCmdDrawIndirectByteCountEXT");
 }
 
+void VulkanAsciiConsumer::Process_vkGetImageViewHandleNVX(
+    uint32_t                                    returnValue,
+    format::HandleId                            device,
+    const StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>& pInfo)
+{
+    fprintf(GetFile(), "%s\n", "vkGetImageViewHandleNVX");
+}
+
 void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCountAMD(
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
@@ -3057,12 +3065,31 @@ void VulkanAsciiConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
     fprintf(GetFile(), "%s\n", "vkCreateImagePipeSurfaceFUCHSIA");
 }
 
+void VulkanAsciiConsumer::Process_vkCreateMetalSurfaceEXT(
+    VkResult                                    returnValue,
+    format::HandleId                            instance,
+    const StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>& pCreateInfo,
+    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    const HandlePointerDecoder<VkSurfaceKHR>&   pSurface)
+{
+    fprintf(GetFile(), "%s\n", "vkCreateMetalSurfaceEXT");
+}
+
 void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressEXT(
     VkDeviceAddress                             returnValue,
     format::HandleId                            device,
     const StructPointerDecoder<Decoded_VkBufferDeviceAddressInfoEXT>& pInfo)
 {
     fprintf(GetFile(), "%s\n", "vkGetBufferDeviceAddressEXT");
+}
+
+void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(
+    VkResult                                    returnValue,
+    format::HandleId                            physicalDevice,
+    const PointerDecoder<uint32_t>&             pPropertyCount,
+    const StructPointerDecoder<Decoded_VkCooperativeMatrixPropertiesNV>& pProperties)
+{
+    fprintf(GetFile(), "%s\n", "vkGetPhysicalDeviceCooperativeMatrixPropertiesNV");
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/generated_vulkan_ascii_consumer.h
+++ b/framework/generated/generated_vulkan_ascii_consumer.h
@@ -1588,6 +1588,11 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    counterOffset,
         uint32_t                                    vertexStride) override;
 
+    virtual void Process_vkGetImageViewHandleNVX(
+        uint32_t                                    returnValue,
+        format::HandleId                            device,
+        const StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>& pInfo) override;
+
     virtual void Process_vkCmdDrawIndirectCountAMD(
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
@@ -2076,10 +2081,23 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
         const HandlePointerDecoder<VkSurfaceKHR>&   pSurface) override;
 
+    virtual void Process_vkCreateMetalSurfaceEXT(
+        VkResult                                    returnValue,
+        format::HandleId                            instance,
+        const StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>& pCreateInfo,
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        const HandlePointerDecoder<VkSurfaceKHR>&   pSurface) override;
+
     virtual void Process_vkGetBufferDeviceAddressEXT(
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkBufferDeviceAddressInfoEXT>& pInfo) override;
+
+    virtual void Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(
+        VkResult                                    returnValue,
+        format::HandleId                            physicalDevice,
+        const PointerDecoder<uint32_t>&             pPropertyCount,
+        const StructPointerDecoder<Decoded_VkCooperativeMatrixPropertiesNV>& pProperties) override;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/generated_vulkan_consumer.h
+++ b/framework/generated/generated_vulkan_consumer.h
@@ -1588,6 +1588,11 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    counterOffset,
         uint32_t                                    vertexStride) = 0;
 
+    virtual void Process_vkGetImageViewHandleNVX(
+        uint32_t                                    returnValue,
+        format::HandleId                            device,
+        const StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>& pInfo) = 0;
+
     virtual void Process_vkCmdDrawIndirectCountAMD(
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
@@ -2076,10 +2081,23 @@ class VulkanConsumer : public VulkanConsumerBase
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
         const HandlePointerDecoder<VkSurfaceKHR>&   pSurface) = 0;
 
+    virtual void Process_vkCreateMetalSurfaceEXT(
+        VkResult                                    returnValue,
+        format::HandleId                            instance,
+        const StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>& pCreateInfo,
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        const HandlePointerDecoder<VkSurfaceKHR>&   pSurface) = 0;
+
     virtual void Process_vkGetBufferDeviceAddressEXT(
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkBufferDeviceAddressInfoEXT>& pInfo) = 0;
+
+    virtual void Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(
+        VkResult                                    returnValue,
+        format::HandleId                            physicalDevice,
+        const PointerDecoder<uint32_t>&             pPropertyCount,
+        const StructPointerDecoder<Decoded_VkCooperativeMatrixPropertiesNV>& pProperties) = 0;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/generated_vulkan_decoder.cpp
+++ b/framework/generated/generated_vulkan_decoder.cpp
@@ -5668,6 +5668,26 @@ size_t VulkanDecoder::Decode_vkCmdDrawIndirectByteCountEXT(const uint8_t* parame
     return bytes_read;
 }
 
+size_t VulkanDecoder::Decode_vkGetImageViewHandleNVX(const uint8_t* parameter_buffer, size_t buffer_size)
+{
+    size_t bytes_read = 0;
+
+    format::HandleId device;
+    StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX> pInfo;
+    uint32_t return_value;
+
+    bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &device);
+    bytes_read += pInfo.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));
+    bytes_read += ValueDecoder::DecodeUInt32Value((parameter_buffer + bytes_read), (buffer_size - bytes_read), &return_value);
+
+    for (auto consumer : GetConsumers())
+    {
+        consumer->Process_vkGetImageViewHandleNVX(return_value, device, pInfo);
+    }
+
+    return bytes_read;
+}
+
 size_t VulkanDecoder::Decode_vkCmdDrawIndirectCountAMD(const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
@@ -7414,6 +7434,30 @@ size_t VulkanDecoder::Decode_vkCreateImagePipeSurfaceFUCHSIA(const uint8_t* para
     return bytes_read;
 }
 
+size_t VulkanDecoder::Decode_vkCreateMetalSurfaceEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+{
+    size_t bytes_read = 0;
+
+    format::HandleId instance;
+    StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT> pCreateInfo;
+    StructPointerDecoder<Decoded_VkAllocationCallbacks> pAllocator;
+    HandlePointerDecoder<VkSurfaceKHR> pSurface;
+    VkResult return_value;
+
+    bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &instance);
+    bytes_read += pCreateInfo.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));
+    bytes_read += pAllocator.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));
+    bytes_read += pSurface.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));
+    bytes_read += ValueDecoder::DecodeEnumValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &return_value);
+
+    for (auto consumer : GetConsumers())
+    {
+        consumer->Process_vkCreateMetalSurfaceEXT(return_value, instance, pCreateInfo, pAllocator, pSurface);
+    }
+
+    return bytes_read;
+}
+
 size_t VulkanDecoder::Decode_vkGetBufferDeviceAddressEXT(const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
@@ -7434,10 +7478,32 @@ size_t VulkanDecoder::Decode_vkGetBufferDeviceAddressEXT(const uint8_t* paramete
     return bytes_read;
 }
 
-void VulkanDecoder::DecodeFunctionCall(format::ApiCallId  call_id,
-                                       const ApiCallInfo& call_info,
-                                       const uint8_t*     parameter_buffer,
-                                       size_t             buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(const uint8_t* parameter_buffer, size_t buffer_size)
+{
+    size_t bytes_read = 0;
+
+    format::HandleId physicalDevice;
+    PointerDecoder<uint32_t> pPropertyCount;
+    StructPointerDecoder<Decoded_VkCooperativeMatrixPropertiesNV> pProperties;
+    VkResult return_value;
+
+    bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &physicalDevice);
+    bytes_read += pPropertyCount.DecodeUInt32((parameter_buffer + bytes_read), (buffer_size - bytes_read));
+    bytes_read += pProperties.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));
+    bytes_read += ValueDecoder::DecodeEnumValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &return_value);
+
+    for (auto consumer : GetConsumers())
+    {
+        consumer->Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(return_value, physicalDevice, pPropertyCount, pProperties);
+    }
+
+    return bytes_read;
+}
+
+void VulkanDecoder::DecodeFunctionCall(format::ApiCallId             call_id,
+                                       const ApiCallInfo&            call_info,
+                                       const uint8_t*                parameter_buffer,
+                                       size_t                        buffer_size)
 {
     switch(call_id)
     {
@@ -8203,6 +8269,9 @@ void VulkanDecoder::DecodeFunctionCall(format::ApiCallId  call_id,
     case format::ApiCallId::ApiCall_vkCmdDrawIndirectByteCountEXT:
         Decode_vkCmdDrawIndirectByteCountEXT(parameter_buffer, buffer_size);
         break;
+    case format::ApiCallId::ApiCall_vkGetImageViewHandleNVX:
+        Decode_vkGetImageViewHandleNVX(parameter_buffer, buffer_size);
+        break;
     case format::ApiCallId::ApiCall_vkCmdDrawIndirectCountAMD:
         Decode_vkCmdDrawIndirectCountAMD(parameter_buffer, buffer_size);
         break;
@@ -8434,8 +8503,14 @@ void VulkanDecoder::DecodeFunctionCall(format::ApiCallId  call_id,
     case format::ApiCallId::ApiCall_vkCreateImagePipeSurfaceFUCHSIA:
         Decode_vkCreateImagePipeSurfaceFUCHSIA(parameter_buffer, buffer_size);
         break;
+    case format::ApiCallId::ApiCall_vkCreateMetalSurfaceEXT:
+        Decode_vkCreateMetalSurfaceEXT(parameter_buffer, buffer_size);
+        break;
     case format::ApiCallId::ApiCall_vkGetBufferDeviceAddressEXT:
         Decode_vkGetBufferDeviceAddressEXT(parameter_buffer, buffer_size);
+        break;
+    case format::ApiCallId::ApiCall_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV:
+        Decode_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(parameter_buffer, buffer_size);
         break;
     }
 }

--- a/framework/generated/generated_vulkan_decoder.h
+++ b/framework/generated/generated_vulkan_decoder.h
@@ -38,10 +38,10 @@ class VulkanDecoder : public VulkanDecoderBase
 
     virtual ~VulkanDecoder() override { }
 
-    virtual void DecodeFunctionCall(format::ApiCallId  call_id,
-                                    const ApiCallInfo& call_info,
-                                    const uint8_t*     parameter_buffer,
-                                    size_t             buffer_size) override;
+    virtual void DecodeFunctionCall(format::ApiCallId             call_id,
+                                    const ApiCallInfo&            call_info,
+                                    const uint8_t*                parameter_buffer,
+                                    size_t                        buffer_size) override;
 
   private:
     size_t Decode_vkCreateInstance(const uint8_t* parameter_buffer, size_t buffer_size);
@@ -550,6 +550,8 @@ class VulkanDecoder : public VulkanDecoderBase
 
     size_t Decode_vkCmdDrawIndirectByteCountEXT(const uint8_t* parameter_buffer, size_t buffer_size);
 
+    size_t Decode_vkGetImageViewHandleNVX(const uint8_t* parameter_buffer, size_t buffer_size);
+
     size_t Decode_vkCmdDrawIndirectCountAMD(const uint8_t* parameter_buffer, size_t buffer_size);
 
     size_t Decode_vkCmdDrawIndexedIndirectCountAMD(const uint8_t* parameter_buffer, size_t buffer_size);
@@ -704,7 +706,11 @@ class VulkanDecoder : public VulkanDecoderBase
 
     size_t Decode_vkCreateImagePipeSurfaceFUCHSIA(const uint8_t* parameter_buffer, size_t buffer_size);
 
+    size_t Decode_vkCreateMetalSurfaceEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+
     size_t Decode_vkGetBufferDeviceAddressEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+
+    size_t Decode_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(const uint8_t* parameter_buffer, size_t buffer_size);
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/generated_vulkan_dispatch_table.h
+++ b/framework/generated/generated_vulkan_dispatch_table.h
@@ -132,6 +132,8 @@ static VKAPI_ATTR void VKAPI_CALL SubmitDebugUtilsMessageEXT(VkInstance, VkDebug
 static VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceMultisamplePropertiesEXT(VkPhysicalDevice, VkSampleCountFlagBits, VkMultisamplePropertiesEXT*) {}
 static VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCalibrateableTimeDomainsEXT(VkPhysicalDevice, uint32_t*, VkTimeDomainEXT*) { return VK_SUCCESS; }
 static VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(VkInstance, const VkImagePipeSurfaceCreateInfoFUCHSIA*, const VkAllocationCallbacks*, VkSurfaceKHR*) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL CreateMetalSurfaceEXT(VkInstance, const VkMetalSurfaceCreateInfoEXT*, const VkAllocationCallbacks*, VkSurfaceKHR*) { return VK_SUCCESS; }
+static VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceCooperativeMatrixPropertiesNV(VkPhysicalDevice, uint32_t*, VkCooperativeMatrixPropertiesNV*) { return VK_SUCCESS; }
 static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice, const char*) { return nullptr; }
 static VKAPI_ATTR void VKAPI_CALL DestroyDevice(VkDevice, const VkAllocationCallbacks*) {}
 static VKAPI_ATTR void VKAPI_CALL GetDeviceQueue(VkDevice, uint32_t, uint32_t, VkQueue*) {}
@@ -325,6 +327,7 @@ static VKAPI_ATTR void VKAPI_CALL CmdEndTransformFeedbackEXT(VkCommandBuffer, ui
 static VKAPI_ATTR void VKAPI_CALL CmdBeginQueryIndexedEXT(VkCommandBuffer, VkQueryPool, uint32_t, VkQueryControlFlags, uint32_t) {}
 static VKAPI_ATTR void VKAPI_CALL CmdEndQueryIndexedEXT(VkCommandBuffer, VkQueryPool, uint32_t, uint32_t) {}
 static VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectByteCountEXT(VkCommandBuffer, uint32_t, uint32_t, VkBuffer, VkDeviceSize, uint32_t, uint32_t) {}
+static VKAPI_ATTR uint32_t VKAPI_CALL GetImageViewHandleNVX(VkDevice, const VkImageViewHandleInfoNVX*) { return 0; }
 static VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountAMD(VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, uint32_t, uint32_t) {}
 static VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountAMD(VkCommandBuffer, VkBuffer, VkDeviceSize, VkBuffer, VkDeviceSize, uint32_t, uint32_t) {}
 static VKAPI_ATTR VkResult VKAPI_CALL GetShaderInfoAMD(VkDevice, VkPipeline, VkShaderStageFlagBits, VkShaderInfoTypeAMD, size_t*, void*) { return VK_SUCCESS; }
@@ -480,6 +483,8 @@ struct InstanceTable
     PFN_vkGetPhysicalDeviceMultisamplePropertiesEXT GetPhysicalDeviceMultisamplePropertiesEXT{ noop::GetPhysicalDeviceMultisamplePropertiesEXT };
     PFN_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT GetPhysicalDeviceCalibrateableTimeDomainsEXT{ noop::GetPhysicalDeviceCalibrateableTimeDomainsEXT };
     PFN_vkCreateImagePipeSurfaceFUCHSIA CreateImagePipeSurfaceFUCHSIA{ noop::CreateImagePipeSurfaceFUCHSIA };
+    PFN_vkCreateMetalSurfaceEXT CreateMetalSurfaceEXT{ noop::CreateMetalSurfaceEXT };
+    PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV GetPhysicalDeviceCooperativeMatrixPropertiesNV{ noop::GetPhysicalDeviceCooperativeMatrixPropertiesNV };
 };
 
 struct DeviceTable
@@ -677,6 +682,7 @@ struct DeviceTable
     PFN_vkCmdBeginQueryIndexedEXT CmdBeginQueryIndexedEXT{ noop::CmdBeginQueryIndexedEXT };
     PFN_vkCmdEndQueryIndexedEXT CmdEndQueryIndexedEXT{ noop::CmdEndQueryIndexedEXT };
     PFN_vkCmdDrawIndirectByteCountEXT CmdDrawIndirectByteCountEXT{ noop::CmdDrawIndirectByteCountEXT };
+    PFN_vkGetImageViewHandleNVX GetImageViewHandleNVX{ noop::GetImageViewHandleNVX };
     PFN_vkCmdDrawIndirectCountAMD CmdDrawIndirectCountAMD{ noop::CmdDrawIndirectCountAMD };
     PFN_vkCmdDrawIndexedIndirectCountAMD CmdDrawIndexedIndirectCountAMD{ noop::CmdDrawIndexedIndirectCountAMD };
     PFN_vkGetShaderInfoAMD GetShaderInfoAMD{ noop::GetShaderInfoAMD };
@@ -837,6 +843,8 @@ static void LoadInstanceTable(PFN_vkGetInstanceProcAddr gpa, VkInstance instance
     LoadFunction(gpa, instance, "vkGetPhysicalDeviceMultisamplePropertiesEXT", &table->GetPhysicalDeviceMultisamplePropertiesEXT);
     LoadFunction(gpa, instance, "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", &table->GetPhysicalDeviceCalibrateableTimeDomainsEXT);
     LoadFunction(gpa, instance, "vkCreateImagePipeSurfaceFUCHSIA", &table->CreateImagePipeSurfaceFUCHSIA);
+    LoadFunction(gpa, instance, "vkCreateMetalSurfaceEXT", &table->CreateMetalSurfaceEXT);
+    LoadFunction(gpa, instance, "vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", &table->GetPhysicalDeviceCooperativeMatrixPropertiesNV);
 }
 
 static void LoadDeviceTable(PFN_vkGetDeviceProcAddr gpa, VkDevice device, DeviceTable* table)
@@ -1036,6 +1044,7 @@ static void LoadDeviceTable(PFN_vkGetDeviceProcAddr gpa, VkDevice device, Device
     LoadFunction(gpa, device, "vkCmdBeginQueryIndexedEXT", &table->CmdBeginQueryIndexedEXT);
     LoadFunction(gpa, device, "vkCmdEndQueryIndexedEXT", &table->CmdEndQueryIndexedEXT);
     LoadFunction(gpa, device, "vkCmdDrawIndirectByteCountEXT", &table->CmdDrawIndirectByteCountEXT);
+    LoadFunction(gpa, device, "vkGetImageViewHandleNVX", &table->GetImageViewHandleNVX);
     LoadFunction(gpa, device, "vkCmdDrawIndirectCountAMD", &table->CmdDrawIndirectCountAMD);
     LoadFunction(gpa, device, "vkCmdDrawIndexedIndirectCountAMD", &table->CmdDrawIndexedIndirectCountAMD);
     LoadFunction(gpa, device, "vkGetShaderInfoAMD", &table->GetShaderInfoAMD);

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -3782,6 +3782,18 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndirectByteCountEXT(
     Dispatcher<format::ApiCallId::ApiCall_vkCmdDrawIndirectByteCountEXT, void, PFN_vkCmdDrawIndirectByteCountEXT>::Dispatch(this, vkCmdDrawIndirectByteCountEXT, in_commandBuffer, instanceCount, firstInstance, in_counterBuffer, counterBufferOffset, counterOffset, vertexStride);
 }
 
+void VulkanReplayConsumer::Process_vkGetImageViewHandleNVX(
+    uint32_t                                    returnValue,
+    format::HandleId                            device,
+    const StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>& pInfo)
+{
+    VkDevice in_device = GetObjectMapper().MapVkDevice(device);
+    const VkImageViewHandleInfoNVX* in_pInfo = pInfo.GetPointer();
+    MapStructHandles(pInfo.GetMetaStructPointer(), GetObjectMapper());
+
+    Dispatcher<format::ApiCallId::ApiCall_vkGetImageViewHandleNVX, uint32_t, PFN_vkGetImageViewHandleNVX>::Dispatch(this, vkGetImageViewHandleNVX, in_device, in_pInfo);
+}
+
 void VulkanReplayConsumer::Process_vkCmdDrawIndirectCountAMD(
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
@@ -4948,6 +4960,26 @@ void VulkanReplayConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
     AddHandles<VkSurfaceKHR>(pSurface.GetPointer(), 1, out_pSurface, 1, &VulkanObjectMapper::AddVkSurfaceKHR);
 }
 
+void VulkanReplayConsumer::Process_vkCreateMetalSurfaceEXT(
+    VkResult                                    returnValue,
+    format::HandleId                            instance,
+    const StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>& pCreateInfo,
+    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    const HandlePointerDecoder<VkSurfaceKHR>&   pSurface)
+{
+    VkInstance in_instance = GetObjectMapper().MapVkInstance(instance);
+    const VkMetalSurfaceCreateInfoEXT* in_pCreateInfo = pCreateInfo.GetPointer();
+    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
+    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
+    VkSurfaceKHR out_pSurface_value = static_cast<VkSurfaceKHR>(0);
+    VkSurfaceKHR* out_pSurface = &out_pSurface_value;
+
+    VkResult replay_result = Dispatcher<format::ApiCallId::ApiCall_vkCreateMetalSurfaceEXT, VkResult, PFN_vkCreateMetalSurfaceEXT>::Dispatch(this, returnValue, vkCreateMetalSurfaceEXT, in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
+    CheckResult("vkCreateMetalSurfaceEXT", returnValue, replay_result);
+
+    AddHandles<VkSurfaceKHR>(pSurface.GetPointer(), 1, out_pSurface, 1, &VulkanObjectMapper::AddVkSurfaceKHR);
+}
+
 void VulkanReplayConsumer::Process_vkGetBufferDeviceAddressEXT(
     VkDeviceAddress                             returnValue,
     format::HandleId                            device,
@@ -4958,6 +4990,23 @@ void VulkanReplayConsumer::Process_vkGetBufferDeviceAddressEXT(
     MapStructHandles(pInfo.GetMetaStructPointer(), GetObjectMapper());
 
     Dispatcher<format::ApiCallId::ApiCall_vkGetBufferDeviceAddressEXT, VkDeviceAddress, PFN_vkGetBufferDeviceAddressEXT>::Dispatch(this, vkGetBufferDeviceAddressEXT, in_device, in_pInfo);
+}
+
+void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(
+    VkResult                                    returnValue,
+    format::HandleId                            physicalDevice,
+    const PointerDecoder<uint32_t>&             pPropertyCount,
+    const StructPointerDecoder<Decoded_VkCooperativeMatrixPropertiesNV>& pProperties)
+{
+    VkPhysicalDevice in_physicalDevice = GetObjectMapper().MapVkPhysicalDevice(physicalDevice);
+    uint32_t out_pPropertyCount_value = pPropertyCount.IsNull() ? static_cast<uint32_t>(0) : *(pPropertyCount.GetPointer());
+    uint32_t* out_pPropertyCount = &out_pPropertyCount_value;
+    VkCooperativeMatrixPropertiesNV* out_pProperties = pProperties.IsNull() ? nullptr : AllocateArray<VkCooperativeMatrixPropertiesNV>(out_pPropertyCount_value, VkCooperativeMatrixPropertiesNV{ VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_NV, nullptr });
+
+    VkResult replay_result = Dispatcher<format::ApiCallId::ApiCall_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, VkResult, PFN_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV>::Dispatch(this, returnValue, vkGetPhysicalDeviceCooperativeMatrixPropertiesNV, in_physicalDevice, out_pPropertyCount, out_pProperties);
+    CheckResult("vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", returnValue, replay_result);
+
+    FreeArray<VkCooperativeMatrixPropertiesNV>(&out_pProperties);
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/generated_vulkan_replay_consumer.h
+++ b/framework/generated/generated_vulkan_replay_consumer.h
@@ -1588,6 +1588,11 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    counterOffset,
         uint32_t                                    vertexStride) override;
 
+    virtual void Process_vkGetImageViewHandleNVX(
+        uint32_t                                    returnValue,
+        format::HandleId                            device,
+        const StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>& pInfo) override;
+
     virtual void Process_vkCmdDrawIndirectCountAMD(
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
@@ -2076,10 +2081,23 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
         const HandlePointerDecoder<VkSurfaceKHR>&   pSurface) override;
 
+    virtual void Process_vkCreateMetalSurfaceEXT(
+        VkResult                                    returnValue,
+        format::HandleId                            instance,
+        const StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>& pCreateInfo,
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        const HandlePointerDecoder<VkSurfaceKHR>&   pSurface) override;
+
     virtual void Process_vkGetBufferDeviceAddressEXT(
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkBufferDeviceAddressInfoEXT>& pInfo) override;
+
+    virtual void Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(
+        VkResult                                    returnValue,
+        format::HandleId                            physicalDevice,
+        const PointerDecoder<uint32_t>&             pPropertyCount,
+        const StructPointerDecoder<Decoded_VkCooperativeMatrixPropertiesNV>& pProperties) override;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/generated_vulkan_struct_decoders.cpp
+++ b/framework/generated/generated_vulkan_struct_decoders.cpp
@@ -4599,6 +4599,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysica
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->vulkanMemoryModel));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->vulkanMemoryModelDeviceScope));
+    bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->vulkanMemoryModelAvailabilityVisibilityChains));
 
     return bytes_read;
 }
@@ -4793,6 +4794,25 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->rasterizationStream));
+
+    return bytes_read;
+}
+
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageViewHandleInfoNVX* wrapper)
+{
+    assert((wrapper != nullptr) && (wrapper->value != nullptr));
+
+    size_t bytes_read = 0;
+    VkImageViewHandleInfoNVX* value = wrapper->value;
+
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
+    bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->imageView));
+    value->imageView = VK_NULL_HANDLE;
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->descriptorType));
+    bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->sampler));
+    value->sampler = VK_NULL_HANDLE;
 
     return bytes_read;
 }
@@ -5614,6 +5634,37 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->conservativeRasterizationMode));
     bytes_read += ValueDecoder::DecodeFloatValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->extraPrimitiveOverestimationSize));
+
+    return bytes_read;
+}
+
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT* wrapper)
+{
+    assert((wrapper != nullptr) && (wrapper->value != nullptr));
+
+    size_t bytes_read = 0;
+    VkPhysicalDeviceDepthClipEnableFeaturesEXT* value = wrapper->value;
+
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
+    bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->depthClipEnable));
+
+    return bytes_read;
+}
+
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT* wrapper)
+{
+    assert((wrapper != nullptr) && (wrapper->value != nullptr));
+
+    size_t bytes_read = 0;
+    VkPipelineRasterizationDepthClipStateCreateInfoEXT* value = wrapper->value;
+
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
+    bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
+    bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->depthClipEnable));
 
     return bytes_read;
 }
@@ -6859,6 +6910,37 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     return bytes_read;
 }
 
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT* wrapper)
+{
+    assert((wrapper != nullptr) && (wrapper->value != nullptr));
+
+    size_t bytes_read = 0;
+    VkPhysicalDeviceImageViewImageFormatInfoEXT* value = wrapper->value;
+
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageViewType));
+
+    return bytes_read;
+}
+
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT* wrapper)
+{
+    assert((wrapper != nullptr) && (wrapper->value != nullptr));
+
+    size_t bytes_read = 0;
+    VkFilterCubicImageViewImageFormatPropertiesEXT* value = wrapper->value;
+
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
+    bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->filterCubic));
+    bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->filterCubicMinmax));
+
+    return bytes_read;
+}
+
 size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
@@ -7242,6 +7324,23 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImagePi
     return bytes_read;
 }
 
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMetalSurfaceCreateInfoEXT* wrapper)
+{
+    assert((wrapper != nullptr) && (wrapper->value != nullptr));
+
+    size_t bytes_read = 0;
+    VkMetalSurfaceCreateInfoEXT* value = wrapper->value;
+
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
+    bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
+    bytes_read += ValueDecoder::DecodeAddress((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pLayer));
+    value->pLayer = nullptr;
+
+    return bytes_read;
+}
+
 size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
@@ -7357,6 +7456,21 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryP
     return bytes_read;
 }
 
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* wrapper)
+{
+    assert((wrapper != nullptr) && (wrapper->value != nullptr));
+
+    size_t bytes_read = 0;
+    VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* value = wrapper->value;
+
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
+    bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->dedicatedAllocationImageAliasing));
+
+    return bytes_read;
+}
+
 size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceBufferAddressFeaturesEXT* wrapper)
 {
     assert((wrapper != nullptr) && (wrapper->value != nullptr));
@@ -7436,6 +7550,74 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkValidat
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->disabledValidationFeatureCount));
     bytes_read += wrapper->pDisabledValidationFeatures.DecodeEnum((buffer + bytes_read), (buffer_size - bytes_read));
     value->pDisabledValidationFeatures = wrapper->pDisabledValidationFeatures.GetPointer();
+
+    return bytes_read;
+}
+
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCooperativeMatrixPropertiesNV* wrapper)
+{
+    assert((wrapper != nullptr) && (wrapper->value != nullptr));
+
+    size_t bytes_read = 0;
+    VkCooperativeMatrixPropertiesNV* value = wrapper->value;
+
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
+    bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->MSize));
+    bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->NSize));
+    bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->KSize));
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->AType));
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->BType));
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->CType));
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->DType));
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->scope));
+
+    return bytes_read;
+}
+
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV* wrapper)
+{
+    assert((wrapper != nullptr) && (wrapper->value != nullptr));
+
+    size_t bytes_read = 0;
+    VkPhysicalDeviceCooperativeMatrixFeaturesNV* value = wrapper->value;
+
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
+    bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->cooperativeMatrix));
+    bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->cooperativeMatrixRobustBufferAccess));
+
+    return bytes_read;
+}
+
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV* wrapper)
+{
+    assert((wrapper != nullptr) && (wrapper->value != nullptr));
+
+    size_t bytes_read = 0;
+    VkPhysicalDeviceCooperativeMatrixPropertiesNV* value = wrapper->value;
+
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
+    bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->cooperativeMatrixSupportedStages));
+
+    return bytes_read;
+}
+
+size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* wrapper)
+{
+    assert((wrapper != nullptr) && (wrapper->value != nullptr));
+
+    size_t bytes_read = 0;
+    VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* value = wrapper->value;
+
+    bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
+    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
+    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
+    bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->ycbcrImageArrays));
 
     return bytes_read;
 }

--- a/framework/generated/generated_vulkan_struct_decoders.h
+++ b/framework/generated/generated_vulkan_struct_decoders.h
@@ -2667,6 +2667,17 @@ struct Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT
     std::unique_ptr<PNextNode> pNext;
 };
 
+struct Decoded_VkImageViewHandleInfoNVX
+{
+    using struct_type = VkImageViewHandleInfoNVX;
+
+    VkImageViewHandleInfoNVX* value{ nullptr };
+
+    std::unique_ptr<PNextNode> pNext;
+    format::HandleId imageView{ 0 };
+    format::HandleId sampler{ 0 };
+};
+
 struct Decoded_VkTextureLODGatherFormatPropertiesAMD
 {
     using struct_type = VkTextureLODGatherFormatPropertiesAMD;
@@ -3112,6 +3123,24 @@ struct Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT
     using struct_type = VkPipelineRasterizationConservativeStateCreateInfoEXT;
 
     VkPipelineRasterizationConservativeStateCreateInfoEXT* value{ nullptr };
+
+    std::unique_ptr<PNextNode> pNext;
+};
+
+struct Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT
+{
+    using struct_type = VkPhysicalDeviceDepthClipEnableFeaturesEXT;
+
+    VkPhysicalDeviceDepthClipEnableFeaturesEXT* value{ nullptr };
+
+    std::unique_ptr<PNextNode> pNext;
+};
+
+struct Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT
+{
+    using struct_type = VkPipelineRasterizationDepthClipStateCreateInfoEXT;
+
+    VkPipelineRasterizationDepthClipStateCreateInfoEXT* value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
 };
@@ -3778,6 +3807,24 @@ struct Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV
     std::unique_ptr<PNextNode> pNext;
 };
 
+struct Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT
+{
+    using struct_type = VkPhysicalDeviceImageViewImageFormatInfoEXT;
+
+    VkPhysicalDeviceImageViewImageFormatInfoEXT* value{ nullptr };
+
+    std::unique_ptr<PNextNode> pNext;
+};
+
+struct Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT
+{
+    using struct_type = VkFilterCubicImageViewImageFormatPropertiesEXT;
+
+    VkFilterCubicImageViewImageFormatPropertiesEXT* value{ nullptr };
+
+    std::unique_ptr<PNextNode> pNext;
+};
+
 struct Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT
 {
     using struct_type = VkDeviceQueueGlobalPriorityCreateInfoEXT;
@@ -3987,6 +4034,16 @@ struct Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA
     std::unique_ptr<PNextNode> pNext;
 };
 
+struct Decoded_VkMetalSurfaceCreateInfoEXT
+{
+    using struct_type = VkMetalSurfaceCreateInfoEXT;
+
+    VkMetalSurfaceCreateInfoEXT* value{ nullptr };
+
+    std::unique_ptr<PNextNode> pNext;
+    uint64_t pLayer{ 0 };
+};
+
 struct Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT
 {
     using struct_type = VkPhysicalDeviceFragmentDensityMapFeaturesEXT;
@@ -4055,6 +4112,15 @@ struct Decoded_VkMemoryPriorityAllocateInfoEXT
     std::unique_ptr<PNextNode> pNext;
 };
 
+struct Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV
+{
+    using struct_type = VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV;
+
+    VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* value{ nullptr };
+
+    std::unique_ptr<PNextNode> pNext;
+};
+
 struct Decoded_VkPhysicalDeviceBufferAddressFeaturesEXT
 {
     using struct_type = VkPhysicalDeviceBufferAddressFeaturesEXT;
@@ -4101,6 +4167,42 @@ struct Decoded_VkValidationFeaturesEXT
     std::unique_ptr<PNextNode> pNext;
     PointerDecoder<VkValidationFeatureEnableEXT> pEnabledValidationFeatures;
     PointerDecoder<VkValidationFeatureDisableEXT> pDisabledValidationFeatures;
+};
+
+struct Decoded_VkCooperativeMatrixPropertiesNV
+{
+    using struct_type = VkCooperativeMatrixPropertiesNV;
+
+    VkCooperativeMatrixPropertiesNV* value{ nullptr };
+
+    std::unique_ptr<PNextNode> pNext;
+};
+
+struct Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV
+{
+    using struct_type = VkPhysicalDeviceCooperativeMatrixFeaturesNV;
+
+    VkPhysicalDeviceCooperativeMatrixFeaturesNV* value{ nullptr };
+
+    std::unique_ptr<PNextNode> pNext;
+};
+
+struct Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV
+{
+    using struct_type = VkPhysicalDeviceCooperativeMatrixPropertiesNV;
+
+    VkPhysicalDeviceCooperativeMatrixPropertiesNV* value{ nullptr };
+
+    std::unique_ptr<PNextNode> pNext;
+};
+
+struct Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT
+{
+    using struct_type = VkPhysicalDeviceYcbcrImageArraysFeaturesEXT;
+
+    VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* value{ nullptr };
+
+    std::unique_ptr<PNextNode> pNext;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/generated_vulkan_struct_decoders_forward.h
+++ b/framework/generated/generated_vulkan_struct_decoders_forward.h
@@ -618,6 +618,10 @@ size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT* wrapper);
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT* wrapper);
 
+struct Decoded_VkImageViewHandleInfoNVX;
+
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImageViewHandleInfoNVX* wrapper);
+
 struct Decoded_VkTextureLODGatherFormatPropertiesAMD;
 
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkTextureLODGatherFormatPropertiesAMD* wrapper);
@@ -753,6 +757,12 @@ struct Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT;
 
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT* wrapper);
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT* wrapper);
+
+struct Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT;
+struct Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT;
+
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT* wrapper);
 
 struct Decoded_VkXYColorEXT;
 struct Decoded_VkHdrMetadataEXT;
@@ -924,6 +934,12 @@ struct Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV;
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* wrapper);
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV* wrapper);
 
+struct Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT;
+struct Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT;
+
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT* wrapper);
+
 struct Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT;
 
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT* wrapper);
@@ -998,6 +1014,10 @@ struct Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA;
 
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA* wrapper);
 
+struct Decoded_VkMetalSurfaceCreateInfoEXT;
+
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMetalSurfaceCreateInfoEXT* wrapper);
+
 struct Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT;
 struct Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT;
 struct Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT;
@@ -1020,6 +1040,10 @@ struct Decoded_VkMemoryPriorityAllocateInfoEXT;
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceMemoryPriorityFeaturesEXT* wrapper);
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkMemoryPriorityAllocateInfoEXT* wrapper);
 
+struct Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV;
+
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* wrapper);
+
 struct Decoded_VkPhysicalDeviceBufferAddressFeaturesEXT;
 struct Decoded_VkBufferDeviceAddressInfoEXT;
 struct Decoded_VkBufferDeviceAddressCreateInfoEXT;
@@ -1035,6 +1059,18 @@ size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded
 struct Decoded_VkValidationFeaturesEXT;
 
 size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkValidationFeaturesEXT* wrapper);
+
+struct Decoded_VkCooperativeMatrixPropertiesNV;
+struct Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV;
+struct Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV;
+
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkCooperativeMatrixPropertiesNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV* wrapper);
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV* wrapper);
+
+struct Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT;
+
+size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* wrapper);
 
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/generated_vulkan_struct_encoders.cpp
+++ b/framework/generated/generated_vulkan_struct_encoders.cpp
@@ -2419,6 +2419,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceVulkanMemoryM
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeVkBool32Value(value.vulkanMemoryModel);
     encoder->EncodeVkBool32Value(value.vulkanMemoryModelDeviceScope);
+    encoder->EncodeVkBool32Value(value.vulkanMemoryModelAvailabilityVisibilityChains);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkDebugReportCallbackCreateInfoEXT& value)
@@ -2517,6 +2518,15 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRasterizationStateS
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeUInt32Value(value.rasterizationStream);
+}
+
+void EncodeStruct(ParameterEncoder* encoder, const VkImageViewHandleInfoNVX& value)
+{
+    encoder->EncodeEnumValue(value.sType);
+    EncodePNextStruct(encoder, value.pNext);
+    encoder->EncodeHandleIdValue(value.imageView);
+    encoder->EncodeEnumValue(value.descriptorType);
+    encoder->EncodeHandleIdValue(value.sampler);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkTextureLODGatherFormatPropertiesAMD& value)
@@ -2930,6 +2940,21 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRasterizationConser
     encoder->EncodeFlagsValue(value.flags);
     encoder->EncodeEnumValue(value.conservativeRasterizationMode);
     encoder->EncodeFloatValue(value.extraPrimitiveOverestimationSize);
+}
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDepthClipEnableFeaturesEXT& value)
+{
+    encoder->EncodeEnumValue(value.sType);
+    EncodePNextStruct(encoder, value.pNext);
+    encoder->EncodeVkBool32Value(value.depthClipEnable);
+}
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRasterizationDepthClipStateCreateInfoEXT& value)
+{
+    encoder->EncodeEnumValue(value.sType);
+    EncodePNextStruct(encoder, value.pNext);
+    encoder->EncodeFlagsValue(value.flags);
+    encoder->EncodeVkBool32Value(value.depthClipEnable);
 }
 
 void EncodeStruct(ParameterEncoder* encoder, const VkXYColorEXT& value)
@@ -3575,6 +3600,21 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRepresentativeFragm
     encoder->EncodeVkBool32Value(value.representativeFragmentTestEnable);
 }
 
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceImageViewImageFormatInfoEXT& value)
+{
+    encoder->EncodeEnumValue(value.sType);
+    EncodePNextStruct(encoder, value.pNext);
+    encoder->EncodeEnumValue(value.imageViewType);
+}
+
+void EncodeStruct(ParameterEncoder* encoder, const VkFilterCubicImageViewImageFormatPropertiesEXT& value)
+{
+    encoder->EncodeEnumValue(value.sType);
+    EncodePNextStruct(encoder, value.pNext);
+    encoder->EncodeVkBool32Value(value.filterCubic);
+    encoder->EncodeVkBool32Value(value.filterCubicMinmax);
+}
+
 void EncodeStruct(ParameterEncoder* encoder, const VkDeviceQueueGlobalPriorityCreateInfoEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -3770,6 +3810,14 @@ void EncodeStruct(ParameterEncoder* encoder, const VkImagePipeSurfaceCreateInfoF
     encoder->EncodeUInt32Value(value.imagePipeHandle);
 }
 
+void EncodeStruct(ParameterEncoder* encoder, const VkMetalSurfaceCreateInfoEXT& value)
+{
+    encoder->EncodeEnumValue(value.sType);
+    EncodePNextStruct(encoder, value.pNext);
+    encoder->EncodeFlagsValue(value.flags);
+    encoder->EncodeVoidPtr(value.pLayer);
+}
+
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentDensityMapFeaturesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -3824,6 +3872,13 @@ void EncodeStruct(ParameterEncoder* encoder, const VkMemoryPriorityAllocateInfoE
     encoder->EncodeFloatValue(value.priority);
 }
 
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV& value)
+{
+    encoder->EncodeEnumValue(value.sType);
+    EncodePNextStruct(encoder, value.pNext);
+    encoder->EncodeVkBool32Value(value.dedicatedAllocationImageAliasing);
+}
+
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceBufferAddressFeaturesEXT& value)
 {
     encoder->EncodeEnumValue(value.sType);
@@ -3862,6 +3917,42 @@ void EncodeStruct(ParameterEncoder* encoder, const VkValidationFeaturesEXT& valu
     encoder->EncodeEnumArray(value.pEnabledValidationFeatures, value.enabledValidationFeatureCount);
     encoder->EncodeUInt32Value(value.disabledValidationFeatureCount);
     encoder->EncodeEnumArray(value.pDisabledValidationFeatures, value.disabledValidationFeatureCount);
+}
+
+void EncodeStruct(ParameterEncoder* encoder, const VkCooperativeMatrixPropertiesNV& value)
+{
+    encoder->EncodeEnumValue(value.sType);
+    EncodePNextStruct(encoder, value.pNext);
+    encoder->EncodeUInt32Value(value.MSize);
+    encoder->EncodeUInt32Value(value.NSize);
+    encoder->EncodeUInt32Value(value.KSize);
+    encoder->EncodeEnumValue(value.AType);
+    encoder->EncodeEnumValue(value.BType);
+    encoder->EncodeEnumValue(value.CType);
+    encoder->EncodeEnumValue(value.DType);
+    encoder->EncodeEnumValue(value.scope);
+}
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceCooperativeMatrixFeaturesNV& value)
+{
+    encoder->EncodeEnumValue(value.sType);
+    EncodePNextStruct(encoder, value.pNext);
+    encoder->EncodeVkBool32Value(value.cooperativeMatrix);
+    encoder->EncodeVkBool32Value(value.cooperativeMatrixRobustBufferAccess);
+}
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceCooperativeMatrixPropertiesNV& value)
+{
+    encoder->EncodeEnumValue(value.sType);
+    EncodePNextStruct(encoder, value.pNext);
+    encoder->EncodeFlagsValue(value.cooperativeMatrixSupportedStages);
+}
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT& value)
+{
+    encoder->EncodeEnumValue(value.sType);
+    EncodePNextStruct(encoder, value.pNext);
+    encoder->EncodeVkBool32Value(value.ycbcrImageArrays);
 }
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/generated/generated_vulkan_struct_encoders.h
+++ b/framework/generated/generated_vulkan_struct_encoders.h
@@ -329,6 +329,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceTransformFeed
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceTransformFeedbackPropertiesEXT& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRasterizationStateStreamCreateInfoEXT& value);
 
+void EncodeStruct(ParameterEncoder* encoder, const VkImageViewHandleInfoNVX& value);
+
 void EncodeStruct(ParameterEncoder* encoder, const VkTextureLODGatherFormatPropertiesAMD& value);
 
 void EncodeStruct(ParameterEncoder* encoder, const VkShaderResourceUsageAMD& value);
@@ -396,6 +398,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPipelineDiscardRectangleSta
 
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceConservativeRasterizationPropertiesEXT& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRasterizationConservativeStateCreateInfoEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDepthClipEnableFeaturesEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRasterizationDepthClipStateCreateInfoEXT& value);
 
 void EncodeStruct(ParameterEncoder* encoder, const VkXYColorEXT& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkHdrMetadataEXT& value);
@@ -482,6 +487,9 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceRayTracingPro
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkPipelineRepresentativeFragmentTestStateCreateInfoNV& value);
 
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceImageViewImageFormatInfoEXT& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkFilterCubicImageViewImageFormatPropertiesEXT& value);
+
 void EncodeStruct(ParameterEncoder* encoder, const VkDeviceQueueGlobalPriorityCreateInfoEXT& value);
 
 void EncodeStruct(ParameterEncoder* encoder, const VkImportMemoryHostPointerInfoEXT& value);
@@ -519,6 +527,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDevicePCIBusInfoPro
 
 void EncodeStruct(ParameterEncoder* encoder, const VkImagePipeSurfaceCreateInfoFUCHSIA& value);
 
+void EncodeStruct(ParameterEncoder* encoder, const VkMetalSurfaceCreateInfoEXT& value);
+
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentDensityMapFeaturesEXT& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceFragmentDensityMapPropertiesEXT& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkRenderPassFragmentDensityMapCreateInfoEXT& value);
@@ -530,6 +540,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryBudgetP
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceMemoryPriorityFeaturesEXT& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkMemoryPriorityAllocateInfoEXT& value);
 
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV& value);
+
 void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceBufferAddressFeaturesEXT& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkBufferDeviceAddressInfoEXT& value);
 void EncodeStruct(ParameterEncoder* encoder, const VkBufferDeviceAddressCreateInfoEXT& value);
@@ -537,6 +549,12 @@ void EncodeStruct(ParameterEncoder* encoder, const VkBufferDeviceAddressCreateIn
 void EncodeStruct(ParameterEncoder* encoder, const VkImageStencilUsageCreateInfoEXT& value);
 
 void EncodeStruct(ParameterEncoder* encoder, const VkValidationFeaturesEXT& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkCooperativeMatrixPropertiesNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceCooperativeMatrixFeaturesNV& value);
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceCooperativeMatrixPropertiesNV& value);
+
+void EncodeStruct(ParameterEncoder* encoder, const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT& value);
 
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/generated_vulkan_struct_handle_mappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.cpp
@@ -2493,6 +2493,23 @@ void MapStructHandles(Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT* w
     }
 }
 
+void MapStructHandles(Decoded_VkImageViewHandleInfoNVX* wrapper, const VulkanObjectMapper& object_mapper)
+{
+    if ((wrapper != nullptr) && (wrapper->value != nullptr))
+    {
+        VkImageViewHandleInfoNVX* value = wrapper->value;
+
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
+
+        value->imageView = object_mapper.MapVkImageView(wrapper->imageView);
+
+        value->sampler = object_mapper.MapVkSampler(wrapper->sampler);
+    }
+}
+
 void MapStructHandles(Decoded_VkTextureLODGatherFormatPropertiesAMD* wrapper, const VulkanObjectMapper& object_mapper)
 {
     if (wrapper != nullptr)
@@ -2938,6 +2955,28 @@ void MapStructHandles(Decoded_VkPhysicalDeviceConservativeRasterizationPropertie
 }
 
 void MapStructHandles(Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
+{
+    if (wrapper != nullptr)
+    {
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
+    }
+}
+
+void MapStructHandles(Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
+{
+    if (wrapper != nullptr)
+    {
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
+    }
+}
+
+void MapStructHandles(Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
 {
     if (wrapper != nullptr)
     {
@@ -3685,6 +3724,28 @@ void MapStructHandles(Decoded_VkPipelineRepresentativeFragmentTestStateCreateInf
     }
 }
 
+void MapStructHandles(Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
+{
+    if (wrapper != nullptr)
+    {
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
+    }
+}
+
+void MapStructHandles(Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
+{
+    if (wrapper != nullptr)
+    {
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
+    }
+}
+
 void MapStructHandles(Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
 {
     if (wrapper != nullptr)
@@ -3916,6 +3977,17 @@ void MapStructHandles(Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA* wrapper, cons
     }
 }
 
+void MapStructHandles(Decoded_VkMetalSurfaceCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
+{
+    if (wrapper != nullptr)
+    {
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
+    }
+}
+
 void MapStructHandles(Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
 {
     if (wrapper != nullptr)
@@ -3993,6 +4065,17 @@ void MapStructHandles(Decoded_VkMemoryPriorityAllocateInfoEXT* wrapper, const Vu
     }
 }
 
+void MapStructHandles(Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper)
+{
+    if (wrapper != nullptr)
+    {
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
+    }
+}
+
 void MapStructHandles(Decoded_VkPhysicalDeviceBufferAddressFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
 {
     if (wrapper != nullptr)
@@ -4042,6 +4125,50 @@ void MapStructHandles(Decoded_VkImageStencilUsageCreateInfoEXT* wrapper, const V
 }
 
 void MapStructHandles(Decoded_VkValidationFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
+{
+    if (wrapper != nullptr)
+    {
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
+    }
+}
+
+void MapStructHandles(Decoded_VkCooperativeMatrixPropertiesNV* wrapper, const VulkanObjectMapper& object_mapper)
+{
+    if (wrapper != nullptr)
+    {
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
+    }
+}
+
+void MapStructHandles(Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper)
+{
+    if (wrapper != nullptr)
+    {
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
+    }
+}
+
+void MapStructHandles(Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV* wrapper, const VulkanObjectMapper& object_mapper)
+{
+    if (wrapper != nullptr)
+    {
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
+    }
+}
+
+void MapStructHandles(Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
 {
     if (wrapper != nullptr)
     {
@@ -4339,6 +4466,12 @@ void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectM
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT:
             MapStructHandles(reinterpret_cast<Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT*>(wrapper), object_mapper);
             break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT:
+            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(wrapper), object_mapper);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_DEPTH_CLIP_STATE_CREATE_INFO_EXT:
+            MapStructHandles(reinterpret_cast<Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT*>(wrapper), object_mapper);
+            break;
         case VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT:
             MapStructHandles(reinterpret_cast<Decoded_VkDebugUtilsMessengerCreateInfoEXT*>(wrapper), object_mapper);
             break;
@@ -4453,6 +4586,12 @@ void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectM
         case VK_STRUCTURE_TYPE_PIPELINE_REPRESENTATIVE_FRAGMENT_TEST_STATE_CREATE_INFO_NV:
             MapStructHandles(reinterpret_cast<Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV*>(wrapper), object_mapper);
             break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_IMAGE_FORMAT_INFO_EXT:
+            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT*>(wrapper), object_mapper);
+            break;
+        case VK_STRUCTURE_TYPE_FILTER_CUBIC_IMAGE_VIEW_IMAGE_FORMAT_PROPERTIES_EXT:
+            MapStructHandles(reinterpret_cast<Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT*>(wrapper), object_mapper);
+            break;
         case VK_STRUCTURE_TYPE_DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT:
             MapStructHandles(reinterpret_cast<Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT*>(wrapper), object_mapper);
             break;
@@ -4525,6 +4664,9 @@ void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectM
         case VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT:
             MapStructHandles(reinterpret_cast<Decoded_VkMemoryPriorityAllocateInfoEXT*>(wrapper), object_mapper);
             break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV:
+            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(wrapper), object_mapper);
+            break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_ADDRESS_FEATURES_EXT:
             MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceBufferAddressFeaturesEXT*>(wrapper), object_mapper);
             break;
@@ -4536,6 +4678,15 @@ void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectM
             break;
         case VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT:
             MapStructHandles(reinterpret_cast<Decoded_VkValidationFeaturesEXT*>(wrapper), object_mapper);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV:
+            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(wrapper), object_mapper);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV:
+            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV*>(wrapper), object_mapper);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT:
+            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(wrapper), object_mapper);
             break;
         }
     }

--- a/framework/generated/generated_vulkan_struct_handle_mappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.h
@@ -425,6 +425,8 @@ void MapStructHandles(Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT* wr
 
 void MapStructHandles(Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
 
+void MapStructHandles(Decoded_VkImageViewHandleInfoNVX* wrapper, const VulkanObjectMapper& object_mapper);
+
 void MapStructHandles(Decoded_VkTextureLODGatherFormatPropertiesAMD* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkPhysicalDeviceCornerSampledImageFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper);
@@ -502,6 +504,10 @@ void MapStructHandles(Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT* wrap
 void MapStructHandles(Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
+
+void MapStructHandles(Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
+
+void MapStructHandles(Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkHdrMetadataEXT* wrapper, const VulkanObjectMapper& object_mapper);
 
@@ -627,6 +633,10 @@ void MapStructHandles(Decoded_VkPhysicalDeviceRepresentativeFragmentTestFeatures
 
 void MapStructHandles(Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
 
+void MapStructHandles(Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
+
+void MapStructHandles(Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
+
 void MapStructHandles(Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkImportMemoryHostPointerInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
@@ -669,6 +679,8 @@ void MapStructHandles(Decoded_VkPhysicalDevicePCIBusInfoPropertiesEXT* wrapper, 
 
 void MapStructHandles(Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA* wrapper, const VulkanObjectMapper& object_mapper);
 
+void MapStructHandles(Decoded_VkMetalSurfaceCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
+
 void MapStructHandles(Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
@@ -683,6 +695,8 @@ void MapStructHandles(Decoded_VkPhysicalDeviceMemoryPriorityFeaturesEXT* wrapper
 
 void MapStructHandles(Decoded_VkMemoryPriorityAllocateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
 
+void MapStructHandles(Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper);
+
 void MapStructHandles(Decoded_VkPhysicalDeviceBufferAddressFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkBufferDeviceAddressInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
@@ -692,6 +706,14 @@ void MapStructHandles(Decoded_VkBufferDeviceAddressCreateInfoEXT* wrapper, const
 void MapStructHandles(Decoded_VkImageStencilUsageCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkValidationFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
+
+void MapStructHandles(Decoded_VkCooperativeMatrixPropertiesNV* wrapper, const VulkanObjectMapper& object_mapper);
+
+void MapStructHandles(Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper);
+
+void MapStructHandles(Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV* wrapper, const VulkanObjectMapper& object_mapper);
+
+void MapStructHandles(Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectMapper& object_mapper);
 

--- a/framework/generated/vulkan_generators/platform_types.json
+++ b/framework/generated/vulkan_generators/platform_types.json
@@ -38,5 +38,11 @@
       "zx_handle_t" : { "baseType" : "uint32_t", "replaceWith" : "uint32_t" }
     },
     "structs" : []
+  },
+  "metal": {
+    "types": {
+      "CAMetalLayer" : { "baseType" :  "void", "replaceWith" : "void"}
+    },
+    "structs": []
   }
 }

--- a/framework/generated/vulkan_generators/vulkan_dispatch_table_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_dispatch_table_generator.py
@@ -44,7 +44,11 @@ class VulkanDispatchTableGenerator(BaseGenerator):
                                processCmds=True, processStructs=False, featureBreak=False,
                                errFile=errFile, warnFile=warnFile, diagFile=diagFile)
         # Map of return types to default return values for no-op functions
-        self.RETURN_DEFAULTS = { 'VkResult' : 'VK_SUCCESS', 'VkBool32' : 'VK_TRUE', 'PFN_vkVoidFunction' : 'nullptr', 'VkDeviceAddress' : '0' }
+        self.RETURN_DEFAULTS = { 'VkResult' : 'VK_SUCCESS',
+                                 'VkBool32' : 'VK_TRUE',
+                                 'PFN_vkVoidFunction' : 'nullptr',
+                                 'VkDeviceAddress' : '0',
+                                 'uint32_t' : '0' }
 
         self.instanceCmdNames = dict()      # Map of API call names to no-op function declarations
         self.deviceCmdNames = dict()        # Map of API call names to no-op function declarations


### PR DESCRIPTION
- Update volk and Vulkan-Headers submodules
- Add API Call IDs for:
  * vkGetPhysicalDeviceCooperativeMatrixPropertiesNV
  * vkGetImageViewHandleNVX
  * vkCreateMetalSurfaceEXT
- Add PLATFORM_METAL_EXT declarations to platform_types.h
- Add CAMetalSurface* entry to platform_types.json, to instruct the
  code generators to treat this type as void*
- Add a uint32_t entry to the dispatch table generator's default return
  value table, which defines the value that should be returned by the
  generated no-op functions that return this type
  (vkGetImageViewHandleNVX is the first Vulkan API call to return this
  type)
- Generate code from the 1.1.102 version of vk.xml