### PR TITLE
Refine Handle Processing for pNext Extensions Structs

### DIFF
--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -36,7 +36,6 @@ void VulkanReplayConsumer::Process_vkCreateInstance(
     const HandlePointerDecoder<VkInstance>&     pInstance)
 {
     const VkInstanceCreateInfo* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkInstance out_pInstance_value = static_cast<VkInstance>(0);
     VkInstance* out_pInstance = &out_pInstance_value;
@@ -454,7 +453,6 @@ void VulkanReplayConsumer::Process_vkCreateFence(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkFenceCreateInfo* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkFence out_pFence_value = static_cast<VkFence>(0);
     VkFence* out_pFence = &out_pFence_value;
@@ -528,7 +526,6 @@ void VulkanReplayConsumer::Process_vkCreateSemaphore(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkSemaphoreCreateInfo* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkSemaphore out_pSemaphore_value = static_cast<VkSemaphore>(0);
     VkSemaphore* out_pSemaphore = &out_pSemaphore_value;
@@ -560,7 +557,6 @@ void VulkanReplayConsumer::Process_vkCreateEvent(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkEventCreateInfo* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkEvent out_pEvent_value = static_cast<VkEvent>(0);
     VkEvent* out_pEvent = &out_pEvent_value;
@@ -628,7 +624,6 @@ void VulkanReplayConsumer::Process_vkCreateQueryPool(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkQueryPoolCreateInfo* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkQueryPool out_pQueryPool_value = static_cast<VkQueryPool>(0);
     VkQueryPool* out_pQueryPool = &out_pQueryPool_value;
@@ -681,7 +676,6 @@ void VulkanReplayConsumer::Process_vkCreateBuffer(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkBufferCreateInfo* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkBuffer out_pBuffer_value = static_cast<VkBuffer>(0);
     VkBuffer* out_pBuffer = &out_pBuffer_value;
@@ -856,7 +850,6 @@ void VulkanReplayConsumer::Process_vkCreatePipelineCache(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkPipelineCacheCreateInfo* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkPipelineCache out_pPipelineCache_value = static_cast<VkPipelineCache>(0);
     VkPipelineCache* out_pPipelineCache = &out_pPipelineCache_value;
@@ -1075,7 +1068,6 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorPool(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkDescriptorPoolCreateInfo* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkDescriptorPool out_pDescriptorPool_value = static_cast<VkDescriptorPool>(0);
     VkDescriptorPool* out_pDescriptorPool = &out_pDescriptorPool_value;
@@ -1201,7 +1193,6 @@ void VulkanReplayConsumer::Process_vkCreateRenderPass(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkRenderPassCreateInfo* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkRenderPass out_pRenderPass_value = static_cast<VkRenderPass>(0);
     VkRenderPass* out_pRenderPass = &out_pRenderPass_value;
@@ -1246,7 +1237,6 @@ void VulkanReplayConsumer::Process_vkCreateCommandPool(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkCommandPoolCreateInfo* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkCommandPool out_pCommandPool_value = static_cast<VkCommandPool>(0);
     VkCommandPool* out_pCommandPool = &out_pCommandPool_value;
@@ -1782,7 +1772,6 @@ void VulkanReplayConsumer::Process_vkCmdWaitEvents(
     VkEvent* in_pEvents = pEvents.GetHandlePointer();
     MapHandles<VkEvent>(pEvents.GetPointer(), pEvents.GetLength(), in_pEvents, eventCount, &VulkanObjectMapper::MapVkEvent);
     const VkMemoryBarrier* in_pMemoryBarriers = pMemoryBarriers.GetPointer();
-    MapStructArrayHandles(pMemoryBarriers.GetMetaStructPointer(), pMemoryBarriers.GetLength(), GetObjectMapper());
     const VkBufferMemoryBarrier* in_pBufferMemoryBarriers = pBufferMemoryBarriers.GetPointer();
     MapStructArrayHandles(pBufferMemoryBarriers.GetMetaStructPointer(), pBufferMemoryBarriers.GetLength(), GetObjectMapper());
     const VkImageMemoryBarrier* in_pImageMemoryBarriers = pImageMemoryBarriers.GetPointer();
@@ -1805,7 +1794,6 @@ void VulkanReplayConsumer::Process_vkCmdPipelineBarrier(
 {
     VkCommandBuffer in_commandBuffer = GetObjectMapper().MapVkCommandBuffer(commandBuffer);
     const VkMemoryBarrier* in_pMemoryBarriers = pMemoryBarriers.GetPointer();
-    MapStructArrayHandles(pMemoryBarriers.GetMetaStructPointer(), pMemoryBarriers.GetLength(), GetObjectMapper());
     const VkBufferMemoryBarrier* in_pBufferMemoryBarriers = pBufferMemoryBarriers.GetPointer();
     MapStructArrayHandles(pBufferMemoryBarriers.GetMetaStructPointer(), pBufferMemoryBarriers.GetLength(), GetObjectMapper());
     const VkImageMemoryBarrier* in_pImageMemoryBarriers = pImageMemoryBarriers.GetPointer();
@@ -2104,7 +2092,6 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2(
 {
     VkPhysicalDevice in_physicalDevice = GetObjectMapper().MapVkPhysicalDevice(physicalDevice);
     const VkPhysicalDeviceImageFormatInfo2* in_pImageFormatInfo = pImageFormatInfo.GetPointer();
-    MapStructHandles(pImageFormatInfo.GetMetaStructPointer(), GetObjectMapper());
     VkImageFormatProperties2 out_pImageFormatProperties_value = { VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2, nullptr };
     VkImageFormatProperties2* out_pImageFormatProperties = &out_pImageFormatProperties_value;
 
@@ -2146,7 +2133,6 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
 {
     VkPhysicalDevice in_physicalDevice = GetObjectMapper().MapVkPhysicalDevice(physicalDevice);
     const VkPhysicalDeviceSparseImageFormatInfo2* in_pFormatInfo = pFormatInfo.GetPointer();
-    MapStructHandles(pFormatInfo.GetMetaStructPointer(), GetObjectMapper());
     uint32_t out_pPropertyCount_value = pPropertyCount.IsNull() ? static_cast<uint32_t>(0) : *(pPropertyCount.GetPointer());
     uint32_t* out_pPropertyCount = &out_pPropertyCount_value;
     VkSparseImageFormatProperties2* out_pProperties = pProperties.IsNull() ? nullptr : AllocateArray<VkSparseImageFormatProperties2>(out_pPropertyCount_value, VkSparseImageFormatProperties2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2, nullptr });
@@ -2174,7 +2160,6 @@ void VulkanReplayConsumer::Process_vkGetDeviceQueue2(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkDeviceQueueInfo2* in_pQueueInfo = pQueueInfo.GetPointer();
-    MapStructHandles(pQueueInfo.GetMetaStructPointer(), GetObjectMapper());
     VkQueue out_pQueue_value = static_cast<VkQueue>(0);
     VkQueue* out_pQueue = &out_pQueue_value;
 
@@ -2192,7 +2177,6 @@ void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversion(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkSamplerYcbcrConversionCreateInfo* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkSamplerYcbcrConversion out_pYcbcrConversion_value = static_cast<VkSamplerYcbcrConversion>(0);
     VkSamplerYcbcrConversion* out_pYcbcrConversion = &out_pYcbcrConversion_value;
@@ -2254,7 +2238,6 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalBufferProperties(
 {
     VkPhysicalDevice in_physicalDevice = GetObjectMapper().MapVkPhysicalDevice(physicalDevice);
     const VkPhysicalDeviceExternalBufferInfo* in_pExternalBufferInfo = pExternalBufferInfo.GetPointer();
-    MapStructHandles(pExternalBufferInfo.GetMetaStructPointer(), GetObjectMapper());
     VkExternalBufferProperties out_pExternalBufferProperties_value = { VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES, nullptr };
     VkExternalBufferProperties* out_pExternalBufferProperties = &out_pExternalBufferProperties_value;
 
@@ -2268,7 +2251,6 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalFenceProperties(
 {
     VkPhysicalDevice in_physicalDevice = GetObjectMapper().MapVkPhysicalDevice(physicalDevice);
     const VkPhysicalDeviceExternalFenceInfo* in_pExternalFenceInfo = pExternalFenceInfo.GetPointer();
-    MapStructHandles(pExternalFenceInfo.GetMetaStructPointer(), GetObjectMapper());
     VkExternalFenceProperties out_pExternalFenceProperties_value = { VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES, nullptr };
     VkExternalFenceProperties* out_pExternalFenceProperties = &out_pExternalFenceProperties_value;
 
@@ -2282,7 +2264,6 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalSemaphorePropertie
 {
     VkPhysicalDevice in_physicalDevice = GetObjectMapper().MapVkPhysicalDevice(physicalDevice);
     const VkPhysicalDeviceExternalSemaphoreInfo* in_pExternalSemaphoreInfo = pExternalSemaphoreInfo.GetPointer();
-    MapStructHandles(pExternalSemaphoreInfo.GetMetaStructPointer(), GetObjectMapper());
     VkExternalSemaphoreProperties out_pExternalSemaphoreProperties_value = { VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES, nullptr };
     VkExternalSemaphoreProperties* out_pExternalSemaphoreProperties = &out_pExternalSemaphoreProperties_value;
 
@@ -2613,7 +2594,6 @@ void VulkanReplayConsumer::Process_vkCreateDisplayModeKHR(
     VkPhysicalDevice in_physicalDevice = GetObjectMapper().MapVkPhysicalDevice(physicalDevice);
     VkDisplayKHR in_display = GetObjectMapper().MapVkDisplayKHR(display);
     const VkDisplayModeCreateInfoKHR* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkDisplayModeKHR out_pMode_value = static_cast<VkDisplayModeKHR>(0);
     VkDisplayModeKHR* out_pMode = &out_pMode_value;
@@ -2689,7 +2669,6 @@ void VulkanReplayConsumer::Process_vkCreateXlibSurfaceKHR(
 {
     VkInstance in_instance = GetObjectMapper().MapVkInstance(instance);
     const VkXlibSurfaceCreateInfoKHR* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkSurfaceKHR out_pSurface_value = static_cast<VkSurfaceKHR>(0);
     VkSurfaceKHR* out_pSurface = &out_pSurface_value;
@@ -2722,7 +2701,6 @@ void VulkanReplayConsumer::Process_vkCreateXcbSurfaceKHR(
 {
     VkInstance in_instance = GetObjectMapper().MapVkInstance(instance);
     const VkXcbSurfaceCreateInfoKHR* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkSurfaceKHR out_pSurface_value = static_cast<VkSurfaceKHR>(0);
     VkSurfaceKHR* out_pSurface = &out_pSurface_value;
@@ -2755,7 +2733,6 @@ void VulkanReplayConsumer::Process_vkCreateWaylandSurfaceKHR(
 {
     VkInstance in_instance = GetObjectMapper().MapVkInstance(instance);
     const VkWaylandSurfaceCreateInfoKHR* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkSurfaceKHR out_pSurface_value = static_cast<VkSurfaceKHR>(0);
     VkSurfaceKHR* out_pSurface = &out_pSurface_value;
@@ -2787,7 +2764,6 @@ void VulkanReplayConsumer::Process_vkCreateAndroidSurfaceKHR(
 {
     VkInstance in_instance = GetObjectMapper().MapVkInstance(instance);
     const VkAndroidSurfaceCreateInfoKHR* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkSurfaceKHR out_pSurface_value = static_cast<VkSurfaceKHR>(0);
     VkSurfaceKHR* out_pSurface = &out_pSurface_value;
@@ -2807,7 +2783,6 @@ void VulkanReplayConsumer::Process_vkCreateWin32SurfaceKHR(
 {
     VkInstance in_instance = GetObjectMapper().MapVkInstance(instance);
     const VkWin32SurfaceCreateInfoKHR* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkSurfaceKHR out_pSurface_value = static_cast<VkSurfaceKHR>(0);
     VkSurfaceKHR* out_pSurface = &out_pSurface_value;
@@ -2870,7 +2845,6 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
 {
     VkPhysicalDevice in_physicalDevice = GetObjectMapper().MapVkPhysicalDevice(physicalDevice);
     const VkPhysicalDeviceImageFormatInfo2* in_pImageFormatInfo = pImageFormatInfo.GetPointer();
-    MapStructHandles(pImageFormatInfo.GetMetaStructPointer(), GetObjectMapper());
     VkImageFormatProperties2 out_pImageFormatProperties_value = { VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2, nullptr };
     VkImageFormatProperties2* out_pImageFormatProperties = &out_pImageFormatProperties_value;
 
@@ -2912,7 +2886,6 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
 {
     VkPhysicalDevice in_physicalDevice = GetObjectMapper().MapVkPhysicalDevice(physicalDevice);
     const VkPhysicalDeviceSparseImageFormatInfo2* in_pFormatInfo = pFormatInfo.GetPointer();
-    MapStructHandles(pFormatInfo.GetMetaStructPointer(), GetObjectMapper());
     uint32_t out_pPropertyCount_value = pPropertyCount.IsNull() ? static_cast<uint32_t>(0) : *(pPropertyCount.GetPointer());
     uint32_t* out_pPropertyCount = &out_pPropertyCount_value;
     VkSparseImageFormatProperties2* out_pProperties = pProperties.IsNull() ? nullptr : AllocateArray<VkSparseImageFormatProperties2>(out_pPropertyCount_value, VkSparseImageFormatProperties2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2, nullptr });
@@ -2994,7 +2967,6 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalBufferPropertiesKH
 {
     VkPhysicalDevice in_physicalDevice = GetObjectMapper().MapVkPhysicalDevice(physicalDevice);
     const VkPhysicalDeviceExternalBufferInfo* in_pExternalBufferInfo = pExternalBufferInfo.GetPointer();
-    MapStructHandles(pExternalBufferInfo.GetMetaStructPointer(), GetObjectMapper());
     VkExternalBufferProperties out_pExternalBufferProperties_value = { VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES, nullptr };
     VkExternalBufferProperties* out_pExternalBufferProperties = &out_pExternalBufferProperties_value;
 
@@ -3073,7 +3045,6 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalSemaphorePropertie
 {
     VkPhysicalDevice in_physicalDevice = GetObjectMapper().MapVkPhysicalDevice(physicalDevice);
     const VkPhysicalDeviceExternalSemaphoreInfo* in_pExternalSemaphoreInfo = pExternalSemaphoreInfo.GetPointer();
-    MapStructHandles(pExternalSemaphoreInfo.GetMetaStructPointer(), GetObjectMapper());
     VkExternalSemaphoreProperties out_pExternalSemaphoreProperties_value = { VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES, nullptr };
     VkExternalSemaphoreProperties* out_pExternalSemaphoreProperties = &out_pExternalSemaphoreProperties_value;
 
@@ -3197,7 +3168,6 @@ void VulkanReplayConsumer::Process_vkCreateRenderPass2KHR(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkRenderPassCreateInfo2KHR* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkRenderPass out_pRenderPass_value = static_cast<VkRenderPass>(0);
     VkRenderPass* out_pRenderPass = &out_pRenderPass_value;
@@ -3217,7 +3187,6 @@ void VulkanReplayConsumer::Process_vkCmdBeginRenderPass2KHR(
     const VkRenderPassBeginInfo* in_pRenderPassBegin = pRenderPassBegin.GetPointer();
     MapStructHandles(pRenderPassBegin.GetMetaStructPointer(), GetObjectMapper());
     const VkSubpassBeginInfoKHR* in_pSubpassBeginInfo = pSubpassBeginInfo.GetPointer();
-    MapStructHandles(pSubpassBeginInfo.GetMetaStructPointer(), GetObjectMapper());
 
     Dispatcher<format::ApiCallId::ApiCall_vkCmdBeginRenderPass2KHR, void, PFN_vkCmdBeginRenderPass2KHR>::Dispatch(this, vkCmdBeginRenderPass2KHR, in_commandBuffer, in_pRenderPassBegin, in_pSubpassBeginInfo);
 }
@@ -3229,9 +3198,7 @@ void VulkanReplayConsumer::Process_vkCmdNextSubpass2KHR(
 {
     VkCommandBuffer in_commandBuffer = GetObjectMapper().MapVkCommandBuffer(commandBuffer);
     const VkSubpassBeginInfoKHR* in_pSubpassBeginInfo = pSubpassBeginInfo.GetPointer();
-    MapStructHandles(pSubpassBeginInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkSubpassEndInfoKHR* in_pSubpassEndInfo = pSubpassEndInfo.GetPointer();
-    MapStructHandles(pSubpassEndInfo.GetMetaStructPointer(), GetObjectMapper());
 
     Dispatcher<format::ApiCallId::ApiCall_vkCmdNextSubpass2KHR, void, PFN_vkCmdNextSubpass2KHR>::Dispatch(this, vkCmdNextSubpass2KHR, in_commandBuffer, in_pSubpassBeginInfo, in_pSubpassEndInfo);
 }
@@ -3242,7 +3209,6 @@ void VulkanReplayConsumer::Process_vkCmdEndRenderPass2KHR(
 {
     VkCommandBuffer in_commandBuffer = GetObjectMapper().MapVkCommandBuffer(commandBuffer);
     const VkSubpassEndInfoKHR* in_pSubpassEndInfo = pSubpassEndInfo.GetPointer();
-    MapStructHandles(pSubpassEndInfo.GetMetaStructPointer(), GetObjectMapper());
 
     Dispatcher<format::ApiCallId::ApiCall_vkCmdEndRenderPass2KHR, void, PFN_vkCmdEndRenderPass2KHR>::Dispatch(this, vkCmdEndRenderPass2KHR, in_commandBuffer, in_pSubpassEndInfo);
 }
@@ -3266,7 +3232,6 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalFencePropertiesKHR
 {
     VkPhysicalDevice in_physicalDevice = GetObjectMapper().MapVkPhysicalDevice(physicalDevice);
     const VkPhysicalDeviceExternalFenceInfo* in_pExternalFenceInfo = pExternalFenceInfo.GetPointer();
-    MapStructHandles(pExternalFenceInfo.GetMetaStructPointer(), GetObjectMapper());
     VkExternalFenceProperties out_pExternalFenceProperties_value = { VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES, nullptr };
     VkExternalFenceProperties* out_pExternalFenceProperties = &out_pExternalFenceProperties_value;
 
@@ -3493,7 +3458,6 @@ void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkSamplerYcbcrConversionCreateInfo* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkSamplerYcbcrConversion out_pYcbcrConversion_value = static_cast<VkSamplerYcbcrConversion>(0);
     VkSamplerYcbcrConversion* out_pYcbcrConversion = &out_pYcbcrConversion_value;
@@ -3599,7 +3563,6 @@ void VulkanReplayConsumer::Process_vkCreateDebugReportCallbackEXT(
 {
     VkInstance in_instance = GetObjectMapper().MapVkInstance(instance);
     const VkDebugReportCallbackCreateInfoEXT* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkDebugReportCallbackEXT out_pCallback_value = static_cast<VkDebugReportCallbackEXT>(0);
     VkDebugReportCallbackEXT* out_pCallback = &out_pCallback_value;
@@ -3646,7 +3609,6 @@ void VulkanReplayConsumer::Process_vkDebugMarkerSetObjectTagEXT(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkDebugMarkerObjectTagInfoEXT* in_pTagInfo = pTagInfo.GetPointer();
-    MapStructHandles(pTagInfo.GetMetaStructPointer(), GetObjectMapper());
 
     VkResult replay_result = Dispatcher<format::ApiCallId::ApiCall_vkDebugMarkerSetObjectTagEXT, VkResult, PFN_vkDebugMarkerSetObjectTagEXT>::Dispatch(this, returnValue, vkDebugMarkerSetObjectTagEXT, in_device, in_pTagInfo);
     CheckResult("vkDebugMarkerSetObjectTagEXT", returnValue, replay_result);
@@ -3659,7 +3621,6 @@ void VulkanReplayConsumer::Process_vkDebugMarkerSetObjectNameEXT(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkDebugMarkerObjectNameInfoEXT* in_pNameInfo = pNameInfo.GetPointer();
-    MapStructHandles(pNameInfo.GetMetaStructPointer(), GetObjectMapper());
 
     VkResult replay_result = Dispatcher<format::ApiCallId::ApiCall_vkDebugMarkerSetObjectNameEXT, VkResult, PFN_vkDebugMarkerSetObjectNameEXT>::Dispatch(this, returnValue, vkDebugMarkerSetObjectNameEXT, in_device, in_pNameInfo);
     CheckResult("vkDebugMarkerSetObjectNameEXT", returnValue, replay_result);
@@ -3671,7 +3632,6 @@ void VulkanReplayConsumer::Process_vkCmdDebugMarkerBeginEXT(
 {
     VkCommandBuffer in_commandBuffer = GetObjectMapper().MapVkCommandBuffer(commandBuffer);
     const VkDebugMarkerMarkerInfoEXT* in_pMarkerInfo = pMarkerInfo.GetPointer();
-    MapStructHandles(pMarkerInfo.GetMetaStructPointer(), GetObjectMapper());
 
     Dispatcher<format::ApiCallId::ApiCall_vkCmdDebugMarkerBeginEXT, void, PFN_vkCmdDebugMarkerBeginEXT>::Dispatch(this, vkCmdDebugMarkerBeginEXT, in_commandBuffer, in_pMarkerInfo);
 }
@@ -3690,7 +3650,6 @@ void VulkanReplayConsumer::Process_vkCmdDebugMarkerInsertEXT(
 {
     VkCommandBuffer in_commandBuffer = GetObjectMapper().MapVkCommandBuffer(commandBuffer);
     const VkDebugMarkerMarkerInfoEXT* in_pMarkerInfo = pMarkerInfo.GetPointer();
-    MapStructHandles(pMarkerInfo.GetMetaStructPointer(), GetObjectMapper());
 
     Dispatcher<format::ApiCallId::ApiCall_vkCmdDebugMarkerInsertEXT, void, PFN_vkCmdDebugMarkerInsertEXT>::Dispatch(this, vkCmdDebugMarkerInsertEXT, in_commandBuffer, in_pMarkerInfo);
 }
@@ -3893,7 +3852,6 @@ void VulkanReplayConsumer::Process_vkCreateViSurfaceNN(
 {
     VkInstance in_instance = GetObjectMapper().MapVkInstance(instance);
     const VkViSurfaceCreateInfoNN* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkSurfaceKHR out_pSurface_value = static_cast<VkSurfaceKHR>(0);
     VkSurfaceKHR* out_pSurface = &out_pSurface_value;
@@ -3954,7 +3912,6 @@ void VulkanReplayConsumer::Process_vkCreateIndirectCommandsLayoutNVX(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkIndirectCommandsLayoutCreateInfoNVX* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkIndirectCommandsLayoutNVX out_pIndirectCommandsLayout_value = static_cast<VkIndirectCommandsLayoutNVX>(0);
     VkIndirectCommandsLayoutNVX* out_pIndirectCommandsLayout = &out_pIndirectCommandsLayout_value;
@@ -3986,7 +3943,6 @@ void VulkanReplayConsumer::Process_vkCreateObjectTableNVX(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkObjectTableCreateInfoNVX* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkObjectTableNVX out_pObjectTable_value = static_cast<VkObjectTableNVX>(0);
     VkObjectTableNVX* out_pObjectTable = &out_pObjectTable_value;
@@ -4120,7 +4076,6 @@ void VulkanReplayConsumer::Process_vkDisplayPowerControlEXT(
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     VkDisplayKHR in_display = GetObjectMapper().MapVkDisplayKHR(display);
     const VkDisplayPowerInfoEXT* in_pDisplayPowerInfo = pDisplayPowerInfo.GetPointer();
-    MapStructHandles(pDisplayPowerInfo.GetMetaStructPointer(), GetObjectMapper());
 
     VkResult replay_result = Dispatcher<format::ApiCallId::ApiCall_vkDisplayPowerControlEXT, VkResult, PFN_vkDisplayPowerControlEXT>::Dispatch(this, returnValue, vkDisplayPowerControlEXT, in_device, in_display, in_pDisplayPowerInfo);
     CheckResult("vkDisplayPowerControlEXT", returnValue, replay_result);
@@ -4135,7 +4090,6 @@ void VulkanReplayConsumer::Process_vkRegisterDeviceEventEXT(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkDeviceEventInfoEXT* in_pDeviceEventInfo = pDeviceEventInfo.GetPointer();
-    MapStructHandles(pDeviceEventInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkFence out_pFence_value = static_cast<VkFence>(0);
     VkFence* out_pFence = &out_pFence_value;
@@ -4157,7 +4111,6 @@ void VulkanReplayConsumer::Process_vkRegisterDisplayEventEXT(
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     VkDisplayKHR in_display = GetObjectMapper().MapVkDisplayKHR(display);
     const VkDisplayEventInfoEXT* in_pDisplayEventInfo = pDisplayEventInfo.GetPointer();
-    MapStructHandles(pDisplayEventInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkFence out_pFence_value = static_cast<VkFence>(0);
     VkFence* out_pFence = &out_pFence_value;
@@ -4240,7 +4193,6 @@ void VulkanReplayConsumer::Process_vkSetHdrMetadataEXT(
     VkSwapchainKHR* in_pSwapchains = pSwapchains.GetHandlePointer();
     MapHandles<VkSwapchainKHR>(pSwapchains.GetPointer(), pSwapchains.GetLength(), in_pSwapchains, swapchainCount, &VulkanObjectMapper::MapVkSwapchainKHR);
     const VkHdrMetadataEXT* in_pMetadata = pMetadata.GetPointer();
-    MapStructArrayHandles(pMetadata.GetMetaStructPointer(), pMetadata.GetLength(), GetObjectMapper());
 
     Dispatcher<format::ApiCallId::ApiCall_vkSetHdrMetadataEXT, void, PFN_vkSetHdrMetadataEXT>::Dispatch(this, vkSetHdrMetadataEXT, in_device, swapchainCount, in_pSwapchains, in_pMetadata);
 }
@@ -4254,7 +4206,6 @@ void VulkanReplayConsumer::Process_vkCreateIOSSurfaceMVK(
 {
     VkInstance in_instance = GetObjectMapper().MapVkInstance(instance);
     const VkIOSSurfaceCreateInfoMVK* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkSurfaceKHR out_pSurface_value = static_cast<VkSurfaceKHR>(0);
     VkSurfaceKHR* out_pSurface = &out_pSurface_value;
@@ -4274,7 +4225,6 @@ void VulkanReplayConsumer::Process_vkCreateMacOSSurfaceMVK(
 {
     VkInstance in_instance = GetObjectMapper().MapVkInstance(instance);
     const VkMacOSSurfaceCreateInfoMVK* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkSurfaceKHR out_pSurface_value = static_cast<VkSurfaceKHR>(0);
     VkSurfaceKHR* out_pSurface = &out_pSurface_value;
@@ -4292,7 +4242,6 @@ void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectNameEXT(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkDebugUtilsObjectNameInfoEXT* in_pNameInfo = pNameInfo.GetPointer();
-    MapStructHandles(pNameInfo.GetMetaStructPointer(), GetObjectMapper());
 
     VkResult replay_result = Dispatcher<format::ApiCallId::ApiCall_vkSetDebugUtilsObjectNameEXT, VkResult, PFN_vkSetDebugUtilsObjectNameEXT>::Dispatch(this, returnValue, vkSetDebugUtilsObjectNameEXT, in_device, in_pNameInfo);
     CheckResult("vkSetDebugUtilsObjectNameEXT", returnValue, replay_result);
@@ -4305,7 +4254,6 @@ void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectTagEXT(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkDebugUtilsObjectTagInfoEXT* in_pTagInfo = pTagInfo.GetPointer();
-    MapStructHandles(pTagInfo.GetMetaStructPointer(), GetObjectMapper());
 
     VkResult replay_result = Dispatcher<format::ApiCallId::ApiCall_vkSetDebugUtilsObjectTagEXT, VkResult, PFN_vkSetDebugUtilsObjectTagEXT>::Dispatch(this, returnValue, vkSetDebugUtilsObjectTagEXT, in_device, in_pTagInfo);
     CheckResult("vkSetDebugUtilsObjectTagEXT", returnValue, replay_result);
@@ -4317,7 +4265,6 @@ void VulkanReplayConsumer::Process_vkQueueBeginDebugUtilsLabelEXT(
 {
     VkQueue in_queue = GetObjectMapper().MapVkQueue(queue);
     const VkDebugUtilsLabelEXT* in_pLabelInfo = pLabelInfo.GetPointer();
-    MapStructHandles(pLabelInfo.GetMetaStructPointer(), GetObjectMapper());
 
     Dispatcher<format::ApiCallId::ApiCall_vkQueueBeginDebugUtilsLabelEXT, void, PFN_vkQueueBeginDebugUtilsLabelEXT>::Dispatch(this, vkQueueBeginDebugUtilsLabelEXT, in_queue, in_pLabelInfo);
 }
@@ -4336,7 +4283,6 @@ void VulkanReplayConsumer::Process_vkQueueInsertDebugUtilsLabelEXT(
 {
     VkQueue in_queue = GetObjectMapper().MapVkQueue(queue);
     const VkDebugUtilsLabelEXT* in_pLabelInfo = pLabelInfo.GetPointer();
-    MapStructHandles(pLabelInfo.GetMetaStructPointer(), GetObjectMapper());
 
     Dispatcher<format::ApiCallId::ApiCall_vkQueueInsertDebugUtilsLabelEXT, void, PFN_vkQueueInsertDebugUtilsLabelEXT>::Dispatch(this, vkQueueInsertDebugUtilsLabelEXT, in_queue, in_pLabelInfo);
 }
@@ -4347,7 +4293,6 @@ void VulkanReplayConsumer::Process_vkCmdBeginDebugUtilsLabelEXT(
 {
     VkCommandBuffer in_commandBuffer = GetObjectMapper().MapVkCommandBuffer(commandBuffer);
     const VkDebugUtilsLabelEXT* in_pLabelInfo = pLabelInfo.GetPointer();
-    MapStructHandles(pLabelInfo.GetMetaStructPointer(), GetObjectMapper());
 
     Dispatcher<format::ApiCallId::ApiCall_vkCmdBeginDebugUtilsLabelEXT, void, PFN_vkCmdBeginDebugUtilsLabelEXT>::Dispatch(this, vkCmdBeginDebugUtilsLabelEXT, in_commandBuffer, in_pLabelInfo);
 }
@@ -4366,7 +4311,6 @@ void VulkanReplayConsumer::Process_vkCmdInsertDebugUtilsLabelEXT(
 {
     VkCommandBuffer in_commandBuffer = GetObjectMapper().MapVkCommandBuffer(commandBuffer);
     const VkDebugUtilsLabelEXT* in_pLabelInfo = pLabelInfo.GetPointer();
-    MapStructHandles(pLabelInfo.GetMetaStructPointer(), GetObjectMapper());
 
     Dispatcher<format::ApiCallId::ApiCall_vkCmdInsertDebugUtilsLabelEXT, void, PFN_vkCmdInsertDebugUtilsLabelEXT>::Dispatch(this, vkCmdInsertDebugUtilsLabelEXT, in_commandBuffer, in_pLabelInfo);
 }
@@ -4380,7 +4324,6 @@ void VulkanReplayConsumer::Process_vkCreateDebugUtilsMessengerEXT(
 {
     VkInstance in_instance = GetObjectMapper().MapVkInstance(instance);
     const VkDebugUtilsMessengerCreateInfoEXT* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkDebugUtilsMessengerEXT out_pMessenger_value = static_cast<VkDebugUtilsMessengerEXT>(0);
     VkDebugUtilsMessengerEXT* out_pMessenger = &out_pMessenger_value;
@@ -4411,7 +4354,6 @@ void VulkanReplayConsumer::Process_vkSubmitDebugUtilsMessageEXT(
 {
     VkInstance in_instance = GetObjectMapper().MapVkInstance(instance);
     const VkDebugUtilsMessengerCallbackDataEXT* in_pCallbackData = pCallbackData.GetPointer();
-    MapStructHandles(pCallbackData.GetMetaStructPointer(), GetObjectMapper());
 
     Dispatcher<format::ApiCallId::ApiCall_vkSubmitDebugUtilsMessageEXT, void, PFN_vkSubmitDebugUtilsMessageEXT>::Dispatch(this, vkSubmitDebugUtilsMessageEXT, in_instance, messageSeverity, messageTypes, in_pCallbackData);
 }
@@ -4455,7 +4397,6 @@ void VulkanReplayConsumer::Process_vkCmdSetSampleLocationsEXT(
 {
     VkCommandBuffer in_commandBuffer = GetObjectMapper().MapVkCommandBuffer(commandBuffer);
     const VkSampleLocationsInfoEXT* in_pSampleLocationsInfo = pSampleLocationsInfo.GetPointer();
-    MapStructHandles(pSampleLocationsInfo.GetMetaStructPointer(), GetObjectMapper());
 
     Dispatcher<format::ApiCallId::ApiCall_vkCmdSetSampleLocationsEXT, void, PFN_vkCmdSetSampleLocationsEXT>::Dispatch(this, vkCmdSetSampleLocationsEXT, in_commandBuffer, in_pSampleLocationsInfo);
 }
@@ -4496,7 +4437,6 @@ void VulkanReplayConsumer::Process_vkCreateValidationCacheEXT(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkValidationCacheCreateInfoEXT* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkValidationCacheEXT out_pValidationCache_value = static_cast<VkValidationCacheEXT>(0);
     VkValidationCacheEXT* out_pValidationCache = &out_pValidationCache_value;
@@ -4853,7 +4793,6 @@ void VulkanReplayConsumer::Process_vkGetCalibratedTimestampsEXT(
 {
     VkDevice in_device = GetObjectMapper().MapVkDevice(device);
     const VkCalibratedTimestampInfoEXT* in_pTimestampInfos = pTimestampInfos.GetPointer();
-    MapStructArrayHandles(pTimestampInfos.GetMetaStructPointer(), pTimestampInfos.GetLength(), GetObjectMapper());
     uint64_t* out_pTimestamps = pTimestamps.IsNull() ? nullptr : AllocateArray<uint64_t>(timestampCount);
     uint64_t out_pMaxDeviation_value = static_cast<uint64_t>(0);
     uint64_t* out_pMaxDeviation = &out_pMaxDeviation_value;
@@ -4949,7 +4888,6 @@ void VulkanReplayConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
 {
     VkInstance in_instance = GetObjectMapper().MapVkInstance(instance);
     const VkImagePipeSurfaceCreateInfoFUCHSIA* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkSurfaceKHR out_pSurface_value = static_cast<VkSurfaceKHR>(0);
     VkSurfaceKHR* out_pSurface = &out_pSurface_value;
@@ -4969,7 +4907,6 @@ void VulkanReplayConsumer::Process_vkCreateMetalSurfaceEXT(
 {
     VkInstance in_instance = GetObjectMapper().MapVkInstance(instance);
     const VkMetalSurfaceCreateInfoEXT* in_pCreateInfo = pCreateInfo.GetPointer();
-    MapStructHandles(pCreateInfo.GetMetaStructPointer(), GetObjectMapper());
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
     VkSurfaceKHR out_pSurface_value = static_cast<VkSurfaceKHR>(0);
     VkSurfaceKHR* out_pSurface = &out_pSurface_value;

--- a/framework/generated/generated_vulkan_struct_handle_mappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.cpp
@@ -42,41 +42,6 @@ static void MapHandleArray(const format::HandleId*   ids,
     }
 }
 
-void MapStructHandles(Decoded_VkApplicationInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkInstanceCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
-        MapStructArrayHandles<Decoded_VkApplicationInfo>(wrapper->pApplicationInfo.GetMetaStructPointer(), 1, object_mapper);
-    }
-}
-
-void MapStructHandles(Decoded_VkDeviceQueueCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
 void MapStructHandles(Decoded_VkDeviceCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
 {
     if (wrapper != nullptr)
@@ -85,8 +50,6 @@ void MapStructHandles(Decoded_VkDeviceCreateInfo* wrapper, const VulkanObjectMap
         {
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
         }
-
-        MapStructArrayHandles<Decoded_VkDeviceQueueCreateInfo>(wrapper->pQueueCreateInfos.GetMetaStructPointer(), wrapper->pQueueCreateInfos.GetLength(), object_mapper);
     }
 }
 
@@ -95,6 +58,21 @@ void MapStructHandles(Decoded_VkSubmitInfo* wrapper, const VulkanObjectMapper& o
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkSubmitInfo* value = wrapper->value;
+
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
+
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
+
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
 
         if (wrapper->pNext)
         {
@@ -117,6 +95,21 @@ void MapStructHandles(Decoded_VkMemoryAllocateInfo* wrapper, const VulkanObjectM
         {
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
         }
+
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
+
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
+
+        if (wrapper->pNext)
+        {
+            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
+        }
     }
 }
 
@@ -125,11 +118,6 @@ void MapStructHandles(Decoded_VkMappedMemoryRange* wrapper, const VulkanObjectMa
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkMappedMemoryRange* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->memory = object_mapper.MapVkDeviceMemory(wrapper->memory);
     }
@@ -197,11 +185,6 @@ void MapStructHandles(Decoded_VkBindSparseInfo* wrapper, const VulkanObjectMappe
     {
         VkBindSparseInfo* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         MapHandleArray<VkSemaphore>(wrapper->pWaitSemaphores.GetPointer(), wrapper->pWaitSemaphores.GetHandlePointer(), wrapper->pWaitSemaphores.GetLength(), object_mapper, &VulkanObjectMapper::MapVkSemaphore);
 
         MapStructArrayHandles<Decoded_VkSparseBufferMemoryBindInfo>(wrapper->pBufferBinds.GetMetaStructPointer(), wrapper->pBufferBinds.GetLength(), object_mapper);
@@ -214,71 +197,11 @@ void MapStructHandles(Decoded_VkBindSparseInfo* wrapper, const VulkanObjectMappe
     }
 }
 
-void MapStructHandles(Decoded_VkFenceCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkSemaphoreCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkEventCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkQueryPoolCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkBufferCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
 void MapStructHandles(Decoded_VkBufferViewCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
 {
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkBufferViewCreateInfo* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->buffer = object_mapper.MapVkBuffer(wrapper->buffer);
     }
@@ -321,128 +244,13 @@ void MapStructHandles(Decoded_VkShaderModuleCreateInfo* wrapper, const VulkanObj
     }
 }
 
-void MapStructHandles(Decoded_VkPipelineCacheCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
 void MapStructHandles(Decoded_VkPipelineShaderStageCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
 {
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkPipelineShaderStageCreateInfo* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->module = object_mapper.MapVkShaderModule(wrapper->module);
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineVertexInputStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineInputAssemblyStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineTessellationStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineViewportStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineRasterizationStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineMultisampleStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineDepthStencilStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineColorBlendStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineDynamicStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -452,30 +260,7 @@ void MapStructHandles(Decoded_VkGraphicsPipelineCreateInfo* wrapper, const Vulka
     {
         VkGraphicsPipelineCreateInfo* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         MapStructArrayHandles<Decoded_VkPipelineShaderStageCreateInfo>(wrapper->pStages.GetMetaStructPointer(), wrapper->pStages.GetLength(), object_mapper);
-
-        MapStructArrayHandles<Decoded_VkPipelineVertexInputStateCreateInfo>(wrapper->pVertexInputState.GetMetaStructPointer(), 1, object_mapper);
-
-        MapStructArrayHandles<Decoded_VkPipelineInputAssemblyStateCreateInfo>(wrapper->pInputAssemblyState.GetMetaStructPointer(), 1, object_mapper);
-
-        MapStructArrayHandles<Decoded_VkPipelineTessellationStateCreateInfo>(wrapper->pTessellationState.GetMetaStructPointer(), 1, object_mapper);
-
-        MapStructArrayHandles<Decoded_VkPipelineViewportStateCreateInfo>(wrapper->pViewportState.GetMetaStructPointer(), 1, object_mapper);
-
-        MapStructArrayHandles<Decoded_VkPipelineRasterizationStateCreateInfo>(wrapper->pRasterizationState.GetMetaStructPointer(), 1, object_mapper);
-
-        MapStructArrayHandles<Decoded_VkPipelineMultisampleStateCreateInfo>(wrapper->pMultisampleState.GetMetaStructPointer(), 1, object_mapper);
-
-        MapStructArrayHandles<Decoded_VkPipelineDepthStencilStateCreateInfo>(wrapper->pDepthStencilState.GetMetaStructPointer(), 1, object_mapper);
-
-        MapStructArrayHandles<Decoded_VkPipelineColorBlendStateCreateInfo>(wrapper->pColorBlendState.GetMetaStructPointer(), 1, object_mapper);
-
-        MapStructArrayHandles<Decoded_VkPipelineDynamicStateCreateInfo>(wrapper->pDynamicState.GetMetaStructPointer(), 1, object_mapper);
 
         value->layout = object_mapper.MapVkPipelineLayout(wrapper->layout);
 
@@ -491,11 +276,6 @@ void MapStructHandles(Decoded_VkComputePipelineCreateInfo* wrapper, const Vulkan
     {
         VkComputePipelineCreateInfo* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         MapStructHandles(&wrapper->stage, object_mapper);
 
         value->layout = object_mapper.MapVkPipelineLayout(wrapper->layout);
@@ -509,11 +289,6 @@ void MapStructHandles(Decoded_VkPipelineLayoutCreateInfo* wrapper, const VulkanO
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkPipelineLayoutCreateInfo* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         MapHandleArray<VkDescriptorSetLayout>(wrapper->pSetLayouts.GetPointer(), wrapper->pSetLayouts.GetHandlePointer(), wrapper->pSetLayouts.GetLength(), object_mapper, &VulkanObjectMapper::MapVkDescriptorSetLayout);
     }
@@ -544,23 +319,7 @@ void MapStructHandles(Decoded_VkDescriptorSetLayoutCreateInfo* wrapper, const Vu
 {
     if (wrapper != nullptr)
     {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         MapStructArrayHandles<Decoded_VkDescriptorSetLayoutBinding>(wrapper->pBindings.GetMetaStructPointer(), wrapper->pBindings.GetLength(), object_mapper);
-    }
-}
-
-void MapStructHandles(Decoded_VkDescriptorPoolCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -569,11 +328,6 @@ void MapStructHandles(Decoded_VkDescriptorSetAllocateInfo* wrapper, const Vulkan
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkDescriptorSetAllocateInfo* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->descriptorPool = object_mapper.MapVkDescriptorPool(wrapper->descriptorPool);
 
@@ -630,11 +384,6 @@ void MapStructHandles(Decoded_VkCopyDescriptorSet* wrapper, const VulkanObjectMa
     {
         VkCopyDescriptorSet* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->srcSet = object_mapper.MapVkDescriptorSet(wrapper->srcSet);
 
         value->dstSet = object_mapper.MapVkDescriptorSet(wrapper->dstSet);
@@ -647,36 +396,9 @@ void MapStructHandles(Decoded_VkFramebufferCreateInfo* wrapper, const VulkanObje
     {
         VkFramebufferCreateInfo* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->renderPass = object_mapper.MapVkRenderPass(wrapper->renderPass);
 
         MapHandleArray<VkImageView>(wrapper->pAttachments.GetPointer(), wrapper->pAttachments.GetHandlePointer(), wrapper->pAttachments.GetLength(), object_mapper, &VulkanObjectMapper::MapVkImageView);
-    }
-}
-
-void MapStructHandles(Decoded_VkRenderPassCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkCommandPoolCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -685,11 +407,6 @@ void MapStructHandles(Decoded_VkCommandBufferAllocateInfo* wrapper, const Vulkan
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkCommandBufferAllocateInfo* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->commandPool = object_mapper.MapVkCommandPool(wrapper->commandPool);
     }
@@ -701,11 +418,6 @@ void MapStructHandles(Decoded_VkCommandBufferInheritanceInfo* wrapper, const Vul
     {
         VkCommandBufferInheritanceInfo* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->renderPass = object_mapper.MapVkRenderPass(wrapper->renderPass);
 
         value->framebuffer = object_mapper.MapVkFramebuffer(wrapper->framebuffer);
@@ -716,23 +428,7 @@ void MapStructHandles(Decoded_VkCommandBufferBeginInfo* wrapper, const VulkanObj
 {
     if (wrapper != nullptr)
     {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         MapStructArrayHandles<Decoded_VkCommandBufferInheritanceInfo>(wrapper->pInheritanceInfo.GetMetaStructPointer(), 1, object_mapper);
-    }
-}
-
-void MapStructHandles(Decoded_VkMemoryBarrier* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -741,11 +437,6 @@ void MapStructHandles(Decoded_VkBufferMemoryBarrier* wrapper, const VulkanObject
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkBufferMemoryBarrier* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->buffer = object_mapper.MapVkBuffer(wrapper->buffer);
     }
@@ -757,11 +448,6 @@ void MapStructHandles(Decoded_VkImageMemoryBarrier* wrapper, const VulkanObjectM
     {
         VkImageMemoryBarrier* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->image = object_mapper.MapVkImage(wrapper->image);
     }
 }
@@ -772,25 +458,9 @@ void MapStructHandles(Decoded_VkRenderPassBeginInfo* wrapper, const VulkanObject
     {
         VkRenderPassBeginInfo* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->renderPass = object_mapper.MapVkRenderPass(wrapper->renderPass);
 
         value->framebuffer = object_mapper.MapVkFramebuffer(wrapper->framebuffer);
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceSubgroupProperties* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -799,11 +469,6 @@ void MapStructHandles(Decoded_VkBindBufferMemoryInfo* wrapper, const VulkanObjec
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkBindBufferMemoryInfo* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->buffer = object_mapper.MapVkBuffer(wrapper->buffer);
 
@@ -828,119 +493,15 @@ void MapStructHandles(Decoded_VkBindImageMemoryInfo* wrapper, const VulkanObject
     }
 }
 
-void MapStructHandles(Decoded_VkPhysicalDevice16BitStorageFeatures* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkMemoryDedicatedRequirements* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
 void MapStructHandles(Decoded_VkMemoryDedicatedAllocateInfo* wrapper, const VulkanObjectMapper& object_mapper)
 {
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkMemoryDedicatedAllocateInfo* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->image = object_mapper.MapVkImage(wrapper->image);
 
         value->buffer = object_mapper.MapVkBuffer(wrapper->buffer);
-    }
-}
-
-void MapStructHandles(Decoded_VkMemoryAllocateFlagsInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDeviceGroupRenderPassBeginInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDeviceGroupCommandBufferBeginInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDeviceGroupSubmitInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDeviceGroupBindSparseInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkBindBufferMemoryDeviceGroupInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkBindImageMemoryDeviceGroupInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -949,11 +510,6 @@ void MapStructHandles(Decoded_VkPhysicalDeviceGroupProperties* wrapper, const Vu
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkPhysicalDeviceGroupProperties* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         MapHandleArray<VkPhysicalDevice>(wrapper->physicalDevices.GetPointer(), wrapper->physicalDevices.GetHandlePointer(), wrapper->physicalDevices.GetLength(), object_mapper, &VulkanObjectMapper::MapVkPhysicalDevice);
     }
@@ -965,11 +521,6 @@ void MapStructHandles(Decoded_VkDeviceGroupDeviceCreateInfo* wrapper, const Vulk
     {
         VkDeviceGroupDeviceCreateInfo* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         MapHandleArray<VkPhysicalDevice>(wrapper->pPhysicalDevices.GetPointer(), wrapper->pPhysicalDevices.GetHandlePointer(), wrapper->pPhysicalDevices.GetLength(), object_mapper, &VulkanObjectMapper::MapVkPhysicalDevice);
     }
 }
@@ -979,11 +530,6 @@ void MapStructHandles(Decoded_VkBufferMemoryRequirementsInfo2* wrapper, const Vu
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkBufferMemoryRequirementsInfo2* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->buffer = object_mapper.MapVkBuffer(wrapper->buffer);
     }
@@ -995,11 +541,6 @@ void MapStructHandles(Decoded_VkImageMemoryRequirementsInfo2* wrapper, const Vul
     {
         VkImageMemoryRequirementsInfo2* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->image = object_mapper.MapVkImage(wrapper->image);
     }
 }
@@ -1010,276 +551,7 @@ void MapStructHandles(Decoded_VkImageSparseMemoryRequirementsInfo2* wrapper, con
     {
         VkImageSparseMemoryRequirementsInfo2* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->image = object_mapper.MapVkImage(wrapper->image);
-    }
-}
-
-void MapStructHandles(Decoded_VkMemoryRequirements2* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkSparseImageMemoryRequirements2* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceFeatures2* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceProperties2* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkFormatProperties2* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkImageFormatProperties2* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceImageFormatInfo2* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkQueueFamilyProperties2* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMemoryProperties2* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkSparseImageFormatProperties2* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceSparseImageFormatInfo2* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDevicePointClippingProperties* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkRenderPassInputAttachmentAspectCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkImageViewUsageCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineTessellationDomainOriginStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkRenderPassMultiviewCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMultiviewFeatures* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMultiviewProperties* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceVariablePointerFeatures* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceProtectedMemoryFeatures* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceProtectedMemoryProperties* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDeviceQueueInfo2* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkProtectedSubmitInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkSamplerYcbcrConversionCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -1289,56 +561,7 @@ void MapStructHandles(Decoded_VkSamplerYcbcrConversionInfo* wrapper, const Vulka
     {
         VkSamplerYcbcrConversionInfo* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->conversion = object_mapper.MapVkSamplerYcbcrConversion(wrapper->conversion);
-    }
-}
-
-void MapStructHandles(Decoded_VkBindImagePlaneMemoryInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkImagePlaneMemoryRequirementsInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceSamplerYcbcrConversionFeatures* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkSamplerYcbcrConversionImageFormatProperties* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -1348,201 +571,9 @@ void MapStructHandles(Decoded_VkDescriptorUpdateTemplateCreateInfo* wrapper, con
     {
         VkDescriptorUpdateTemplateCreateInfo* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->descriptorSetLayout = object_mapper.MapVkDescriptorSetLayout(wrapper->descriptorSetLayout);
 
         value->pipelineLayout = object_mapper.MapVkPipelineLayout(wrapper->pipelineLayout);
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceExternalImageFormatInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkExternalImageFormatProperties* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceExternalBufferInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkExternalBufferProperties* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceIDProperties* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkExternalMemoryImageCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkExternalMemoryBufferCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkExportMemoryAllocateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceExternalFenceInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkExternalFenceProperties* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkExportFenceCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkExportSemaphoreCreateInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceExternalSemaphoreInfo* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkExternalSemaphoreProperties* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMaintenance3Properties* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDescriptorSetLayoutSupport* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceShaderDrawParameterFeatures* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -1551,11 +582,6 @@ void MapStructHandles(Decoded_VkSwapchainCreateInfoKHR* wrapper, const VulkanObj
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkSwapchainCreateInfoKHR* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->surface = object_mapper.MapVkSurfaceKHR(wrapper->surface);
 
@@ -1569,11 +595,6 @@ void MapStructHandles(Decoded_VkPresentInfoKHR* wrapper, const VulkanObjectMappe
     {
         VkPresentInfoKHR* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         MapHandleArray<VkSemaphore>(wrapper->pWaitSemaphores.GetPointer(), wrapper->pWaitSemaphores.GetHandlePointer(), wrapper->pWaitSemaphores.GetLength(), object_mapper, &VulkanObjectMapper::MapVkSemaphore);
 
         MapHandleArray<VkSwapchainKHR>(wrapper->pSwapchains.GetPointer(), wrapper->pSwapchains.GetHandlePointer(), wrapper->pSwapchains.GetLength(), object_mapper, &VulkanObjectMapper::MapVkSwapchainKHR);
@@ -1586,11 +607,6 @@ void MapStructHandles(Decoded_VkImageSwapchainCreateInfoKHR* wrapper, const Vulk
     {
         VkImageSwapchainCreateInfoKHR* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->swapchain = object_mapper.MapVkSwapchainKHR(wrapper->swapchain);
     }
 }
@@ -1600,11 +616,6 @@ void MapStructHandles(Decoded_VkBindImageMemorySwapchainInfoKHR* wrapper, const 
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkBindImageMemorySwapchainInfoKHR* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->swapchain = object_mapper.MapVkSwapchainKHR(wrapper->swapchain);
     }
@@ -1616,49 +627,11 @@ void MapStructHandles(Decoded_VkAcquireNextImageInfoKHR* wrapper, const VulkanOb
     {
         VkAcquireNextImageInfoKHR* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->swapchain = object_mapper.MapVkSwapchainKHR(wrapper->swapchain);
 
         value->semaphore = object_mapper.MapVkSemaphore(wrapper->semaphore);
 
         value->fence = object_mapper.MapVkFence(wrapper->fence);
-    }
-}
-
-void MapStructHandles(Decoded_VkDeviceGroupPresentCapabilitiesKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDeviceGroupPresentInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDeviceGroupSwapchainCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -1682,17 +655,6 @@ void MapStructHandles(Decoded_VkDisplayModePropertiesKHR* wrapper, const VulkanO
     }
 }
 
-void MapStructHandles(Decoded_VkDisplayModeCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
 void MapStructHandles(Decoded_VkDisplayPlanePropertiesKHR* wrapper, const VulkanObjectMapper& object_mapper)
 {
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
@@ -1709,111 +671,7 @@ void MapStructHandles(Decoded_VkDisplaySurfaceCreateInfoKHR* wrapper, const Vulk
     {
         VkDisplaySurfaceCreateInfoKHR* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->displayMode = object_mapper.MapVkDisplayModeKHR(wrapper->displayMode);
-    }
-}
-
-void MapStructHandles(Decoded_VkDisplayPresentInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkXlibSurfaceCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkXcbSurfaceCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkWaylandSurfaceCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkAndroidSurfaceCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkWin32SurfaceCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkImportMemoryWin32HandleInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkExportMemoryWin32HandleInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkMemoryWin32HandlePropertiesKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -1823,34 +681,7 @@ void MapStructHandles(Decoded_VkMemoryGetWin32HandleInfoKHR* wrapper, const Vulk
     {
         VkMemoryGetWin32HandleInfoKHR* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->memory = object_mapper.MapVkDeviceMemory(wrapper->memory);
-    }
-}
-
-void MapStructHandles(Decoded_VkImportMemoryFdInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkMemoryFdPropertiesKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -1859,11 +690,6 @@ void MapStructHandles(Decoded_VkMemoryGetFdInfoKHR* wrapper, const VulkanObjectM
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkMemoryGetFdInfoKHR* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->memory = object_mapper.MapVkDeviceMemory(wrapper->memory);
     }
@@ -1874,11 +700,6 @@ void MapStructHandles(Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR* wrapper, c
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkWin32KeyedMutexAcquireReleaseInfoKHR* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         MapHandleArray<VkDeviceMemory>(wrapper->pAcquireSyncs.GetPointer(), wrapper->pAcquireSyncs.GetHandlePointer(), wrapper->pAcquireSyncs.GetLength(), object_mapper, &VulkanObjectMapper::MapVkDeviceMemory);
 
@@ -1892,34 +713,7 @@ void MapStructHandles(Decoded_VkImportSemaphoreWin32HandleInfoKHR* wrapper, cons
     {
         VkImportSemaphoreWin32HandleInfoKHR* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->semaphore = object_mapper.MapVkSemaphore(wrapper->semaphore);
-    }
-}
-
-void MapStructHandles(Decoded_VkExportSemaphoreWin32HandleInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkD3D12FenceSubmitInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -1928,11 +722,6 @@ void MapStructHandles(Decoded_VkSemaphoreGetWin32HandleInfoKHR* wrapper, const V
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkSemaphoreGetWin32HandleInfoKHR* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->semaphore = object_mapper.MapVkSemaphore(wrapper->semaphore);
     }
@@ -1944,11 +733,6 @@ void MapStructHandles(Decoded_VkImportSemaphoreFdInfoKHR* wrapper, const VulkanO
     {
         VkImportSemaphoreFdInfoKHR* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->semaphore = object_mapper.MapVkSemaphore(wrapper->semaphore);
     }
 }
@@ -1959,147 +743,7 @@ void MapStructHandles(Decoded_VkSemaphoreGetFdInfoKHR* wrapper, const VulkanObje
     {
         VkSemaphoreGetFdInfoKHR* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->semaphore = object_mapper.MapVkSemaphore(wrapper->semaphore);
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDevicePushDescriptorPropertiesKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceFloat16Int8FeaturesKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPresentRegionsKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkAttachmentDescription2KHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkAttachmentReference2KHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkSubpassDescription2KHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
-        MapStructArrayHandles<Decoded_VkAttachmentReference2KHR>(wrapper->pInputAttachments.GetMetaStructPointer(), wrapper->pInputAttachments.GetLength(), object_mapper);
-
-        MapStructArrayHandles<Decoded_VkAttachmentReference2KHR>(wrapper->pColorAttachments.GetMetaStructPointer(), wrapper->pColorAttachments.GetLength(), object_mapper);
-
-        MapStructArrayHandles<Decoded_VkAttachmentReference2KHR>(wrapper->pResolveAttachments.GetMetaStructPointer(), wrapper->pResolveAttachments.GetLength(), object_mapper);
-
-        MapStructArrayHandles<Decoded_VkAttachmentReference2KHR>(wrapper->pDepthStencilAttachment.GetMetaStructPointer(), 1, object_mapper);
-    }
-}
-
-void MapStructHandles(Decoded_VkSubpassDependency2KHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkRenderPassCreateInfo2KHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
-        MapStructArrayHandles<Decoded_VkAttachmentDescription2KHR>(wrapper->pAttachments.GetMetaStructPointer(), wrapper->pAttachments.GetLength(), object_mapper);
-
-        MapStructArrayHandles<Decoded_VkSubpassDescription2KHR>(wrapper->pSubpasses.GetMetaStructPointer(), wrapper->pSubpasses.GetLength(), object_mapper);
-
-        MapStructArrayHandles<Decoded_VkSubpassDependency2KHR>(wrapper->pDependencies.GetMetaStructPointer(), wrapper->pDependencies.GetLength(), object_mapper);
-    }
-}
-
-void MapStructHandles(Decoded_VkSubpassBeginInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkSubpassEndInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkSharedPresentSurfaceCapabilitiesKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -2109,23 +753,7 @@ void MapStructHandles(Decoded_VkImportFenceWin32HandleInfoKHR* wrapper, const Vu
     {
         VkImportFenceWin32HandleInfoKHR* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->fence = object_mapper.MapVkFence(wrapper->fence);
-    }
-}
-
-void MapStructHandles(Decoded_VkExportFenceWin32HandleInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -2134,11 +762,6 @@ void MapStructHandles(Decoded_VkFenceGetWin32HandleInfoKHR* wrapper, const Vulka
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkFenceGetWin32HandleInfoKHR* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->fence = object_mapper.MapVkFence(wrapper->fence);
     }
@@ -2150,11 +773,6 @@ void MapStructHandles(Decoded_VkImportFenceFdInfoKHR* wrapper, const VulkanObjec
     {
         VkImportFenceFdInfoKHR* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->fence = object_mapper.MapVkFence(wrapper->fence);
     }
 }
@@ -2164,11 +782,6 @@ void MapStructHandles(Decoded_VkFenceGetFdInfoKHR* wrapper, const VulkanObjectMa
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkFenceGetFdInfoKHR* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->fence = object_mapper.MapVkFence(wrapper->fence);
     }
@@ -2180,34 +793,7 @@ void MapStructHandles(Decoded_VkPhysicalDeviceSurfaceInfo2KHR* wrapper, const Vu
     {
         VkPhysicalDeviceSurfaceInfo2KHR* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->surface = object_mapper.MapVkSurfaceKHR(wrapper->surface);
-    }
-}
-
-void MapStructHandles(Decoded_VkSurfaceCapabilities2KHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkSurfaceFormat2KHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -2215,11 +801,6 @@ void MapStructHandles(Decoded_VkDisplayProperties2KHR* wrapper, const VulkanObje
 {
     if (wrapper != nullptr)
     {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         MapStructHandles(&wrapper->displayProperties, object_mapper);
     }
 }
@@ -2228,11 +809,6 @@ void MapStructHandles(Decoded_VkDisplayPlaneProperties2KHR* wrapper, const Vulka
 {
     if (wrapper != nullptr)
     {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         MapStructHandles(&wrapper->displayPlaneProperties, object_mapper);
     }
 }
@@ -2241,11 +817,6 @@ void MapStructHandles(Decoded_VkDisplayModeProperties2KHR* wrapper, const Vulkan
 {
     if (wrapper != nullptr)
     {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         MapStructHandles(&wrapper->displayModeProperties, object_mapper);
     }
 }
@@ -2256,190 +827,7 @@ void MapStructHandles(Decoded_VkDisplayPlaneInfo2KHR* wrapper, const VulkanObjec
     {
         VkDisplayPlaneInfo2KHR* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->mode = object_mapper.MapVkDisplayModeKHR(wrapper->mode);
-    }
-}
-
-void MapStructHandles(Decoded_VkDisplayPlaneCapabilities2KHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkImageFormatListCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDevice8BitStorageFeaturesKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceShaderAtomicInt64FeaturesKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceDriverPropertiesKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceFloatControlsPropertiesKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkSubpassDescriptionDepthStencilResolveKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
-        MapStructArrayHandles<Decoded_VkAttachmentReference2KHR>(wrapper->pDepthStencilResolveAttachment.GetMetaStructPointer(), 1, object_mapper);
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceDepthStencilResolvePropertiesKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceVulkanMemoryModelFeaturesKHR* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDebugReportCallbackCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineRasterizationStateRasterizationOrderAMD* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDebugMarkerObjectNameInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDebugMarkerObjectTagInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDebugMarkerMarkerInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDedicatedAllocationImageCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDedicatedAllocationBufferCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -2449,47 +837,9 @@ void MapStructHandles(Decoded_VkDedicatedAllocationMemoryAllocateInfoNV* wrapper
     {
         VkDedicatedAllocationMemoryAllocateInfoNV* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->image = object_mapper.MapVkImage(wrapper->image);
 
         value->buffer = object_mapper.MapVkBuffer(wrapper->buffer);
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceTransformFeedbackFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -2499,80 +849,9 @@ void MapStructHandles(Decoded_VkImageViewHandleInfoNVX* wrapper, const VulkanObj
     {
         VkImageViewHandleInfoNVX* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->imageView = object_mapper.MapVkImageView(wrapper->imageView);
 
         value->sampler = object_mapper.MapVkSampler(wrapper->sampler);
-    }
-}
-
-void MapStructHandles(Decoded_VkTextureLODGatherFormatPropertiesAMD* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceCornerSampledImageFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkExternalMemoryImageCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkExportMemoryAllocateInfoNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkImportMemoryWin32HandleInfoNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkExportMemoryWin32HandleInfoNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -2582,58 +861,9 @@ void MapStructHandles(Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV* wrapper, co
     {
         VkWin32KeyedMutexAcquireReleaseInfoNV* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         MapHandleArray<VkDeviceMemory>(wrapper->pAcquireSyncs.GetPointer(), wrapper->pAcquireSyncs.GetHandlePointer(), wrapper->pAcquireSyncs.GetLength(), object_mapper, &VulkanObjectMapper::MapVkDeviceMemory);
 
         MapHandleArray<VkDeviceMemory>(wrapper->pReleaseSyncs.GetPointer(), wrapper->pReleaseSyncs.GetHandlePointer(), wrapper->pReleaseSyncs.GetLength(), object_mapper, &VulkanObjectMapper::MapVkDeviceMemory);
-    }
-}
-
-void MapStructHandles(Decoded_VkValidationFlagsEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkViSurfaceCreateInfoNN* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkImageViewASTCDecodeModeEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceASTCDecodeFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -2643,56 +873,7 @@ void MapStructHandles(Decoded_VkConditionalRenderingBeginInfoEXT* wrapper, const
     {
         VkConditionalRenderingBeginInfoEXT* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->buffer = object_mapper.MapVkBuffer(wrapper->buffer);
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceConditionalRenderingFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkCommandBufferInheritanceConditionalRenderingInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDeviceGeneratedCommandsFeaturesNVX* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDeviceGeneratedCommandsLimitsNVX* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -2706,27 +887,11 @@ void MapStructHandles(Decoded_VkIndirectCommandsTokenNVX* wrapper, const VulkanO
     }
 }
 
-void MapStructHandles(Decoded_VkIndirectCommandsLayoutCreateInfoNVX* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
 void MapStructHandles(Decoded_VkCmdProcessCommandsInfoNVX* wrapper, const VulkanObjectMapper& object_mapper)
 {
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkCmdProcessCommandsInfoNVX* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->objectTable = object_mapper.MapVkObjectTableNVX(wrapper->objectTable);
 
@@ -2748,25 +913,9 @@ void MapStructHandles(Decoded_VkCmdReserveSpaceForCommandsInfoNVX* wrapper, cons
     {
         VkCmdReserveSpaceForCommandsInfoNVX* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->objectTable = object_mapper.MapVkObjectTableNVX(wrapper->objectTable);
 
         value->indirectCommandsLayout = object_mapper.MapVkIndirectCommandsLayoutNVX(wrapper->indirectCommandsLayout);
-    }
-}
-
-void MapStructHandles(Decoded_VkObjectTableCreateInfoNVX* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -2822,596 +971,13 @@ void MapStructHandles(Decoded_VkObjectTablePushConstantEntryNVX* wrapper, const 
     }
 }
 
-void MapStructHandles(Decoded_VkPipelineViewportWScalingStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkSurfaceCapabilities2EXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDisplayPowerInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDeviceEventInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDisplayEventInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkSwapchainCounterCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPresentTimesInfoGOOGLE* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineViewportSwizzleStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceDiscardRectanglePropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkHdrMetadataEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkIOSSurfaceCreateInfoMVK* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkMacOSSurfaceCreateInfoMVK* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDebugUtilsObjectNameInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDebugUtilsObjectTagInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDebugUtilsLabelEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDebugUtilsMessengerCallbackDataEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
-        MapStructArrayHandles<Decoded_VkDebugUtilsLabelEXT>(wrapper->pQueueLabels.GetMetaStructPointer(), wrapper->pQueueLabels.GetLength(), object_mapper);
-
-        MapStructArrayHandles<Decoded_VkDebugUtilsLabelEXT>(wrapper->pCmdBufLabels.GetMetaStructPointer(), wrapper->pCmdBufLabels.GetLength(), object_mapper);
-
-        MapStructArrayHandles<Decoded_VkDebugUtilsObjectNameInfoEXT>(wrapper->pObjects.GetMetaStructPointer(), wrapper->pObjects.GetLength(), object_mapper);
-    }
-}
-
-void MapStructHandles(Decoded_VkDebugUtilsMessengerCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkAndroidHardwareBufferUsageANDROID* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkAndroidHardwareBufferPropertiesANDROID* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkAndroidHardwareBufferFormatPropertiesANDROID* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkImportAndroidHardwareBufferInfoANDROID* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
 void MapStructHandles(Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID* wrapper, const VulkanObjectMapper& object_mapper)
 {
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkMemoryGetAndroidHardwareBufferInfoANDROID* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->memory = object_mapper.MapVkDeviceMemory(wrapper->memory);
-    }
-}
-
-void MapStructHandles(Decoded_VkExternalFormatANDROID* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkSamplerReductionModeCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceInlineUniformBlockFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceInlineUniformBlockPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkWriteDescriptorSetInlineUniformBlockEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDescriptorPoolInlineUniformBlockCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkSampleLocationsInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkAttachmentSampleLocationsEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        MapStructHandles(&wrapper->sampleLocationsInfo, object_mapper);
-    }
-}
-
-void MapStructHandles(Decoded_VkSubpassSampleLocationsEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        MapStructHandles(&wrapper->sampleLocationsInfo, object_mapper);
-    }
-}
-
-void MapStructHandles(Decoded_VkRenderPassSampleLocationsBeginInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
-        MapStructArrayHandles<Decoded_VkAttachmentSampleLocationsEXT>(wrapper->pAttachmentInitialSampleLocations.GetMetaStructPointer(), wrapper->pAttachmentInitialSampleLocations.GetLength(), object_mapper);
-
-        MapStructArrayHandles<Decoded_VkSubpassSampleLocationsEXT>(wrapper->pPostSubpassSampleLocations.GetMetaStructPointer(), wrapper->pPostSubpassSampleLocations.GetLength(), object_mapper);
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineSampleLocationsStateCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
-        MapStructHandles(&wrapper->sampleLocationsInfo, object_mapper);
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceSampleLocationsPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkMultisamplePropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineColorBlendAdvancedStateCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineCoverageToColorStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineCoverageModulationStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDrmFormatModifierPropertiesListEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceImageDrmFormatModifierInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkImageDrmFormatModifierListCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkImageDrmFormatModifierExplicitCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkImageDrmFormatModifierPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkValidationCacheCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -3421,122 +987,7 @@ void MapStructHandles(Decoded_VkShaderModuleValidationCacheCreateInfoEXT* wrappe
     {
         VkShaderModuleValidationCacheCreateInfoEXT* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->validationCache = object_mapper.MapVkValidationCacheEXT(wrapper->validationCache);
-    }
-}
-
-void MapStructHandles(Decoded_VkDescriptorSetLayoutBindingFlagsCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceDescriptorIndexingFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceDescriptorIndexingPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDescriptorSetVariableDescriptorCountAllocateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDescriptorSetVariableDescriptorCountLayoutSupportEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineViewportShadingRateImageStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceShadingRateImageFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceShadingRateImagePropertiesNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkRayTracingShaderGroupCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -3546,14 +997,7 @@ void MapStructHandles(Decoded_VkRayTracingPipelineCreateInfoNV* wrapper, const V
     {
         VkRayTracingPipelineCreateInfoNV* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         MapStructArrayHandles<Decoded_VkPipelineShaderStageCreateInfo>(wrapper->pStages.GetMetaStructPointer(), wrapper->pStages.GetLength(), object_mapper);
-
-        MapStructArrayHandles<Decoded_VkRayTracingShaderGroupCreateInfoNV>(wrapper->pGroups.GetMetaStructPointer(), wrapper->pGroups.GetLength(), object_mapper);
 
         value->layout = object_mapper.MapVkPipelineLayout(wrapper->layout);
 
@@ -3566,11 +1010,6 @@ void MapStructHandles(Decoded_VkGeometryTrianglesNV* wrapper, const VulkanObject
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkGeometryTrianglesNV* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->vertexData = object_mapper.MapVkBuffer(wrapper->vertexData);
 
@@ -3585,11 +1024,6 @@ void MapStructHandles(Decoded_VkGeometryAABBNV* wrapper, const VulkanObjectMappe
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkGeometryAABBNV* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->aabbData = object_mapper.MapVkBuffer(wrapper->aabbData);
     }
@@ -3609,11 +1043,6 @@ void MapStructHandles(Decoded_VkGeometryNV* wrapper, const VulkanObjectMapper& o
 {
     if (wrapper != nullptr)
     {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         MapStructHandles(&wrapper->geometry, object_mapper);
     }
 }
@@ -3622,11 +1051,6 @@ void MapStructHandles(Decoded_VkAccelerationStructureInfoNV* wrapper, const Vulk
 {
     if (wrapper != nullptr)
     {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         MapStructArrayHandles<Decoded_VkGeometryNV>(wrapper->pGeometries.GetMetaStructPointer(), wrapper->pGeometries.GetLength(), object_mapper);
     }
 }
@@ -3635,11 +1059,6 @@ void MapStructHandles(Decoded_VkAccelerationStructureCreateInfoNV* wrapper, cons
 {
     if (wrapper != nullptr)
     {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         MapStructHandles(&wrapper->info, object_mapper);
     }
 }
@@ -3649,11 +1068,6 @@ void MapStructHandles(Decoded_VkBindAccelerationStructureMemoryInfoNV* wrapper, 
     if ((wrapper != nullptr) && (wrapper->value != nullptr))
     {
         VkBindAccelerationStructureMemoryInfoNV* value = wrapper->value;
-
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
 
         value->accelerationStructure = object_mapper.MapVkAccelerationStructureNV(wrapper->accelerationStructure);
 
@@ -3667,11 +1081,6 @@ void MapStructHandles(Decoded_VkWriteDescriptorSetAccelerationStructureNV* wrapp
     {
         VkWriteDescriptorSetAccelerationStructureNV* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         MapHandleArray<VkAccelerationStructureNV>(wrapper->pAccelerationStructures.GetPointer(), wrapper->pAccelerationStructures.GetHandlePointer(), wrapper->pAccelerationStructures.GetLength(), object_mapper, &VulkanObjectMapper::MapVkAccelerationStructureNV);
     }
 }
@@ -3682,408 +1091,7 @@ void MapStructHandles(Decoded_VkAccelerationStructureMemoryRequirementsInfoNV* w
     {
         VkAccelerationStructureMemoryRequirementsInfoNV* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->accelerationStructure = object_mapper.MapVkAccelerationStructureNV(wrapper->accelerationStructure);
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceRayTracingPropertiesNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkImportMemoryHostPointerInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkMemoryHostPointerPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceExternalMemoryHostPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkCalibratedTimestampInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceShaderCorePropertiesAMD* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkDeviceMemoryOverallocationCreateInfoAMD* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineVertexInputDivisorStateCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMeshShaderFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMeshShaderPropertiesNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceShaderImageFootprintFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPipelineViewportExclusiveScissorStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceExclusiveScissorFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkQueueFamilyCheckpointPropertiesNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkCheckpointDataNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDevicePCIBusInfoPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkMetalSurfaceCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceScalarBlockLayoutFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMemoryBudgetPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMemoryPriorityFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkMemoryPriorityAllocateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceBufferAddressFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -4093,89 +1101,7 @@ void MapStructHandles(Decoded_VkBufferDeviceAddressInfoEXT* wrapper, const Vulka
     {
         VkBufferDeviceAddressInfoEXT* value = wrapper->value;
 
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-
         value->buffer = object_mapper.MapVkBuffer(wrapper->buffer);
-    }
-}
-
-void MapStructHandles(Decoded_VkBufferDeviceAddressCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkImageStencilUsageCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkValidationFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkCooperativeMatrixPropertiesNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
-    }
-}
-
-void MapStructHandles(Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper)
-{
-    if (wrapper != nullptr)
-    {
-        if (wrapper->pNext)
-        {
-            MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
-        }
     }
 }
 
@@ -4190,122 +1116,14 @@ void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectM
         default:
             // TODO: Report or raise fatal error for unrecongized sType?
             break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceSubgroupProperties*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDevice16BitStorageFeatures*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS:
-            MapStructHandles(reinterpret_cast<Decoded_VkMemoryDedicatedRequirements*>(wrapper), object_mapper);
-            break;
         case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO:
             MapStructHandles(reinterpret_cast<Decoded_VkMemoryDedicatedAllocateInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkMemoryAllocateFlagsInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_DEVICE_GROUP_RENDER_PASS_BEGIN_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkDeviceGroupRenderPassBeginInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_DEVICE_GROUP_COMMAND_BUFFER_BEGIN_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkDeviceGroupCommandBufferBeginInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_DEVICE_GROUP_SUBMIT_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkDeviceGroupSubmitInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_DEVICE_GROUP_BIND_SPARSE_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkDeviceGroupBindSparseInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_DEVICE_GROUP_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkBindBufferMemoryDeviceGroupInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_DEVICE_GROUP_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkBindImageMemoryDeviceGroupInfo*>(wrapper), object_mapper);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO:
             MapStructHandles(reinterpret_cast<Decoded_VkDeviceGroupDeviceCreateInfo*>(wrapper), object_mapper);
             break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceFeatures2*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_POINT_CLIPPING_PROPERTIES:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDevicePointClippingProperties*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkRenderPassInputAttachmentAspectCreateInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkImageViewUsageCreateInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineTessellationDomainOriginStateCreateInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkRenderPassMultiviewCreateInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceMultiviewFeatures*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceMultiviewProperties*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTER_FEATURES:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceVariablePointerFeatures*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceProtectedMemoryFeatures*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_PROPERTIES:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceProtectedMemoryProperties*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PROTECTED_SUBMIT_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkProtectedSubmitInfo*>(wrapper), object_mapper);
-            break;
         case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO:
             MapStructHandles(reinterpret_cast<Decoded_VkSamplerYcbcrConversionInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_BIND_IMAGE_PLANE_MEMORY_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkBindImagePlaneMemoryInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_IMAGE_PLANE_MEMORY_REQUIREMENTS_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkImagePlaneMemoryRequirementsInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES:
-            MapStructHandles(reinterpret_cast<Decoded_VkSamplerYcbcrConversionImageFormatProperties*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceExternalImageFormatInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES:
-            MapStructHandles(reinterpret_cast<Decoded_VkExternalImageFormatProperties*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceIDProperties*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkExternalMemoryImageCreateInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkExternalMemoryBufferCreateInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkExportMemoryAllocateInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkExportFenceCreateInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO:
-            MapStructHandles(reinterpret_cast<Decoded_VkExportSemaphoreCreateInfo*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceMaintenance3Properties*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETER_FEATURES:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceShaderDrawParameterFeatures*>(wrapper), object_mapper);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_SWAPCHAIN_CREATE_INFO_KHR:
             MapStructHandles(reinterpret_cast<Decoded_VkImageSwapchainCreateInfoKHR*>(wrapper), object_mapper);
@@ -4313,380 +1131,20 @@ void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectM
         case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHR:
             MapStructHandles(reinterpret_cast<Decoded_VkBindImageMemorySwapchainInfoKHR*>(wrapper), object_mapper);
             break;
-        case VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_INFO_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkDeviceGroupPresentInfoKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_DEVICE_GROUP_SWAPCHAIN_CREATE_INFO_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkDeviceGroupSwapchainCreateInfoKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_DISPLAY_PRESENT_INFO_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkDisplayPresentInfoKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkImportMemoryWin32HandleInfoKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkExportMemoryWin32HandleInfoKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkImportMemoryFdInfoKHR*>(wrapper), object_mapper);
-            break;
         case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR:
             MapStructHandles(reinterpret_cast<Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkExportSemaphoreWin32HandleInfoKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkD3D12FenceSubmitInfoKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDevicePushDescriptorPropertiesKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceFloat16Int8FeaturesKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkPresentRegionsKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkSharedPresentSurfaceCapabilitiesKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_EXPORT_FENCE_WIN32_HANDLE_INFO_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkExportFenceWin32HandleInfoKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkImageFormatListCreateInfoKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDevice8BitStorageFeaturesKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceShaderAtomicInt64FeaturesKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceDriverPropertiesKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceFloatControlsPropertiesKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkSubpassDescriptionDepthStencilResolveKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceDepthStencilResolvePropertiesKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES_KHR:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceVulkanMemoryModelFeaturesKHR*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkDebugReportCallbackCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineRasterizationStateRasterizationOrderAMD*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkDedicatedAllocationImageCreateInfoNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkDedicatedAllocationBufferCreateInfoNV*>(wrapper), object_mapper);
             break;
         case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV:
             MapStructHandles(reinterpret_cast<Decoded_VkDedicatedAllocationMemoryAllocateInfoNV*>(wrapper), object_mapper);
             break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD:
-            MapStructHandles(reinterpret_cast<Decoded_VkTextureLODGatherFormatPropertiesAMD*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceCornerSampledImageFeaturesNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkExternalMemoryImageCreateInfoNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkExportMemoryAllocateInfoNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkImportMemoryWin32HandleInfoNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkExportMemoryWin32HandleInfoNV*>(wrapper), object_mapper);
-            break;
         case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV:
             MapStructHandles(reinterpret_cast<Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkValidationFlagsEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_IMAGE_VIEW_ASTC_DECODE_MODE_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkImageViewASTCDecodeModeEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceASTCDecodeFeaturesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_CONDITIONAL_RENDERING_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkCommandBufferInheritanceConditionalRenderingInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_W_SCALING_STATE_CREATE_INFO_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineViewportWScalingStateCreateInfoNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_SWAPCHAIN_COUNTER_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkSwapchainCounterCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE:
-            MapStructHandles(reinterpret_cast<Decoded_VkPresentTimesInfoGOOGLE*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineViewportSwizzleStateCreateInfoNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceDiscardRectanglePropertiesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_DEPTH_CLIP_STATE_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkDebugUtilsMessengerCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID:
-            MapStructHandles(reinterpret_cast<Decoded_VkAndroidHardwareBufferUsageANDROID*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID:
-            MapStructHandles(reinterpret_cast<Decoded_VkAndroidHardwareBufferFormatPropertiesANDROID*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID:
-            MapStructHandles(reinterpret_cast<Decoded_VkImportAndroidHardwareBufferInfoANDROID*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID:
-            MapStructHandles(reinterpret_cast<Decoded_VkExternalFormatANDROID*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkSamplerReductionModeCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceInlineUniformBlockFeaturesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceInlineUniformBlockPropertiesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkWriteDescriptorSetInlineUniformBlockEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkDescriptorPoolInlineUniformBlockCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkSampleLocationsInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_RENDER_PASS_SAMPLE_LOCATIONS_BEGIN_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkRenderPassSampleLocationsBeginInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_SAMPLE_LOCATIONS_STATE_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineSampleLocationsStateCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceSampleLocationsPropertiesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineColorBlendAdvancedStateCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_TO_COLOR_STATE_CREATE_INFO_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineCoverageToColorStateCreateInfoNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_MODULATION_STATE_CREATE_INFO_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineCoverageModulationStateCreateInfoNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkDrmFormatModifierPropertiesListEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_DRM_FORMAT_MODIFIER_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceImageDrmFormatModifierInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkImageDrmFormatModifierListCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_EXPLICIT_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkImageDrmFormatModifierExplicitCreateInfoEXT*>(wrapper), object_mapper);
             break;
         case VK_STRUCTURE_TYPE_SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT:
             MapStructHandles(reinterpret_cast<Decoded_VkShaderModuleValidationCacheCreateInfoEXT*>(wrapper), object_mapper);
             break;
-        case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkDescriptorSetLayoutBindingFlagsCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceDescriptorIndexingFeaturesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceDescriptorIndexingPropertiesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkDescriptorSetVariableDescriptorCountAllocateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkDescriptorSetVariableDescriptorCountLayoutSupportEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SHADING_RATE_IMAGE_STATE_CREATE_INFO_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineViewportShadingRateImageStateCreateInfoNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_FEATURES_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceShadingRateImageFeaturesNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_PROPERTIES_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceShadingRateImagePropertiesNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_COARSE_SAMPLE_ORDER_STATE_CREATE_INFO_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV*>(wrapper), object_mapper);
-            break;
         case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_NV:
             MapStructHandles(reinterpret_cast<Decoded_VkWriteDescriptorSetAccelerationStructureNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PROPERTIES_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceRayTracingPropertiesNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_REPRESENTATIVE_FRAGMENT_TEST_STATE_CREATE_INFO_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_IMAGE_FORMAT_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_FILTER_CUBIC_IMAGE_VIEW_IMAGE_FORMAT_PROPERTIES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_IMPORT_MEMORY_HOST_POINTER_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkImportMemoryHostPointerInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceExternalMemoryHostPropertiesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_AMD:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceShaderCorePropertiesAMD*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_DEVICE_MEMORY_OVERALLOCATION_CREATE_INFO_AMD:
-            MapStructHandles(reinterpret_cast<Decoded_VkDeviceMemoryOverallocationCreateInfoAMD*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineVertexInputDivisorStateCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceMeshShaderFeaturesNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceMeshShaderPropertiesNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_EXCLUSIVE_SCISSOR_STATE_CREATE_INFO_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPipelineViewportExclusiveScissorStateCreateInfoNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceExclusiveScissorFeaturesNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkQueueFamilyCheckpointPropertiesNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDevicePCIBusInfoPropertiesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceScalarBlockLayoutFeaturesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceMemoryBudgetPropertiesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkMemoryPriorityAllocateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_ADDRESS_FEATURES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceBufferAddressFeaturesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkBufferDeviceAddressCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_IMAGE_STENCIL_USAGE_CREATE_INFO_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkImageStencilUsageCreateInfoEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkValidationFeaturesEXT*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV*>(wrapper), object_mapper);
-            break;
-        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT:
-            MapStructHandles(reinterpret_cast<Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(wrapper), object_mapper);
             break;
         }
     }

--- a/framework/generated/generated_vulkan_struct_handle_mappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.h
@@ -33,12 +33,6 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-void MapStructHandles(Decoded_VkApplicationInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkInstanceCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDeviceQueueCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkDeviceCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkSubmitInfo* wrapper, const VulkanObjectMapper& object_mapper);
@@ -59,16 +53,6 @@ void MapStructHandles(Decoded_VkSparseImageMemoryBindInfo* wrapper, const Vulkan
 
 void MapStructHandles(Decoded_VkBindSparseInfo* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkFenceCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSemaphoreCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkEventCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkQueryPoolCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkBufferCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkBufferViewCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkImageCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
@@ -77,27 +61,7 @@ void MapStructHandles(Decoded_VkImageViewCreateInfo* wrapper, const VulkanObject
 
 void MapStructHandles(Decoded_VkShaderModuleCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkPipelineCacheCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkPipelineShaderStageCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineVertexInputStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineInputAssemblyStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineTessellationStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineViewportStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineRasterizationStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineMultisampleStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineDepthStencilStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineColorBlendStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineDynamicStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkGraphicsPipelineCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
 
@@ -111,8 +75,6 @@ void MapStructHandles(Decoded_VkDescriptorSetLayoutBinding* wrapper, const Vulka
 
 void MapStructHandles(Decoded_VkDescriptorSetLayoutCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkDescriptorPoolCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkDescriptorSetAllocateInfo* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkDescriptorImageInfo* wrapper, const VulkanObjectMapper& object_mapper);
@@ -125,17 +87,11 @@ void MapStructHandles(Decoded_VkCopyDescriptorSet* wrapper, const VulkanObjectMa
 
 void MapStructHandles(Decoded_VkFramebufferCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkRenderPassCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkCommandPoolCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkCommandBufferAllocateInfo* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkCommandBufferInheritanceInfo* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkCommandBufferBeginInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkMemoryBarrier* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkBufferMemoryBarrier* wrapper, const VulkanObjectMapper& object_mapper);
 
@@ -143,31 +99,11 @@ void MapStructHandles(Decoded_VkImageMemoryBarrier* wrapper, const VulkanObjectM
 
 void MapStructHandles(Decoded_VkRenderPassBeginInfo* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkPhysicalDeviceSubgroupProperties* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkBindBufferMemoryInfo* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkBindImageMemoryInfo* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkPhysicalDevice16BitStorageFeatures* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkMemoryDedicatedRequirements* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkMemoryDedicatedAllocateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkMemoryAllocateFlagsInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDeviceGroupRenderPassBeginInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDeviceGroupCommandBufferBeginInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDeviceGroupSubmitInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDeviceGroupBindSparseInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkBindBufferMemoryDeviceGroupInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkBindImageMemoryDeviceGroupInfo* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkPhysicalDeviceGroupProperties* wrapper, const VulkanObjectMapper& object_mapper);
 
@@ -179,99 +115,9 @@ void MapStructHandles(Decoded_VkImageMemoryRequirementsInfo2* wrapper, const Vul
 
 void MapStructHandles(Decoded_VkImageSparseMemoryRequirementsInfo2* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkMemoryRequirements2* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSparseImageMemoryRequirements2* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceFeatures2* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceProperties2* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkFormatProperties2* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkImageFormatProperties2* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceImageFormatInfo2* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkQueueFamilyProperties2* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMemoryProperties2* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSparseImageFormatProperties2* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceSparseImageFormatInfo2* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDevicePointClippingProperties* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkRenderPassInputAttachmentAspectCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkImageViewUsageCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineTessellationDomainOriginStateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkRenderPassMultiviewCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMultiviewFeatures* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMultiviewProperties* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceVariablePointerFeatures* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceProtectedMemoryFeatures* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceProtectedMemoryProperties* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDeviceQueueInfo2* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkProtectedSubmitInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSamplerYcbcrConversionCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkSamplerYcbcrConversionInfo* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkBindImagePlaneMemoryInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkImagePlaneMemoryRequirementsInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceSamplerYcbcrConversionFeatures* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSamplerYcbcrConversionImageFormatProperties* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkDescriptorUpdateTemplateCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceExternalImageFormatInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkExternalImageFormatProperties* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceExternalBufferInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkExternalBufferProperties* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceIDProperties* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkExternalMemoryImageCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkExternalMemoryBufferCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkExportMemoryAllocateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceExternalFenceInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkExternalFenceProperties* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkExportFenceCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkExportSemaphoreCreateInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceExternalSemaphoreInfo* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkExternalSemaphoreProperties* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMaintenance3Properties* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDescriptorSetLayoutSupport* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceShaderDrawParameterFeatures* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkSwapchainCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
 
@@ -283,45 +129,15 @@ void MapStructHandles(Decoded_VkBindImageMemorySwapchainInfoKHR* wrapper, const 
 
 void MapStructHandles(Decoded_VkAcquireNextImageInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkDeviceGroupPresentCapabilitiesKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDeviceGroupPresentInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDeviceGroupSwapchainCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkDisplayPropertiesKHR* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkDisplayModePropertiesKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDisplayModeCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkDisplayPlanePropertiesKHR* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkDisplaySurfaceCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkDisplayPresentInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkXlibSurfaceCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkXcbSurfaceCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkWaylandSurfaceCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkAndroidSurfaceCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkWin32SurfaceCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkImportMemoryWin32HandleInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkExportMemoryWin32HandleInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkMemoryWin32HandlePropertiesKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkMemoryGetWin32HandleInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkImportMemoryFdInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkMemoryFdPropertiesKHR* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkMemoryGetFdInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
 
@@ -329,41 +145,13 @@ void MapStructHandles(Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR* wrapper, c
 
 void MapStructHandles(Decoded_VkImportSemaphoreWin32HandleInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkExportSemaphoreWin32HandleInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkD3D12FenceSubmitInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkSemaphoreGetWin32HandleInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkImportSemaphoreFdInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkSemaphoreGetFdInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkPhysicalDevicePushDescriptorPropertiesKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceFloat16Int8FeaturesKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPresentRegionsKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkAttachmentDescription2KHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkAttachmentReference2KHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSubpassDescription2KHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSubpassDependency2KHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkRenderPassCreateInfo2KHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSubpassBeginInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSubpassEndInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSharedPresentSurfaceCapabilitiesKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkImportFenceWin32HandleInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkExportFenceWin32HandleInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkFenceGetWin32HandleInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
 
@@ -373,10 +161,6 @@ void MapStructHandles(Decoded_VkFenceGetFdInfoKHR* wrapper, const VulkanObjectMa
 
 void MapStructHandles(Decoded_VkPhysicalDeviceSurfaceInfo2KHR* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkSurfaceCapabilities2KHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSurfaceFormat2KHR* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkDisplayProperties2KHR* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkDisplayPlaneProperties2KHR* wrapper, const VulkanObjectMapper& object_mapper);
@@ -385,89 +169,19 @@ void MapStructHandles(Decoded_VkDisplayModeProperties2KHR* wrapper, const Vulkan
 
 void MapStructHandles(Decoded_VkDisplayPlaneInfo2KHR* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkDisplayPlaneCapabilities2KHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkImageFormatListCreateInfoKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDevice8BitStorageFeaturesKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceShaderAtomicInt64FeaturesKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceDriverPropertiesKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceFloatControlsPropertiesKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSubpassDescriptionDepthStencilResolveKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceDepthStencilResolvePropertiesKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceVulkanMemoryModelFeaturesKHR* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDebugReportCallbackCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineRasterizationStateRasterizationOrderAMD* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDebugMarkerObjectNameInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDebugMarkerObjectTagInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDebugMarkerMarkerInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDedicatedAllocationImageCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDedicatedAllocationBufferCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkDedicatedAllocationMemoryAllocateInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceTransformFeedbackFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkImageViewHandleInfoNVX* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkTextureLODGatherFormatPropertiesAMD* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceCornerSampledImageFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkExternalMemoryImageCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkExportMemoryAllocateInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkImportMemoryWin32HandleInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkExportMemoryWin32HandleInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkValidationFlagsEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkViSurfaceCreateInfoNN* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkImageViewASTCDecodeModeEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceASTCDecodeFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkConditionalRenderingBeginInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkPhysicalDeviceConditionalRenderingFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkCommandBufferInheritanceConditionalRenderingInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDeviceGeneratedCommandsFeaturesNVX* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDeviceGeneratedCommandsLimitsNVX* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkIndirectCommandsTokenNVX* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkIndirectCommandsLayoutCreateInfoNVX* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkCmdProcessCommandsInfoNVX* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkCmdReserveSpaceForCommandsInfoNVX* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkObjectTableCreateInfoNVX* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkObjectTablePipelineEntryNVX* wrapper, const VulkanObjectMapper& object_mapper);
 
@@ -479,133 +193,9 @@ void MapStructHandles(Decoded_VkObjectTableIndexBufferEntryNVX* wrapper, const V
 
 void MapStructHandles(Decoded_VkObjectTablePushConstantEntryNVX* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkPipelineViewportWScalingStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSurfaceCapabilities2EXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDisplayPowerInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDeviceEventInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDisplayEventInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSwapchainCounterCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPresentTimesInfoGOOGLE* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineViewportSwizzleStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceDiscardRectanglePropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkHdrMetadataEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkIOSSurfaceCreateInfoMVK* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkMacOSSurfaceCreateInfoMVK* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDebugUtilsObjectNameInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDebugUtilsObjectTagInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDebugUtilsLabelEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDebugUtilsMessengerCallbackDataEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDebugUtilsMessengerCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkAndroidHardwareBufferUsageANDROID* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkAndroidHardwareBufferPropertiesANDROID* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkAndroidHardwareBufferFormatPropertiesANDROID* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkImportAndroidHardwareBufferInfoANDROID* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkExternalFormatANDROID* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSamplerReductionModeCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceInlineUniformBlockFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceInlineUniformBlockPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkWriteDescriptorSetInlineUniformBlockEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDescriptorPoolInlineUniformBlockCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSampleLocationsInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkAttachmentSampleLocationsEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkSubpassSampleLocationsEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkRenderPassSampleLocationsBeginInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineSampleLocationsStateCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceSampleLocationsPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkMultisamplePropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineColorBlendAdvancedStateCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineCoverageToColorStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineCoverageModulationStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDrmFormatModifierPropertiesListEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceImageDrmFormatModifierInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkImageDrmFormatModifierListCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkImageDrmFormatModifierExplicitCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkImageDrmFormatModifierPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkValidationCacheCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkShaderModuleValidationCacheCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDescriptorSetLayoutBindingFlagsCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceDescriptorIndexingFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceDescriptorIndexingPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDescriptorSetVariableDescriptorCountAllocateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDescriptorSetVariableDescriptorCountLayoutSupportEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineViewportShadingRateImageStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceShadingRateImageFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceShadingRateImagePropertiesNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkRayTracingShaderGroupCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapStructHandles(Decoded_VkRayTracingPipelineCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
 
@@ -627,93 +217,7 @@ void MapStructHandles(Decoded_VkWriteDescriptorSetAccelerationStructureNV* wrapp
 
 void MapStructHandles(Decoded_VkAccelerationStructureMemoryRequirementsInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
 
-void MapStructHandles(Decoded_VkPhysicalDeviceRayTracingPropertiesNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkImportMemoryHostPointerInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkMemoryHostPointerPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceExternalMemoryHostPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkCalibratedTimestampInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceShaderCorePropertiesAMD* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkDeviceMemoryOverallocationCreateInfoAMD* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineVertexInputDivisorStateCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMeshShaderFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMeshShaderPropertiesNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceShaderImageFootprintFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPipelineViewportExclusiveScissorStateCreateInfoNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceExclusiveScissorFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkQueueFamilyCheckpointPropertiesNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkCheckpointDataNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDevicePCIBusInfoPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkMetalSurfaceCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceScalarBlockLayoutFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMemoryBudgetPropertiesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceMemoryPriorityFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkMemoryPriorityAllocateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceBufferAddressFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
 void MapStructHandles(Decoded_VkBufferDeviceAddressInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkBufferDeviceAddressCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkImageStencilUsageCreateInfoEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkValidationFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkCooperativeMatrixPropertiesNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV* wrapper, const VulkanObjectMapper& object_mapper);
-
-void MapStructHandles(Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* wrapper, const VulkanObjectMapper& object_mapper);
 
 void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectMapper& object_mapper);
 

--- a/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -80,25 +80,12 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
     def genStruct(self, typeinfo, typename, alias):
         BaseGenerator.genStruct(self, typeinfo, typename, alias)
 
-        handles = []
         if (typename not in self.STRUCT_BLACKLIST) and not alias:
+            self.checkStructMemberHandles(typename, self.structsWithHandles)
+
             sType = self.makeStructureTypeEnum(typeinfo, typename)
             if sType:
                 self.sTypeValues[typename] = sType
-
-            for value in self.featureStructMembers[typename]:
-                if self.isHandle(value.baseType):
-                    # The member is a handle.
-                    handles.append(value)
-                elif self.isStruct(value.baseType) and value.baseType in self.structsWithHandles:
-                    # The member is a struct that contains a handle.
-                    handles.append(value)
-                elif 'pNext' in value.name:
-                    # The pNext member may point to a struct that contains handles to map.
-                    # TODO: Make this conditional on the struct being extended by structs with handles.
-                    handles.append(value)
-            if handles:
-                self.structsWithHandles[typename] = handles
 
     #
     # Indicates that the current feature has C++ code to generate.

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_body_generator.py
@@ -114,22 +114,8 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
     def genStruct(self, typeinfo, typename, alias):
         BaseGenerator.genStruct(self, typeinfo, typename, alias)
 
-        handles = []
         if (typename not in self.STRUCT_BLACKLIST) and not alias:
-            for value in self.featureStructMembers[typename]:
-                if self.isHandle(value.baseType):
-                    # The member is a handle.
-                    handles.append(value)
-                elif self.isStruct(value.baseType) and value.baseType in self.structsWithHandles:
-                    # The member is a struct that contains a handle.
-                    handles.append(value)
-                elif 'pNext' in value.name:
-                    # The pNext member may point to a struct that contains handles to map.
-                    # TODO: Make this conditional on the struct being extended by structs with handles.
-                    handles.append(value)
-            if handles:
-                self.structsWithHandles[typename] = handles
-
+            if self.checkStructMemberHandles(typename, self.structsWithHandles):
                 # Track this struct if it can be present in a pNext chain, for generating the MapPNextStructHandles code.
                 parentStructs = typeinfo.elem.get('structextends')
                 if parentStructs:

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
@@ -92,21 +92,8 @@ class VulkanStructHandleMappersHeaderGenerator(BaseGenerator):
     def genStruct(self, typeinfo, typename, alias):
         BaseGenerator.genStruct(self, typeinfo, typename, alias)
 
-        handles = []
         if (typename not in self.STRUCT_BLACKLIST) and not alias:
-            for value in self.featureStructMembers[typename]:
-                if self.isHandle(value.baseType):
-                    # The member is a handle.
-                    handles.append(value)
-                elif self.isStruct(value.baseType) and value.baseType in self.structsWithHandles:
-                    # The member is a struct that contains a handle.
-                    handles.append(value)
-                elif 'pNext' in value.name:
-                    # The pNext member may point to a struct that contains handles to map.
-                    # TODO: Make this conditional on the struct being extended by structs with handles.
-                    handles.append(value)
-            if handles:
-                self.structsWithHandles[typename] = handles
+            self.checkStructMemberHandles(typename, self.structsWithHandles)
 
     #
     # Indicates that the current feature has C++ code to generate.


### PR DESCRIPTION
Code generation for mapping handles in structs was using the following
criteria to determine if a struct contained handles:
- A struct member has a handle type
- A struct member is a struct that has a member with a handle type
- The struct contains a pNext member

Structs with pNext members were processed for handle mapping even if
the valid extension structs did not contain handles. This was due to
code generator not having information for the valid extension structs
at the time that the parent struct was processed.

This change adds support for retrieiving extension struct information
from the registry when processing the parent struct, changing the pNext
criteria to:
- The struct contains a pNext member that can point to a structure that
  has a member with a handle type.
