### PR TITLE
Destroy Window if Surface Creation Fails

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -241,6 +241,10 @@ VkResult VulkanReplayConsumerBase::CreateSurface(VkInstance instance, VkFlags fl
 
         window_map_.insert(std::make_pair(key, window));
     }
+    else
+    {
+        window_factory_->Destroy(window);
+    }
 
     return result;
 }


### PR DESCRIPTION
If VkSurface creation fails on replay, destroy the window that was created for that surface.