### PR TITLE
Add Buffer Memory to Trim Snapshot

### DIFF
--- a/framework/encode/custom_encoder_commands.h
+++ b/framework/encode/custom_encoder_commands.h
@@ -67,6 +67,16 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDestroyInstance>
     }
 };
 
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkGetPhysicalDeviceMemoryProperties(args...);
+    }
+};
+
 // Dispatch custom command for window resize command generation.
 template <>
 struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateSwapchainKHR>

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -681,36 +681,44 @@ void TraceManager::PostProcess_vkMapMemory(VkResult         result,
 
     if ((result == VK_SUCCESS) && (ppData != nullptr))
     {
-        std::lock_guard<std::mutex> lock(memory_tracker_lock_);
-        MemoryTracker::EntryInfo*   info      = nullptr;
-        bool                        first_map = memory_tracker_.MapEntry(memory, offset, size, (*ppData), &info);
-
-        if ((info != nullptr) && (info->mapped_size > 0) &&
-            (memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kPageGuard))
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
         {
-            if (first_map)
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackMappedMemory(memory, (*ppData), offset, size);
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(memory_tracker_lock_);
+            MemoryTracker::EntryInfo*   info      = nullptr;
+            bool                        first_map = memory_tracker_.MapEntry(memory, offset, size, (*ppData), &info);
+
+            if ((info != nullptr) && (info->mapped_size > 0) &&
+                (memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kPageGuard))
             {
-                GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, info->mapped_size);
+                if (first_map)
+                {
+                    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, info->mapped_size);
 
-                util::PageGuardManager* manager = util::PageGuardManager::Get();
+                    util::PageGuardManager* manager = util::PageGuardManager::Get();
 
-                assert(manager != nullptr);
+                    assert(manager != nullptr);
 
-                info->tracked_memory = manager->AddMemory(
-                    format::ToHandleId(memory), (*ppData), static_cast<size_t>(info->mapped_size), false);
+                    info->tracked_memory = manager->AddMemory(
+                        format::ToHandleId(memory), (*ppData), static_cast<size_t>(info->mapped_size), false);
+                }
+                else
+                {
+                    // The application has mapped the same VkDeviceMemory object more than once and the pageguard
+                    // manager is already tracking it, so we will return the pointer obtained from the pageguard manager
+                    // on the first map call.
+                    GFXRECON_LOG_WARNING(
+                        "VkDeviceMemory object with handle = %" PRIx64 " has been mapped more than once", memory);
+                }
+
+                // Return the pointer provided by the pageguard manager, which may be a pointer to shadow memory, not
+                // the mapped memory.
+                (*ppData) = info->tracked_memory;
             }
-            else
-            {
-                // The application has mapped the same VkDeviceMemory object more than once and the pageguard manager is
-                // already tracking it, so we will return the pointer obtained from the pageguard manager on the first
-                // map call.
-                GFXRECON_LOG_WARNING("VkDeviceMemory object with handle = %" PRIx64 " has been mapped more than once",
-                                     memory);
-            }
-
-            // Return the pointer provided by the pageguard manager, which may be a pointer to shadow memory, not the
-            // mapped memory.
-            (*ppData) = info->tracked_memory;
         }
     }
 }
@@ -792,38 +800,47 @@ void TraceManager::PreProcess_vkUnmapMemory(VkDevice device, VkDeviceMemory memo
 {
     GFXRECON_UNREFERENCED_PARAMETER(device);
 
-    std::lock_guard<std::mutex> lock(memory_tracker_lock_);
-
-    if (memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kPageGuard)
+    if ((capture_mode_ & kModeTrack) == kModeTrack)
     {
-        util::PageGuardManager* manager = util::PageGuardManager::Get();
-        assert(manager != nullptr);
-
-        auto info = memory_tracker_.GetEntryInfo(memory);
-
-        if ((info != nullptr) && (info->mapped_memory != nullptr))
-        {
-            manager->ProcessMemoryEntry(
-                format::ToHandleId(memory),
-                [this](uint64_t memory_id, void* start_address, size_t offset, size_t size) {
-                    WriteFillMemoryCmd(format::FromHandleId<VkDeviceMemory>(memory_id), offset, size, start_address);
-                });
-
-            manager->RemoveMemory(format::ToHandleId(memory));
-        }
-    }
-    else if (memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kUnassisted)
-    {
-        // Write the entire mapped region.
-        auto info = memory_tracker_.GetEntryInfo(memory);
-        if ((info != nullptr) && (info->mapped_memory != nullptr))
-        {
-            // We set offset to 0, because the pointer returned by vkMapMemory already includes the offset.
-            WriteFillMemoryCmd(memory, 0, info->mapped_size, info->mapped_memory);
-        }
+        assert(state_tracker_ != nullptr);
+        state_tracker_->TrackMappedMemory(memory, nullptr, 0, 0);
     }
 
-    memory_tracker_.UnmapEntry(memory);
+    {
+        std::lock_guard<std::mutex> lock(memory_tracker_lock_);
+
+        if (memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kPageGuard)
+        {
+            util::PageGuardManager* manager = util::PageGuardManager::Get();
+            assert(manager != nullptr);
+
+            auto info = memory_tracker_.GetEntryInfo(memory);
+
+            if ((info != nullptr) && (info->mapped_memory != nullptr))
+            {
+                manager->ProcessMemoryEntry(
+                    format::ToHandleId(memory),
+                    [this](uint64_t memory_id, void* start_address, size_t offset, size_t size) {
+                        WriteFillMemoryCmd(
+                            format::FromHandleId<VkDeviceMemory>(memory_id), offset, size, start_address);
+                    });
+
+                manager->RemoveMemory(format::ToHandleId(memory));
+            }
+        }
+        else if (memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kUnassisted)
+        {
+            // Write the entire mapped region.
+            auto info = memory_tracker_.GetEntryInfo(memory);
+            if ((info != nullptr) && (info->mapped_memory != nullptr))
+            {
+                // We set offset to 0, because the pointer returned by vkMapMemory already includes the offset.
+                WriteFillMemoryCmd(memory, 0, info->mapped_size, info->mapped_memory);
+            }
+        }
+
+        memory_tracker_.UnmapEntry(memory);
+    }
 }
 
 void TraceManager::PreProcess_vkFreeMemory(VkDevice                     device,

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -378,7 +378,11 @@ void TraceManager::EndFrame()
                     auto thread_data = GetThreadData();
                     assert(thread_data != nullptr);
 
-                    VulkanStateWriter state_writer(file_stream_.get(), compressor_.get(), thread_data->thread_id_);
+                    VulkanStateWriter state_writer(file_stream_.get(),
+                                                   compressor_.get(),
+                                                   thread_data->thread_id_,
+                                                   &instance_tables_,
+                                                   &device_tables_);
                     state_tracker_->WriteState(&state_writer);
                 }
                 else

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -117,8 +117,9 @@ class TraceManager
     }
 
     // Single object creation.
-    template <typename Wrapper, typename CreateInfo>
+    template <typename ParentHandle, typename Wrapper, typename CreateInfo>
     void EndCreateApiCallTrace(VkResult                      result,
+                               ParentHandle                  parent_handle,
                                typename Wrapper::HandleType* handle,
                                const CreateInfo*             create_info,
                                ParameterEncoder*             encoder)
@@ -130,16 +131,17 @@ class TraceManager
             auto thread_data = GetThreadData();
             assert(thread_data != nullptr);
 
-            state_tracker_->AddEntry<Wrapper, CreateInfo>(
-                handle, create_info, thread_data->call_id_, thread_data->parameter_buffer_.get());
+            state_tracker_->AddEntry<ParentHandle, Wrapper, CreateInfo>(
+                parent_handle, handle, create_info, thread_data->call_id_, thread_data->parameter_buffer_.get());
         }
 
         EndApiCallTrace(encoder);
     }
 
     // Multiple object creation.
-    template <typename Wrapper, typename CreateInfo>
+    template <typename ParentHandle, typename Wrapper, typename CreateInfo>
     void EndCreateApiCallTrace(VkResult                      result,
+                               ParentHandle                  parent_handle,
                                uint32_t                      count,
                                typename Wrapper::HandleType* handles,
                                const CreateInfo*             create_infos,
@@ -152,8 +154,12 @@ class TraceManager
             auto thread_data = GetThreadData();
             assert(thread_data != nullptr);
 
-            state_tracker_->AddGroupEntry<Wrapper, CreateInfo>(
-                count, handles, create_infos, thread_data->call_id_, thread_data->parameter_buffer_.get());
+            state_tracker_->AddGroupEntry<ParentHandle, Wrapper, CreateInfo>(parent_handle,
+                                                                             count,
+                                                                             handles,
+                                                                             create_infos,
+                                                                             thread_data->call_id_,
+                                                                             thread_data->parameter_buffer_.get());
         }
 
         EndApiCallTrace(encoder);

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -204,6 +204,16 @@ class TraceManager
     bool GetDescriptorUpdateTemplateInfo(VkDescriptorUpdateTemplate update_template,
                                          const UpdateTemplateInfo** info) const;
 
+    void PostProcess_vkGetPhysicalDeviceMemoryProperties(VkPhysicalDevice                  physicalDevice,
+                                                         VkPhysicalDeviceMemoryProperties* pMemoryProperties)
+    {
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties);
+        }
+    }
+
     void PreProcess_vkCreateSwapchain(VkDevice                        device,
                                       const VkSwapchainCreateInfoKHR* pCreateInfo,
                                       const VkAllocationCallbacks*    pAllocator,

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -193,7 +193,11 @@ struct CommandBufferWrapper : public HandleWrapper<VkCommandBuffer>
 
 struct DeviceMemoryWrapper : public HandleWrapper<VkDeviceMemory>
 {
-    // TODO: Track mapped state
+    uint32_t     memory_type_index{ std::numeric_limits<uint32_t>::max() };
+    VkDeviceSize allocation_size{ 0 };
+    const void*  mapped_data{ nullptr };
+    VkDeviceSize mapped_offset{ 0 };
+    VkDeviceSize mapped_size{ 0 };
 };
 
 struct QueryPoolWrapper : public HandleWrapper<VkQueryPool>

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -137,6 +137,7 @@ struct DisplayKHRWrapper : public HandleWrapper<VkDisplayKHR>
 // handle wrapper, which will ensure it is destroyed when the VkInstance handle wrapper is destroyed.
 struct PhysicalDeviceWrapper : public HandleWrapper<VkPhysicalDevice>
 {
+    std::vector<VkMemoryType>                            memory_types;
     std::unordered_map<VkDisplayKHR, DisplayKHRWrapper*> displays;
 };
 
@@ -147,6 +148,7 @@ struct InstanceWrapper : public HandleWrapper<VkInstance>
 
 struct DeviceWrapper : public HandleWrapper<VkDevice>
 {
+    PhysicalDeviceWrapper*                     physical_device;
     std::unordered_map<VkQueue, QueueWrapper*> queues;
 };
 

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -157,6 +157,8 @@ struct BufferWrapper : public HandleWrapper<VkBuffer>
     VkDevice       bind_device{ VK_NULL_HANDLE };
     VkDeviceMemory bind_memory{ VK_NULL_HANDLE };
     VkDeviceSize   bind_offset{ 0 };
+    uint32_t       queue_family_index{ 0 };
+    VkDeviceSize   created_size{ 0 };
 };
 
 struct ImageWrapper : public HandleWrapper<VkImage>

--- a/framework/encode/vulkan_state_table.h
+++ b/framework/encode/vulkan_state_table.h
@@ -161,6 +161,9 @@ class VulkanStateTable
     PhysicalDeviceWrapper*       GetPhysicalDeviceWrapper(format::HandleId id)       { return GetWrapper<PhysicalDeviceWrapper>(id, physical_device_map_); }
     const PhysicalDeviceWrapper* GetPhysicalDeviceWrapper(format::HandleId id) const { return GetWrapper<PhysicalDeviceWrapper>(id, physical_device_map_); }
 
+    DeviceMemoryWrapper*       GetDeviceMemoryWrapper(format::HandleId id)       { return GetWrapper<DeviceMemoryWrapper>(id, device_memory_map_); }
+    const DeviceMemoryWrapper* GetDeviceMemoryWrapper(format::HandleId id) const { return GetWrapper<DeviceMemoryWrapper>(id, device_memory_map_); }
+
     BufferWrapper*       GetBufferWrapper(format::HandleId id)       { return GetWrapper<BufferWrapper>(id, buffer_map_); }
     const BufferWrapper* GetBufferWrapper(format::HandleId id) const { return GetWrapper<BufferWrapper>(id, buffer_map_); }
 

--- a/framework/encode/vulkan_state_table.h
+++ b/framework/encode/vulkan_state_table.h
@@ -161,6 +161,9 @@ class VulkanStateTable
     PhysicalDeviceWrapper*       GetPhysicalDeviceWrapper(format::HandleId id)       { return GetWrapper<PhysicalDeviceWrapper>(id, physical_device_map_); }
     const PhysicalDeviceWrapper* GetPhysicalDeviceWrapper(format::HandleId id) const { return GetWrapper<PhysicalDeviceWrapper>(id, physical_device_map_); }
 
+    DeviceWrapper*       GetDeviceWrapper(format::HandleId id)       { return GetWrapper<DeviceWrapper>(id, device_map_); }
+    const DeviceWrapper* GetDeviceWrapper(format::HandleId id) const { return GetWrapper<DeviceWrapper>(id, device_map_); }
+
     DeviceMemoryWrapper*       GetDeviceMemoryWrapper(format::HandleId id)       { return GetWrapper<DeviceMemoryWrapper>(id, device_memory_map_); }
     const DeviceMemoryWrapper* GetDeviceMemoryWrapper(format::HandleId id) const { return GetWrapper<DeviceMemoryWrapper>(id, device_memory_map_); }
 

--- a/framework/encode/vulkan_state_table.h
+++ b/framework/encode/vulkan_state_table.h
@@ -158,6 +158,9 @@ class VulkanStateTable
     //
 
     // clang-format off
+    PhysicalDeviceWrapper*       GetPhysicalDeviceWrapper(format::HandleId id)       { return GetWrapper<PhysicalDeviceWrapper>(id, physical_device_map_); }
+    const PhysicalDeviceWrapper* GetPhysicalDeviceWrapper(format::HandleId id) const { return GetWrapper<PhysicalDeviceWrapper>(id, physical_device_map_); }
+
     BufferWrapper*       GetBufferWrapper(format::HandleId id)       { return GetWrapper<BufferWrapper>(id, buffer_map_); }
     const BufferWrapper* GetBufferWrapper(format::HandleId id) const { return GetWrapper<BufferWrapper>(id, buffer_map_); }
 

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -23,6 +23,27 @@ VulkanStateTracker::VulkanStateTracker() : object_count_(0) {}
 
 VulkanStateTracker::~VulkanStateTracker() {}
 
+void VulkanStateTracker::TrackPhysicalDeviceMemoryProperties(VkPhysicalDevice                        physical_device,
+                                                             const VkPhysicalDeviceMemoryProperties* properties)
+{
+    assert(properties != nullptr);
+
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    PhysicalDeviceWrapper* wrapper = state_table_.GetPhysicalDeviceWrapper(format::ToHandleId(physical_device));
+    if (wrapper != nullptr)
+    {
+        for (uint32_t i = 0; i < properties->memoryTypeCount; ++i)
+        {
+            wrapper->memory_types.push_back(properties->memoryTypes[i]);
+        }
+    }
+    else
+    {
+        GFXRECON_LOG_WARNING("Attempting to track memory properties for unrecognized physical device handle");
+    }
+}
+
 void VulkanStateTracker::TrackBufferMemoryBinding(VkDevice       device,
                                                   VkBuffer       buffer,
                                                   VkDeviceMemory memory,

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -84,5 +84,25 @@ void VulkanStateTracker::TrackImageMemoryBinding(VkDevice       device,
     }
 }
 
+void VulkanStateTracker::TrackMappedMemory(VkDeviceMemory memory,
+                                           void*          mapped_data,
+                                           VkDeviceSize   mapped_offset,
+                                           VkDeviceSize   mapped_size)
+{
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    DeviceMemoryWrapper* wrapper = state_table_.GetDeviceMemoryWrapper(format::ToHandleId(memory));
+    if (wrapper != nullptr)
+    {
+        wrapper->mapped_data   = mapped_data;
+        wrapper->mapped_offset = mapped_offset;
+        wrapper->mapped_size   = mapped_size;
+    }
+    else
+    {
+        GFXRECON_LOG_WARNING("Attempting to track mapped state for unrecognized device memory handle");
+    }
+}
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -157,6 +157,9 @@ class VulkanStateTracker
         }
     }
 
+    void TrackPhysicalDeviceMemoryProperties(VkPhysicalDevice                        physical_device,
+                                             const VkPhysicalDeviceMemoryProperties* properties);
+
     void TrackBufferMemoryBinding(VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset);
 
     void TrackImageMemoryBinding(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset);

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -164,6 +164,9 @@ class VulkanStateTracker
 
     void TrackImageMemoryBinding(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset);
 
+    void
+    TrackMappedMemory(VkDeviceMemory memory, void* mapped_data, VkDeviceSize mapped_offset, VkDeviceSize mapped_size);
+
   private:
     // TODO: Evaluate need for per-type locks.
     std::mutex mutex_;

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -52,8 +52,9 @@ class VulkanStateTracker
         }
     }
 
-    template <typename Wrapper, typename CreateInfo>
-    void AddEntry(typename Wrapper::HandleType*   new_handle,
+    template <typename ParentHandle, typename Wrapper, typename CreateInfo>
+    void AddEntry(ParentHandle                    parent_handle,
+                  typename Wrapper::HandleType*   new_handle,
                   const CreateInfo*               create_info,
                   format::ApiCallId               create_call_id,
                   const util::MemoryOutputStream* create_parameter_buffer)
@@ -70,7 +71,8 @@ class VulkanStateTracker
                 std::unique_lock<std::mutex> lock(mutex_);
 
                 wrapper->handle_id = ++object_count_;
-                vulkan_state_tracker::InitializeState<Wrapper, CreateInfo>(
+                vulkan_state_tracker::InitializeState<ParentHandle, Wrapper, CreateInfo>(
+                    parent_handle,
                     wrapper,
                     create_info,
                     create_call_id,
@@ -88,8 +90,9 @@ class VulkanStateTracker
         }
     }
 
-    template <typename Wrapper, typename CreateInfo>
-    void AddGroupEntry(uint32_t                        count,
+    template <typename ParentHandle, typename Wrapper, typename CreateInfo>
+    void AddGroupEntry(ParentHandle                    parent_handle,
+                       uint32_t                        count,
                        typename Wrapper::HandleType*   new_handles,
                        const CreateInfo*               create_infos,
                        format::ApiCallId               create_call_id,
@@ -120,8 +123,8 @@ class VulkanStateTracker
                     Wrapper* wrapper   = new Wrapper;
                     wrapper->handle    = new_handles[i];
                     wrapper->handle_id = ++object_count_;
-                    vulkan_state_tracker::InitializeState<Wrapper, CreateInfo>(
-                        wrapper, create_info, create_call_id, create_parameters, &state_table_);
+                    vulkan_state_tracker::InitializeState<ParentHandle, Wrapper, CreateInfo>(
+                        parent_handle, wrapper, create_info, create_call_id, create_parameters, &state_table_);
 
                     // Attempts to add a new entry to the table. Operation will fail for duplicate handles.
                     // TODO: Handle wrapping will introduce a unique ID that eliminates duplicates.

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -52,37 +52,42 @@ inline const void* GetCreateInfoEntry<void>(uint32_t, const void*)
     return nullptr;
 }
 
-template <typename Wrapper, typename CreateInfo>
-void InitializeState(Wrapper*                wrapper,
-                     const CreateInfo*       create_info,
-                     format::ApiCallId       create_call_id,
-                     CreateParameters        create_parameters,
-                     VulkanStateTable*       state_table)
+template <typename ParentHandle, typename Wrapper, typename CreateInfo>
+void InitializeState(ParentHandle      parent_handle,
+                     Wrapper*          wrapper,
+                     const CreateInfo* create_info,
+                     format::ApiCallId create_call_id,
+                     CreateParameters  create_parameters,
+                     VulkanStateTable* state_table)
 {
     assert(wrapper != nullptr);
     assert(create_parameters != nullptr);
 
-    GFXRECON_UNREFERENCED_PARAMETER(state_table);
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
     GFXRECON_UNREFERENCED_PARAMETER(create_info);
+    GFXRECON_UNREFERENCED_PARAMETER(state_table);
 
-    wrapper->create_call_id = create_call_id;
+    wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 }
 
 template <>
-inline void
-InitializeState<CommandBufferWrapper, VkCommandBufferAllocateInfo>(CommandBufferWrapper*              wrapper,
-                                                                   const VkCommandBufferAllocateInfo* alloc_info,
-                                                                   format::ApiCallId                  create_call_id,
-                                                                   CreateParameters                   create_parameters,
-                                                                   VulkanStateTable*                  state_table)
+inline void InitializeState<VkDevice, CommandBufferWrapper, VkCommandBufferAllocateInfo>(
+    VkDevice                           parent_handle,
+    CommandBufferWrapper*              wrapper,
+    const VkCommandBufferAllocateInfo* alloc_info,
+    format::ApiCallId                  create_call_id,
+    CreateParameters                   create_parameters,
+    VulkanStateTable*                  state_table)
 {
     assert(wrapper != nullptr);
     assert(alloc_info != nullptr);
     assert(create_parameters != nullptr);
     assert(state_table != nullptr);
 
-    wrapper->create_call_id = create_call_id;
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+
+    wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
     CommandPoolWrapper* pool_wrapper = state_table->GetCommandPoolWrapper(format::ToHandleId(alloc_info->commandPool));
@@ -96,19 +101,22 @@ InitializeState<CommandBufferWrapper, VkCommandBufferAllocateInfo>(CommandBuffer
 }
 
 template <>
-inline void
-InitializeState<PipelineLayoutWrapper, VkPipelineLayoutCreateInfo>(PipelineLayoutWrapper*            wrapper,
-                                                                   const VkPipelineLayoutCreateInfo* create_info,
-                                                                   format::ApiCallId                 create_call_id,
-                                                                   CreateParameters                  create_parameters,
-                                                                   VulkanStateTable*                 state_table)
+inline void InitializeState<VkDevice, PipelineLayoutWrapper, VkPipelineLayoutCreateInfo>(
+    VkDevice                          parent_handle,
+    PipelineLayoutWrapper*            wrapper,
+    const VkPipelineLayoutCreateInfo* create_info,
+    format::ApiCallId                 create_call_id,
+    CreateParameters                  create_parameters,
+    VulkanStateTable*                 state_table)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
     assert(create_parameters != nullptr);
     assert(state_table != nullptr);
 
-    wrapper->create_call_id = create_call_id;
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+
+    wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
     std::shared_ptr<PipelineLayoutDependencies> layout_dependencies = std::make_shared<PipelineLayoutDependencies>();
@@ -133,16 +141,20 @@ InitializeState<PipelineLayoutWrapper, VkPipelineLayoutCreateInfo>(PipelineLayou
 }
 
 template <>
-inline void InitializeState<FramebufferWrapper, VkFramebufferCreateInfo>(FramebufferWrapper*            wrapper,
-                                                                         const VkFramebufferCreateInfo* create_info,
-                                                                         format::ApiCallId              create_call_id,
-                                                                         CreateParameters  create_parameters,
-                                                                         VulkanStateTable* state_table)
+inline void
+InitializeState<VkDevice, FramebufferWrapper, VkFramebufferCreateInfo>(VkDevice                       parent_handle,
+                                                                       FramebufferWrapper*            wrapper,
+                                                                       const VkFramebufferCreateInfo* create_info,
+                                                                       format::ApiCallId              create_call_id,
+                                                                       CreateParameters               create_parameters,
+                                                                       VulkanStateTable*              state_table)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
     assert(create_parameters != nullptr);
     assert(state_table != nullptr);
+
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
 
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
@@ -159,19 +171,22 @@ inline void InitializeState<FramebufferWrapper, VkFramebufferCreateInfo>(Framebu
 }
 
 template <>
-inline void
-InitializeState<PipelineWrapper, VkGraphicsPipelineCreateInfo>(PipelineWrapper*                    wrapper,
-                                                               const VkGraphicsPipelineCreateInfo* create_info,
-                                                               format::ApiCallId                   create_call_id,
-                                                               CreateParameters                    create_parameters,
-                                                               VulkanStateTable*                   state_table)
+inline void InitializeState<VkDevice, PipelineWrapper, VkGraphicsPipelineCreateInfo>(
+    VkDevice                            parent_handle,
+    PipelineWrapper*                    wrapper,
+    const VkGraphicsPipelineCreateInfo* create_info,
+    format::ApiCallId                   create_call_id,
+    CreateParameters                    create_parameters,
+    VulkanStateTable*                   state_table)
 {
     assert(wrapper != nullptr);
     assert((create_info != nullptr) && (create_info->pStages != nullptr));
     assert(create_parameters != nullptr);
     assert(state_table != nullptr);
 
-    wrapper->create_call_id = create_call_id;
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+
+    wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
     for (uint32_t i = 0; i < create_info->stageCount; ++i)
@@ -214,18 +229,21 @@ InitializeState<PipelineWrapper, VkGraphicsPipelineCreateInfo>(PipelineWrapper* 
 
 template <>
 inline void
-InitializeState<PipelineWrapper, VkComputePipelineCreateInfo>(PipelineWrapper*                   wrapper,
-                                                              const VkComputePipelineCreateInfo* create_info,
-                                                              format::ApiCallId                  create_call_id,
-                                                              CreateParameters                   create_parameters,
-                                                              VulkanStateTable*                  state_table)
+InitializeState<VkDevice, PipelineWrapper, VkComputePipelineCreateInfo>(VkDevice         parent_handle,
+                                                                        PipelineWrapper* wrapper,
+                                                                        const VkComputePipelineCreateInfo* create_info,
+                                                                        format::ApiCallId create_call_id,
+                                                                        CreateParameters  create_parameters,
+                                                                        VulkanStateTable* state_table)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
     assert(create_parameters != nullptr);
     assert(state_table != nullptr);
 
-    wrapper->create_call_id = create_call_id;
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+
+    wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
     ShaderModuleWrapper* shader_wrapper =
@@ -254,19 +272,22 @@ InitializeState<PipelineWrapper, VkComputePipelineCreateInfo>(PipelineWrapper*  
 }
 
 template <>
-inline void
-InitializeState<PipelineWrapper, VkRayTracingPipelineCreateInfoNV>(PipelineWrapper*                        wrapper,
-                                                                   const VkRayTracingPipelineCreateInfoNV* create_info,
-                                                                   format::ApiCallId create_call_id,
-                                                                   CreateParameters  create_parameters,
-                                                                   VulkanStateTable* state_table)
+inline void InitializeState<VkDevice, PipelineWrapper, VkRayTracingPipelineCreateInfoNV>(
+    VkDevice                                parent_handle,
+    PipelineWrapper*                        wrapper,
+    const VkRayTracingPipelineCreateInfoNV* create_info,
+    format::ApiCallId                       create_call_id,
+    CreateParameters                        create_parameters,
+    VulkanStateTable*                       state_table)
 {
     assert(wrapper != nullptr);
     assert((create_info != nullptr) && (create_info->pStages != nullptr));
     assert(create_parameters != nullptr);
     assert(state_table != nullptr);
 
-    wrapper->create_call_id = create_call_id;
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+
+    wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
     for (uint32_t i = 0; i < create_info->stageCount; ++i)
@@ -298,19 +319,22 @@ InitializeState<PipelineWrapper, VkRayTracingPipelineCreateInfoNV>(PipelineWrapp
 }
 
 template <>
-inline void
-InitializeState<DescriptorSetWrapper, VkDescriptorSetAllocateInfo>(DescriptorSetWrapper*              wrapper,
-                                                                   const VkDescriptorSetAllocateInfo* alloc_info,
-                                                                   format::ApiCallId                  create_call_id,
-                                                                   CreateParameters                   create_parameters,
-                                                                   VulkanStateTable*                  state_table)
+inline void InitializeState<VkDevice, DescriptorSetWrapper, VkDescriptorSetAllocateInfo>(
+    VkDevice                           parent_handle,
+    DescriptorSetWrapper*              wrapper,
+    const VkDescriptorSetAllocateInfo* alloc_info,
+    format::ApiCallId                  create_call_id,
+    CreateParameters                   create_parameters,
+    VulkanStateTable*                  state_table)
 {
     assert(state_table != nullptr);
     assert(wrapper != nullptr);
     assert(alloc_info != nullptr);
     assert(create_parameters != nullptr);
 
-    wrapper->create_call_id = create_call_id;
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+
+    wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
     DescriptorPoolWrapper* pool_wrapper =

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -72,6 +72,27 @@ void InitializeState(ParentHandle      parent_handle,
 }
 
 template <>
+inline void InitializeState<VkPhysicalDevice, DeviceWrapper, VkDeviceCreateInfo>(VkPhysicalDevice parent_handle,
+                                                                                 DeviceWrapper*   wrapper,
+                                                                                 const VkDeviceCreateInfo* create_info,
+                                                                                 format::ApiCallId create_call_id,
+                                                                                 CreateParameters  create_parameters,
+                                                                                 VulkanStateTable* state_table)
+{
+    assert(wrapper != nullptr);
+    assert(create_parameters != nullptr);
+    assert(state_table != nullptr);
+
+    GFXRECON_UNREFERENCED_PARAMETER(create_info);
+
+    wrapper->create_call_id    = create_call_id;
+    wrapper->create_parameters = std::move(create_parameters);
+
+    wrapper->physical_device = state_table->GetPhysicalDeviceWrapper(format::ToHandleId(parent_handle));
+    assert(wrapper->physical_device != nullptr);
+}
+
+template <>
 inline void InitializeState<VkDevice, CommandBufferWrapper, VkCommandBufferAllocateInfo>(
     VkDevice                           parent_handle,
     CommandBufferWrapper*              wrapper,

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -369,6 +369,28 @@ inline void InitializeState<VkDevice, DescriptorSetWrapper, VkDescriptorSetAlloc
     }
 }
 
+template <>
+inline void InitializeState<VkDevice, DeviceMemoryWrapper, VkMemoryAllocateInfo>(VkDevice             parent_handle,
+                                                                                 DeviceMemoryWrapper* wrapper,
+                                                                                 const VkMemoryAllocateInfo* alloc_info,
+                                                                                 format::ApiCallId create_call_id,
+                                                                                 CreateParameters  create_parameters,
+                                                                                 VulkanStateTable* state_table)
+{
+    assert(wrapper != nullptr);
+    assert(alloc_info != nullptr);
+    assert(create_parameters != nullptr);
+
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+    GFXRECON_UNREFERENCED_PARAMETER(state_table);
+
+    wrapper->create_call_id    = create_call_id;
+    wrapper->create_parameters = std::move(create_parameters);
+
+    wrapper->memory_type_index = alloc_info->memoryTypeIndex;
+    wrapper->allocation_size   = alloc_info->allocationSize;
+}
+
 GFXRECON_END_NAMESPACE(vulkan_state_tracker)
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -391,6 +391,33 @@ inline void InitializeState<VkDevice, DeviceMemoryWrapper, VkMemoryAllocateInfo>
     wrapper->allocation_size   = alloc_info->allocationSize;
 }
 
+template <>
+inline void InitializeState<VkDevice, BufferWrapper, VkBufferCreateInfo>(VkDevice                  parent_handle,
+                                                                         BufferWrapper*            wrapper,
+                                                                         const VkBufferCreateInfo* create_info,
+                                                                         format::ApiCallId         create_call_id,
+                                                                         CreateParameters          create_parameters,
+                                                                         VulkanStateTable*         state_table)
+{
+    assert(wrapper != nullptr);
+    assert(create_info != nullptr);
+    assert(create_parameters != nullptr);
+
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+    GFXRECON_UNREFERENCED_PARAMETER(state_table);
+
+    wrapper->create_call_id    = create_call_id;
+    wrapper->create_parameters = std::move(create_parameters);
+
+    wrapper->created_size = create_info->size;
+
+    // TODO: Do we need to track the queue family that the buffer is actually used with?
+    if (create_info->queueFamilyIndexCount > 0)
+    {
+        wrapper->queue_family_index = create_info->pQueueFamilyIndices[0];
+    }
+}
+
 GFXRECON_END_NAMESPACE(vulkan_state_tracker)
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -59,11 +59,50 @@ class VulkanStateWriter
 
     void WritePipelineState(const VulkanStateTable& state_table);
 
+    void WriteStagingBufferCreateCommands(VkDevice                    device,
+                                          VkDeviceSize                buffer_size,
+                                          VkBuffer                    buffer,
+                                          const VkMemoryRequirements& memory_requirements,
+                                          uint32_t                    memory_type_index,
+                                          VkDeviceMemory              memory);
+
+    void WriteCommandProcessingCreateCommands(VkDevice        device,
+                                              uint32_t        queue_family_index,
+                                              VkQueue         queue,
+                                              VkCommandPool   command_pool,
+                                              VkCommandBuffer command_buffer);
+
+    void WriteMappedMemoryCopyCommands(VkDevice           device,
+                                       VkDeviceMemory     source_memory,
+                                       const void*        source_data,
+                                       VkDeviceSize       source_offset,
+                                       VkDeviceSize       source_size,
+                                       VkDeviceMemory     replay_memory,
+                                       VkDeviceSize       replay_offset,
+                                       VkDeviceSize       replay_size,
+                                       const DeviceTable& dispatch_table);
+
+    void WriteStagingCopyCommands(VkDevice        device,
+                                  VkQueue         queue,
+                                  VkCommandBuffer command_buffer,
+                                  VkBuffer        source,
+                                  VkBuffer        destination,
+                                  VkDeviceSize    source_offset,
+                                  VkDeviceSize    destination_offset,
+                                  VkDeviceSize    size);
+
+    void WriteDestroyDeviceObject(format::ApiCallId            call_id,
+                                  format::HandleId             device_id,
+                                  format::HandleId             object_id,
+                                  const VkAllocationCallbacks* allocator);
+
     void DestroyTemporaryDeviceObject(format::ApiCallId         call_id,
-                                      format::HandleId          handle,
+                                      format::HandleId          object_id,
                                       util::MemoryOutputStream* create_parameters);
 
     void WriteFunctionCall(format::ApiCallId call_id, util::MemoryOutputStream* parameter_buffer);
+
+    void WriteFillMemoryCmd(VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size, const void* data);
 
     template <typename Wrapper>
     void StandardCreateWrite(const VulkanStateTable& state_table)

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -49,6 +49,27 @@ class VulkanStateWriter
     void WriteState(const VulkanStateTable& state_table);
 
   private:
+    // Data structures for processing resource memory snapshots.
+    struct BufferSnapshotEntry
+    {
+        const BufferWrapper*       buffer_wrapper{ nullptr };
+        const DeviceMemoryWrapper* memory_wrapper{ nullptr };
+        bool                       is_host_visible{ 0 };
+    };
+
+    typedef std::vector<BufferSnapshotEntry>                 BufferSnapshotList;
+    typedef std::unordered_map<uint32_t, BufferSnapshotList> BufferSnapshotQueueFamilyTable;
+
+    struct BufferSnapshotData
+    {
+        BufferSnapshotList             map_copy_wrappers;
+        BufferSnapshotQueueFamilyTable staging_copy_wrappers;
+        VkDeviceSize                   max_staging_copy_size{ 0 };
+        VkDeviceSize                   max_device_local_buffer_size{ 0 };
+        uint32_t                       num_device_local_buffers{ 0 };
+    };
+
+  private:
     void WriteDeviceState(const VulkanStateTable& state_table);
 
     void WriteBufferState(const VulkanStateTable& state_table);
@@ -60,6 +81,11 @@ class VulkanStateWriter
     void WritePipelineLayoutState(const VulkanStateTable& state_table);
 
     void WritePipelineState(const VulkanStateTable& state_table);
+
+    void ProcessBufferMemory(VkDevice                  device,
+                             const BufferSnapshotData& snapshot_data,
+                             const VulkanStateTable&   state_table,
+                             const DeviceTable&        dispatch_table);
 
     void WriteStagingBufferCreateCommands(VkDevice                    device,
                                           VkDeviceSize                buffer_size,

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -49,6 +49,8 @@ class VulkanStateWriter
     void WriteState(const VulkanStateTable& state_table);
 
   private:
+    void WriteDeviceState(const VulkanStateTable& state_table);
+
     void WriteBufferState(const VulkanStateTable& state_table);
 
     void WriteImageState(const VulkanStateTable& state_table);

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -51,7 +51,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pInstance);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<InstanceWrapper, VkInstanceCreateInfo>(result, pInstance, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<const void*, InstanceWrapper, VkInstanceCreateInfo>(result, nullptr, pInstance, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateInstance>::Dispatch(TraceManager::Get(), result, pCreateInfo, pAllocator, pInstance);
@@ -94,7 +94,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(
         encoder->EncodeUInt32Ptr(pPhysicalDeviceCount);
         encoder->EncodeHandleIdArray(pPhysicalDevices, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<PhysicalDeviceWrapper, void>(result, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, pPhysicalDevices, nullptr, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkInstance, PhysicalDeviceWrapper, void>(result, instance, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, pPhysicalDevices, nullptr, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkEnumeratePhysicalDevices>::Dispatch(TraceManager::Get(), result, instance, pPhysicalDeviceCount, pPhysicalDevices);
@@ -251,7 +251,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pDevice);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<DeviceWrapper, VkDeviceCreateInfo>(result, pDevice, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkPhysicalDevice, DeviceWrapper, VkDeviceCreateInfo>(result, physicalDevice, pDevice, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDevice>::Dispatch(TraceManager::Get(), result, physicalDevice, pCreateInfo, pAllocator, pDevice);
@@ -295,7 +295,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceQueue(
         encoder->EncodeUInt32Value(queueFamilyIndex);
         encoder->EncodeUInt32Value(queueIndex);
         encoder->EncodeHandleIdPtr(pQueue);
-        TraceManager::Get()->EndCreateApiCallTrace<QueueWrapper, void>(VK_SUCCESS, pQueue, nullptr, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, QueueWrapper, void>(VK_SUCCESS, device, pQueue, nullptr, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDeviceQueue>::Dispatch(TraceManager::Get(), device, queueFamilyIndex, queueIndex, pQueue);
@@ -385,7 +385,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateMemory(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pMemory);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<DeviceMemoryWrapper, VkMemoryAllocateInfo>(result, pMemory, pAllocateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, DeviceMemoryWrapper, VkMemoryAllocateInfo>(result, device, pMemory, pAllocateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateMemory>::Dispatch(TraceManager::Get(), result, device, pAllocateInfo, pAllocator, pMemory);
@@ -724,7 +724,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFence(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pFence);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<FenceWrapper, VkFenceCreateInfo>(result, pFence, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, FenceWrapper, VkFenceCreateInfo>(result, device, pFence, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateFence>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pFence);
@@ -845,7 +845,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSemaphore(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSemaphore);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SemaphoreWrapper, VkSemaphoreCreateInfo>(result, pSemaphore, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, SemaphoreWrapper, VkSemaphoreCreateInfo>(result, device, pSemaphore, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSemaphore>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pSemaphore);
@@ -892,7 +892,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateEvent(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pEvent);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<EventWrapper, VkEventCreateInfo>(result, pEvent, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, EventWrapper, VkEventCreateInfo>(result, device, pEvent, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateEvent>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pEvent);
@@ -1005,7 +1005,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateQueryPool(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pQueryPool);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<QueryPoolWrapper, VkQueryPoolCreateInfo>(result, pQueryPool, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, QueryPoolWrapper, VkQueryPoolCreateInfo>(result, device, pQueryPool, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateQueryPool>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pQueryPool);
@@ -1086,7 +1086,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBuffer(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pBuffer);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<BufferWrapper, VkBufferCreateInfo>(result, pBuffer, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, BufferWrapper, VkBufferCreateInfo>(result, device, pBuffer, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateBuffer>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pBuffer);
@@ -1133,7 +1133,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBufferView(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pView);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<BufferViewWrapper, VkBufferViewCreateInfo>(result, pView, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, BufferViewWrapper, VkBufferViewCreateInfo>(result, device, pView, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateBufferView>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pView);
@@ -1180,7 +1180,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImage(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pImage);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<ImageWrapper, VkImageCreateInfo>(result, pImage, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, ImageWrapper, VkImageCreateInfo>(result, device, pImage, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateImage>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pImage);
@@ -1250,7 +1250,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImageView(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pView);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<ImageViewWrapper, VkImageViewCreateInfo>(result, pView, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, ImageViewWrapper, VkImageViewCreateInfo>(result, device, pView, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateImageView>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pView);
@@ -1297,7 +1297,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pShaderModule);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<ShaderModuleWrapper, VkShaderModuleCreateInfo>(result, pShaderModule, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, ShaderModuleWrapper, VkShaderModuleCreateInfo>(result, device, pShaderModule, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateShaderModule>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pShaderModule);
@@ -1344,7 +1344,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineCache(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pPipelineCache);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<PipelineCacheWrapper, VkPipelineCacheCreateInfo>(result, pPipelineCache, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, PipelineCacheWrapper, VkPipelineCacheCreateInfo>(result, device, pPipelineCache, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreatePipelineCache>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pPipelineCache);
@@ -1447,7 +1447,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<PipelineWrapper, VkGraphicsPipelineCreateInfo>(result, createInfoCount, pPipelines, pCreateInfos, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, PipelineWrapper, VkGraphicsPipelineCreateInfo>(result, device, createInfoCount, pPipelines, pCreateInfos, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateGraphicsPipelines>::Dispatch(TraceManager::Get(), result, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
@@ -1477,7 +1477,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<PipelineWrapper, VkComputePipelineCreateInfo>(result, createInfoCount, pPipelines, pCreateInfos, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, PipelineWrapper, VkComputePipelineCreateInfo>(result, device, createInfoCount, pPipelines, pCreateInfos, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateComputePipelines>::Dispatch(TraceManager::Get(), result, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
@@ -1524,7 +1524,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pPipelineLayout);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<PipelineLayoutWrapper, VkPipelineLayoutCreateInfo>(result, pPipelineLayout, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, PipelineLayoutWrapper, VkPipelineLayoutCreateInfo>(result, device, pPipelineLayout, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreatePipelineLayout>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pPipelineLayout);
@@ -1571,7 +1571,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSampler(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSampler);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SamplerWrapper, VkSamplerCreateInfo>(result, pSampler, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, SamplerWrapper, VkSamplerCreateInfo>(result, device, pSampler, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSampler>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pSampler);
@@ -1618,7 +1618,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorSetLayout(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSetLayout);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<DescriptorSetLayoutWrapper, VkDescriptorSetLayoutCreateInfo>(result, pSetLayout, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, DescriptorSetLayoutWrapper, VkDescriptorSetLayoutCreateInfo>(result, device, pSetLayout, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorSetLayout>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pSetLayout);
@@ -1665,7 +1665,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorPool(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pDescriptorPool);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<DescriptorPoolWrapper, VkDescriptorPoolCreateInfo>(result, pDescriptorPool, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, DescriptorPoolWrapper, VkDescriptorPoolCreateInfo>(result, device, pDescriptorPool, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorPool>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pDescriptorPool);
@@ -1734,7 +1734,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(
         EncodeStructPtr(encoder, pAllocateInfo);
         encoder->EncodeHandleIdArray(pDescriptorSets, pAllocateInfo->descriptorSetCount);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<DescriptorSetWrapper, VkDescriptorSetAllocateInfo>(result, pAllocateInfo->descriptorSetCount, pDescriptorSets, pAllocateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, DescriptorSetWrapper, VkDescriptorSetAllocateInfo>(result, device, pAllocateInfo->descriptorSetCount, pDescriptorSets, pAllocateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateDescriptorSets>::Dispatch(TraceManager::Get(), result, device, pAllocateInfo, pDescriptorSets);
@@ -1811,7 +1811,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateFramebuffer(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pFramebuffer);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<FramebufferWrapper, VkFramebufferCreateInfo>(result, pFramebuffer, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, FramebufferWrapper, VkFramebufferCreateInfo>(result, device, pFramebuffer, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateFramebuffer>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pFramebuffer);
@@ -1858,7 +1858,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pRenderPass);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<RenderPassWrapper, VkRenderPassCreateInfo>(result, pRenderPass, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, RenderPassWrapper, VkRenderPassCreateInfo>(result, device, pRenderPass, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRenderPass>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pRenderPass);
@@ -1926,7 +1926,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateCommandPool(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pCommandPool);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<CommandPoolWrapper, VkCommandPoolCreateInfo>(result, pCommandPool, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, CommandPoolWrapper, VkCommandPoolCreateInfo>(result, device, pCommandPool, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateCommandPool>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pCommandPool);
@@ -1995,7 +1995,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateCommandBuffers(
         EncodeStructPtr(encoder, pAllocateInfo);
         encoder->EncodeHandleIdArray(pCommandBuffers, pAllocateInfo->commandBufferCount);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<CommandBufferWrapper, VkCommandBufferAllocateInfo>(result, pAllocateInfo->commandBufferCount, pCommandBuffers, pAllocateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, CommandBufferWrapper, VkCommandBufferAllocateInfo>(result, device, pAllocateInfo->commandBufferCount, pCommandBuffers, pAllocateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateCommandBuffers>::Dispatch(TraceManager::Get(), result, device, pAllocateInfo, pCommandBuffers);
@@ -3556,7 +3556,7 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceQueue2(
         encoder->EncodeHandleIdValue(device);
         EncodeStructPtr(encoder, pQueueInfo);
         encoder->EncodeHandleIdPtr(pQueue);
-        TraceManager::Get()->EndCreateApiCallTrace<QueueWrapper, void>(VK_SUCCESS, pQueue, nullptr, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, QueueWrapper, void>(VK_SUCCESS, device, pQueue, nullptr, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDeviceQueue2>::Dispatch(TraceManager::Get(), device, pQueueInfo, pQueue);
@@ -3580,7 +3580,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversion(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pYcbcrConversion);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SamplerYcbcrConversionWrapper, VkSamplerYcbcrConversionCreateInfo>(result, pYcbcrConversion, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, SamplerYcbcrConversionWrapper, VkSamplerYcbcrConversionCreateInfo>(result, device, pYcbcrConversion, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversion>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pYcbcrConversion);
@@ -3627,7 +3627,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplate(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pDescriptorUpdateTemplate);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<DescriptorUpdateTemplateWrapper, VkDescriptorUpdateTemplateCreateInfo>(result, pDescriptorUpdateTemplate, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, DescriptorUpdateTemplateWrapper, VkDescriptorUpdateTemplateCreateInfo>(result, device, pDescriptorUpdateTemplate, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplate>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
@@ -3881,7 +3881,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSwapchainKHR(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSwapchain);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(result, pSwapchain, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(result, device, pSwapchain, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSwapchainKHR>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pSwapchain);
@@ -3928,7 +3928,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(
         encoder->EncodeUInt32Ptr(pSwapchainImageCount);
         encoder->EncodeHandleIdArray(pSwapchainImages, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<ImageWrapper, void>(result, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, pSwapchainImages, nullptr, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, ImageWrapper, void>(result, device, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, pSwapchainImages, nullptr, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetSwapchainImagesKHR>::Dispatch(TraceManager::Get(), result, device, swapchain, pSwapchainImageCount, pSwapchainImages);
@@ -4150,7 +4150,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneSupportedDisplaysKHR(
         encoder->EncodeUInt32Ptr(pDisplayCount);
         encoder->EncodeHandleIdArray(pDisplays, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<DisplayKHRWrapper, void>(result, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, pDisplays, nullptr, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkPhysicalDevice, DisplayKHRWrapper, void>(result, physicalDevice, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, pDisplays, nullptr, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDisplayPlaneSupportedDisplaysKHR>::Dispatch(TraceManager::Get(), result, physicalDevice, planeIndex, pDisplayCount, pDisplays);
@@ -4204,7 +4204,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayModeKHR(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pMode);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<DisplayModeKHRWrapper, VkDisplayModeCreateInfoKHR>(result, pMode, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkPhysicalDevice, DisplayModeKHRWrapper, VkDisplayModeCreateInfoKHR>(result, physicalDevice, pMode, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDisplayModeKHR>::Dispatch(TraceManager::Get(), result, physicalDevice, display, pCreateInfo, pAllocator, pMode);
@@ -4256,7 +4256,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDisplayPlaneSurfaceKHR(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SurfaceKHRWrapper, VkDisplaySurfaceCreateInfoKHR>(result, pSurface, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkInstance, SurfaceKHRWrapper, VkDisplaySurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDisplayPlaneSurfaceKHR>::Dispatch(TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -4284,7 +4284,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSharedSwapchainsKHR(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdArray(pSwapchains, swapchainCount);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(result, swapchainCount, pSwapchains, pCreateInfos, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(result, device, swapchainCount, pSwapchains, pCreateInfos, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSharedSwapchainsKHR>::Dispatch(TraceManager::Get(), result, device, swapchainCount, pCreateInfos, pAllocator, pSwapchains);
@@ -4310,7 +4310,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXlibSurfaceKHR(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SurfaceKHRWrapper, VkXlibSurfaceCreateInfoKHR>(result, pSurface, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkInstance, SurfaceKHRWrapper, VkXlibSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateXlibSurfaceKHR>::Dispatch(TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -4362,7 +4362,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateXcbSurfaceKHR(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SurfaceKHRWrapper, VkXcbSurfaceCreateInfoKHR>(result, pSurface, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkInstance, SurfaceKHRWrapper, VkXcbSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateXcbSurfaceKHR>::Dispatch(TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -4414,7 +4414,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWaylandSurfaceKHR(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SurfaceKHRWrapper, VkWaylandSurfaceCreateInfoKHR>(result, pSurface, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkInstance, SurfaceKHRWrapper, VkWaylandSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateWaylandSurfaceKHR>::Dispatch(TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -4464,7 +4464,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAndroidSurfaceKHR(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SurfaceKHRWrapper, VkAndroidSurfaceCreateInfoKHR>(result, pSurface, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkInstance, SurfaceKHRWrapper, VkAndroidSurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateAndroidSurfaceKHR>::Dispatch(TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -4490,7 +4490,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateWin32SurfaceKHR(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SurfaceKHRWrapper, VkWin32SurfaceCreateInfoKHR>(result, pSurface, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkInstance, SurfaceKHRWrapper, VkWin32SurfaceCreateInfoKHR>(result, instance, pSurface, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateWin32SurfaceKHR>::Dispatch(TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -5063,7 +5063,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDescriptorUpdateTemplateKHR(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pDescriptorUpdateTemplate);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<DescriptorUpdateTemplateWrapper, VkDescriptorUpdateTemplateCreateInfo>(result, pDescriptorUpdateTemplate, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, DescriptorUpdateTemplateWrapper, VkDescriptorUpdateTemplateCreateInfo>(result, device, pDescriptorUpdateTemplate, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplateKHR>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
@@ -5110,7 +5110,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRenderPass2KHR(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pRenderPass);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<RenderPassWrapper, VkRenderPassCreateInfo2KHR>(result, pRenderPass, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, RenderPassWrapper, VkRenderPassCreateInfo2KHR>(result, device, pRenderPass, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRenderPass2KHR>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pRenderPass);
@@ -5545,7 +5545,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversionKHR(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pYcbcrConversion);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SamplerYcbcrConversionWrapper, VkSamplerYcbcrConversionCreateInfo>(result, pYcbcrConversion, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, SamplerYcbcrConversionWrapper, VkSamplerYcbcrConversionCreateInfo>(result, device, pYcbcrConversion, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversionKHR>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pYcbcrConversion);
@@ -5719,7 +5719,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugReportCallbackEXT(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pCallback);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<DebugReportCallbackEXTWrapper, VkDebugReportCallbackCreateInfoEXT>(result, pCallback, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkInstance, DebugReportCallbackEXTWrapper, VkDebugReportCallbackCreateInfoEXT>(result, instance, pCallback, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDebugReportCallbackEXT>::Dispatch(TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pCallback);
@@ -6220,7 +6220,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateViSurfaceNN(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SurfaceKHRWrapper, VkViSurfaceCreateInfoNN>(result, pSurface, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkInstance, SurfaceKHRWrapper, VkViSurfaceCreateInfoNN>(result, instance, pSurface, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateViSurfaceNN>::Dispatch(TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -6320,7 +6320,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIndirectCommandsLayoutNVX(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pIndirectCommandsLayout);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<IndirectCommandsLayoutNVXWrapper, VkIndirectCommandsLayoutCreateInfoNVX>(result, pIndirectCommandsLayout, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, IndirectCommandsLayoutNVXWrapper, VkIndirectCommandsLayoutCreateInfoNVX>(result, device, pIndirectCommandsLayout, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateIndirectCommandsLayoutNVX>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pIndirectCommandsLayout);
@@ -6367,7 +6367,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateObjectTableNVX(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pObjectTable);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<ObjectTableNVXWrapper, VkObjectTableCreateInfoNVX>(result, pObjectTable, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, ObjectTableNVXWrapper, VkObjectTableCreateInfoNVX>(result, device, pObjectTable, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateObjectTableNVX>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pObjectTable);
@@ -6532,7 +6532,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetRandROutputDisplayEXT(
         encoder->EncodeSizeTValue(rrOutput);
         encoder->EncodeHandleIdPtr(pDisplay);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<DisplayKHRWrapper, void>(result, pDisplay, nullptr, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkPhysicalDevice, DisplayKHRWrapper, void>(result, physicalDevice, pDisplay, nullptr, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetRandROutputDisplayEXT>::Dispatch(TraceManager::Get(), result, physicalDevice, dpy, rrOutput, pDisplay);
@@ -6606,7 +6606,7 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDeviceEventEXT(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pFence);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<FenceWrapper, void>(result, pFence, nullptr, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, FenceWrapper, void>(result, device, pFence, nullptr, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkRegisterDeviceEventEXT>::Dispatch(TraceManager::Get(), result, device, pDeviceEventInfo, pAllocator, pFence);
@@ -6634,7 +6634,7 @@ VKAPI_ATTR VkResult VKAPI_CALL RegisterDisplayEventEXT(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pFence);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<FenceWrapper, void>(result, pFence, nullptr, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, FenceWrapper, void>(result, device, pFence, nullptr, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkRegisterDisplayEventEXT>::Dispatch(TraceManager::Get(), result, device, display, pDisplayEventInfo, pAllocator, pFence);
@@ -6782,7 +6782,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateIOSSurfaceMVK(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SurfaceKHRWrapper, VkIOSSurfaceCreateInfoMVK>(result, pSurface, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkInstance, SurfaceKHRWrapper, VkIOSSurfaceCreateInfoMVK>(result, instance, pSurface, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateIOSSurfaceMVK>::Dispatch(TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -6808,7 +6808,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMacOSSurfaceMVK(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SurfaceKHRWrapper, VkMacOSSurfaceCreateInfoMVK>(result, pSurface, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkInstance, SurfaceKHRWrapper, VkMacOSSurfaceCreateInfoMVK>(result, instance, pSurface, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateMacOSSurfaceMVK>::Dispatch(TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -6988,7 +6988,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDebugUtilsMessengerEXT(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pMessenger);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<DebugUtilsMessengerEXTWrapper, VkDebugUtilsMessengerCreateInfoEXT>(result, pMessenger, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkInstance, DebugUtilsMessengerEXTWrapper, VkDebugUtilsMessengerCreateInfoEXT>(result, instance, pMessenger, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDebugUtilsMessengerEXT>::Dispatch(TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pMessenger);
@@ -7170,7 +7170,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateValidationCacheEXT(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pValidationCache);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<ValidationCacheEXTWrapper, VkValidationCacheCreateInfoEXT>(result, pValidationCache, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, ValidationCacheEXTWrapper, VkValidationCacheCreateInfoEXT>(result, device, pValidationCache, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateValidationCacheEXT>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pValidationCache);
@@ -7336,7 +7336,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureNV(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pAccelerationStructure);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<AccelerationStructureNVWrapper, VkAccelerationStructureCreateInfoNV>(result, pAccelerationStructure, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, AccelerationStructureNVWrapper, VkAccelerationStructureCreateInfoNV>(result, device, pAccelerationStructure, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateAccelerationStructureNV>::Dispatch(TraceManager::Get(), result, device, pCreateInfo, pAllocator, pAccelerationStructure);
@@ -7533,7 +7533,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<PipelineWrapper, VkRayTracingPipelineCreateInfoNV>(result, createInfoCount, pPipelines, pCreateInfos, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, PipelineWrapper, VkRayTracingPipelineCreateInfoNV>(result, device, createInfoCount, pPipelines, pCreateInfos, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesNV>::Dispatch(TraceManager::Get(), result, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
@@ -7907,7 +7907,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateImagePipeSurfaceFUCHSIA(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SurfaceKHRWrapper, VkImagePipeSurfaceCreateInfoFUCHSIA>(result, pSurface, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkInstance, SurfaceKHRWrapper, VkImagePipeSurfaceCreateInfoFUCHSIA>(result, instance, pSurface, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateImagePipeSurfaceFUCHSIA>::Dispatch(TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);
@@ -7933,7 +7933,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateMetalSurfaceEXT(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdPtr(pSurface);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<SurfaceKHRWrapper, VkMetalSurfaceCreateInfoEXT>(result, pSurface, pCreateInfo, encoder);
+        TraceManager::Get()->EndCreateApiCallTrace<VkInstance, SurfaceKHRWrapper, VkMetalSurfaceCreateInfoEXT>(result, instance, pSurface, pCreateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateMetalSurfaceEXT>::Dispatch(TraceManager::Get(), result, instance, pCreateInfo, pAllocator, pSurface);


### PR DESCRIPTION
Add support for tracking buffer resource memory state and writing buffer memory content to the trimming state snapshot that is written before the trimmed frames.  Writing buffer memory to the state snapshot requires staging copies for device local memory.