### PR TITLE
Add Image Memory to State Snapshot

### DIFF
--- a/framework/encode/custom_encoder_commands.h
+++ b/framework/encode/custom_encoder_commands.h
@@ -131,6 +131,66 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkBindImageMemory>
 };
 
 template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginRenderPass>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdBeginRenderPass(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginRenderPass2KHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdBeginRenderPass2KHR(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndRenderPass>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdEndRenderPass(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdEndRenderPass2KHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdEndRenderPass2KHR(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPipelineBarrier>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdPipelineBarrier(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdExecuteCommands>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdExecuteCommands(args...);
+    }
+};
+
+template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkMapMemory>
 {
     template <typename... Args>
@@ -177,6 +237,16 @@ struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueSubmit>
     static void Dispatch(TraceManager* manager, Args... args)
     {
         manager->PreProcess_vkQueueSubmit(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueSubmit>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkQueueSubmit(result, args...);
     }
 };
 

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -241,7 +241,100 @@ class TraceManager
         if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS))
         {
             assert(state_tracker_ != nullptr);
-            state_tracker_->TrackImageMemoryBinding(device, image , memory, memoryOffset);
+            state_tracker_->TrackImageMemoryBinding(device, image, memory, memoryOffset);
+        }
+    }
+
+    void PostProcess_vkCmdBeginRenderPass(VkCommandBuffer              commandBuffer,
+                                          const VkRenderPassBeginInfo* pRenderPassBegin,
+                                          VkSubpassContents            contents)
+    {
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            assert(state_tracker_ != nullptr);
+            GFXRECON_UNREFERENCED_PARAMETER(contents);
+            state_tracker_->TrackBeginRenderPass(commandBuffer, pRenderPassBegin);
+        }
+    }
+
+    void PostProcess_vkCmdBeginRenderPass2KHR(VkCommandBuffer              commandBuffer,
+                                              const VkRenderPassBeginInfo* pRenderPassBegin,
+                                              const VkSubpassBeginInfoKHR* pSubpassBeginInfo)
+    {
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            assert(state_tracker_ != nullptr);
+            GFXRECON_UNREFERENCED_PARAMETER(pSubpassBeginInfo);
+            state_tracker_->TrackBeginRenderPass(commandBuffer, pRenderPassBegin);
+        }
+    }
+
+    void PostProcess_vkCmdEndRenderPass(VkCommandBuffer commandBuffer)
+    {
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackEndRenderPass(commandBuffer);
+        }
+    }
+
+    void PostProcess_vkCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfoKHR* pSubpassEndInfo)
+    {
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            assert(state_tracker_ != nullptr);
+            GFXRECON_UNREFERENCED_PARAMETER(pSubpassEndInfo);
+            state_tracker_->TrackEndRenderPass(commandBuffer);
+        }
+    }
+
+    void PostProcess_vkCmdPipelineBarrier(VkCommandBuffer              commandBuffer,
+                                          VkPipelineStageFlags         srcStageMask,
+                                          VkPipelineStageFlags         dstStageMask,
+                                          VkDependencyFlags            dependencyFlags,
+                                          uint32_t                     memoryBarrierCount,
+                                          const VkMemoryBarrier*       pMemoryBarriers,
+                                          uint32_t                     bufferMemoryBarrierCount,
+                                          const VkBufferMemoryBarrier* pBufferMemoryBarriers,
+                                          uint32_t                     imageMemoryBarrierCount,
+                                          const VkImageMemoryBarrier*  pImageMemoryBarriers)
+    {
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            assert(state_tracker_ != nullptr);
+
+            GFXRECON_UNREFERENCED_PARAMETER(srcStageMask);
+            GFXRECON_UNREFERENCED_PARAMETER(dstStageMask);
+            GFXRECON_UNREFERENCED_PARAMETER(dependencyFlags);
+            GFXRECON_UNREFERENCED_PARAMETER(memoryBarrierCount);
+            GFXRECON_UNREFERENCED_PARAMETER(pMemoryBarriers);
+            GFXRECON_UNREFERENCED_PARAMETER(bufferMemoryBarrierCount);
+            GFXRECON_UNREFERENCED_PARAMETER(pBufferMemoryBarriers);
+
+            state_tracker_->TrackImageBarriers(commandBuffer, imageMemoryBarrierCount, pImageMemoryBarriers);
+        }
+    }
+
+    void PostProcess_vkCmdExecuteCommands(VkCommandBuffer        commandBuffer,
+                                          uint32_t               commandBufferCount,
+                                          const VkCommandBuffer* pCommandBuffers)
+    {
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers);
+        }
+    }
+
+    void PostProcess_vkQueueSubmit(
+        VkResult result, VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence)
+    {
+        if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS))
+        {
+            assert(state_tracker_ != nullptr);
+            GFXRECON_UNREFERENCED_PARAMETER(queue);
+            GFXRECON_UNREFERENCED_PARAMETER(fence);
+            state_tracker_->TrackImageLayoutTransitions(submitCount, pSubmits);
         }
     }
 

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -163,9 +163,17 @@ struct BufferWrapper : public HandleWrapper<VkBuffer>
 
 struct ImageWrapper : public HandleWrapper<VkImage>
 {
-    VkDevice       bind_device{ VK_NULL_HANDLE };
-    VkDeviceMemory bind_memory{ VK_NULL_HANDLE };
-    VkDeviceSize   bind_offset{ 0 };
+    VkDevice              bind_device{ VK_NULL_HANDLE };
+    VkDeviceMemory        bind_memory{ VK_NULL_HANDLE };
+    VkDeviceSize          bind_offset{ 0 };
+    uint32_t              queue_family_index{ 0 };
+    VkImageType           image_type{ VK_IMAGE_TYPE_2D };
+    VkFormat              format{ VK_FORMAT_UNDEFINED };
+    VkExtent3D            extent{ 0, 0, 0 };
+    uint32_t              mip_levels{ 0 };
+    uint32_t              array_layers{ 0 };
+    VkSampleCountFlagBits samples{};
+    VkImageTiling         tiling{};
 };
 
 struct FramebufferWrapper : public HandleWrapper<VkFramebuffer>

--- a/framework/encode/vulkan_state_table.h
+++ b/framework/encode/vulkan_state_table.h
@@ -173,8 +173,17 @@ class VulkanStateTable
     ImageWrapper*       GetImageWrapper(format::HandleId id)       { return GetWrapper<ImageWrapper>(id, image_map_); }
     const ImageWrapper* GetImageWrapper(format::HandleId id) const { return GetWrapper<ImageWrapper>(id, image_map_); }
 
+    ImageViewWrapper*       GetImageViewWrapper(format::HandleId id)       { return GetWrapper<ImageViewWrapper>(id, image_view_map_); }
+    const ImageViewWrapper* GetImageViewWrapper(format::HandleId id) const { return GetWrapper<ImageViewWrapper>(id, image_view_map_); }
+
+    FramebufferWrapper*       GetFramebufferWrapper(format::HandleId id)       { return GetWrapper<FramebufferWrapper>(id, framebuffer_map_); }
+    const FramebufferWrapper* GetFramebufferWrapper(format::HandleId id) const { return GetWrapper<FramebufferWrapper>(id, framebuffer_map_); }
+
     CommandPoolWrapper*       GetCommandPoolWrapper(format::HandleId id)       { return GetWrapper<CommandPoolWrapper>(id, command_pool_map_);}
     const CommandPoolWrapper* GetCommandPoolWrapper(format::HandleId id) const { return GetWrapper<CommandPoolWrapper>(id, command_pool_map_);}
+
+    CommandBufferWrapper*       GetCommandBufferWrapper(format::HandleId id)       { return GetWrapper<CommandBufferWrapper>(id, command_buffer_map_);}
+    const CommandBufferWrapper* GetCommandBufferWrapper(format::HandleId id) const { return GetWrapper<CommandBufferWrapper>(id, command_buffer_map_);}
 
     DescriptorPoolWrapper*       GetDescriptorPoolWrapper(format::HandleId id)       { return GetWrapper<DescriptorPoolWrapper>(id, descriptor_pool_map_); }
     const DescriptorPoolWrapper* GetDescriptorPoolWrapper(format::HandleId id) const { return GetWrapper<DescriptorPoolWrapper>(id, descriptor_pool_map_); }

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -167,6 +167,20 @@ class VulkanStateTracker
     void
     TrackMappedMemory(VkDeviceMemory memory, void* mapped_data, VkDeviceSize mapped_offset, VkDeviceSize mapped_size);
 
+    void TrackBeginRenderPass(VkCommandBuffer command_buffer, const VkRenderPassBeginInfo* begin_info);
+
+    void TrackEndRenderPass(VkCommandBuffer command_buffer);
+
+    void TrackExecuteCommands(VkCommandBuffer        command_buffer,
+                              uint32_t               command_buffer_count,
+                              const VkCommandBuffer* command_buffers);
+
+    void TrackImageBarriers(VkCommandBuffer             command_buffer,
+                            uint32_t                    image_barrier_count,
+                            const VkImageMemoryBarrier* image_barriers);
+
+    void TrackImageLayoutTransitions(uint32_t submit_count, const VkSubmitInfo* submits);
+
   private:
     // TODO: Evaluate need for per-type locks.
     std::mutex mutex_;

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -189,6 +189,44 @@ InitializeState<VkDevice, FramebufferWrapper, VkFramebufferCreateInfo>(VkDevice 
         wrapper->render_pass_create_call_id    = render_pass_wrapper->create_call_id;
         wrapper->render_pass_create_parameters = render_pass_wrapper->create_parameters;
     }
+
+    if (create_info->pAttachments != nullptr)
+    {
+        for (uint32_t i = 0; i < create_info->attachmentCount; ++i)
+        {
+            ImageViewWrapper* image_view_wrapper =
+                state_table->GetImageViewWrapper(format::ToHandleId(create_info->pAttachments[i]));
+            wrapper->attachments.push_back(image_view_wrapper->image);
+        }
+    }
+}
+
+template <>
+inline void
+InitializeState<VkDevice, RenderPassWrapper, VkRenderPassCreateInfo>(VkDevice                      parent_handle,
+                                                                     RenderPassWrapper*            wrapper,
+                                                                     const VkRenderPassCreateInfo* create_info,
+                                                                     format::ApiCallId             create_call_id,
+                                                                     CreateParameters              create_parameters,
+                                                                     VulkanStateTable*             state_table)
+{
+    assert(wrapper != nullptr);
+    assert(create_info != nullptr);
+    assert(create_parameters != nullptr);
+
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+    GFXRECON_UNREFERENCED_PARAMETER(state_table);
+
+    wrapper->create_call_id    = create_call_id;
+    wrapper->create_parameters = std::move(create_parameters);
+
+    if (create_info->pAttachments != nullptr)
+    {
+        for (uint32_t i = 0; i < create_info->attachmentCount; ++i)
+        {
+            wrapper->attachment_final_layouts.push_back(create_info->pAttachments[i].finalLayout);
+        }
+    }
 }
 
 template <>
@@ -449,6 +487,27 @@ inline void InitializeState<VkDevice, ImageWrapper, VkImageCreateInfo>(VkDevice 
     {
         wrapper->queue_family_index = create_info->pQueueFamilyIndices[0];
     }
+}
+
+template <>
+inline void InitializeState<VkDevice, ImageViewWrapper, VkImageViewCreateInfo>(VkDevice          parent_handle,
+                                                                               ImageViewWrapper* wrapper,
+                                                                               const VkImageViewCreateInfo* create_info,
+                                                                               format::ApiCallId create_call_id,
+                                                                               CreateParameters  create_parameters,
+                                                                               VulkanStateTable* state_table)
+{
+    assert(wrapper != nullptr);
+    assert(create_info != nullptr);
+    assert(create_parameters != nullptr);
+
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+    GFXRECON_UNREFERENCED_PARAMETER(state_table);
+
+    wrapper->create_call_id    = create_call_id;
+    wrapper->create_parameters = std::move(create_parameters);
+
+    wrapper->image = create_info->image;
 }
 
 GFXRECON_END_NAMESPACE(vulkan_state_tracker)

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -412,7 +412,40 @@ inline void InitializeState<VkDevice, BufferWrapper, VkBufferCreateInfo>(VkDevic
     wrapper->created_size = create_info->size;
 
     // TODO: Do we need to track the queue family that the buffer is actually used with?
-    if (create_info->queueFamilyIndexCount > 0)
+    if ((create_info->queueFamilyIndexCount > 0) && (create_info->pQueueFamilyIndices != nullptr))
+    {
+        wrapper->queue_family_index = create_info->pQueueFamilyIndices[0];
+    }
+}
+
+template <>
+inline void InitializeState<VkDevice, ImageWrapper, VkImageCreateInfo>(VkDevice                 parent_handle,
+                                                                       ImageWrapper*            wrapper,
+                                                                       const VkImageCreateInfo* create_info,
+                                                                       format::ApiCallId        create_call_id,
+                                                                       CreateParameters         create_parameters,
+                                                                       VulkanStateTable*        state_table)
+{
+    assert(wrapper != nullptr);
+    assert(create_info != nullptr);
+    assert(create_parameters != nullptr);
+
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+    GFXRECON_UNREFERENCED_PARAMETER(state_table);
+
+    wrapper->create_call_id    = create_call_id;
+    wrapper->create_parameters = std::move(create_parameters);
+
+    wrapper->image_type   = create_info->imageType;
+    wrapper->format       = create_info->format;
+    wrapper->extent       = create_info->extent;
+    wrapper->mip_levels   = create_info->mipLevels;
+    wrapper->array_layers = create_info->arrayLayers;
+    wrapper->samples      = create_info->samples;
+    wrapper->tiling       = create_info->tiling;
+
+    // TODO: Do we need to track the queue family that the image is actually used with?
+    if ((create_info->queueFamilyIndexCount > 0) && (create_info->pQueueFamilyIndices != nullptr))
     {
         wrapper->queue_family_index = create_info->pQueueFamilyIndices[0];
     }

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -608,14 +608,14 @@ void VulkanStateWriter::ProcessBufferMemory(VkDevice                  device,
                                                      format::ToHandleId(command_pool),
                                                      nullptr);
                         }
-
-                        dispatch_table.DestroyCommandPool(device, command_pool, nullptr);
-                        command_pool = VK_NULL_HANDLE;
                     }
                     else
                     {
                         GFXRECON_LOG_ERROR("Failed to create a command buffer to process trim state");
                     }
+
+                    dispatch_table.DestroyCommandPool(device, command_pool, nullptr);
+                    command_pool = VK_NULL_HANDLE;
                 }
                 else
                 {

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -137,14 +137,52 @@ class VulkanStateWriter
                                        VkDeviceSize       replay_size,
                                        const DeviceTable& dispatch_table);
 
-    void WriteStagingCopyCommands(VkDevice        device,
-                                  VkQueue         queue,
-                                  VkCommandBuffer command_buffer,
-                                  VkBuffer        source,
-                                  VkBuffer        destination,
-                                  VkDeviceSize    source_offset,
-                                  VkDeviceSize    destination_offset,
-                                  VkDeviceSize    size);
+    void WriteBufferCopyCommandExecution(VkQueue         queue,
+                                         VkCommandBuffer command_buffer,
+                                         VkBuffer        source,
+                                         VkBuffer        destination,
+                                         VkDeviceSize    source_offset,
+                                         VkDeviceSize    destination_offset,
+                                         VkDeviceSize    size);
+
+    void WriteImageCopyCommandExecution(VkQueue                  queue,
+                                        VkCommandBuffer          command_buffer,
+                                        VkBuffer                 source,
+                                        VkImage                  destination,
+                                        VkImageLayout            final_layout,
+                                        uint32_t                 copy_regions_size,
+                                        const VkBufferImageCopy* copy_regions);
+
+    void WriteImageLayoutTransitionCommand(VkCommandBuffer      command_buffer,
+                                           VkImage              image,
+                                           VkPipelineStageFlags src_stages,
+                                           VkPipelineStageFlags dst_stages,
+                                           VkAccessFlags        src_access,
+                                           VkAccessFlags        dst_access,
+                                           VkImageLayout        src_layout,
+                                           VkImageLayout        dst_layout,
+                                           uint32_t             mip_levels,
+                                           uint32_t             array_layers,
+                                           VkImageAspectFlags   aspect);
+
+    void WriteImageLayoutTransitionCommandExecution(VkQueue              queue,
+                                                    VkCommandBuffer      command_buffer,
+                                                    VkImage              image,
+                                                    VkPipelineStageFlags src_stages,
+                                                    VkPipelineStageFlags dst_stages,
+                                                    VkAccessFlags        src_access,
+                                                    VkAccessFlags        dst_access,
+                                                    VkImageLayout        src_layout,
+                                                    VkImageLayout        dst_layout,
+                                                    uint32_t             mip_levels,
+                                                    uint32_t             array_layers,
+                                                    VkImageAspectFlags   aspect);
+
+    void WriteCommandBegin(VkCommandBuffer command_buffer);
+
+    void WriteCommandEnd(VkCommandBuffer command_buffer);
+
+    void WriteCommandExecution(VkQueue queue, VkCommandBuffer command_buffer);
 
     void WriteDestroyDeviceObject(format::ApiCallId            call_id,
                                   format::HandleId             device_id,

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -114,6 +114,11 @@ class VulkanStateWriter
                              const VulkanStateTable&   state_table,
                              const DeviceTable&        dispatch_table);
 
+    void ProcessImageMemory(VkDevice                 device,
+                            const ImageSnapshotData& snapshot_data,
+                            const VulkanStateTable&  state_table,
+                            const DeviceTable&       dispatch_table);
+
     void WriteStagingBufferCreateCommands(VkDevice                    device,
                                           VkDeviceSize                buffer_size,
                                           VkBuffer                    buffer,


### PR DESCRIPTION
Add support for tracking image memory state and writing image memory content to the trimming state snapshot, which is written before the trimmed frames. Writing image memory to the state snapshot requires staging copies for device local memory.