### PR TITLE
Use Fullscreen Theme for Android Replay Tool

### DIFF
--- a/android/tools/replay/src/main/res/values/styles.xml
+++ b/android/tools/replay/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="@android:style/Theme.NoTitleBar.OverlayActionModes">
+    <style name="AppTheme" parent="@android:style/Theme.NoTitleBar.Fullscreen">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>


### PR DESCRIPTION
Change the app theme for the Android replay application from
Theme.NoTitleBar.OverlayActionModes to Theme.NoTitleBar.Fullscreen. The
"OverlayActionModes" style renders some UI overlay components that
impact replay performance.
