### PR TITLE
Add Descriptor Update Tracking for Trimming Snapshot

### DIFF
--- a/android/framework/encode/CMakeLists.txt
+++ b/android/framework/encode/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(gfxrecon_encode
                    ${GFXRECON_SOURCE_DIR}/framework/encode/custom_vulkan_api_call_encoders.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/encode/custom_vulkan_struct_encoders.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/custom_vulkan_struct_encoders.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/encode/descriptor_update_template_info.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/memory_tracker.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/memory_tracker.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/encode/parameter_encoder.h

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(gfxrecon_encode
                    custom_vulkan_api_call_encoders.cpp
                    custom_vulkan_struct_encoders.h
                    custom_vulkan_struct_encoders.cpp
+                   descriptor_update_template_info.h
                    memory_tracker.h
                    memory_tracker.cpp
                    parameter_encoder.h

--- a/framework/encode/custom_encoder_commands.h
+++ b/framework/encode/custom_encoder_commands.h
@@ -271,12 +271,42 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkUpdateDescriptorSets>
 };
 
 template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkUpdateDescriptorSetWithTemplate>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkUpdateDescriptorSetWithTemplate(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkUpdateDescriptorSetWithTemplateKHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkUpdateDescriptorSetWithTemplateKHR(args...);
+    }
+};
+
+template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSetKHR>
 {
     template <typename... Args>
     static void Dispatch(TraceManager* manager, Args... args)
     {
         manager->PostProcess_vkCmdPushDescriptorSetKHR(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplateKHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdPushDescriptorSetWithTemplateKHR(args...);
     }
 };
 

--- a/framework/encode/custom_encoder_commands.h
+++ b/framework/encode/custom_encoder_commands.h
@@ -261,6 +261,36 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueSubmit>
 };
 
 template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkUpdateDescriptorSets>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkUpdateDescriptorSets(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPushDescriptorSetKHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdPushDescriptorSetKHR(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkResetDescriptorPool>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkResetDescriptorPool(result, args...);
+    }
+};
+
+template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplate>
 {
     template <typename... Args>

--- a/framework/encode/custom_vulkan_api_call_encoders.cpp
+++ b/framework/encode/custom_vulkan_api_call_encoders.cpp
@@ -18,6 +18,7 @@
 #include "encode/custom_vulkan_api_call_encoders.h"
 
 #include "encode/custom_encoder_commands.h"
+#include "encode/descriptor_update_template_info.h"
 #include "encode/parameter_encoder.h"
 #include "encode/struct_pointer_encoder.h"
 #include "encode/trace_manager.h"
@@ -37,8 +38,8 @@ static void EncodeDescriptorUpdateTemplateInfo(TraceManager*              manage
 {
     assert((manager != nullptr) && (encoder != nullptr));
 
-    bool                                            found = false;
-    const TraceManager::UpdateTemplateInfo*         info  = nullptr;
+    bool                      found = false;
+    const UpdateTemplateInfo* info  = nullptr;
 
     if (data != nullptr)
     {
@@ -50,7 +51,7 @@ static void EncodeDescriptorUpdateTemplateInfo(TraceManager*              manage
         // Write pointer attributes as if we were processing a struct pointer.
         encoder->EncodeStructPtrPreamble(data);
 
-        // The update template data will be written as tightly packed sets of arrays of VkDescriptorImageInfo,
+        // The update template data will be written as tightly packed arrays of VkDescriptorImageInfo,
         // VkDescriptorBufferInfo, and VkBufferView types.  There will be one array per descriptor update entry.  We
         // will write the total number of entries of each type before we write the entries, so that the decoder will
         // know up front how much memory it needs to allocate for decoding.

--- a/framework/encode/descriptor_update_template_info.h
+++ b/framework/encode/descriptor_update_template_info.h
@@ -1,0 +1,56 @@
+/*
+** Copyright (c) 2019 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef GFXRECON_ENCODE_DESCRIPTOR_UPDATE_TEMPLATE_INFO_H
+#define GFXRECON_ENCODE_DESCRIPTOR_UPDATE_TEMPLATE_INFO_H
+
+#include "util/defines.h"
+
+#include "vulkan/vulkan.h"
+
+#include <vector>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(encode)
+
+struct UpdateTemplateEntryInfo
+{
+    uint32_t binding;       // Used for state tracking only.
+    uint32_t array_element; // Used for state tracking only.
+    uint32_t count;
+    size_t   offset;
+    size_t   stride;
+};
+
+struct UpdateTemplateInfo
+{
+    // The counts are the sum of the total descriptorCount for each update template entry type. When written to the
+    // capture file, the update template data will be written as tightly packed arrays of VkDescriptorImageInfo,
+    // VkDescriptorBufferInfo, and VkBufferView types.  There will be one array per descriptor update entry, so the
+    // counts are pre-computed for the file encoding process to know the total number of items to encode prior to
+    // processing the individial UpdateTemplateEntry structures.
+    size_t                               image_info_count{ 0 };
+    size_t                               buffer_info_count{ 0 };
+    size_t                               texel_buffer_view_count{ 0 };
+    std::vector<UpdateTemplateEntryInfo> image_info;
+    std::vector<UpdateTemplateEntryInfo> buffer_info;
+    std::vector<UpdateTemplateEntryInfo> texel_buffer_view;
+};
+
+GFXRECON_END_NAMESPACE(encode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_ENCODE_DESCRIPTOR_UPDATE_TEMPLATE_INFO_H

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -583,21 +583,42 @@ void TraceManager::AddDescriptorUpdateTemplate(VkDescriptorUpdateTemplate       
                 (type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) || (type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) ||
                 (type == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT))
             {
+                UpdateTemplateEntryInfo image_info;
+                image_info.binding       = entry->dstBinding;
+                image_info.array_element = entry->dstArrayElement;
+                image_info.count         = entry->descriptorCount;
+                image_info.offset        = entry->offset;
+                image_info.stride        = entry->stride;
+
                 info.image_info_count += entry->descriptorCount;
-                info.image_info.emplace_back(entry->descriptorCount, entry->offset, entry->stride);
+                info.image_info.emplace_back(image_info);
             }
             else if ((type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER) || (type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER) ||
                      (type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) ||
                      (type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC))
             {
+                UpdateTemplateEntryInfo buffer_info;
+                buffer_info.binding       = entry->dstBinding;
+                buffer_info.array_element = entry->dstArrayElement;
+                buffer_info.count         = entry->descriptorCount;
+                buffer_info.offset        = entry->offset;
+                buffer_info.stride        = entry->stride;
+
                 info.buffer_info_count += entry->descriptorCount;
-                info.buffer_info.emplace_back(entry->descriptorCount, entry->offset, entry->stride);
+                info.buffer_info.emplace_back(buffer_info);
             }
             else if ((type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER) ||
                      (type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER))
             {
+                UpdateTemplateEntryInfo texel_buffer_view_info;
+                texel_buffer_view_info.binding       = entry->dstBinding;
+                texel_buffer_view_info.array_element = entry->dstArrayElement;
+                texel_buffer_view_info.count         = entry->descriptorCount;
+                texel_buffer_view_info.offset        = entry->offset;
+                texel_buffer_view_info.stride        = entry->stride;
+
                 info.texel_buffer_view_count += entry->descriptorCount;
-                info.texel_buffer_view.emplace_back(entry->descriptorCount, entry->offset, entry->stride);
+                info.texel_buffer_view.emplace_back(texel_buffer_view_info);
             }
             else
             {
@@ -636,6 +657,18 @@ bool TraceManager::GetDescriptorUpdateTemplateInfo(VkDescriptorUpdateTemplate up
     }
 
     return found;
+}
+
+void TraceManager::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet            set,
+                                                        VkDescriptorUpdateTemplate update_template,
+                                                        const void*                data)
+{
+    const UpdateTemplateInfo* info = nullptr;
+    if (GetDescriptorUpdateTemplateInfo(update_template, &info))
+    {
+        assert(state_tracker_ != nullptr);
+        state_tracker_->TrackUpdateDescriptorSetWithTemplate(set, info, data);
+    }
 }
 
 void TraceManager::PreProcess_vkCreateSwapchain(VkDevice                        device,

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -627,7 +627,8 @@ bool TraceManager::GetDescriptorUpdateTemplateInfo(VkDescriptorUpdateTemplate up
 
     // We assume that the application will not destroy an update template while it is in use, and that we only need
     // to lock on find for protection from data strcuture changes due to adds and removes of other update templates.
-    auto entry = update_template_map_.find(update_template);
+    std::lock_guard<std::mutex> lock(update_template_map_lock_);
+    auto                        entry = update_template_map_.find(update_template);
     if (entry != update_template_map_.end())
     {
         found   = true;

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -390,6 +390,51 @@ class TraceManager
         }
     }
 
+    void PostProcess_vkUpdateDescriptorSets(VkDevice                    device,
+                                            uint32_t                    descriptorWriteCount,
+                                            const VkWriteDescriptorSet* pDescriptorWrites,
+                                            uint32_t                    descriptorCopyCount,
+                                            const VkCopyDescriptorSet*  pDescriptorCopies)
+    {
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            assert(state_tracker_ != nullptr);
+            GFXRECON_UNREFERENCED_PARAMETER(device);
+            state_tracker_->TrackUpdateDescriptorSets(
+                descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies);
+        }
+    }
+
+    void PostProcess_vkCmdPushDescriptorSetKHR(VkCommandBuffer             commandBuffer,
+                                               VkPipelineBindPoint         pipelineBindPoint,
+                                               VkPipelineLayout            layout,
+                                               uint32_t                    set,
+                                               uint32_t                    descriptorWriteCount,
+                                               const VkWriteDescriptorSet* pDescriptorWrites)
+    {
+        GFXRECON_UNREFERENCED_PARAMETER(commandBuffer);
+        GFXRECON_UNREFERENCED_PARAMETER(pipelineBindPoint);
+        GFXRECON_UNREFERENCED_PARAMETER(layout);
+        GFXRECON_UNREFERENCED_PARAMETER(set);
+        GFXRECON_UNREFERENCED_PARAMETER(descriptorWriteCount);
+        GFXRECON_UNREFERENCED_PARAMETER(pDescriptorWrites);
+        // TODO: Need to be able to map layout + set to a VkDescriptorSet handle.
+    }
+
+    void PostProcess_vkResetDescriptorPool(VkResult                   result,
+                                           VkDevice                   device,
+                                           VkDescriptorPool           descriptorPool,
+                                           VkDescriptorPoolResetFlags flags)
+    {
+        if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS))
+        {
+            assert(state_tracker_ != nullptr);
+            GFXRECON_UNREFERENCED_PARAMETER(device);
+            GFXRECON_UNREFERENCED_PARAMETER(flags);
+            state_tracker_->TrackResetDescriptorPool(descriptorPool);
+        }
+    }
+
     void PostProcess_vkMapMemory(VkResult         result,
                                  VkDevice         device,
                                  VkDeviceMemory   memory,

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -57,6 +57,16 @@ struct DescriptorBindingInfo
     VkDescriptorType type;
 };
 
+struct DescriptorInfo
+{
+    VkDescriptorType                          type;
+    uint32_t                                  count{ 0 };
+    std::unique_ptr<bool[]>                   written;
+    std::unique_ptr<VkDescriptorImageInfo[]>  images;
+    std::unique_ptr<VkDescriptorBufferInfo[]> buffers;
+    std::unique_ptr<VkBufferView[]>           texel_buffer_views;
+};
+
 // VkDescriptorSetLayout create info stored with VkPipelineLayout handle.
 struct DescriptorSetLayoutInfo
 {
@@ -291,10 +301,13 @@ struct DescriptorSetLayoutWrapper : public HandleWrapper<VkDescriptorSetLayout>
 struct DescriptorPoolWrapper;
 struct DescriptorSetWrapper : public HandleWrapper<VkDescriptorSet>
 {
+    VkDevice device{ VK_NULL_HANDLE };
+
+    // Map for descriptor binding index to array of descriptor info.
+    std::unordered_map<uint32_t, DescriptorInfo> bindings;
+
     // Pool from which set was allocated. The set must be removed from the pool's allocation list when destroyed.
     DescriptorPoolWrapper* pool{ nullptr };
-
-    // TODO: Track descriptor write state.
 };
 
 struct DescriptorPoolWrapper : public HandleWrapper<VkDescriptorPool>

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -50,6 +50,13 @@ struct QueryInfo
     format::HandleId    render_pass_id{ 0 };
 };
 
+struct DescriptorBindingInfo
+{
+    uint32_t         binding_index{ 0 };
+    uint32_t         count{ 0 };
+    VkDescriptorType type;
+};
+
 // VkDescriptorSetLayout create info stored with VkPipelineLayout handle.
 struct DescriptorSetLayoutInfo
 {
@@ -102,7 +109,6 @@ struct EventWrapper                     : public HandleWrapper<VkEvent> {};
 struct BufferViewWrapper                : public HandleWrapper<VkBufferView> {};
 struct ShaderModuleWrapper              : public HandleWrapper<VkShaderModule> {};
 struct PipelineCacheWrapper             : public HandleWrapper<VkPipelineCache> {};
-struct DescriptorSetLayoutWrapper       : public HandleWrapper<VkDescriptorSetLayout> {};
 struct SamplerWrapper                   : public HandleWrapper<VkSampler> {};
 struct SamplerYcbcrConversionWrapper    : public HandleWrapper<VkSamplerYcbcrConversion> {};
 struct DescriptorUpdateTemplateWrapper  : public HandleWrapper<VkDescriptorUpdateTemplate> {};
@@ -275,6 +281,11 @@ struct PipelineWrapper : public HandleWrapper<VkPipeline>
 
     // TODO: Base pipeline
     // TODO: Pipeline cache
+};
+
+struct DescriptorSetLayoutWrapper : public HandleWrapper<VkDescriptorSetLayout>
+{
+    std::vector<DescriptorBindingInfo> binding_info;
 };
 
 struct DescriptorPoolWrapper;

--- a/framework/encode/vulkan_state_table.h
+++ b/framework/encode/vulkan_state_table.h
@@ -188,6 +188,9 @@ class VulkanStateTable
     DescriptorPoolWrapper*       GetDescriptorPoolWrapper(format::HandleId id)       { return GetWrapper<DescriptorPoolWrapper>(id, descriptor_pool_map_); }
     const DescriptorPoolWrapper* GetDescriptorPoolWrapper(format::HandleId id) const { return GetWrapper<DescriptorPoolWrapper>(id, descriptor_pool_map_); }
 
+    DescriptorSetWrapper*       GetDescriptorSetWrapper(format::HandleId id)       { return GetWrapper<DescriptorSetWrapper>(id, descriptor_set_map_); }
+    const DescriptorSetWrapper* GetDescriptorSetWrapper(format::HandleId id) const { return GetWrapper<DescriptorSetWrapper>(id, descriptor_set_map_); }
+
     DescriptorSetLayoutWrapper*       GetDescriptorSetLayoutWrapper(format::HandleId id)       { return GetWrapper<DescriptorSetLayoutWrapper>(id, descriptor_set_layout_map_); }
     const DescriptorSetLayoutWrapper* GetDescriptorSetLayoutWrapper(format::HandleId id) const { return GetWrapper<DescriptorSetLayoutWrapper>(id, descriptor_set_layout_map_); }
 

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -114,8 +114,8 @@ class VulkanStateTracker
                     Wrapper* wrapper   = new Wrapper;
                     wrapper->handle    = new_handles[i];
                     wrapper->handle_id = ++object_count_;
-                    vulkan_state_tracker::InitializeState<ParentHandle, Wrapper, AllocateInfo>(
-                        parent_handle, wrapper, alloc_info, create_call_id, create_parameters, &state_table_);
+                    vulkan_state_tracker::InitializePoolObjectState(
+                        parent_handle, wrapper, i, alloc_info, create_call_id, create_parameters, &state_table_);
 
                     // Attempts to add a new entry to the table. Operation will fail for duplicate handles.
                     // TODO: Handle wrapping will introduce a unique ID that eliminates duplicates.

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -17,6 +17,7 @@
 #ifndef GFXRECON_ENCODE_VULKAN_STATE_TRACKER_H
 #define GFXRECON_ENCODE_VULKAN_STATE_TRACKER_H
 
+#include "encode/descriptor_update_template_info.h"
 #include "encode/vulkan_handle_wrappers.h"
 #include "encode/vulkan_state_table.h"
 #include "encode/vulkan_state_tracker_initializers.h"
@@ -229,6 +230,10 @@ class VulkanStateTracker
                                    const VkWriteDescriptorSet* writes,
                                    uint32_t                    copy_count,
                                    const VkCopyDescriptorSet*  copies);
+
+    void TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet           set,
+                                              const UpdateTemplateInfo* template_info,
+                                              const void*               data);
 
     void TrackResetDescriptorPool(VkDescriptorPool descriptor_pool);
 

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -225,6 +225,13 @@ class VulkanStateTracker
 
     void TrackImageLayoutTransitions(uint32_t submit_count, const VkSubmitInfo* submits);
 
+    void TrackUpdateDescriptorSets(uint32_t                    write_count,
+                                   const VkWriteDescriptorSet* writes,
+                                   uint32_t                    copy_count,
+                                   const VkCopyDescriptorSet*  copies);
+
+    void TrackResetDescriptorPool(VkDescriptorPool descriptor_pool);
+
   private:
     // TODO: Evaluate need for per-type locks.
     std::mutex mutex_;

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -512,6 +512,42 @@ inline void InitializeState<VkDevice, ImageViewWrapper, VkImageViewCreateInfo>(V
     wrapper->image = create_info->image;
 }
 
+template <>
+inline void InitializeState<VkDevice, DescriptorSetLayoutWrapper, VkDescriptorSetLayoutCreateInfo>(
+    VkDevice                               parent_handle,
+    DescriptorSetLayoutWrapper*            wrapper,
+    const VkDescriptorSetLayoutCreateInfo* create_info,
+    format::ApiCallId                      create_call_id,
+    CreateParameters                       create_parameters,
+    VulkanStateTable*                      state_table)
+{
+    assert(wrapper != nullptr);
+    assert(create_info != nullptr);
+    assert(create_parameters != nullptr);
+
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+    GFXRECON_UNREFERENCED_PARAMETER(state_table);
+
+    wrapper->create_call_id    = create_call_id;
+    wrapper->create_parameters = std::move(create_parameters);
+
+    if ((create_info->bindingCount > 0) && (create_info->pBindings != nullptr))
+    {
+        wrapper->binding_info.reserve(create_info->bindingCount);
+        for (uint32_t i = 0; i < create_info->bindingCount; ++i)
+        {
+            const VkDescriptorSetLayoutBinding* binding = &create_info->pBindings[i];
+
+            DescriptorBindingInfo binding_info;
+            binding_info.binding_index = binding->binding;
+            binding_info.count         = binding->descriptorCount;
+            binding_info.type          = binding->descriptorType;
+
+            wrapper->binding_info.emplace_back(binding_info);
+        }
+    }
+}
+
 GFXRECON_END_NAMESPACE(vulkan_state_tracker)
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -112,6 +112,8 @@ class VulkanStateWriter
 
     void WritePipelineState(const VulkanStateTable& state_table);
 
+    void WriteDescriptorSetState(const VulkanStateTable& state_table);
+
     void ProcessBufferMemory(VkDevice                  device,
                              const BufferSnapshotData& snapshot_data,
                              const VulkanStateTable&   state_table,
@@ -193,6 +195,8 @@ class VulkanStateWriter
     void WriteCommandExecution(VkQueue queue, VkCommandBuffer command_buffer);
 
     void WriteCommandBufferCommands(const CommandBufferWrapper* wrapper);
+
+    void WriteDescriptorUpdateCommand(VkDevice device, const DescriptorInfo* binding, VkWriteDescriptorSet* write);
 
     void WriteDestroyDeviceObject(format::ApiCallId            call_id,
                                   format::HandleId             device_id,

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -94,7 +94,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(
         encoder->EncodeUInt32Ptr(pPhysicalDeviceCount);
         encoder->EncodeHandleIdArray(pPhysicalDevices, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<VkInstance, PhysicalDeviceWrapper, void>(result, instance, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, pPhysicalDevices, nullptr, encoder);
+        TraceManager::Get()->EndGroupCreateApiCallTrace<VkInstance, PhysicalDeviceWrapper, void>(result, instance, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, pPhysicalDevices, nullptr, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkEnumeratePhysicalDevices>::Dispatch(TraceManager::Get(), result, instance, pPhysicalDeviceCount, pPhysicalDevices);
@@ -1447,7 +1447,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, PipelineWrapper, VkGraphicsPipelineCreateInfo>(result, device, createInfoCount, pPipelines, pCreateInfos, encoder);
+        TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, PipelineWrapper, VkGraphicsPipelineCreateInfo>(result, device, createInfoCount, pPipelines, pCreateInfos, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateGraphicsPipelines>::Dispatch(TraceManager::Get(), result, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
@@ -1477,7 +1477,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, PipelineWrapper, VkComputePipelineCreateInfo>(result, device, createInfoCount, pPipelines, pCreateInfos, encoder);
+        TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, PipelineWrapper, VkComputePipelineCreateInfo>(result, device, createInfoCount, pPipelines, pCreateInfos, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateComputePipelines>::Dispatch(TraceManager::Get(), result, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
@@ -1734,7 +1734,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(
         EncodeStructPtr(encoder, pAllocateInfo);
         encoder->EncodeHandleIdArray(pDescriptorSets, pAllocateInfo->descriptorSetCount);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, DescriptorSetWrapper, VkDescriptorSetAllocateInfo>(result, device, pAllocateInfo->descriptorSetCount, pDescriptorSets, pAllocateInfo, encoder);
+        TraceManager::Get()->EndPoolCreateApiCallTrace<VkDevice, DescriptorSetWrapper, VkDescriptorSetAllocateInfo>(result, device, pAllocateInfo->descriptorSetCount, pDescriptorSets, pAllocateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateDescriptorSets>::Dispatch(TraceManager::Get(), result, device, pAllocateInfo, pDescriptorSets);
@@ -1995,7 +1995,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateCommandBuffers(
         EncodeStructPtr(encoder, pAllocateInfo);
         encoder->EncodeHandleIdArray(pCommandBuffers, pAllocateInfo->commandBufferCount);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, CommandBufferWrapper, VkCommandBufferAllocateInfo>(result, device, pAllocateInfo->commandBufferCount, pCommandBuffers, pAllocateInfo, encoder);
+        TraceManager::Get()->EndPoolCreateApiCallTrace<VkDevice, CommandBufferWrapper, VkCommandBufferAllocateInfo>(result, device, pAllocateInfo->commandBufferCount, pCommandBuffers, pAllocateInfo, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateCommandBuffers>::Dispatch(TraceManager::Get(), result, device, pAllocateInfo, pCommandBuffers);
@@ -3928,7 +3928,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(
         encoder->EncodeUInt32Ptr(pSwapchainImageCount);
         encoder->EncodeHandleIdArray(pSwapchainImages, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, ImageWrapper, void>(result, device, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, pSwapchainImages, nullptr, encoder);
+        TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, ImageWrapper, void>(result, device, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, pSwapchainImages, nullptr, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetSwapchainImagesKHR>::Dispatch(TraceManager::Get(), result, device, swapchain, pSwapchainImageCount, pSwapchainImages);
@@ -4150,7 +4150,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneSupportedDisplaysKHR(
         encoder->EncodeUInt32Ptr(pDisplayCount);
         encoder->EncodeHandleIdArray(pDisplays, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<VkPhysicalDevice, DisplayKHRWrapper, void>(result, physicalDevice, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, pDisplays, nullptr, encoder);
+        TraceManager::Get()->EndGroupCreateApiCallTrace<VkPhysicalDevice, DisplayKHRWrapper, void>(result, physicalDevice, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, pDisplays, nullptr, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDisplayPlaneSupportedDisplaysKHR>::Dispatch(TraceManager::Get(), result, physicalDevice, planeIndex, pDisplayCount, pDisplays);
@@ -4284,7 +4284,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSharedSwapchainsKHR(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdArray(pSwapchains, swapchainCount);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(result, device, swapchainCount, pSwapchains, pCreateInfos, encoder);
+        TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(result, device, swapchainCount, pSwapchains, pCreateInfos, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSharedSwapchainsKHR>::Dispatch(TraceManager::Get(), result, device, swapchainCount, pCreateInfos, pAllocator, pSwapchains);
@@ -7533,7 +7533,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCreateApiCallTrace<VkDevice, PipelineWrapper, VkRayTracingPipelineCreateInfoNV>(result, device, createInfoCount, pPipelines, pCreateInfos, encoder);
+        TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, PipelineWrapper, VkRayTracingPipelineCreateInfoNV>(result, device, createInfoCount, pPipelines, pCreateInfos, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesNV>::Dispatch(TraceManager::Get(), result, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -232,7 +232,11 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                         lengthName = '({name} != nullptr) ? (*{name}) : 0'.format(name=lengthName)
                         break
 
-                decl += 'EndCreateApiCallTrace<{}, {}Wrapper, {}>({}, {}, {}, {}, {}, encoder)'.format(parentHandle.baseType, handle.baseType[2:], infoBaseType, returnValue, parentHandle.name, lengthName, handle.name, infoName)
+                callName = 'EndGroupCreateApiCallTrace'
+                if '->' in lengthName:
+                    callName = 'EndPoolCreateApiCallTrace'
+
+                decl += '{}<{}, {}Wrapper, {}>({}, {}, {}, {}, {}, encoder)'.format(callName, parentHandle.baseType, handle.baseType[2:], infoBaseType, returnValue, parentHandle.name, lengthName, handle.name, infoName)
             else:
                 # Instance creation has no handle.
                 if parentHandle:


### PR DESCRIPTION
Initial support for tracking descriptor updates, which are written to the trimming state snapshot for all active descriptor sets.  Does not currently support push descriptor updates.