### PR TITLE
Additional Swapchain Tracking for Trimming State Snapshot

### DIFF
--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -143,9 +143,10 @@ class TraceManager
     }
 
     // Multiple object creation.
-    template <typename ParentHandle, typename Wrapper, typename CreateInfo>
+    template <typename ParentHandle, typename SecondaryHandle, typename Wrapper, typename CreateInfo>
     void EndGroupCreateApiCallTrace(VkResult                      result,
                                     ParentHandle                  parent_handle,
+                                    SecondaryHandle               secondary_handle,
                                     uint32_t                      count,
                                     typename Wrapper::HandleType* handles,
                                     const CreateInfo*             create_infos,
@@ -158,12 +159,14 @@ class TraceManager
             auto thread_data = GetThreadData();
             assert(thread_data != nullptr);
 
-            state_tracker_->AddGroupEntry<ParentHandle, Wrapper, CreateInfo>(parent_handle,
-                                                                             count,
-                                                                             handles,
-                                                                             create_infos,
-                                                                             thread_data->call_id_,
-                                                                             thread_data->parameter_buffer_.get());
+            state_tracker_->AddGroupEntry<ParentHandle, SecondaryHandle, Wrapper, CreateInfo>(
+                parent_handle,
+                secondary_handle,
+                count,
+                handles,
+                create_infos,
+                thread_data->call_id_,
+                thread_data->parameter_buffer_.get());
         }
 
         EndApiCallTrace(encoder);

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -339,7 +339,13 @@ struct CommandPoolWrapper : public HandleWrapper<VkCommandPool>
 
 struct SwapchainKHRWrapper : public HandleWrapper<VkSwapchainKHR>
 {
-    std::vector<bool> image_needs_acquire;
+    VkDevice                   device{ VK_NULL_HANDLE };
+    VkSurfaceKHR               surface{ VK_NULL_HANDLE };
+    uint32_t                   queue_family_index{ 0 };
+    VkFormat                   format{ VK_FORMAT_UNDEFINED };
+    VkExtent3D                 extent{ 0, 0, 0 };
+    uint32_t                   array_layers{ 0 };
+    std::vector<ImageWrapper*> images;
 };
 
 struct ObjectTableNVXWrapper : public HandleWrapper<VkObjectTableNVX>

--- a/framework/encode/vulkan_state_table.h
+++ b/framework/encode/vulkan_state_table.h
@@ -205,6 +205,9 @@ class VulkanStateTable
 
     SemaphoreWrapper*       GetSemaphoreWrapper(format::HandleId id)       { return GetWrapper<SemaphoreWrapper>(id, semaphore_map_); }
     const SemaphoreWrapper* GetSemaphoreWrapper(format::HandleId id) const { return GetWrapper<SemaphoreWrapper>(id, semaphore_map_); }
+
+    SwapchainKHRWrapper*       GetSwapchainKHRWrapper(format::HandleId id)       { return GetWrapper<SwapchainKHRWrapper>(id, swapchain_khr_map_); }
+    const SwapchainKHRWrapper* GetSwapchainKHRWrapper(format::HandleId id) const { return GetWrapper<SwapchainKHRWrapper>(id, swapchain_khr_map_); }
     // clang-format off
 
   private:

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -129,8 +129,9 @@ class VulkanStateTracker
         }
     }
 
-    template <typename ParentHandle, typename Wrapper, typename CreateInfo>
+    template <typename ParentHandle, typename SecondaryHandle, typename Wrapper, typename CreateInfo>
     void AddGroupEntry(ParentHandle                    parent_handle,
+                       SecondaryHandle                 secondary_handle,
                        uint32_t                        count,
                        typename Wrapper::HandleType*   new_handles,
                        const CreateInfo*               create_infos,
@@ -162,8 +163,15 @@ class VulkanStateTracker
                     Wrapper* wrapper   = new Wrapper;
                     wrapper->handle    = new_handles[i];
                     wrapper->handle_id = ++object_count_;
-                    vulkan_state_tracker::InitializeState<ParentHandle, Wrapper, CreateInfo>(
-                        parent_handle, wrapper, create_info, create_call_id, create_parameters, &state_table_);
+                    vulkan_state_tracker::
+                        InitializeGroupObjectState<ParentHandle, SecondaryHandle, Wrapper, CreateInfo>(
+                            parent_handle,
+                            secondary_handle,
+                            wrapper,
+                            create_info,
+                            create_call_id,
+                            create_parameters,
+                            &state_table_);
 
                     // Attempts to add a new entry to the table. Operation will fail for duplicate handles.
                     // TODO: Handle wrapping will introduce a unique ID that eliminates duplicates.

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -73,6 +73,21 @@ void InitializeState(ParentHandle      parent_handle,
     wrapper->create_parameters = std::move(create_parameters);
 }
 
+template <typename ParentHandle, typename SecondaryHandle, typename Wrapper, typename CreateInfo>
+void InitializeGroupObjectState(ParentHandle      parent_handle,
+                                SecondaryHandle   secondary_handle,
+                                Wrapper*          wrapper,
+                                const CreateInfo* create_info,
+                                format::ApiCallId create_call_id,
+                                CreateParameters  create_parameters,
+                                VulkanStateTable* state_table)
+{
+    // The secondary handle is only used by sepcializations.
+    GFXRECON_UNREFERENCED_PARAMETER(secondary_handle);
+    InitializeState<ParentHandle, Wrapper, CreateInfo>(
+        parent_handle, wrapper, create_info, create_call_id, create_parameters, state_table);
+}
+
 template <>
 inline void InitializeState<VkPhysicalDevice, DeviceWrapper, VkDeviceCreateInfo>(VkPhysicalDevice parent_handle,
                                                                                  DeviceWrapper*   wrapper,
@@ -290,8 +305,9 @@ InitializeState<VkDevice, RenderPassWrapper, VkRenderPassCreateInfo>(VkDevice   
 }
 
 template <>
-inline void InitializeState<VkDevice, PipelineWrapper, VkGraphicsPipelineCreateInfo>(
+inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrapper, VkGraphicsPipelineCreateInfo>(
     VkDevice                            parent_handle,
+    VkPipelineCache                     secondary_handle,
     PipelineWrapper*                    wrapper,
     const VkGraphicsPipelineCreateInfo* create_info,
     format::ApiCallId                   create_call_id,
@@ -304,6 +320,9 @@ inline void InitializeState<VkDevice, PipelineWrapper, VkGraphicsPipelineCreateI
     assert(state_table != nullptr);
 
     GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+
+    // TODO: Track pipeline cache dependency.
+    GFXRECON_UNREFERENCED_PARAMETER(secondary_handle);
 
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
@@ -347,13 +366,14 @@ inline void InitializeState<VkDevice, PipelineWrapper, VkGraphicsPipelineCreateI
 }
 
 template <>
-inline void
-InitializeState<VkDevice, PipelineWrapper, VkComputePipelineCreateInfo>(VkDevice         parent_handle,
-                                                                        PipelineWrapper* wrapper,
-                                                                        const VkComputePipelineCreateInfo* create_info,
-                                                                        format::ApiCallId create_call_id,
-                                                                        CreateParameters  create_parameters,
-                                                                        VulkanStateTable* state_table)
+inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrapper, VkComputePipelineCreateInfo>(
+    VkDevice                           parent_handle,
+    VkPipelineCache                    secondary_handle,
+    PipelineWrapper*                   wrapper,
+    const VkComputePipelineCreateInfo* create_info,
+    format::ApiCallId                  create_call_id,
+    CreateParameters                   create_parameters,
+    VulkanStateTable*                  state_table)
 {
     assert(wrapper != nullptr);
     assert(create_info != nullptr);
@@ -361,6 +381,9 @@ InitializeState<VkDevice, PipelineWrapper, VkComputePipelineCreateInfo>(VkDevice
     assert(state_table != nullptr);
 
     GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+
+    // TODO: Track pipeline cache dependency.
+    GFXRECON_UNREFERENCED_PARAMETER(secondary_handle);
 
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
@@ -391,8 +414,9 @@ InitializeState<VkDevice, PipelineWrapper, VkComputePipelineCreateInfo>(VkDevice
 }
 
 template <>
-inline void InitializeState<VkDevice, PipelineWrapper, VkRayTracingPipelineCreateInfoNV>(
+inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrapper, VkRayTracingPipelineCreateInfoNV>(
     VkDevice                                parent_handle,
+    VkPipelineCache                         secondary_handle,
     PipelineWrapper*                        wrapper,
     const VkRayTracingPipelineCreateInfoNV* create_info,
     format::ApiCallId                       create_call_id,
@@ -405,6 +429,9 @@ inline void InitializeState<VkDevice, PipelineWrapper, VkRayTracingPipelineCreat
     assert(state_table != nullptr);
 
     GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+
+    // TODO: Track pipeline cache dependency.
+    GFXRECON_UNREFERENCED_PARAMETER(secondary_handle);
 
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -120,6 +120,8 @@ class VulkanStateWriter
 
     void WriteDescriptorSetState(const VulkanStateTable& state_table);
 
+    void WriteSwapchainKhrState(const VulkanStateTable& state_table);
+
     void ProcessBufferMemory(VkDevice                  device,
                              const BufferSnapshotData& snapshot_data,
                              const VulkanStateTable&   state_table,
@@ -224,6 +226,8 @@ class VulkanStateWriter
     void WriteFunctionCall(format::ApiCallId call_id, util::MemoryOutputStream* parameter_buffer);
 
     void WriteFillMemoryCmd(VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size, const void* data);
+
+    void WriteResizeWindowCmd(VkSurfaceKHR surface, uint32_t width, uint32_t height);
 
     template <typename Wrapper>
     void StandardCreateWrite(const VulkanStateTable& state_table)

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -94,7 +94,7 @@ VKAPI_ATTR VkResult VKAPI_CALL EnumeratePhysicalDevices(
         encoder->EncodeUInt32Ptr(pPhysicalDeviceCount);
         encoder->EncodeHandleIdArray(pPhysicalDevices, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndGroupCreateApiCallTrace<VkInstance, PhysicalDeviceWrapper, void>(result, instance, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, pPhysicalDevices, nullptr, encoder);
+        TraceManager::Get()->EndGroupCreateApiCallTrace<VkInstance, void*, PhysicalDeviceWrapper, void>(result, instance, nullptr, (pPhysicalDeviceCount != nullptr) ? (*pPhysicalDeviceCount) : 0, pPhysicalDevices, nullptr, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkEnumeratePhysicalDevices>::Dispatch(TraceManager::Get(), result, instance, pPhysicalDeviceCount, pPhysicalDevices);
@@ -1447,7 +1447,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, PipelineWrapper, VkGraphicsPipelineCreateInfo>(result, device, createInfoCount, pPipelines, pCreateInfos, encoder);
+        TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, VkPipelineCache, PipelineWrapper, VkGraphicsPipelineCreateInfo>(result, device, pipelineCache, createInfoCount, pPipelines, pCreateInfos, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateGraphicsPipelines>::Dispatch(TraceManager::Get(), result, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
@@ -1477,7 +1477,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, PipelineWrapper, VkComputePipelineCreateInfo>(result, device, createInfoCount, pPipelines, pCreateInfos, encoder);
+        TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, VkPipelineCache, PipelineWrapper, VkComputePipelineCreateInfo>(result, device, pipelineCache, createInfoCount, pPipelines, pCreateInfos, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateComputePipelines>::Dispatch(TraceManager::Get(), result, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
@@ -3928,7 +3928,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetSwapchainImagesKHR(
         encoder->EncodeUInt32Ptr(pSwapchainImageCount);
         encoder->EncodeHandleIdArray(pSwapchainImages, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, ImageWrapper, void>(result, device, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, pSwapchainImages, nullptr, encoder);
+        TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, VkSwapchainKHR, ImageWrapper, void>(result, device, swapchain, (pSwapchainImageCount != nullptr) ? (*pSwapchainImageCount) : 0, pSwapchainImages, nullptr, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetSwapchainImagesKHR>::Dispatch(TraceManager::Get(), result, device, swapchain, pSwapchainImageCount, pSwapchainImages);
@@ -4150,7 +4150,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayPlaneSupportedDisplaysKHR(
         encoder->EncodeUInt32Ptr(pDisplayCount);
         encoder->EncodeHandleIdArray(pDisplays, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndGroupCreateApiCallTrace<VkPhysicalDevice, DisplayKHRWrapper, void>(result, physicalDevice, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, pDisplays, nullptr, encoder);
+        TraceManager::Get()->EndGroupCreateApiCallTrace<VkPhysicalDevice, void*, DisplayKHRWrapper, void>(result, physicalDevice, nullptr, (pDisplayCount != nullptr) ? (*pDisplayCount) : 0, pDisplays, nullptr, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDisplayPlaneSupportedDisplaysKHR>::Dispatch(TraceManager::Get(), result, physicalDevice, planeIndex, pDisplayCount, pDisplays);
@@ -4284,7 +4284,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSharedSwapchainsKHR(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdArray(pSwapchains, swapchainCount);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(result, device, swapchainCount, pSwapchains, pCreateInfos, encoder);
+        TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, void*, SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(result, device, nullptr, swapchainCount, pSwapchains, pCreateInfos, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateSharedSwapchainsKHR>::Dispatch(TraceManager::Get(), result, device, swapchainCount, pCreateInfos, pAllocator, pSwapchains);
@@ -7533,7 +7533,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(
         EncodeStructPtr(encoder, pAllocator);
         encoder->EncodeHandleIdArray(pPipelines, createInfoCount);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, PipelineWrapper, VkRayTracingPipelineCreateInfoNV>(result, device, createInfoCount, pPipelines, pCreateInfos, encoder);
+        TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, VkPipelineCache, PipelineWrapper, VkRayTracingPipelineCreateInfoNV>(result, device, pipelineCache, createInfoCount, pPipelines, pCreateInfos, encoder);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesNV>::Dispatch(TraceManager::Get(), result, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);


### PR DESCRIPTION
* Track swapchain image with swapchain wrapper.
* Write window resize commands to state snapshot prior to writing swapchain creation packet.