### PR TITLE
Add 'Get Property' API Call Tracking for Trimming State Snapshot

### DIFF
--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -31,6 +31,11 @@ target_sources(gfxrecon_encode
                    ${CMAKE_SOURCE_DIR}/framework/generated/generated_encode_pnext_struct.cpp
               )
 
+if (MSVC AND (MSVC_VERSION LESS 1910))
+    # This file fails to compile with VS2015, requiring the default section limit of 2^16 to be increased.
+    set_source_files_properties(${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_api_call_encoders.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+endif()
+
 target_include_directories(gfxrecon_encode
                            PUBLIC
                                ${CMAKE_SOURCE_DIR}/framework)

--- a/framework/encode/custom_encoder_commands.h
+++ b/framework/encode/custom_encoder_commands.h
@@ -78,6 +78,26 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemor
 };
 
 template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties2>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkGetPhysicalDeviceMemoryProperties2(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties2KHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkGetPhysicalDeviceMemoryProperties2(args...);
+    }
+};
+
+template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties>
 {
     template <typename... Args>

--- a/framework/encode/custom_encoder_commands.h
+++ b/framework/encode/custom_encoder_commands.h
@@ -129,6 +129,46 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueue
     }
 };
 
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceSupportKHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkGetPhysicalDeviceSurfaceSupportKHR(result, args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceCapabilitiesKHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(result, args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceFormatsKHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkGetPhysicalDeviceSurfaceFormatsKHR(result, args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfacePresentModesKHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkGetPhysicalDeviceSurfacePresentModesKHR(result, args...);
+    }
+};
+
 // Dispatch custom command for window resize command generation.
 template <>
 struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateSwapchainKHR>
@@ -440,18 +480,6 @@ struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdate
         manager->PreProcess_vkDestroyDescriptorUpdateTemplateKHR(args...);
     }
 };
-
-#if defined(__ANDROID__)
-template <>
-struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfacePresentModesKHR>
-{
-    template <typename... Args>
-    static void Dispatch(TraceManager* manager, Args... args)
-    {
-        manager->PreProcess_GetPhysicalDeviceSurfacePresentModesKHR(args...);
-    }
-};
-#endif
 
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/custom_encoder_commands.h
+++ b/framework/encode/custom_encoder_commands.h
@@ -77,6 +77,38 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemor
     }
 };
 
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkGetPhysicalDeviceQueueFamilyProperties(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties2>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkGetPhysicalDeviceQueueFamilyProperties2(
+            format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties2, args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties2KHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkGetPhysicalDeviceQueueFamilyProperties2(
+            format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties2KHR, args...);
+    }
+};
+
 // Dispatch custom command for window resize command generation.
 template <>
 struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateSwapchainKHR>

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -985,22 +985,14 @@ void TraceManager::PreProcess_vkDestroyDescriptorUpdateTemplateKHR(VkDevice     
 }
 
 #if defined(__ANDROID__)
-void TraceManager::PreProcess_GetPhysicalDeviceSurfacePresentModesKHR(VkResult          result,
-                                                                      VkPhysicalDevice  physicalDevice,
-                                                                      VkSurfaceKHR      surface,
-                                                                      uint32_t*         pPresentModeCount,
-                                                                      VkPresentModeKHR* pPresentModes)
+void TraceManager::OverrideGetPhysicalDeviceSurfacePresentModesKHR(uint32_t*         pPresentModeCount,
+                                                                   VkPresentModeKHR* pPresentModes)
 {
-    GFXRECON_UNREFERENCED_PARAMETER(physicalDevice);
-    GFXRECON_UNREFERENCED_PARAMETER(surface);
+    assert((pPresentModeCount != nullptr) && (pPresentModes != nullptr));
 
-    if ((result == VK_SUCCESS) && (pPresentModeCount != nullptr) && ((*pPresentModeCount) > 0) &&
-        (pPresentModes != nullptr))
+    for (uint32_t i = 0; i < (*pPresentModeCount); ++i)
     {
-        for (uint32_t i = 0; i < (*pPresentModeCount); ++i)
-        {
-            pPresentModes[i] = VK_PRESENT_MODE_FIFO_KHR;
-        }
+        pPresentModes[i] = VK_PRESENT_MODE_FIFO_KHR;
     }
 }
 #endif

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -236,6 +236,33 @@ class TraceManager
         }
     }
 
+    void PostProcess_vkGetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice         physicalDevice,
+                                                              uint32_t*                pQueueFamilyPropertyCount,
+                                                              VkQueueFamilyProperties* pQueueFamilyProperties)
+    {
+        if (((capture_mode_ & kModeTrack) == kModeTrack) && (pQueueFamilyPropertyCount != nullptr) &&
+            (pQueueFamilyProperties != nullptr))
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackPhysicalDeviceQueueFamilyProperties(
+                physicalDevice, *pQueueFamilyPropertyCount, pQueueFamilyProperties);
+        }
+    }
+
+    void PostProcess_vkGetPhysicalDeviceQueueFamilyProperties2(format::ApiCallId         call_id,
+                                                               VkPhysicalDevice          physicalDevice,
+                                                               uint32_t*                 pQueueFamilyPropertyCount,
+                                                               VkQueueFamilyProperties2* pQueueFamilyProperties)
+    {
+        if (((capture_mode_ & kModeTrack) == kModeTrack) && (pQueueFamilyPropertyCount != nullptr) &&
+            (pQueueFamilyProperties != nullptr))
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackPhysicalDeviceQueueFamilyProperties2(
+                call_id, physicalDevice, *pQueueFamilyPropertyCount, pQueueFamilyProperties);
+        }
+    }
+
     void PreProcess_vkCreateSwapchain(VkDevice                        device,
                                       const VkSwapchainCreateInfoKHR* pCreateInfo,
                                       const VkAllocationCallbacks*    pAllocator,

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -236,6 +236,16 @@ class TraceManager
         }
     }
 
+    void PostProcess_vkGetPhysicalDeviceMemoryProperties2(VkPhysicalDevice                   physicalDevice,
+                                                          VkPhysicalDeviceMemoryProperties2* pMemoryProperties)
+    {
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties);
+        }
+    }
+
     void PostProcess_vkGetPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice         physicalDevice,
                                                               uint32_t*                pQueueFamilyPropertyCount,
                                                               VkQueueFamilyProperties* pQueueFamilyProperties)

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -273,6 +273,65 @@ class TraceManager
         }
     }
 
+    void PostProcess_vkGetPhysicalDeviceSurfaceSupportKHR(VkResult         result,
+                                                          VkPhysicalDevice physicalDevice,
+                                                          uint32_t         queueFamilyIndex,
+                                                          VkSurfaceKHR     surface,
+                                                          VkBool32*        pSupported)
+    {
+        if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS) && (pSupported != nullptr))
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackPhysicalDeviceSurfaceSupport(physicalDevice, queueFamilyIndex, surface, *pSupported);
+        }
+    }
+
+    void PostProcess_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(VkResult                  result,
+                                                               VkPhysicalDevice          physicalDevice,
+                                                               VkSurfaceKHR              surface,
+                                                               VkSurfaceCapabilitiesKHR* pSurfaceCapabilities)
+    {
+        if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS) && (pSurfaceCapabilities != nullptr))
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackPhysicalDeviceSurfaceCapabilities(physicalDevice, surface, *pSurfaceCapabilities);
+        }
+    }
+
+    void PostProcess_vkGetPhysicalDeviceSurfaceFormatsKHR(VkResult            result,
+                                                          VkPhysicalDevice    physicalDevice,
+                                                          VkSurfaceKHR        surface,
+                                                          uint32_t*           pSurfaceFormatCount,
+                                                          VkSurfaceFormatKHR* pSurfaceFormats)
+    {
+        if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS) &&
+            (pSurfaceFormatCount != nullptr) && (pSurfaceFormats != nullptr))
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackPhysicalDeviceSurfaceFormats(
+                physicalDevice, surface, *pSurfaceFormatCount, pSurfaceFormats);
+        }
+    }
+
+    void PostProcess_vkGetPhysicalDeviceSurfacePresentModesKHR(VkResult          result,
+                                                               VkPhysicalDevice  physicalDevice,
+                                                               VkSurfaceKHR      surface,
+                                                               uint32_t*         pPresentModeCount,
+                                                               VkPresentModeKHR* pPresentModes)
+    {
+        if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS) && (pPresentModeCount != nullptr) &&
+            (pPresentModes != nullptr))
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackPhysicalDeviceSurfacePresentModes(
+                physicalDevice, surface, *pPresentModeCount, pPresentModes);
+
+#if defined(__ANDROID__)
+            OverrideGetPhysicalDeviceSurfacePresentModesKHR(pPresentModeCount, pPresentModes);
+#endif
+        }
+    }
+
     void PreProcess_vkCreateSwapchain(VkDevice                        device,
                                       const VkSwapchainCreateInfoKHR* pCreateInfo,
                                       const VkAllocationCallbacks*    pAllocator,
@@ -565,11 +624,7 @@ class TraceManager
                                                          const VkAllocationCallbacks* pAllocator);
 
 #if defined(__ANDROID__)
-    void PreProcess_GetPhysicalDeviceSurfacePresentModesKHR(VkResult          result,
-                                                            VkPhysicalDevice  physicalDevice,
-                                                            VkSurfaceKHR      surface,
-                                                            uint32_t*         pPresentModeCount,
-                                                            VkPresentModeKHR* pPresentModes);
+    void OverrideGetPhysicalDeviceSurfacePresentModesKHR(uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes);
 #endif
 
   protected:

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -150,8 +150,10 @@ struct DisplayKHRWrapper : public HandleWrapper<VkDisplayKHR>
 // handle wrapper, which will ensure it is destroyed when the VkInstance handle wrapper is destroyed.
 struct PhysicalDeviceWrapper : public HandleWrapper<VkPhysicalDevice>
 {
-    std::vector<VkMemoryType>                            memory_types;
     std::unordered_map<VkDisplayKHR, DisplayKHRWrapper*> displays;
+
+    // Track memory types for use when creating snapshots of buffer and image resource memory content.
+    std::vector<VkMemoryType> memory_types;
 
     // Track queue family properties retrieval call data to write to state snapshot after physical device creation.
     // The queue family data is only written to the state snapshot if the application made the API call to retrieve it.

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -152,6 +152,14 @@ struct PhysicalDeviceWrapper : public HandleWrapper<VkPhysicalDevice>
 {
     std::vector<VkMemoryType>                            memory_types;
     std::unordered_map<VkDisplayKHR, DisplayKHRWrapper*> displays;
+
+    // Track queue family properties retrieval call data to write to state snapshot after physical device creation.
+    // The queue family data is only written to the state snapshot if the application made the API call to retrieve it.
+    format::ApiCallId                           queue_family_properties_call_id{ format::ApiCallId::ApiCall_Unknown };
+    uint32_t                                    queue_family_properties_count{ 0 };
+    std::unique_ptr<VkQueueFamilyProperties[]>  queue_family_properties;
+    std::unique_ptr<VkQueueFamilyProperties2[]> queue_family_properties2;
+    std::vector<std::unique_ptr<VkQueueFamilyCheckpointPropertiesNV>> queue_family_checkpoint_properties;
 };
 
 struct InstanceWrapper : public HandleWrapper<VkInstance>

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -120,7 +120,6 @@ struct PipelineCacheWrapper             : public HandleWrapper<VkPipelineCache> 
 struct SamplerWrapper                   : public HandleWrapper<VkSampler> {};
 struct SamplerYcbcrConversionWrapper    : public HandleWrapper<VkSamplerYcbcrConversion> {};
 struct DescriptorUpdateTemplateWrapper  : public HandleWrapper<VkDescriptorUpdateTemplate> {};
-struct SurfaceKHRWrapper                : public HandleWrapper<VkSurfaceKHR> {};
 struct DebugReportCallbackEXTWrapper    : public HandleWrapper<VkDebugReportCallbackEXT> {};
 struct DebugUtilsMessengerEXTWrapper    : public HandleWrapper<VkDebugUtilsMessengerEXT> {};
 struct ValidationCacheEXTWrapper        : public HandleWrapper<VkValidationCacheEXT> {};
@@ -347,6 +346,16 @@ struct CommandPoolWrapper : public HandleWrapper<VkCommandPool>
 {
     // Track command buffer info, which must be destroyed on command pool reset.
     std::unordered_map<VkCommandBuffer, CommandBufferWrapper*> allocated_buffers;
+};
+
+struct SurfaceKHRWrapper : public HandleWrapper<VkSurfaceKHR>
+{
+    // Track results from calls to vkGetPhysicalDeviceSurfaceSupportKHR to write to the state snapshot after surface
+    // creation. The call is only written to the state snapshot if it was previously called by the application.
+    std::unordered_map<VkPhysicalDevice, std::unordered_map<uint32_t, VkBool32>> surface_support;
+    std::unordered_map<VkPhysicalDevice, VkSurfaceCapabilitiesKHR>               surface_capabilities;
+    std::unordered_map<VkPhysicalDevice, std::vector<VkSurfaceFormatKHR>>        surface_formats;
+    std::unordered_map<VkPhysicalDevice, std::vector<VkPresentModeKHR>>          surface_present_modes;
 };
 
 struct SwapchainKHRWrapper : public HandleWrapper<VkSwapchainKHR>

--- a/framework/encode/vulkan_state_table.h
+++ b/framework/encode/vulkan_state_table.h
@@ -206,6 +206,9 @@ class VulkanStateTable
     SemaphoreWrapper*       GetSemaphoreWrapper(format::HandleId id)       { return GetWrapper<SemaphoreWrapper>(id, semaphore_map_); }
     const SemaphoreWrapper* GetSemaphoreWrapper(format::HandleId id) const { return GetWrapper<SemaphoreWrapper>(id, semaphore_map_); }
 
+    SurfaceKHRWrapper*       GetSurfaceKHRWrapper(format::HandleId id)       { return GetWrapper<SurfaceKHRWrapper>(id, surface_khr_map_); }
+    const SurfaceKHRWrapper* GetSurfaceKHRWrapper(format::HandleId id) const { return GetWrapper<SurfaceKHRWrapper>(id, surface_khr_map_); }
+
     SwapchainKHRWrapper*       GetSwapchainKHRWrapper(format::HandleId id)       { return GetWrapper<SwapchainKHRWrapper>(id, swapchain_khr_map_); }
     const SwapchainKHRWrapper* GetSwapchainKHRWrapper(format::HandleId id) const { return GetWrapper<SwapchainKHRWrapper>(id, swapchain_khr_map_); }
     // clang-format off

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -178,6 +178,84 @@ void VulkanStateTracker::TrackPhysicalDeviceQueueFamilyProperties2(format::ApiCa
     }
 }
 
+void VulkanStateTracker::TrackPhysicalDeviceSurfaceSupport(VkPhysicalDevice physical_device,
+                                                           uint32_t         queue_family_index,
+                                                           VkSurfaceKHR     surface,
+                                                           VkBool32         supported)
+{
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    SurfaceKHRWrapper* wrapper = state_table_.GetSurfaceKHRWrapper(format::ToHandleId(surface));
+    if (wrapper != nullptr)
+    {
+        auto& entry               = wrapper->surface_support[physical_device];
+        entry[queue_family_index] = supported;
+    }
+    else
+    {
+        GFXRECON_LOG_WARNING("Attempting to track surface support state for unrecognized surface handle");
+    }
+}
+
+void VulkanStateTracker::TrackPhysicalDeviceSurfaceCapabilities(VkPhysicalDevice                physical_device,
+                                                                VkSurfaceKHR                    surface,
+                                                                const VkSurfaceCapabilitiesKHR& capabilities)
+{
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    SurfaceKHRWrapper* wrapper = state_table_.GetSurfaceKHRWrapper(format::ToHandleId(surface));
+    if (wrapper != nullptr)
+    {
+        wrapper->surface_capabilities[physical_device] = capabilities;
+    }
+    else
+    {
+        GFXRECON_LOG_WARNING("Attempting to track surface capability state for unrecognized surface handle");
+    }
+}
+
+void VulkanStateTracker::TrackPhysicalDeviceSurfaceFormats(VkPhysicalDevice          physical_device,
+                                                           VkSurfaceKHR              surface,
+                                                           uint32_t                  format_count,
+                                                           const VkSurfaceFormatKHR* formats)
+{
+    assert(formats != nullptr);
+
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    SurfaceKHRWrapper* wrapper = state_table_.GetSurfaceKHRWrapper(format::ToHandleId(surface));
+    if (wrapper != nullptr)
+    {
+        auto& entry = wrapper->surface_formats[physical_device];
+        entry.assign(formats, formats + format_count);
+    }
+    else
+    {
+        GFXRECON_LOG_WARNING("Attempting to track surface format support state for unrecognized surface handle");
+    }
+}
+
+void VulkanStateTracker::TrackPhysicalDeviceSurfacePresentModes(VkPhysicalDevice        physical_device,
+                                                                VkSurfaceKHR            surface,
+                                                                uint32_t                mode_count,
+                                                                const VkPresentModeKHR* modes)
+{
+    assert(modes != nullptr);
+
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    SurfaceKHRWrapper* wrapper = state_table_.GetSurfaceKHRWrapper(format::ToHandleId(surface));
+    if (wrapper != nullptr)
+    {
+        auto& entry = wrapper->surface_present_modes[physical_device];
+        entry.assign(modes, modes + mode_count);
+    }
+    else
+    {
+        GFXRECON_LOG_WARNING("Attempting to track surface capability state for unrecognized surface handle");
+    }
+}
+
 void VulkanStateTracker::TrackBufferMemoryBinding(VkDevice       device,
                                                   VkBuffer       buffer,
                                                   VkDeviceMemory memory,

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -214,6 +214,13 @@ class VulkanStateTracker
     void TrackPhysicalDeviceMemoryProperties(VkPhysicalDevice                        physical_device,
                                              const VkPhysicalDeviceMemoryProperties* properties);
 
+    void TrackPhysicalDeviceMemoryProperties2(VkPhysicalDevice                         physical_device,
+                                              const VkPhysicalDeviceMemoryProperties2* properties)
+    {
+        assert(properties != nullptr);
+        TrackPhysicalDeviceMemoryProperties(physical_device, &properties->memoryProperties);
+    }
+
     void TrackPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice               physical_device,
                                                   uint32_t                       property_count,
                                                   const VkQueueFamilyProperties* properties);

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -214,6 +214,15 @@ class VulkanStateTracker
     void TrackPhysicalDeviceMemoryProperties(VkPhysicalDevice                        physical_device,
                                              const VkPhysicalDeviceMemoryProperties* properties);
 
+    void TrackPhysicalDeviceQueueFamilyProperties(VkPhysicalDevice               physical_device,
+                                                  uint32_t                       property_count,
+                                                  const VkQueueFamilyProperties* properties);
+
+    void TrackPhysicalDeviceQueueFamilyProperties2(format::ApiCallId               call_id,
+                                                   VkPhysicalDevice                physical_device,
+                                                   uint32_t                        property_count,
+                                                   const VkQueueFamilyProperties2* properties);
+
     void TrackBufferMemoryBinding(VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset);
 
     void TrackImageMemoryBinding(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset);

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -230,6 +230,25 @@ class VulkanStateTracker
                                                    uint32_t                        property_count,
                                                    const VkQueueFamilyProperties2* properties);
 
+    void TrackPhysicalDeviceSurfaceSupport(VkPhysicalDevice physical_device,
+                                           uint32_t         queue_family_index,
+                                           VkSurfaceKHR     surface,
+                                           VkBool32         supported);
+
+    void TrackPhysicalDeviceSurfaceCapabilities(VkPhysicalDevice                physical_device,
+                                                VkSurfaceKHR                    surface,
+                                                const VkSurfaceCapabilitiesKHR& capabilities);
+
+    void TrackPhysicalDeviceSurfaceFormats(VkPhysicalDevice          physical_device,
+                                           VkSurfaceKHR              surface,
+                                           uint32_t                  format_count,
+                                           const VkSurfaceFormatKHR* formats);
+
+    void TrackPhysicalDeviceSurfacePresentModes(VkPhysicalDevice        physical_device,
+                                                VkSurfaceKHR            surface,
+                                                uint32_t                mode_count,
+                                                const VkPresentModeKHR* modes);
+
     void TrackBufferMemoryBinding(VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset);
 
     void TrackImageMemoryBinding(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset);

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -122,6 +122,8 @@ class VulkanStateWriter
 
     void WriteDescriptorSetState(const VulkanStateTable& state_table);
 
+    void WriteSurfaceKhrState(const VulkanStateTable& state_table);
+
     void WriteSwapchainKhrState(const VulkanStateTable& state_table);
 
     void ProcessBufferMemory(VkDevice                  device,
@@ -141,6 +143,25 @@ class VulkanStateWriter
                                                      VkPhysicalDevice  physical_device,
                                                      uint32_t          property_count,
                                                      T*                properties);
+
+    void WriteGetPhysicalDeviceSurfaceSupport(VkPhysicalDevice physical_device,
+                                              uint32_t         queue_family_index,
+                                              VkSurfaceKHR     surface,
+                                              VkBool32         supported);
+
+    void WriteGetPhysicalDeviceSurfaceCapabilities(VkPhysicalDevice                physical_device,
+                                                   VkSurfaceKHR                    surface,
+                                                   const VkSurfaceCapabilitiesKHR& capabilities);
+
+    void WriteGetPhysicalDeviceSurfaceFormats(VkPhysicalDevice          physical_device,
+                                              VkSurfaceKHR              surface,
+                                              uint32_t                  format_count,
+                                              const VkSurfaceFormatKHR* formats);
+
+    void WriteGetPhysicalDeviceSurfacePresentModes(VkPhysicalDevice        physical_device,
+                                                   VkSurfaceKHR            surface,
+                                                   uint32_t                mode_count,
+                                                   const VkPresentModeKHR* pPresentModes);
 
     void WriteStagingBufferCreateCommands(VkDevice                    device,
                                           VkDeviceSize                buffer_size,

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -98,6 +98,8 @@ class VulkanStateWriter
     };
 
   private:
+    void WritePhysicalDeviceState(const VulkanStateTable& state_table);
+
     void WriteDeviceState(const VulkanStateTable& state_table);
 
     void WriteCommandBufferState(const VulkanStateTable& state_table);
@@ -133,6 +135,12 @@ class VulkanStateWriter
                             const DeviceTable&       dispatch_table);
 
     void WriteMappedMemoryState(const VulkanStateTable& state_table);
+
+    template <typename T>
+    void WriteGetPhysicalDeviceQueueFamilyProperties(format::ApiCallId call_id,
+                                                     VkPhysicalDevice  physical_device,
+                                                     uint32_t          property_count,
+                                                     T*                properties);
 
     void WriteStagingBufferCreateCommands(VkDevice                    device,
                                           VkDeviceSize                buffer_size,


### PR DESCRIPTION
Track results from the following VkPhsyicalDevice and VkSurfaceKHR property query calls, which will be written to the state snapshot after physical device/surface creation. The calls are only written to the state snapshot if they were previously made by the application being captured.
* vkGetPhysicalDeviceQueueFamilyProperties2
* vkGetPhysicalDeviceQueueFamilyProperties2KHR
* vkGetPhysicalDeviceSurfaceSupportKHR
* vkGetPhysicalDeviceSurfaceCapabilitiesKHR
* vkGetPhysicalDeviceSurfaceFormatsKHR
* vkGetPhysicalDeviceSurfacePresentModesKHR

Adding these calls to the trimming state snapshot removes validation errors generated by vkCreateDevice and VkSwapchainKHR related calls, which expect the queries to be made.