### PR TITLE
Add Swapchain Image Acquired/Submitted State Tracking for Trimming

### DIFF
--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -354,7 +354,8 @@ class TraceManager
         if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS))
         {
             assert((state_tracker_ != nullptr) && (index != nullptr));
-            state_tracker_->TrackSemaphoreSignalState(0, nullptr, 1, &semaphore);
+            state_tracker_->TrackSemaphoreSignalState(
+                0, nullptr, 1, &semaphore, SemaphoreWrapper::SignalSourceAcquireImage);
             state_tracker_->TrackAcquireImage(*index, swapchain, semaphore, fence);
         }
     }
@@ -367,7 +368,8 @@ class TraceManager
         if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS))
         {
             assert((state_tracker_ != nullptr) && (pAcquireInfo != nullptr) && (index != nullptr));
-            state_tracker_->TrackSemaphoreSignalState(0, nullptr, 1, &pAcquireInfo->semaphore);
+            state_tracker_->TrackSemaphoreSignalState(
+                0, nullptr, 1, &pAcquireInfo->semaphore, SemaphoreWrapper::SignalSourceAcquireImage);
             state_tracker_->TrackAcquireImage(
                 *index, pAcquireInfo->swapchain, pAcquireInfo->semaphore, pAcquireInfo->fence);
         }
@@ -378,8 +380,11 @@ class TraceManager
         if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS))
         {
             assert((state_tracker_ != nullptr) && (pPresentInfo != nullptr));
-            state_tracker_->TrackSemaphoreSignalState(
-                pPresentInfo->waitSemaphoreCount, pPresentInfo->pWaitSemaphores, 0, nullptr);
+            state_tracker_->TrackSemaphoreSignalState(pPresentInfo->waitSemaphoreCount,
+                                                      pPresentInfo->pWaitSemaphores,
+                                                      0,
+                                                      nullptr,
+                                                      SemaphoreWrapper::SignalSourceQueue);
             state_tracker_->TrackPresentedImages(
                 pPresentInfo->swapchainCount, pPresentInfo->pSwapchains, pPresentInfo->pImageIndices, queue);
         }
@@ -398,7 +403,8 @@ class TraceManager
                 state_tracker_->TrackSemaphoreSignalState(pBindInfo[i].waitSemaphoreCount,
                                                           pBindInfo[i].pWaitSemaphores,
                                                           pBindInfo[i].signalSemaphoreCount,
-                                                          pBindInfo[i].pSignalSemaphores);
+                                                          pBindInfo[i].pSignalSemaphores,
+                                                          SemaphoreWrapper::SignalSourceQueue);
             }
         }
     }
@@ -515,7 +521,8 @@ class TraceManager
                 state_tracker_->TrackSemaphoreSignalState(pSubmits[i].waitSemaphoreCount,
                                                           pSubmits[i].pWaitSemaphores,
                                                           pSubmits[i].signalSemaphoreCount,
-                                                          pSubmits[i].pSignalSemaphores);
+                                                          pSubmits[i].pSignalSemaphores,
+                                                          SemaphoreWrapper::SignalSourceQueue);
             }
         }
     }

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -92,6 +92,14 @@ struct ShaderModuleInfo
     CreateParameters  create_parameters;
 };
 
+struct ImageAcquiredInfo
+{
+    bool        is_acquired{ true };
+    VkSemaphore acquired_semaphore{ VK_NULL_HANDLE };
+    VkFence     acquired_fence{ VK_NULL_HANDLE };
+    VkQueue     last_presented_queue{ VK_NULL_HANDLE };
+};
+
 //
 // Handle wrappers for storing object state information with object handles.
 //
@@ -360,13 +368,15 @@ struct SurfaceKHRWrapper : public HandleWrapper<VkSurfaceKHR>
 
 struct SwapchainKHRWrapper : public HandleWrapper<VkSwapchainKHR>
 {
-    VkDevice                   device{ VK_NULL_HANDLE };
-    VkSurfaceKHR               surface{ VK_NULL_HANDLE };
-    uint32_t                   queue_family_index{ 0 };
-    VkFormat                   format{ VK_FORMAT_UNDEFINED };
-    VkExtent3D                 extent{ 0, 0, 0 };
-    uint32_t                   array_layers{ 0 };
-    std::vector<ImageWrapper*> images;
+    VkDevice                       device{ VK_NULL_HANDLE };
+    VkSurfaceKHR                   surface{ VK_NULL_HANDLE };
+    uint32_t                       queue_family_index{ 0 };
+    VkFormat                       format{ VK_FORMAT_UNDEFINED };
+    VkExtent3D                     extent{ 0, 0, 0 };
+    uint32_t                       array_layers{ 0 };
+    uint32_t                       last_presented_image{ std::numeric_limits<uint32_t>::max() };
+    std::vector<ImageAcquiredInfo> image_acquired_info;
+    std::vector<ImageWrapper*>     images;
 };
 
 struct ObjectTableNVXWrapper : public HandleWrapper<VkObjectTableNVX>

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -244,8 +244,15 @@ struct SemaphoreWrapper : public HandleWrapper<VkSemaphore>
     // AcquireNextImageKHR, or AcquireNextImage2KHR as a signal semaphore. State is not signaled when a semaphore is
     // submitted to QueueSubmit, QueueBindSparse, or QueuePresentKHR as a wait semaphore. Initial state after creation
     // is not signaled.
-    bool     signaled{ false };
-    VkDevice device{ VK_NULL_HANDLE };
+    enum SignalSource
+    {
+        SignalSourceNone         = 0, // Semaphore is not pending signal.
+        SignalSourceQueue        = 1, // Semaphore is pending signal from a queue operation.
+        SignalSourceAcquireImage = 2  // Semaphore is pending signal from a swapchain acquire image operation.
+    };
+
+    SignalSource signaled{ SignalSourceNone };
+    VkDevice     device{ VK_NULL_HANDLE };
 };
 
 struct CommandPoolWrapper;

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -892,34 +892,41 @@ void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t           wait_count
                                                    uint32_t           signal_count,
                                                    const VkSemaphore* signals)
 {
-    if (waits != nullptr)
+    if (((waits != nullptr) && (wait_count > 0)) || ((signals != nullptr) && (signal_count > 0)))
     {
-        for (uint32_t i = 0; i < wait_count; ++i)
+        std::unique_lock<std::mutex> lock(mutex_);
+
+        if (waits != nullptr)
         {
-            SemaphoreWrapper* wrapper = state_table_.GetSemaphoreWrapper(format::ToHandleId(waits[i]));
-            if (wrapper != nullptr)
+            for (uint32_t i = 0; i < wait_count; ++i)
             {
-                wrapper->signaled = false;
-            }
-            else
-            {
-                GFXRECON_LOG_WARNING("Attempting to track semaphore signaled state for unrecognized semaphore handle");
+                SemaphoreWrapper* wrapper = state_table_.GetSemaphoreWrapper(format::ToHandleId(waits[i]));
+                if (wrapper != nullptr)
+                {
+                    wrapper->signaled = false;
+                }
+                else
+                {
+                    GFXRECON_LOG_WARNING(
+                        "Attempting to track semaphore signaled state for unrecognized semaphore handle");
+                }
             }
         }
-    }
 
-    if (signals != nullptr)
-    {
-        for (uint32_t i = 0; i < signal_count; ++i)
+        if (signals != nullptr)
         {
-            SemaphoreWrapper* wrapper = state_table_.GetSemaphoreWrapper(format::ToHandleId(signals[i]));
-            if (wrapper != nullptr)
+            for (uint32_t i = 0; i < signal_count; ++i)
             {
-                wrapper->signaled = true;
-            }
-            else
-            {
-                GFXRECON_LOG_WARNING("Attempting to track semaphore signaled state for unrecognized semaphore handle");
+                SemaphoreWrapper* wrapper = state_table_.GetSemaphoreWrapper(format::ToHandleId(signals[i]));
+                if (wrapper != nullptr)
+                {
+                    wrapper->signaled = true;
+                }
+                else
+                {
+                    GFXRECON_LOG_WARNING(
+                        "Attempting to track semaphore signaled state for unrecognized semaphore handle");
+                }
             }
         }
     }

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -887,10 +887,11 @@ void VulkanStateTracker::TrackResetDescriptorPool(VkDescriptorPool descriptor_po
     }
 }
 
-void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t           wait_count,
-                                                   const VkSemaphore* waits,
-                                                   uint32_t           signal_count,
-                                                   const VkSemaphore* signals)
+void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t                       wait_count,
+                                                   const VkSemaphore*             waits,
+                                                   uint32_t                       signal_count,
+                                                   const VkSemaphore*             signals,
+                                                   SemaphoreWrapper::SignalSource signal_source)
 {
     if (((waits != nullptr) && (wait_count > 0)) || ((signals != nullptr) && (signal_count > 0)))
     {
@@ -903,7 +904,7 @@ void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t           wait_count
                 SemaphoreWrapper* wrapper = state_table_.GetSemaphoreWrapper(format::ToHandleId(waits[i]));
                 if (wrapper != nullptr)
                 {
-                    wrapper->signaled = false;
+                    wrapper->signaled = SemaphoreWrapper::SignalSourceNone;
                 }
                 else
                 {
@@ -920,7 +921,7 @@ void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t           wait_count
                 SemaphoreWrapper* wrapper = state_table_.GetSemaphoreWrapper(format::ToHandleId(signals[i]));
                 if (wrapper != nullptr)
                 {
-                    wrapper->signaled = true;
+                    wrapper->signaled = signal_source;
                 }
                 else
                 {

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -290,6 +290,13 @@ class VulkanStateTracker
                                    uint32_t           signal_count,
                                    const VkSemaphore* signals);
 
+    void TrackAcquireImage(uint32_t image_index, VkSwapchainKHR swapchain, VkSemaphore semaphore, VkFence fence);
+
+    void TrackPresentedImages(uint32_t              count,
+                              const VkSwapchainKHR* swapchains,
+                              const uint32_t*       image_indices,
+                              VkQueue               queue);
+
   private:
     template <typename Wrapper>
     void DestroyState(Wrapper* wrapper)

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -285,10 +285,11 @@ class VulkanStateTracker
 
     void TrackResetDescriptorPool(VkDescriptorPool descriptor_pool);
 
-    void TrackSemaphoreSignalState(uint32_t           wait_count,
-                                   const VkSemaphore* waits,
-                                   uint32_t           signal_count,
-                                   const VkSemaphore* signals);
+    void TrackSemaphoreSignalState(uint32_t                       wait_count,
+                                   const VkSemaphore*             waits,
+                                   uint32_t                       signal_count,
+                                   const VkSemaphore*             signals,
+                                   SemaphoreWrapper::SignalSource signal_source);
 
     void TrackAcquireImage(uint32_t image_index, VkSwapchainKHR swapchain, VkSemaphore semaphore, VkFence fence);
 

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -611,6 +611,7 @@ inline void InitializeGroupObjectState<VkDevice, VkSwapchainKHR, ImageWrapper, v
     wrapper->queue_family_index = swapchain_wrapper->queue_family_index;
 
     swapchain_wrapper->images.push_back(wrapper);
+    swapchain_wrapper->image_acquired_info.emplace_back(ImageAcquiredInfo{});
 }
 
 template <>

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -138,6 +138,8 @@ class VulkanStateWriter
 
     void WriteMappedMemoryState(const VulkanStateTable& state_table);
 
+    void WriteSwapchainImageState(const VulkanStateTable& state_table);
+
     template <typename T>
     void WriteGetPhysicalDeviceQueueFamilyProperties(format::ApiCallId call_id,
                                                      VkPhysicalDevice  physical_device,
@@ -235,14 +237,25 @@ class VulkanStateWriter
     void WriteCommandExecution(VkQueue                queue,
                                uint32_t               command_buffer_count,
                                const VkCommandBuffer* command_buffers,
-                               uint32_t               semaphore_count,
-                               const VkSemaphore*     semaphores);
+                               uint32_t               signal_semaphore_count,
+                               const VkSemaphore*     signal_semaphores,
+                               uint32_t               wait_semaphore_count,
+                               const VkSemaphore*     wait_semaphores);
 
     void WriteCommandBufferCommands(const CommandBufferWrapper* wrapper);
 
     void WriteDescriptorUpdateCommand(VkDevice device, const DescriptorInfo* binding, VkWriteDescriptorSet* write);
 
+    void WriteAcquireNextImage(
+        VkDevice device, VkSwapchainKHR swapchain, VkSemaphore semaphore, VkFence fence, uint32_t image_index);
+
+    void WriteQueuePresent(VkQueue queue, VkSwapchainKHR swapchain, uint32_t image_index);
+
     void WriteCreateFence(VkDevice device, VkFence fence, bool signaled);
+
+    void WriteWaitForFence(VkDevice device, VkFence fence);
+
+    void WriteResetFence(VkDevice device, VkFence fence);
 
     void WriteSetEvent(VkDevice device, VkEvent event);
 
@@ -275,6 +288,8 @@ class VulkanStateWriter
             }
         });
     }
+
+    void GetFenceStatus(VkDevice device, VkFence fence, bool* result);
 
     VkMemoryPropertyFlags
     GetMemoryProperties(VkDevice device, VkDeviceMemory memory, const VulkanStateTable& state_table);


### PR DESCRIPTION
Update the trimming state tracker to track swapchain image acquire and present info, including a Boolean value to indicate that the image is currently acquired, handles for the fence and/or semaphore specified at image acquire, the handle to the queue that the image was last presented on, and the index of the last presented image.

When writing the state snapshot, swapchain images are processed with two passes. The first pass acquires each image, transitions it to the present source layout, and submits it to release it.  The second pass acquires all images up to the last presented image, in order to increase chance that the first image acquired on replay is the same image acquired by the first captured frame.  Images that are not currently acquired are released with present, while images that are currently acquired remain acquired and are transitioned to their current layout if that layout is not present source. Processing continues after the last presented image to acquire any images that are currently acquired, while images that are not acquired are ignored.

Future changes to the replay tool will allow swapchain image handling to be improved such that calls to present in the trimming state snapshot should be unnecessary.