### PR TITLE
Misc Fixes for Trimming State Track/Write

### DIFF
--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -189,7 +189,7 @@ class TraceManager
     template <typename Wrapper>
     void EndDestroyApiCallTrace(uint32_t count, const typename Wrapper::HandleType* handles, ParameterEncoder* encoder)
     {
-        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        if (((capture_mode_ & kModeTrack) == kModeTrack) && (handles != nullptr))
         {
             assert(state_tracker_ != nullptr);
 

--- a/framework/encode/vulkan_state_table.h
+++ b/framework/encode/vulkan_state_table.h
@@ -170,11 +170,17 @@ class VulkanStateTable
     BufferWrapper*       GetBufferWrapper(format::HandleId id)       { return GetWrapper<BufferWrapper>(id, buffer_map_); }
     const BufferWrapper* GetBufferWrapper(format::HandleId id) const { return GetWrapper<BufferWrapper>(id, buffer_map_); }
 
+    BufferViewWrapper*       GetBufferViewWrapper(format::HandleId id)       { return GetWrapper<BufferViewWrapper>(id, buffer_view_map_); }
+    const BufferViewWrapper* GetBufferViewWrapper(format::HandleId id) const { return GetWrapper<BufferViewWrapper>(id, buffer_view_map_); }
+
     ImageWrapper*       GetImageWrapper(format::HandleId id)       { return GetWrapper<ImageWrapper>(id, image_map_); }
     const ImageWrapper* GetImageWrapper(format::HandleId id) const { return GetWrapper<ImageWrapper>(id, image_map_); }
 
     ImageViewWrapper*       GetImageViewWrapper(format::HandleId id)       { return GetWrapper<ImageViewWrapper>(id, image_view_map_); }
     const ImageViewWrapper* GetImageViewWrapper(format::HandleId id) const { return GetWrapper<ImageViewWrapper>(id, image_view_map_); }
+
+    SamplerWrapper*       GetSamplerWrapper(format::HandleId id)       { return GetWrapper<SamplerWrapper>(id, sampler_map_); }
+    const SamplerWrapper* GetSamplerWrapper(format::HandleId id) const { return GetWrapper<SamplerWrapper>(id, sampler_map_); }
 
     FramebufferWrapper*       GetFramebufferWrapper(format::HandleId id)       { return GetWrapper<FramebufferWrapper>(id, framebuffer_map_); }
     const FramebufferWrapper* GetFramebufferWrapper(format::HandleId id) const { return GetWrapper<FramebufferWrapper>(id, framebuffer_map_); }

--- a/framework/encode/vulkan_state_table.h
+++ b/framework/encode/vulkan_state_table.h
@@ -25,7 +25,7 @@
 
 #include <cassert>
 #include <functional>
-#include <unordered_map>
+#include <map>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
@@ -221,14 +221,14 @@ class VulkanStateTable
 
   private:
     template <typename T>
-    bool InsertEntry(format::HandleId id, T* wrapper, std::unordered_map<format::HandleId, T*>& map)
+    bool InsertEntry(format::HandleId id, T* wrapper, std::map<format::HandleId, T*>& map)
     {
         const auto& inserted = map.insert(std::make_pair(id, wrapper));
         return inserted.second;
     }
 
     template <typename T>
-    T* RemoveEntry(format::HandleId id, std::unordered_map<format::HandleId, T*>& map)
+    T* RemoveEntry(format::HandleId id, std::map<format::HandleId, T*>& map)
     {
         T*   result = nullptr;
         auto entry  = map.find(id);
@@ -243,57 +243,57 @@ class VulkanStateTable
     }
 
     template <typename T>
-    T* GetWrapper(format::HandleId id, std::unordered_map<format::HandleId, T*>& map)
+    T* GetWrapper(format::HandleId id, std::map<format::HandleId, T*>& map)
     {
         auto entry = map.find(id);
         return (entry != map.end()) ? entry->second : nullptr;
     }
 
     template <typename T>
-    const T* GetWrapper(format::HandleId id, const std::unordered_map<format::HandleId, T*>& map) const
+    const T* GetWrapper(format::HandleId id, const std::map<format::HandleId, T*>& map) const
     {
         auto entry = map.find(id);
         return (entry != map.end()) ? entry->second : nullptr;
     }
 
   private:
-    std::unordered_map<format::HandleId, InstanceWrapper*>                  instance_map_;
-    std::unordered_map<format::HandleId, PhysicalDeviceWrapper*>            physical_device_map_;
-    std::unordered_map<format::HandleId, DeviceWrapper*>                    device_map_;
-    std::unordered_map<format::HandleId, QueueWrapper*>                     queue_map_;
-    std::unordered_map<format::HandleId, SemaphoreWrapper*>                 semaphore_map_;
-    std::unordered_map<format::HandleId, CommandBufferWrapper*>             command_buffer_map_;
-    std::unordered_map<format::HandleId, FenceWrapper*>                     fence_map_;
-    std::unordered_map<format::HandleId, DeviceMemoryWrapper*>              device_memory_map_;
-    std::unordered_map<format::HandleId, BufferWrapper*>                    buffer_map_;
-    std::unordered_map<format::HandleId, ImageWrapper*>                     image_map_;
-    std::unordered_map<format::HandleId, EventWrapper*>                     event_map_;
-    std::unordered_map<format::HandleId, QueryPoolWrapper*>                 query_pool_map_;
-    std::unordered_map<format::HandleId, BufferViewWrapper*>                buffer_view_map_;
-    std::unordered_map<format::HandleId, ImageViewWrapper*>                 image_view_map_;
-    std::unordered_map<format::HandleId, ShaderModuleWrapper*>              shader_module_map_;
-    std::unordered_map<format::HandleId, PipelineCacheWrapper*>             pipeline_cache_map_;
-    std::unordered_map<format::HandleId, PipelineLayoutWrapper*>            pipeline_layout_map_;
-    std::unordered_map<format::HandleId, RenderPassWrapper*>                render_pass_map_;
-    std::unordered_map<format::HandleId, PipelineWrapper*>                  pipeline_map_;
-    std::unordered_map<format::HandleId, DescriptorSetLayoutWrapper*>       descriptor_set_layout_map_;
-    std::unordered_map<format::HandleId, SamplerWrapper*>                   sampler_map_;
-    std::unordered_map<format::HandleId, DescriptorPoolWrapper*>            descriptor_pool_map_;
-    std::unordered_map<format::HandleId, DescriptorSetWrapper*>             descriptor_set_map_;
-    std::unordered_map<format::HandleId, FramebufferWrapper*>               framebuffer_map_;
-    std::unordered_map<format::HandleId, CommandPoolWrapper*>               command_pool_map_;
-    std::unordered_map<format::HandleId, SamplerYcbcrConversionWrapper*>    sampler_ycbcr_conversion_map_;
-    std::unordered_map<format::HandleId, DescriptorUpdateTemplateWrapper*>  descriptor_update_template_map_;
-    std::unordered_map<format::HandleId, SurfaceKHRWrapper*>                surface_khr_map_;
-    std::unordered_map<format::HandleId, SwapchainKHRWrapper*>              swapchain_khr_map_;
-    std::unordered_map<format::HandleId, DisplayKHRWrapper*>                display_khr_map_;
-    std::unordered_map<format::HandleId, DisplayModeKHRWrapper*>            display_mode_khr_map_;
-    std::unordered_map<format::HandleId, DebugReportCallbackEXTWrapper*>    debug_report_callback_ext_map_;
-    std::unordered_map<format::HandleId, ObjectTableNVXWrapper*>            object_table_nvx_map_;
-    std::unordered_map<format::HandleId, IndirectCommandsLayoutNVXWrapper*> indirect_commands_layout_nvx_map_;
-    std::unordered_map<format::HandleId, DebugUtilsMessengerEXTWrapper*>    debug_utils_messenger_ext_map_;
-    std::unordered_map<format::HandleId, ValidationCacheEXTWrapper*>        validation_cache_ext_map_;
-    std::unordered_map<format::HandleId, AccelerationStructureNVWrapper*>   acceleration_structure_nv_map_;
+    std::map<format::HandleId, InstanceWrapper*>                  instance_map_;
+    std::map<format::HandleId, PhysicalDeviceWrapper*>            physical_device_map_;
+    std::map<format::HandleId, DeviceWrapper*>                    device_map_;
+    std::map<format::HandleId, QueueWrapper*>                     queue_map_;
+    std::map<format::HandleId, SemaphoreWrapper*>                 semaphore_map_;
+    std::map<format::HandleId, CommandBufferWrapper*>             command_buffer_map_;
+    std::map<format::HandleId, FenceWrapper*>                     fence_map_;
+    std::map<format::HandleId, DeviceMemoryWrapper*>              device_memory_map_;
+    std::map<format::HandleId, BufferWrapper*>                    buffer_map_;
+    std::map<format::HandleId, ImageWrapper*>                     image_map_;
+    std::map<format::HandleId, EventWrapper*>                     event_map_;
+    std::map<format::HandleId, QueryPoolWrapper*>                 query_pool_map_;
+    std::map<format::HandleId, BufferViewWrapper*>                buffer_view_map_;
+    std::map<format::HandleId, ImageViewWrapper*>                 image_view_map_;
+    std::map<format::HandleId, ShaderModuleWrapper*>              shader_module_map_;
+    std::map<format::HandleId, PipelineCacheWrapper*>             pipeline_cache_map_;
+    std::map<format::HandleId, PipelineLayoutWrapper*>            pipeline_layout_map_;
+    std::map<format::HandleId, RenderPassWrapper*>                render_pass_map_;
+    std::map<format::HandleId, PipelineWrapper*>                  pipeline_map_;
+    std::map<format::HandleId, DescriptorSetLayoutWrapper*>       descriptor_set_layout_map_;
+    std::map<format::HandleId, SamplerWrapper*>                   sampler_map_;
+    std::map<format::HandleId, DescriptorPoolWrapper*>            descriptor_pool_map_;
+    std::map<format::HandleId, DescriptorSetWrapper*>             descriptor_set_map_;
+    std::map<format::HandleId, FramebufferWrapper*>               framebuffer_map_;
+    std::map<format::HandleId, CommandPoolWrapper*>               command_pool_map_;
+    std::map<format::HandleId, SamplerYcbcrConversionWrapper*>    sampler_ycbcr_conversion_map_;
+    std::map<format::HandleId, DescriptorUpdateTemplateWrapper*>  descriptor_update_template_map_;
+    std::map<format::HandleId, SurfaceKHRWrapper*>                surface_khr_map_;
+    std::map<format::HandleId, SwapchainKHRWrapper*>              swapchain_khr_map_;
+    std::map<format::HandleId, DisplayKHRWrapper*>                display_khr_map_;
+    std::map<format::HandleId, DisplayModeKHRWrapper*>            display_mode_khr_map_;
+    std::map<format::HandleId, DebugReportCallbackEXTWrapper*>    debug_report_callback_ext_map_;
+    std::map<format::HandleId, ObjectTableNVXWrapper*>            object_table_nvx_map_;
+    std::map<format::HandleId, IndirectCommandsLayoutNVXWrapper*> indirect_commands_layout_nvx_map_;
+    std::map<format::HandleId, DebugUtilsMessengerEXTWrapper*>    debug_utils_messenger_ext_map_;
+    std::map<format::HandleId, ValidationCacheEXTWrapper*>        validation_cache_ext_map_;
+    std::map<format::HandleId, AccelerationStructureNVWrapper*>   acceleration_structure_nv_map_;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -187,21 +187,25 @@ class VulkanStateTracker
     template <typename Wrapper>
     void RemoveEntry(typename Wrapper::HandleType handle)
     {
-        Wrapper* wrapper = nullptr;
+        if (handle != VK_NULL_HANDLE)
+        {
+            Wrapper* wrapper = nullptr;
 
-        {
-            std::unique_lock<std::mutex> lock(mutex_);
-            state_table_.RemoveWrapper(format::ToHandleId(handle), &wrapper);
-            DestroyState(wrapper);
-        }
+            {
+                std::unique_lock<std::mutex> lock(mutex_);
+                state_table_.RemoveWrapper(format::ToHandleId(handle), &wrapper);
+                DestroyState(wrapper);
+            }
 
-        if (wrapper != nullptr)
-        {
-            delete wrapper;
-        }
-        else
-        {
-            GFXRECON_LOG_WARNING("Attempting to remove entry from state tracker for object that is not being tracked");
+            if (wrapper != nullptr)
+            {
+                delete wrapper;
+            }
+            else
+            {
+                GFXRECON_LOG_WARNING(
+                    "Attempting to remove entry from state tracker for object that is not being tracked");
+            }
         }
     }
 

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -299,6 +299,9 @@ class VulkanStateWriter
                                  VkMemoryPropertyFlags   memory_property_flags,
                                  const VulkanStateTable& state_table);
 
+    VkQueue
+    GetQueue(VkDevice device, uint32_t queue_family_index, uint32_t queue_index, const DeviceTable& dispatch_table);
+
     VkCommandPool GetCommandPool(VkDevice device, uint32_t queue_family_index, const DeviceTable& dispatch_table);
 
     VkCommandBuffer GetCommandBuffer(VkDevice device, VkCommandPool command_pool, const DeviceTable& dispatch_table);


### PR DESCRIPTION
* When writing descriptor updates to the trimming state snapshot, omit descriptor update writes that refer to Vulkan objects that no longer exist (descriptor sets may outlive objects that they reference).
* Change the data structure used for live object tracking from std::unordered_map to std::map, so that objects can be processed in order of creation when writing the trimming state snapshot (currently requires VK_LAYER_GOOGLE_unique_objects to ensure that handle values are sequence numbers).
* Fix offset specified for staging buffer copy when writing buffer memory content to the trimming state snapshot.
* When processing Vulkan object destroy calls for state tracking, ignore handles with the VK_NULL_HANDLE value.
