### PR TITLE
Add Trimming Setting

### DIFF
--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -169,9 +169,10 @@ void CaptureSettings::LoadSingleOptionEnvVar(OptionsMap*        options,
     std::string value = util::platform::GetEnv(environment_variable.c_str());
     if (!value.empty())
     {
+        std::string entry = util::settings::RemoveQuotes(value);
         GFXRECON_LOG_INFO(
-            "Settings Loader: Found option \"%s\" with value \"%s\"", environment_variable.c_str(), value.c_str());
-        (*options)[option_key] = value;
+            "Settings Loader: Found option \"%s\" with value \"%s\"", environment_variable.c_str(), entry.c_str());
+        (*options)[option_key] = entry;
     }
 }
 

--- a/framework/encode/capture_settings.h
+++ b/framework/encode/capture_settings.h
@@ -97,6 +97,8 @@ class CaptureSettings
 
     static util::Log::Severity ParseLogLevelString(const std::string& value_string, util::Log::Severity default_value);
 
+    static void ParseTrimRangeString(const std::string& value_string, std::vector<CaptureSettings::TrimRange>* ranges);
+
   private:
     TraceSettings       trace_settings_;
     util::Log::Settings log_settings_;

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -697,7 +697,9 @@ class TraceManager
         return thread_data_.get();
     }
 
-    bool CreateCaptureFile();
+    std::string CreateTrimFilename(const std::string& base_filename, const CaptureSettings::TrimRange& trim_range);
+    bool        CreateCaptureFile(const std::string& base_filename);
+
     void WriteFileHeader();
     void BuildOptionList(const format::EnabledOptions&        enabled_options,
                          std::vector<format::FileOptionPair>* option_list);

--- a/framework/util/file_path.cpp
+++ b/framework/util/file_path.cpp
@@ -142,24 +142,28 @@ std::string Join(const std::string& lhs, const std::string& rhs)
     return joined;
 }
 
-std::string GenerateTimestampedFilename(const std::string& filename, bool use_gmt)
+std::string InsertFilenamePostfix(const std::string& filename, const std::string postfix)
 {
     std::string file_extension;
-    std::string core_filename;
-    size_t      period_loc = filename.rfind('.');
+    std::string file_part;
+    size_t      sep_index = filename.rfind('.');
 
-    if (period_loc != std::string::npos)
+    if (sep_index != std::string::npos)
     {
-        file_extension = filename.substr(period_loc, filename.length() - period_loc + 1);
-        core_filename  = filename.substr(0, period_loc);
-    }
-    else
-    {
-        file_extension = "";
-        core_filename  = filename;
+        file_extension = filename.substr(sep_index);
+        file_part      = filename.substr(0, sep_index);
+
+        return file_part + postfix + file_extension;
     }
 
-    return core_filename + "_" + util::datetime::GetDateTimeString(use_gmt) + file_extension;
+    return filename + postfix;
+}
+
+std::string GenerateTimestampedFilename(const std::string& filename, bool use_gmt)
+{
+    std::string timestamp = "_";
+    timestamp += util::datetime::GetDateTimeString(use_gmt);
+    return InsertFilenamePostfix(filename, timestamp);
 }
 
 GFXRECON_END_NAMESPACE(filepath)

--- a/framework/util/file_path.h
+++ b/framework/util/file_path.h
@@ -34,6 +34,8 @@ bool IsDirectory(const std::string& path);
 
 std::string Join(const std::string& lhs, const std::string& rhs);
 
+std::string InsertFilenamePostfix(const std::string& filename, const std::string postfix);
+
 std::string GenerateTimestampedFilename(const std::string& filename, bool use_gmt = false);
 
 GFXRECON_END_NAMESPACE(filepath)

--- a/framework/util/settings_loader.cpp
+++ b/framework/util/settings_loader.cpp
@@ -50,6 +50,30 @@ const char kSettingsEnvVar[] = "VK_LAYER_SETTINGS_PATH";
 const char kSettingsFilename[] = "vk_layer_settings.txt";
 const char kCommentDelimiter   = '#';
 
+std::string RemoveQuotes(const std::string& source)
+{
+    size_t start_index = 0;
+    size_t quote_count = 0;
+
+    if (source.front() == '\"' || source.front() == '\'')
+    {
+        start_index = 1;
+        ++quote_count;
+    }
+
+    if (source.back() == '\"' || source.back() == '\'')
+    {
+        ++quote_count;
+    }
+
+    if (quote_count > 0)
+    {
+        return source.substr(start_index, source.length() - quote_count);
+    }
+
+    return source;
+}
+
 std::string FindLayerSettingsFile()
 {
     std::string settings_file;
@@ -214,7 +238,7 @@ int32_t LoadLayerSettingsFile(const std::string&                            file
                 // Ignore entries with keys that do not start with the filter prefix.
                 if (filter.empty() || (platform::StringCompare(key, filter.c_str(), filter.length()) == 0))
                 {
-                    (*settings)[key] = value;
+                    (*settings)[key] = RemoveQuotes(value);
                 }
             }
 

--- a/framework/util/settings_loader.h
+++ b/framework/util/settings_loader.h
@@ -27,6 +27,8 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)
 GFXRECON_BEGIN_NAMESPACE(settings)
 
+std::string RemoveQuotes(const std::string& source);
+
 std::string FindLayerSettingsFile();
 
 // Returns 0 on success, value of errno on failure.


### PR DESCRIPTION
Add new settings to enable trimming by specifying one or more file ranges to capture.  Settings are:
- Desktop environment variable: GFXRECON_CAPTURE_FRAMES
- Android property: debug.gfxrecon.capture_frames
- vk_layer_settings.txt: lunarg_gfxrecon.capture_frames

Valid values for the setting consist of a string of comma separated list of frame ranges.  Frame ranges are specified for a single frame with a single number or a range of frames with two numbers separated by a '-' character specifying the first and last frame to capture.  For example, the string "20,31-35" captures frame 20 and frames 31, 32, 33, 34, and 35.  Each range is written to a separate file, where the file name includes the frame range (e.g. gfxrecon_capture_frame_20.gfxr).