### PR TITLE
Additional Command Buffer State Tracking for Trimming

### DIFF
--- a/android/framework/encode/CMakeLists.txt
+++ b/android/framework/encode/CMakeLists.txt
@@ -25,6 +25,8 @@ target_sources(gfxrecon_encode
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_state_writer.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_api_call_encoders.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_api_call_encoders.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_command_buffer_util.h
+                   ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_command_buffer_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_dispatch_table.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_struct_encoders.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_struct_encoders.cpp

--- a/android/framework/encode/CMakeLists.txt
+++ b/android/framework/encode/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(gfxrecon_encode
                    ${GFXRECON_SOURCE_DIR}/framework/encode/trace_manager.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/trace_manager.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_handle_wrappers.h
+                   ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_state_info.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_state_table.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_state_tracker.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_state_tracker.cpp

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -26,6 +26,8 @@ target_sources(gfxrecon_encode
                    vulkan_state_writer.cpp
                    ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_api_call_encoders.h
                    ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_api_call_encoders.cpp
+                   ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_command_buffer_util.h
+                   ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_command_buffer_util.cpp
                    ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_dispatch_table.h
                    ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_struct_encoders.h
                    ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_struct_encoders.cpp

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(gfxrecon_encode
                    trace_manager.h
                    trace_manager.cpp
                    vulkan_handle_wrappers.h
+                   vulkan_state_info.h
                    vulkan_state_table.h
                    vulkan_state_tracker.h
                    vulkan_state_tracker.cpp

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -26,6 +26,7 @@
 #include "format/api_call_id.h"
 #include "format/format.h"
 #include "generated/generated_vulkan_dispatch_table.h"
+#include "generated/generated_vulkan_command_buffer_util.h"
 #include "util/compressor.h"
 #include "util/defines.h"
 #include "util/file_output_stream.h"
@@ -212,6 +213,26 @@ class TraceManager
             assert(thread_data != nullptr);
 
             state_tracker_->TrackCommand(command_buffer, thread_data->call_id_, thread_data->parameter_buffer_.get());
+        }
+
+        EndApiCallTrace(encoder);
+    }
+
+    template <typename GetHandlesFunc, typename... GetHandlesArgs>
+    void EndCommandApiCallTrace(VkCommandBuffer   command_buffer,
+                                ParameterEncoder* encoder,
+                                GetHandlesFunc    func,
+                                GetHandlesArgs... args)
+    {
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            assert(state_tracker_ != nullptr);
+
+            auto thread_data = GetThreadData();
+            assert(thread_data != nullptr);
+
+            state_tracker_->TrackCommand(
+                command_buffer, thread_data->call_id_, thread_data->parameter_buffer_.get(), func, args...);
         }
 
         EndApiCallTrace(encoder);

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -26,6 +26,7 @@
 
 #include <limits>
 #include <memory>
+#include <set>
 #include <unordered_map>
 #include <vector>
 
@@ -190,8 +191,9 @@ struct SemaphoreWrapper : public HandleWrapper<VkSemaphore>
 struct CommandPoolWrapper;
 struct CommandBufferWrapper : public HandleWrapper<VkCommandBuffer>
 {
-    VkCommandBufferLevel     level{ VK_COMMAND_BUFFER_LEVEL_PRIMARY };
-    util::MemoryOutputStream command_data;
+    VkCommandBufferLevel       level{ VK_COMMAND_BUFFER_LEVEL_PRIMARY };
+    util::MemoryOutputStream   command_data;
+    std::set<format::HandleId> command_handles[CommandHandleType::NumHandleTypes];
 
     // Pool from which command buffer was allocated. The command buffer must be removed from the pool's allocation list
     // when destroyed.

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -14,9 +14,10 @@
 ** limitations under the License.
 */
 
-#ifndef GFXRECON_ENCODE_HANDLE_WRAPPERS_H
-#define GFXRECON_ENCODE_HANDLE_WRAPPERS_H
+#ifndef GFXRECON_ENCODE_VULKAN_HANDLE_WRAPPERS_H
+#define GFXRECON_ENCODE_VULKAN_HANDLE_WRAPPERS_H
 
+#include "encode/vulkan_state_info.h"
 #include "format/format.h"
 #include "util/defines.h"
 #include "util/memory_output_stream.h"
@@ -30,75 +31,6 @@
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
-
-//
-// Types for state tracking.
-//
-
-typedef std::shared_ptr<util::MemoryOutputStream> CreateParameters;
-
-// Active query state information stored with VkQueryPool handle.
-struct QueryInfo
-{
-    static const uint32_t kInvalidIndex = std::numeric_limits<uint32_t>::max();
-
-    VkQueryControlFlags flags{ 0 };
-    uint32_t            index{ kInvalidIndex };           // Pool index for active query.
-    VkCommandBuffer     command_buffer{ VK_NULL_HANDLE }; // Command buffer for query begin.
-    format::HandleId    command_buffer_id{ 0 };
-    VkRenderPass        render_pass{ VK_NULL_HANDLE }; // Optional render pass containing query.
-    format::HandleId    render_pass_id{ 0 };
-};
-
-struct DescriptorBindingInfo
-{
-    uint32_t         binding_index{ 0 };
-    uint32_t         count{ 0 };
-    VkDescriptorType type;
-};
-
-struct DescriptorInfo
-{
-    VkDescriptorType                          type;
-    uint32_t                                  count{ 0 };
-    std::unique_ptr<bool[]>                   written;
-    std::unique_ptr<VkDescriptorImageInfo[]>  images;
-    std::unique_ptr<VkDescriptorBufferInfo[]> buffers;
-    std::unique_ptr<VkBufferView[]>           texel_buffer_views;
-};
-
-// VkDescriptorSetLayout create info stored with VkPipelineLayout handle.
-struct DescriptorSetLayoutInfo
-{
-    VkDescriptorSetLayout handle{ VK_NULL_HANDLE };
-    format::HandleId      handle_id{ 0 };
-    format::ApiCallId     create_call_id{ format::ApiCallId::ApiCall_Unknown };
-    CreateParameters      create_parameters;
-};
-
-// Create info for all descriptor set layouts required by a pipeline layout.
-// Referenced with a shared pointer by VkPipelineLayout and VkPipeline handles.
-struct PipelineLayoutDependencies
-{
-    std::vector<DescriptorSetLayoutInfo> layouts;
-};
-
-// VkShaderModule create info stored with VkPipeline handle.
-struct ShaderModuleInfo
-{
-    VkShaderModule    handle{ VK_NULL_HANDLE };
-    format::HandleId  handle_id{ 0 };
-    format::ApiCallId create_call_id{ format::ApiCallId::ApiCall_Unknown };
-    CreateParameters  create_parameters;
-};
-
-struct ImageAcquiredInfo
-{
-    bool        is_acquired{ true };
-    VkSemaphore acquired_semaphore{ VK_NULL_HANDLE };
-    VkFence     acquired_fence{ VK_NULL_HANDLE };
-    VkQueue     last_presented_queue{ VK_NULL_HANDLE };
-};
 
 //
 // Handle wrappers for storing object state information with object handles.
@@ -399,4 +331,4 @@ struct AccelerationStructureNVWrapper : public HandleWrapper<VkAccelerationStruc
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
-#endif
+#endif // GFXRECON_ENCODE_VULKAN_HANDLE_WRAPPERS_H

--- a/framework/encode/vulkan_state_info.h
+++ b/framework/encode/vulkan_state_info.h
@@ -1,0 +1,106 @@
+/*
+** Copyright (c) 2019 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef GFXRECON_ENCODE_VULKAN_STATE_INFO_H
+#define GFXRECON_ENCODE_VULKAN_STATE_INFO_H
+
+#include "format/format.h"
+#include "util/defines.h"
+#include "util/memory_output_stream.h"
+
+#include "vulkan/vulkan.h"
+
+#include <limits>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(encode)
+
+//
+// Types for state tracking.
+//
+
+typedef std::shared_ptr<util::MemoryOutputStream> CreateParameters;
+
+// Active query state information stored with VkQueryPool handle.
+struct QueryInfo
+{
+    static const uint32_t kInvalidIndex = std::numeric_limits<uint32_t>::max();
+
+    VkQueryControlFlags flags{ 0 };
+    uint32_t            index{ kInvalidIndex };           // Pool index for active query.
+    VkCommandBuffer     command_buffer{ VK_NULL_HANDLE }; // Command buffer for query begin.
+    format::HandleId    command_buffer_id{ 0 };
+    VkRenderPass        render_pass{ VK_NULL_HANDLE }; // Optional render pass containing query.
+    format::HandleId    render_pass_id{ 0 };
+};
+
+struct DescriptorBindingInfo
+{
+    uint32_t         binding_index{ 0 };
+    uint32_t         count{ 0 };
+    VkDescriptorType type;
+};
+
+struct DescriptorInfo
+{
+    VkDescriptorType                          type;
+    uint32_t                                  count{ 0 };
+    std::unique_ptr<bool[]>                   written;
+    std::unique_ptr<VkDescriptorImageInfo[]>  images;
+    std::unique_ptr<VkDescriptorBufferInfo[]> buffers;
+    std::unique_ptr<VkBufferView[]>           texel_buffer_views;
+};
+
+// VkDescriptorSetLayout create info stored with VkPipelineLayout handle.
+struct DescriptorSetLayoutInfo
+{
+    VkDescriptorSetLayout handle{ VK_NULL_HANDLE };
+    format::HandleId      handle_id{ 0 };
+    format::ApiCallId     create_call_id{ format::ApiCallId::ApiCall_Unknown };
+    CreateParameters      create_parameters;
+};
+
+// Create info for all descriptor set layouts required by a pipeline layout.
+// Referenced with a shared pointer by VkPipelineLayout and VkPipeline handles.
+struct PipelineLayoutDependencies
+{
+    std::vector<DescriptorSetLayoutInfo> layouts;
+};
+
+// VkShaderModule create info stored with VkPipeline handle.
+struct ShaderModuleInfo
+{
+    VkShaderModule    handle{ VK_NULL_HANDLE };
+    format::HandleId  handle_id{ 0 };
+    format::ApiCallId create_call_id{ format::ApiCallId::ApiCall_Unknown };
+    CreateParameters  create_parameters;
+};
+
+struct ImageAcquiredInfo
+{
+    bool        is_acquired{ true };
+    VkSemaphore acquired_semaphore{ VK_NULL_HANDLE };
+    VkFence     acquired_fence{ VK_NULL_HANDLE };
+    VkQueue     last_presented_queue{ VK_NULL_HANDLE };
+};
+
+GFXRECON_END_NAMESPACE(encode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_ENCODE_VULKAN_STATE_INFO_H

--- a/framework/encode/vulkan_state_info.h
+++ b/framework/encode/vulkan_state_info.h
@@ -25,7 +25,6 @@
 
 #include <limits>
 #include <memory>
-#include <unordered_map>
 #include <vector>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
@@ -98,6 +97,26 @@ struct ImageAcquiredInfo
     VkSemaphore acquired_semaphore{ VK_NULL_HANDLE };
     VkFence     acquired_fence{ VK_NULL_HANDLE };
     VkQueue     last_presented_queue{ VK_NULL_HANDLE };
+};
+
+// Types for Vulkan object handles that are recorded to command buffers.
+enum CommandHandleType : uint32_t
+{
+    BufferHandle = 0,
+    CommandBufferHandle,
+    DescriptorSetHandle,
+    EventHandle,
+    FramebufferHandle,
+    ImageHandle,
+    ImageViewHandle,
+    PipelineHandle,
+    PipelineLayoutHandle,
+    QueryPoolHandle,
+    RenderPassHandle,
+    AccelerationStructureNVHandle,
+    IndirectCommandsLayoutNVXHandle,
+    ObjectTableNVXHandle,
+    NumHandleTypes
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/vulkan_state_table.h
+++ b/framework/encode/vulkan_state_table.h
@@ -200,6 +200,12 @@ class VulkanStateTable
     DescriptorSetLayoutWrapper*       GetDescriptorSetLayoutWrapper(format::HandleId id)       { return GetWrapper<DescriptorSetLayoutWrapper>(id, descriptor_set_layout_map_); }
     const DescriptorSetLayoutWrapper* GetDescriptorSetLayoutWrapper(format::HandleId id) const { return GetWrapper<DescriptorSetLayoutWrapper>(id, descriptor_set_layout_map_); }
 
+    QueryPoolWrapper*       GetQueryPoolWrapper(format::HandleId id)       { return GetWrapper<QueryPoolWrapper>(id, query_pool_map_); }
+    const QueryPoolWrapper* GetQueryPoolWrapper(format::HandleId id) const { return GetWrapper<QueryPoolWrapper>(id, query_pool_map_); }
+
+    PipelineWrapper*       GetPipelineWrapper(format::HandleId id)       { return GetWrapper<PipelineWrapper>(id, pipeline_map_); }
+    const PipelineWrapper* GetPipelineWrapper(format::HandleId id) const { return GetWrapper<PipelineWrapper>(id, pipeline_map_); }
+
     PipelineLayoutWrapper*       GetPipelineLayoutWrapper(format::HandleId id)       { return GetWrapper<PipelineLayoutWrapper>(id, pipeline_layout_map_); }
     const PipelineLayoutWrapper* GetPipelineLayoutWrapper(format::HandleId id) const { return GetWrapper<PipelineLayoutWrapper>(id, pipeline_layout_map_); }
 
@@ -209,6 +215,9 @@ class VulkanStateTable
     ShaderModuleWrapper*       GetShaderModuleWrapper(format::HandleId id)       { return GetWrapper<ShaderModuleWrapper>(id, shader_module_map_); }
     const ShaderModuleWrapper* GetShaderModuleWrapper(format::HandleId id) const { return GetWrapper<ShaderModuleWrapper>(id, shader_module_map_); }
 
+    EventWrapper*       GetEventWrapper(format::HandleId id)       { return GetWrapper<EventWrapper>(id, event_map_); }
+    const EventWrapper* GetEventWrapper(format::HandleId id) const { return GetWrapper<EventWrapper>(id, event_map_); }
+
     SemaphoreWrapper*       GetSemaphoreWrapper(format::HandleId id)       { return GetWrapper<SemaphoreWrapper>(id, semaphore_map_); }
     const SemaphoreWrapper* GetSemaphoreWrapper(format::HandleId id) const { return GetWrapper<SemaphoreWrapper>(id, semaphore_map_); }
 
@@ -217,6 +226,15 @@ class VulkanStateTable
 
     SwapchainKHRWrapper*       GetSwapchainKHRWrapper(format::HandleId id)       { return GetWrapper<SwapchainKHRWrapper>(id, swapchain_khr_map_); }
     const SwapchainKHRWrapper* GetSwapchainKHRWrapper(format::HandleId id) const { return GetWrapper<SwapchainKHRWrapper>(id, swapchain_khr_map_); }
+
+    AccelerationStructureNVWrapper*       GetAccelerationStructureNVWrapper(format::HandleId id)       { return GetWrapper<AccelerationStructureNVWrapper>(id, acceleration_structure_nv_map_); }
+    const AccelerationStructureNVWrapper* GetAccelerationStructureNVWrapper(format::HandleId id) const { return GetWrapper<AccelerationStructureNVWrapper>(id, acceleration_structure_nv_map_); }
+
+    IndirectCommandsLayoutNVXWrapper*       GetIndirectCommandsLayoutNVXWrapper(format::HandleId id)       { return GetWrapper<IndirectCommandsLayoutNVXWrapper>(id, indirect_commands_layout_nvx_map_); }
+    const IndirectCommandsLayoutNVXWrapper* GetIndirectCommandsLayoutNVXWrapper(format::HandleId id) const { return GetWrapper<IndirectCommandsLayoutNVXWrapper>(id, indirect_commands_layout_nvx_map_); }
+
+    ObjectTableNVXWrapper*       GetObjectTableNVXWrapper(format::HandleId id)       { return GetWrapper<ObjectTableNVXWrapper>(id, object_table_nvx_map_); }
+    const ObjectTableNVXWrapper* GetObjectTableNVXWrapper(format::HandleId id) const { return GetWrapper<ObjectTableNVXWrapper>(id, object_table_nvx_map_); }
     // clang-format off
 
   private:

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -758,73 +758,6 @@ void VulkanStateWriter::WritePipelineState(const VulkanStateTable& state_table)
     }
 }
 
-bool CheckDescriptorStatus(const DescriptorInfo* descriptor, uint32_t index, const VulkanStateTable& state_table)
-{
-    bool valid = false;
-
-    if (descriptor->written[index])
-    {
-        // Check for handles that may no longer exist, which indicates that this descriptor is stale and should be
-        // ignored, as there is no valid handle to write into it.
-        switch (descriptor->type)
-        {
-            case VK_DESCRIPTOR_TYPE_SAMPLER:
-                if (state_table.GetSamplerWrapper(format::ToHandleId(descriptor->images[index].sampler)) != nullptr)
-                {
-                    valid = true;
-                }
-                break;
-            case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-                // TODO: Sampler handle does not need to be valid if descriptor set was allocated from a layout with
-                // immutable samplers.
-                if ((state_table.GetSamplerWrapper(format::ToHandleId(descriptor->images[index].sampler)) != nullptr) &&
-                    (state_table.GetImageViewWrapper(format::ToHandleId(descriptor->images[index].imageView)) !=
-                     nullptr))
-                {
-                    valid = true;
-                }
-                break;
-            case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-            case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-            case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-                if (state_table.GetImageViewWrapper(format::ToHandleId(descriptor->images[index].imageView)) != nullptr)
-                {
-                    valid = true;
-                }
-                break;
-            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-            case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-            case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-                if (state_table.GetBufferWrapper(format::ToHandleId(descriptor->buffers[index].buffer)) != nullptr)
-                {
-                    valid = true;
-                }
-                break;
-            case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-            case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-                if (state_table.GetBufferViewWrapper(format::ToHandleId(descriptor->texel_buffer_views[index])) !=
-                    nullptr)
-                {
-                    valid = true;
-                }
-                descriptor->texel_buffer_views[index];
-                break;
-            case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
-                // TODO
-                break;
-            case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
-                // TODO
-                break;
-            default:
-                GFXRECON_LOG_WARNING("Attempting to check descriptor write status for unrecognized descriptor type");
-                break;
-        }
-    }
-
-    return valid;
-}
-
 void VulkanStateWriter::WriteDescriptorSetState(const VulkanStateTable& state_table)
 {
     std::set<util::MemoryOutputStream*> processed;
@@ -3154,6 +3087,75 @@ bool VulkanStateWriter::CheckCommandHandle(CommandHandleType       handle_type,
             assert(false);
             return false;
     }
+}
+
+bool VulkanStateWriter::CheckDescriptorStatus(const DescriptorInfo*   descriptor,
+                                              uint32_t                index,
+                                              const VulkanStateTable& state_table)
+{
+    bool valid = false;
+
+    if (descriptor->written[index])
+    {
+        // Check for handles that may no longer exist, which indicates that this descriptor is stale and should be
+        // ignored, as there is no valid handle to write into it.
+        switch (descriptor->type)
+        {
+            case VK_DESCRIPTOR_TYPE_SAMPLER:
+                if (state_table.GetSamplerWrapper(format::ToHandleId(descriptor->images[index].sampler)) != nullptr)
+                {
+                    valid = true;
+                }
+                break;
+            case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+                // TODO: Sampler handle does not need to be valid if descriptor set was allocated from a layout with
+                // immutable samplers.
+                if ((state_table.GetSamplerWrapper(format::ToHandleId(descriptor->images[index].sampler)) != nullptr) &&
+                    (state_table.GetImageViewWrapper(format::ToHandleId(descriptor->images[index].imageView)) !=
+                     nullptr))
+                {
+                    valid = true;
+                }
+                break;
+            case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+            case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+                if (state_table.GetImageViewWrapper(format::ToHandleId(descriptor->images[index].imageView)) != nullptr)
+                {
+                    valid = true;
+                }
+                break;
+            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+            case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+            case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+                if (state_table.GetBufferWrapper(format::ToHandleId(descriptor->buffers[index].buffer)) != nullptr)
+                {
+                    valid = true;
+                }
+                break;
+            case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+            case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+                if (state_table.GetBufferViewWrapper(format::ToHandleId(descriptor->texel_buffer_views[index])) !=
+                    nullptr)
+                {
+                    valid = true;
+                }
+                descriptor->texel_buffer_views[index];
+                break;
+            case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
+                // TODO
+                break;
+            case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
+                // TODO
+                break;
+            default:
+                GFXRECON_LOG_WARNING("Attempting to check descriptor write status for unrecognized descriptor type");
+                break;
+        }
+    }
+
+    return valid;
 }
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -345,6 +345,8 @@ class VulkanStateWriter
     bool
     CheckCommandHandle(CommandHandleType handle_type, format::HandleId handle, const VulkanStateTable& state_table);
 
+    bool CheckDescriptorStatus(const DescriptorInfo* descriptor, uint32_t index, const VulkanStateTable& state_table);
+
   private:
     util::FileOutputStream*  output_stream_;
     util::Compressor*        compressor_;

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -244,7 +244,7 @@ class VulkanStateWriter
                                uint32_t               wait_semaphore_count,
                                const VkSemaphore*     wait_semaphores);
 
-    void WriteCommandBufferCommands(const CommandBufferWrapper* wrapper);
+    void WriteCommandBufferCommands(const CommandBufferWrapper* wrapper, const VulkanStateTable& state_table);
 
     void WriteDescriptorUpdateCommand(VkDevice device, const DescriptorInfo* binding, VkWriteDescriptorSet* write);
 
@@ -339,6 +339,11 @@ class VulkanStateWriter
                                     ImageSnapshotList*         insert_list,
                                     ImageSnapshotData*         snapshot_data,
                                     const DeviceTable&         dispatch_table);
+
+    bool CheckCommandHandles(const CommandBufferWrapper* wrapper, const VulkanStateTable& state_table);
+
+    bool
+    CheckCommandHandle(CommandHandleType handle_type, format::HandleId handle, const VulkanStateTable& state_table);
 
   private:
     util::FileOutputStream*  output_stream_;

--- a/framework/generated/generate_vulkan.py
+++ b/framework/generated/generate_vulkan.py
@@ -32,6 +32,8 @@ generate_targets = [
     'generated_vulkan_struct_encoders.cpp',
     'generated_vulkan_api_call_encoders.h',
     'generated_vulkan_api_call_encoders.cpp',
+    'generated_vulkan_command_buffer_util.h',
+    'generated_vulkan_command_buffer_util.cpp',
     'generated_vulkan_dispatch_table.h',
     'generated_layer_func_table.h',
     'generated_vulkan_struct_decoders.h',

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -28,6 +28,7 @@
 #include "encode/trace_manager.h"
 #include "encode/vulkan_handle_wrappers.h"
 #include "format/api_call_id.h"
+#include "generated/generated_vulkan_command_buffer_util.h"
 #include "util/defines.h"
 
 #include "vulkan/vulkan.h"
@@ -2040,7 +2041,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(
         encoder->EncodeHandleIdValue(commandBuffer);
         EncodeStructPtr(encoder, pBeginInfo);
         encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackBeginCommandBufferHandles, pBeginInfo);
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkBeginCommandBuffer>::Dispatch(TraceManager::Get(), result, commandBuffer, pBeginInfo);
@@ -2103,7 +2104,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindPipeline(
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeEnumValue(pipelineBindPoint);
         encoder->EncodeHandleIdValue(pipeline);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdBindPipelineHandles, pipeline);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline);
@@ -2325,7 +2326,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindDescriptorSets(
         encoder->EncodeHandleIdArray(pDescriptorSets, descriptorSetCount);
         encoder->EncodeUInt32Value(dynamicOffsetCount);
         encoder->EncodeUInt32Array(pDynamicOffsets, dynamicOffsetCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdBindDescriptorSetsHandles, layout, descriptorSetCount, pDescriptorSets);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets);
@@ -2348,7 +2349,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindIndexBuffer(
         encoder->EncodeHandleIdValue(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeEnumValue(indexType);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdBindIndexBufferHandles, buffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdBindIndexBuffer(commandBuffer, buffer, offset, indexType);
@@ -2373,7 +2374,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindVertexBuffers(
         encoder->EncodeUInt32Value(bindingCount);
         encoder->EncodeHandleIdArray(pBuffers, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pOffsets, bindingCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdBindVertexBuffersHandles, bindingCount, pBuffers);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets);
@@ -2450,7 +2451,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirect(
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeUInt32Value(drawCount);
         encoder->EncodeUInt32Value(stride);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdDrawIndirectHandles, buffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride);
@@ -2475,7 +2476,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirect(
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeUInt32Value(drawCount);
         encoder->EncodeUInt32Value(stride);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdDrawIndexedIndirectHandles, buffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride);
@@ -2519,7 +2520,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDispatchIndirect(
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeHandleIdValue(buffer);
         encoder->EncodeVkDeviceSizeValue(offset);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdDispatchIndirectHandles, buffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdDispatchIndirect(commandBuffer, buffer, offset);
@@ -2544,7 +2545,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer(
         encoder->EncodeHandleIdValue(dstBuffer);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdCopyBufferHandles, srcBuffer, dstBuffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions);
@@ -2573,7 +2574,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImage(
         encoder->EncodeEnumValue(dstImageLayout);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdCopyImageHandles, srcImage, dstImage);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
@@ -2604,7 +2605,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBlitImage(
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
         encoder->EncodeEnumValue(filter);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdBlitImageHandles, srcImage, dstImage);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter);
@@ -2631,7 +2632,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage(
         encoder->EncodeEnumValue(dstImageLayout);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdCopyBufferToImageHandles, srcBuffer, dstImage);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions);
@@ -2658,7 +2659,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer(
         encoder->EncodeHandleIdValue(dstBuffer);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdCopyImageToBufferHandles, srcImage, dstBuffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions);
@@ -2683,7 +2684,7 @@ VKAPI_ATTR void VKAPI_CALL CmdUpdateBuffer(
         encoder->EncodeVkDeviceSizeValue(dstOffset);
         encoder->EncodeVkDeviceSizeValue(dataSize);
         encoder->EncodeVoidArray(pData, dataSize);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdUpdateBufferHandles, dstBuffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData);
@@ -2708,7 +2709,7 @@ VKAPI_ATTR void VKAPI_CALL CmdFillBuffer(
         encoder->EncodeVkDeviceSizeValue(dstOffset);
         encoder->EncodeVkDeviceSizeValue(size);
         encoder->EncodeUInt32Value(data);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdFillBufferHandles, dstBuffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data);
@@ -2735,7 +2736,7 @@ VKAPI_ATTR void VKAPI_CALL CmdClearColorImage(
         EncodeStructPtr(encoder, pColor);
         encoder->EncodeUInt32Value(rangeCount);
         EncodeStructArray(encoder, pRanges, rangeCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdClearColorImageHandles, image);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
@@ -2762,7 +2763,7 @@ VKAPI_ATTR void VKAPI_CALL CmdClearDepthStencilImage(
         EncodeStructPtr(encoder, pDepthStencil);
         encoder->EncodeUInt32Value(rangeCount);
         EncodeStructArray(encoder, pRanges, rangeCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdClearDepthStencilImageHandles, image);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges);
@@ -2816,7 +2817,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResolveImage(
         encoder->EncodeEnumValue(dstImageLayout);
         encoder->EncodeUInt32Value(regionCount);
         EncodeStructArray(encoder, pRegions, regionCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdResolveImageHandles, srcImage, dstImage);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
@@ -2837,7 +2838,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent(
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeHandleIdValue(event);
         encoder->EncodeFlagsValue(stageMask);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdSetEventHandles, event);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdSetEvent(commandBuffer, event, stageMask);
@@ -2858,7 +2859,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResetEvent(
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeHandleIdValue(event);
         encoder->EncodeFlagsValue(stageMask);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdResetEventHandles, event);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdResetEvent(commandBuffer, event, stageMask);
@@ -2895,7 +2896,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents(
         EncodeStructArray(encoder, pBufferMemoryBarriers, bufferMemoryBarrierCount);
         encoder->EncodeUInt32Value(imageMemoryBarrierCount);
         EncodeStructArray(encoder, pImageMemoryBarriers, imageMemoryBarrierCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdWaitEventsHandles, eventCount, pEvents, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
@@ -2930,7 +2931,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier(
         EncodeStructArray(encoder, pBufferMemoryBarriers, bufferMemoryBarrierCount);
         encoder->EncodeUInt32Value(imageMemoryBarrierCount);
         EncodeStructArray(encoder, pImageMemoryBarriers, imageMemoryBarrierCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdPipelineBarrierHandles, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
@@ -2953,7 +2954,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginQuery(
         encoder->EncodeHandleIdValue(queryPool);
         encoder->EncodeUInt32Value(query);
         encoder->EncodeFlagsValue(flags);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdBeginQueryHandles, queryPool);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdBeginQuery(commandBuffer, queryPool, query, flags);
@@ -2974,7 +2975,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndQuery(
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeHandleIdValue(queryPool);
         encoder->EncodeUInt32Value(query);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdEndQueryHandles, queryPool);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdEndQuery(commandBuffer, queryPool, query);
@@ -2997,7 +2998,7 @@ VKAPI_ATTR void VKAPI_CALL CmdResetQueryPool(
         encoder->EncodeHandleIdValue(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
         encoder->EncodeUInt32Value(queryCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdResetQueryPoolHandles, queryPool);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount);
@@ -3020,7 +3021,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp(
         encoder->EncodeEnumValue(pipelineStage);
         encoder->EncodeHandleIdValue(queryPool);
         encoder->EncodeUInt32Value(query);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdWriteTimestampHandles, queryPool);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query);
@@ -3051,7 +3052,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyQueryPoolResults(
         encoder->EncodeVkDeviceSizeValue(dstOffset);
         encoder->EncodeVkDeviceSizeValue(stride);
         encoder->EncodeFlagsValue(flags);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdCopyQueryPoolResultsHandles, queryPool, dstBuffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags);
@@ -3078,7 +3079,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushConstants(
         encoder->EncodeUInt32Value(offset);
         encoder->EncodeUInt32Value(size);
         encoder->EncodeVoidArray(pValues, size);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdPushConstantsHandles, layout);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues);
@@ -3099,7 +3100,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass(
         encoder->EncodeHandleIdValue(commandBuffer);
         EncodeStructPtr(encoder, pRenderPassBegin);
         encoder->EncodeEnumValue(contents);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdBeginRenderPassHandles, pRenderPassBegin);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents);
@@ -3156,7 +3157,7 @@ VKAPI_ATTR void VKAPI_CALL CmdExecuteCommands(
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeUInt32Value(commandBufferCount);
         encoder->EncodeHandleIdArray(pCommandBuffers, commandBufferCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdExecuteCommandsHandles, commandBufferCount, pCommandBuffers);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers);
@@ -5037,7 +5038,7 @@ VKAPI_ATTR void VKAPI_CALL CmdPushDescriptorSetKHR(
         encoder->EncodeUInt32Value(set);
         encoder->EncodeUInt32Value(descriptorWriteCount);
         EncodeStructArray(encoder, pDescriptorWrites, descriptorWriteCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdPushDescriptorSetKHRHandles, layout, descriptorWriteCount, pDescriptorWrites);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites);
@@ -5131,7 +5132,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass2KHR(
         encoder->EncodeHandleIdValue(commandBuffer);
         EncodeStructPtr(encoder, pRenderPassBegin);
         EncodeStructPtr(encoder, pSubpassBeginInfo);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdBeginRenderPass2KHRHandles, pRenderPassBegin);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
@@ -5664,7 +5665,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountKHR(
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdDrawIndirectCountKHRHandles, buffer, countBuffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
@@ -5693,7 +5694,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountKHR(
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdDrawIndexedIndirectCountKHRHandles, buffer, countBuffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
@@ -5897,7 +5898,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindTransformFeedbackBuffersEXT(
         encoder->EncodeHandleIdArray(pBuffers, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pOffsets, bindingCount);
         encoder->EncodeVkDeviceSizeArray(pSizes, bindingCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdBindTransformFeedbackBuffersEXTHandles, bindingCount, pBuffers);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes);
@@ -5922,7 +5923,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginTransformFeedbackEXT(
         encoder->EncodeUInt32Value(counterBufferCount);
         encoder->EncodeHandleIdArray(pCounterBuffers, counterBufferCount);
         encoder->EncodeVkDeviceSizeArray(pCounterBufferOffsets, counterBufferCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdBeginTransformFeedbackEXTHandles, counterBufferCount, pCounterBuffers);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets);
@@ -5947,7 +5948,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndTransformFeedbackEXT(
         encoder->EncodeUInt32Value(counterBufferCount);
         encoder->EncodeHandleIdArray(pCounterBuffers, counterBufferCount);
         encoder->EncodeVkDeviceSizeArray(pCounterBufferOffsets, counterBufferCount);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdEndTransformFeedbackEXTHandles, counterBufferCount, pCounterBuffers);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets);
@@ -5972,7 +5973,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginQueryIndexedEXT(
         encoder->EncodeUInt32Value(query);
         encoder->EncodeFlagsValue(flags);
         encoder->EncodeUInt32Value(index);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdBeginQueryIndexedEXTHandles, queryPool);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index);
@@ -5995,7 +5996,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndQueryIndexedEXT(
         encoder->EncodeHandleIdValue(queryPool);
         encoder->EncodeUInt32Value(query);
         encoder->EncodeUInt32Value(index);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdEndQueryIndexedEXTHandles, queryPool);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index);
@@ -6024,7 +6025,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectByteCountEXT(
         encoder->EncodeVkDeviceSizeValue(counterBufferOffset);
         encoder->EncodeUInt32Value(counterOffset);
         encoder->EncodeUInt32Value(vertexStride);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdDrawIndirectByteCountEXTHandles, counterBuffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride);
@@ -6075,7 +6076,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndirectCountAMD(
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdDrawIndirectCountAMDHandles, buffer, countBuffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
@@ -6104,7 +6105,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawIndexedIndirectCountAMD(
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdDrawIndexedIndirectCountAMDHandles, buffer, countBuffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
@@ -6239,7 +6240,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginConditionalRenderingEXT(
     {
         encoder->EncodeHandleIdValue(commandBuffer);
         EncodeStructPtr(encoder, pConditionalRenderingBegin);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdBeginConditionalRenderingEXTHandles, pConditionalRenderingBegin);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin);
@@ -6275,7 +6276,7 @@ VKAPI_ATTR void VKAPI_CALL CmdProcessCommandsNVX(
     {
         encoder->EncodeHandleIdValue(commandBuffer);
         EncodeStructPtr(encoder, pProcessCommandsInfo);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdProcessCommandsNVXHandles, pProcessCommandsInfo);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdProcessCommandsNVX(commandBuffer, pProcessCommandsInfo);
@@ -6294,7 +6295,7 @@ VKAPI_ATTR void VKAPI_CALL CmdReserveSpaceForCommandsNVX(
     {
         encoder->EncodeHandleIdValue(commandBuffer);
         EncodeStructPtr(encoder, pReserveSpaceInfo);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdReserveSpaceForCommandsNVXHandles, pReserveSpaceInfo);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdReserveSpaceForCommandsNVX(commandBuffer, pReserveSpaceInfo);
@@ -7264,7 +7265,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBindShadingRateImageNV(
         encoder->EncodeHandleIdValue(commandBuffer);
         encoder->EncodeHandleIdValue(imageView);
         encoder->EncodeEnumValue(imageLayout);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdBindShadingRateImageNVHandles, imageView);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout);
@@ -7435,7 +7436,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructureNV(
         encoder->EncodeHandleIdValue(src);
         encoder->EncodeHandleIdValue(scratch);
         encoder->EncodeVkDeviceSizeValue(scratchOffset);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdBuildAccelerationStructureNVHandles, pInfo, instanceData, dst, src, scratch);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset);
@@ -7458,7 +7459,7 @@ VKAPI_ATTR void VKAPI_CALL CmdCopyAccelerationStructureNV(
         encoder->EncodeHandleIdValue(dst);
         encoder->EncodeHandleIdValue(src);
         encoder->EncodeEnumValue(mode);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdCopyAccelerationStructureNVHandles, dst, src);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode);
@@ -7503,7 +7504,7 @@ VKAPI_ATTR void VKAPI_CALL CmdTraceRaysNV(
         encoder->EncodeUInt32Value(width);
         encoder->EncodeUInt32Value(height);
         encoder->EncodeUInt32Value(depth);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdTraceRaysNVHandles, raygenShaderBindingTableBuffer, missShaderBindingTableBuffer, hitShaderBindingTableBuffer, callableShaderBindingTableBuffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth);
@@ -7616,7 +7617,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteAccelerationStructuresPropertiesNV(
         encoder->EncodeEnumValue(queryType);
         encoder->EncodeHandleIdValue(queryPool);
         encoder->EncodeUInt32Value(firstQuery);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdWriteAccelerationStructuresPropertiesNVHandles, accelerationStructureCount, pAccelerationStructures, queryPool);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery);
@@ -7691,7 +7692,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteBufferMarkerAMD(
         encoder->EncodeHandleIdValue(dstBuffer);
         encoder->EncodeVkDeviceSizeValue(dstOffset);
         encoder->EncodeUInt32Value(marker);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdWriteBufferMarkerAMDHandles, dstBuffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
@@ -7789,7 +7790,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectNV(
         encoder->EncodeVkDeviceSizeValue(offset);
         encoder->EncodeUInt32Value(drawCount);
         encoder->EncodeUInt32Value(stride);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdDrawMeshTasksIndirectNVHandles, buffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride);
@@ -7818,7 +7819,7 @@ VKAPI_ATTR void VKAPI_CALL CmdDrawMeshTasksIndirectCountNV(
         encoder->EncodeVkDeviceSizeValue(countBufferOffset);
         encoder->EncodeUInt32Value(maxDrawCount);
         encoder->EncodeUInt32Value(stride);
-        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder);
+        TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdDrawMeshTasksIndirectCountNVHandles, buffer, countBuffer);
     }
 
     TraceManager::Get()->GetDeviceTable(commandBuffer)->CmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);

--- a/framework/generated/generated_vulkan_command_buffer_util.cpp
+++ b/framework/generated/generated_vulkan_command_buffer_util.cpp
@@ -1,0 +1,539 @@
+/*
+** Copyright (c) 2018-2019 Valve Corporation
+** Copyright (c) 2018-2019 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+/*
+** This file is generated from the Khronos Vulkan XML API Registry.
+**
+*/
+
+#include "generated/generated_vulkan_command_buffer_util.h"
+
+#include "format/format.h"
+#include "format/format_util.h"
+#include "encode/vulkan_state_info.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(encode)
+
+void TrackBeginCommandBufferHandles(CommandBufferWrapper* wrapper, const VkCommandBufferBeginInfo* pBeginInfo)
+{
+    assert(wrapper != nullptr);
+
+    if (pBeginInfo != nullptr)
+    {
+    }
+}
+
+void TrackCmdBindPipelineHandles(CommandBufferWrapper* wrapper, VkPipeline pipeline)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::PipelineHandle].insert(format::ToHandleId(pipeline));
+}
+
+void TrackCmdBindDescriptorSetsHandles(CommandBufferWrapper* wrapper, VkPipelineLayout layout, uint32_t descriptorSetCount, const VkDescriptorSet* pDescriptorSets)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(format::ToHandleId(layout));
+
+    if (pDescriptorSets != nullptr)
+    {
+        for (uint32_t i = 0; i < descriptorSetCount; ++i)
+        {
+            wrapper->command_handles[CommandHandleType::DescriptorSetHandle].insert(format::ToHandleId(pDescriptorSets[i]));
+        }
+    }
+}
+
+void TrackCmdBindIndexBufferHandles(CommandBufferWrapper* wrapper, VkBuffer buffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(buffer));
+}
+
+void TrackCmdBindVertexBuffersHandles(CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
+{
+    assert(wrapper != nullptr);
+
+    if (pBuffers != nullptr)
+    {
+        for (uint32_t i = 0; i < bindingCount; ++i)
+        {
+            wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(pBuffers[i]));
+        }
+    }
+}
+
+void TrackCmdDrawIndirectHandles(CommandBufferWrapper* wrapper, VkBuffer buffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(buffer));
+}
+
+void TrackCmdDrawIndexedIndirectHandles(CommandBufferWrapper* wrapper, VkBuffer buffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(buffer));
+}
+
+void TrackCmdDispatchIndirectHandles(CommandBufferWrapper* wrapper, VkBuffer buffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(buffer));
+}
+
+void TrackCmdCopyBufferHandles(CommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkBuffer dstBuffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(srcBuffer));
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(dstBuffer));
+}
+
+void TrackCmdCopyImageHandles(CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::ImageHandle].insert(format::ToHandleId(srcImage));
+    wrapper->command_handles[CommandHandleType::ImageHandle].insert(format::ToHandleId(dstImage));
+}
+
+void TrackCmdBlitImageHandles(CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::ImageHandle].insert(format::ToHandleId(srcImage));
+    wrapper->command_handles[CommandHandleType::ImageHandle].insert(format::ToHandleId(dstImage));
+}
+
+void TrackCmdCopyBufferToImageHandles(CommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkImage dstImage)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(srcBuffer));
+    wrapper->command_handles[CommandHandleType::ImageHandle].insert(format::ToHandleId(dstImage));
+}
+
+void TrackCmdCopyImageToBufferHandles(CommandBufferWrapper* wrapper, VkImage srcImage, VkBuffer dstBuffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::ImageHandle].insert(format::ToHandleId(srcImage));
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(dstBuffer));
+}
+
+void TrackCmdUpdateBufferHandles(CommandBufferWrapper* wrapper, VkBuffer dstBuffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(dstBuffer));
+}
+
+void TrackCmdFillBufferHandles(CommandBufferWrapper* wrapper, VkBuffer dstBuffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(dstBuffer));
+}
+
+void TrackCmdClearColorImageHandles(CommandBufferWrapper* wrapper, VkImage image)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::ImageHandle].insert(format::ToHandleId(image));
+}
+
+void TrackCmdClearDepthStencilImageHandles(CommandBufferWrapper* wrapper, VkImage image)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::ImageHandle].insert(format::ToHandleId(image));
+}
+
+void TrackCmdResolveImageHandles(CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::ImageHandle].insert(format::ToHandleId(srcImage));
+    wrapper->command_handles[CommandHandleType::ImageHandle].insert(format::ToHandleId(dstImage));
+}
+
+void TrackCmdSetEventHandles(CommandBufferWrapper* wrapper, VkEvent event)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::EventHandle].insert(format::ToHandleId(event));
+}
+
+void TrackCmdResetEventHandles(CommandBufferWrapper* wrapper, VkEvent event)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::EventHandle].insert(format::ToHandleId(event));
+}
+
+void TrackCmdWaitEventsHandles(CommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers)
+{
+    assert(wrapper != nullptr);
+
+    if (pEvents != nullptr)
+    {
+        for (uint32_t i = 0; i < eventCount; ++i)
+        {
+            wrapper->command_handles[CommandHandleType::EventHandle].insert(format::ToHandleId(pEvents[i]));
+        }
+    }
+
+    if (pBufferMemoryBarriers != nullptr)
+    {
+        for (uint32_t i = 0; i < bufferMemoryBarrierCount; ++i)
+        {
+            wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(pBufferMemoryBarriers[i].buffer));
+        }
+    }
+
+    if (pImageMemoryBarriers != nullptr)
+    {
+        for (uint32_t i = 0; i < imageMemoryBarrierCount; ++i)
+        {
+            wrapper->command_handles[CommandHandleType::ImageHandle].insert(format::ToHandleId(pImageMemoryBarriers[i].image));
+        }
+    }
+}
+
+void TrackCmdPipelineBarrierHandles(CommandBufferWrapper* wrapper, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers)
+{
+    assert(wrapper != nullptr);
+
+    if (pBufferMemoryBarriers != nullptr)
+    {
+        for (uint32_t i = 0; i < bufferMemoryBarrierCount; ++i)
+        {
+            wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(pBufferMemoryBarriers[i].buffer));
+        }
+    }
+
+    if (pImageMemoryBarriers != nullptr)
+    {
+        for (uint32_t i = 0; i < imageMemoryBarrierCount; ++i)
+        {
+            wrapper->command_handles[CommandHandleType::ImageHandle].insert(format::ToHandleId(pImageMemoryBarriers[i].image));
+        }
+    }
+}
+
+void TrackCmdBeginQueryHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(format::ToHandleId(queryPool));
+}
+
+void TrackCmdEndQueryHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(format::ToHandleId(queryPool));
+}
+
+void TrackCmdResetQueryPoolHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(format::ToHandleId(queryPool));
+}
+
+void TrackCmdWriteTimestampHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(format::ToHandleId(queryPool));
+}
+
+void TrackCmdCopyQueryPoolResultsHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool, VkBuffer dstBuffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(format::ToHandleId(queryPool));
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(dstBuffer));
+}
+
+void TrackCmdPushConstantsHandles(CommandBufferWrapper* wrapper, VkPipelineLayout layout)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(format::ToHandleId(layout));
+}
+
+void TrackCmdBeginRenderPassHandles(CommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin)
+{
+    assert(wrapper != nullptr);
+
+    if (pRenderPassBegin != nullptr)
+    {
+        wrapper->command_handles[CommandHandleType::RenderPassHandle].insert(format::ToHandleId((*pRenderPassBegin).renderPass));
+        wrapper->command_handles[CommandHandleType::FramebufferHandle].insert(format::ToHandleId((*pRenderPassBegin).framebuffer));
+    }
+}
+
+void TrackCmdExecuteCommandsHandles(CommandBufferWrapper* wrapper, uint32_t commandBufferCount, const VkCommandBuffer* pCommandBuffers)
+{
+    assert(wrapper != nullptr);
+
+    if (pCommandBuffers != nullptr)
+    {
+        for (uint32_t i = 0; i < commandBufferCount; ++i)
+        {
+            wrapper->command_handles[CommandHandleType::CommandBufferHandle].insert(format::ToHandleId(pCommandBuffers[i]));
+        }
+    }
+}
+
+void TrackCmdPushDescriptorSetKHRHandles(CommandBufferWrapper* wrapper, VkPipelineLayout layout, uint32_t descriptorWriteCount, const VkWriteDescriptorSet* pDescriptorWrites)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::PipelineLayoutHandle].insert(format::ToHandleId(layout));
+
+    if (pDescriptorWrites != nullptr)
+    {
+        for (uint32_t i = 0; i < descriptorWriteCount; ++i)
+        {
+            wrapper->command_handles[CommandHandleType::DescriptorSetHandle].insert(format::ToHandleId(pDescriptorWrites[i].dstSet));
+        }
+    }
+}
+
+void TrackCmdBeginRenderPass2KHRHandles(CommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin)
+{
+    assert(wrapper != nullptr);
+
+    if (pRenderPassBegin != nullptr)
+    {
+        wrapper->command_handles[CommandHandleType::RenderPassHandle].insert(format::ToHandleId((*pRenderPassBegin).renderPass));
+        wrapper->command_handles[CommandHandleType::FramebufferHandle].insert(format::ToHandleId((*pRenderPassBegin).framebuffer));
+    }
+}
+
+void TrackCmdDrawIndirectCountKHRHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(buffer));
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(countBuffer));
+}
+
+void TrackCmdDrawIndexedIndirectCountKHRHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(buffer));
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(countBuffer));
+}
+
+void TrackCmdBindTransformFeedbackBuffersEXTHandles(CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers)
+{
+    assert(wrapper != nullptr);
+
+    if (pBuffers != nullptr)
+    {
+        for (uint32_t i = 0; i < bindingCount; ++i)
+        {
+            wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(pBuffers[i]));
+        }
+    }
+}
+
+void TrackCmdBeginTransformFeedbackEXTHandles(CommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers)
+{
+    assert(wrapper != nullptr);
+
+    if (pCounterBuffers != nullptr)
+    {
+        for (uint32_t i = 0; i < counterBufferCount; ++i)
+        {
+            wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(pCounterBuffers[i]));
+        }
+    }
+}
+
+void TrackCmdEndTransformFeedbackEXTHandles(CommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers)
+{
+    assert(wrapper != nullptr);
+
+    if (pCounterBuffers != nullptr)
+    {
+        for (uint32_t i = 0; i < counterBufferCount; ++i)
+        {
+            wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(pCounterBuffers[i]));
+        }
+    }
+}
+
+void TrackCmdBeginQueryIndexedEXTHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(format::ToHandleId(queryPool));
+}
+
+void TrackCmdEndQueryIndexedEXTHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(format::ToHandleId(queryPool));
+}
+
+void TrackCmdDrawIndirectByteCountEXTHandles(CommandBufferWrapper* wrapper, VkBuffer counterBuffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(counterBuffer));
+}
+
+void TrackCmdDrawIndirectCountAMDHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(buffer));
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(countBuffer));
+}
+
+void TrackCmdDrawIndexedIndirectCountAMDHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(buffer));
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(countBuffer));
+}
+
+void TrackCmdBeginConditionalRenderingEXTHandles(CommandBufferWrapper* wrapper, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin)
+{
+    assert(wrapper != nullptr);
+
+    if (pConditionalRenderingBegin != nullptr)
+    {
+        wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId((*pConditionalRenderingBegin).buffer));
+    }
+}
+
+void TrackCmdProcessCommandsNVXHandles(CommandBufferWrapper* wrapper, const VkCmdProcessCommandsInfoNVX* pProcessCommandsInfo)
+{
+    assert(wrapper != nullptr);
+
+    if (pProcessCommandsInfo != nullptr)
+    {
+        wrapper->command_handles[CommandHandleType::ObjectTableNVXHandle].insert(format::ToHandleId((*pProcessCommandsInfo).objectTable));
+        wrapper->command_handles[CommandHandleType::IndirectCommandsLayoutNVXHandle].insert(format::ToHandleId((*pProcessCommandsInfo).indirectCommandsLayout));
+        wrapper->command_handles[CommandHandleType::CommandBufferHandle].insert(format::ToHandleId((*pProcessCommandsInfo).targetCommandBuffer));
+        wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId((*pProcessCommandsInfo).sequencesCountBuffer));
+        wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId((*pProcessCommandsInfo).sequencesIndexBuffer));
+    }
+}
+
+void TrackCmdReserveSpaceForCommandsNVXHandles(CommandBufferWrapper* wrapper, const VkCmdReserveSpaceForCommandsInfoNVX* pReserveSpaceInfo)
+{
+    assert(wrapper != nullptr);
+
+    if (pReserveSpaceInfo != nullptr)
+    {
+        wrapper->command_handles[CommandHandleType::ObjectTableNVXHandle].insert(format::ToHandleId((*pReserveSpaceInfo).objectTable));
+        wrapper->command_handles[CommandHandleType::IndirectCommandsLayoutNVXHandle].insert(format::ToHandleId((*pReserveSpaceInfo).indirectCommandsLayout));
+    }
+}
+
+void TrackCmdBindShadingRateImageNVHandles(CommandBufferWrapper* wrapper, VkImageView imageView)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::ImageViewHandle].insert(format::ToHandleId(imageView));
+}
+
+void TrackCmdBuildAccelerationStructureNVHandles(CommandBufferWrapper* wrapper, const VkAccelerationStructureInfoNV* pInfo, VkBuffer instanceData, VkAccelerationStructureNV dst, VkAccelerationStructureNV src, VkBuffer scratch)
+{
+    assert(wrapper != nullptr);
+
+    if (pInfo != nullptr)
+    {
+    }
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(instanceData));
+    wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(format::ToHandleId(dst));
+    wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(format::ToHandleId(src));
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(scratch));
+}
+
+void TrackCmdCopyAccelerationStructureNVHandles(CommandBufferWrapper* wrapper, VkAccelerationStructureNV dst, VkAccelerationStructureNV src)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(format::ToHandleId(dst));
+    wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(format::ToHandleId(src));
+}
+
+void TrackCmdTraceRaysNVHandles(CommandBufferWrapper* wrapper, VkBuffer raygenShaderBindingTableBuffer, VkBuffer missShaderBindingTableBuffer, VkBuffer hitShaderBindingTableBuffer, VkBuffer callableShaderBindingTableBuffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(raygenShaderBindingTableBuffer));
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(missShaderBindingTableBuffer));
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(hitShaderBindingTableBuffer));
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(callableShaderBindingTableBuffer));
+}
+
+void TrackCmdWriteAccelerationStructuresPropertiesNVHandles(CommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureNV* pAccelerationStructures, VkQueryPool queryPool)
+{
+    assert(wrapper != nullptr);
+
+    if (pAccelerationStructures != nullptr)
+    {
+        for (uint32_t i = 0; i < accelerationStructureCount; ++i)
+        {
+            wrapper->command_handles[CommandHandleType::AccelerationStructureNVHandle].insert(format::ToHandleId(pAccelerationStructures[i]));
+        }
+    }
+    wrapper->command_handles[CommandHandleType::QueryPoolHandle].insert(format::ToHandleId(queryPool));
+}
+
+void TrackCmdWriteBufferMarkerAMDHandles(CommandBufferWrapper* wrapper, VkBuffer dstBuffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(dstBuffer));
+}
+
+void TrackCmdDrawMeshTasksIndirectNVHandles(CommandBufferWrapper* wrapper, VkBuffer buffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(buffer));
+}
+
+void TrackCmdDrawMeshTasksIndirectCountNVHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer)
+{
+    assert(wrapper != nullptr);
+
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(buffer));
+    wrapper->command_handles[CommandHandleType::BufferHandle].insert(format::ToHandleId(countBuffer));
+}
+
+GFXRECON_END_NAMESPACE(encode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/generated_vulkan_command_buffer_util.h
+++ b/framework/generated/generated_vulkan_command_buffer_util.h
@@ -1,0 +1,143 @@
+/*
+** Copyright (c) 2018-2019 Valve Corporation
+** Copyright (c) 2018-2019 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+/*
+** This file is generated from the Khronos Vulkan XML API Registry.
+**
+*/
+
+#ifndef  GFXRECON_GENERATED_VULKAN_COMMAND_BUFFER_UTIL_H
+#define  GFXRECON_GENERATED_VULKAN_COMMAND_BUFFER_UTIL_H
+
+#include "encode/vulkan_handle_wrappers.h"
+#include "util/defines.h"
+
+#include "vulkan/vulkan.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(encode)
+
+void TrackBeginCommandBufferHandles(CommandBufferWrapper* wrapper, const VkCommandBufferBeginInfo* pBeginInfo);
+
+void TrackCmdBindPipelineHandles(CommandBufferWrapper* wrapper, VkPipeline pipeline);
+
+void TrackCmdBindDescriptorSetsHandles(CommandBufferWrapper* wrapper, VkPipelineLayout layout, uint32_t descriptorSetCount, const VkDescriptorSet* pDescriptorSets);
+
+void TrackCmdBindIndexBufferHandles(CommandBufferWrapper* wrapper, VkBuffer buffer);
+
+void TrackCmdBindVertexBuffersHandles(CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
+
+void TrackCmdDrawIndirectHandles(CommandBufferWrapper* wrapper, VkBuffer buffer);
+
+void TrackCmdDrawIndexedIndirectHandles(CommandBufferWrapper* wrapper, VkBuffer buffer);
+
+void TrackCmdDispatchIndirectHandles(CommandBufferWrapper* wrapper, VkBuffer buffer);
+
+void TrackCmdCopyBufferHandles(CommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkBuffer dstBuffer);
+
+void TrackCmdCopyImageHandles(CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage);
+
+void TrackCmdBlitImageHandles(CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage);
+
+void TrackCmdCopyBufferToImageHandles(CommandBufferWrapper* wrapper, VkBuffer srcBuffer, VkImage dstImage);
+
+void TrackCmdCopyImageToBufferHandles(CommandBufferWrapper* wrapper, VkImage srcImage, VkBuffer dstBuffer);
+
+void TrackCmdUpdateBufferHandles(CommandBufferWrapper* wrapper, VkBuffer dstBuffer);
+
+void TrackCmdFillBufferHandles(CommandBufferWrapper* wrapper, VkBuffer dstBuffer);
+
+void TrackCmdClearColorImageHandles(CommandBufferWrapper* wrapper, VkImage image);
+
+void TrackCmdClearDepthStencilImageHandles(CommandBufferWrapper* wrapper, VkImage image);
+
+void TrackCmdResolveImageHandles(CommandBufferWrapper* wrapper, VkImage srcImage, VkImage dstImage);
+
+void TrackCmdSetEventHandles(CommandBufferWrapper* wrapper, VkEvent event);
+
+void TrackCmdResetEventHandles(CommandBufferWrapper* wrapper, VkEvent event);
+
+void TrackCmdWaitEventsHandles(CommandBufferWrapper* wrapper, uint32_t eventCount, const VkEvent* pEvents, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
+
+void TrackCmdPipelineBarrierHandles(CommandBufferWrapper* wrapper, uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier* pImageMemoryBarriers);
+
+void TrackCmdBeginQueryHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool);
+
+void TrackCmdEndQueryHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool);
+
+void TrackCmdResetQueryPoolHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool);
+
+void TrackCmdWriteTimestampHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool);
+
+void TrackCmdCopyQueryPoolResultsHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool, VkBuffer dstBuffer);
+
+void TrackCmdPushConstantsHandles(CommandBufferWrapper* wrapper, VkPipelineLayout layout);
+
+void TrackCmdBeginRenderPassHandles(CommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin);
+
+void TrackCmdExecuteCommandsHandles(CommandBufferWrapper* wrapper, uint32_t commandBufferCount, const VkCommandBuffer* pCommandBuffers);
+
+void TrackCmdPushDescriptorSetKHRHandles(CommandBufferWrapper* wrapper, VkPipelineLayout layout, uint32_t descriptorWriteCount, const VkWriteDescriptorSet* pDescriptorWrites);
+
+void TrackCmdBeginRenderPass2KHRHandles(CommandBufferWrapper* wrapper, const VkRenderPassBeginInfo* pRenderPassBegin);
+
+void TrackCmdDrawIndirectCountKHRHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+
+void TrackCmdDrawIndexedIndirectCountKHRHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+
+void TrackCmdBindTransformFeedbackBuffersEXTHandles(CommandBufferWrapper* wrapper, uint32_t bindingCount, const VkBuffer* pBuffers);
+
+void TrackCmdBeginTransformFeedbackEXTHandles(CommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers);
+
+void TrackCmdEndTransformFeedbackEXTHandles(CommandBufferWrapper* wrapper, uint32_t counterBufferCount, const VkBuffer* pCounterBuffers);
+
+void TrackCmdBeginQueryIndexedEXTHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool);
+
+void TrackCmdEndQueryIndexedEXTHandles(CommandBufferWrapper* wrapper, VkQueryPool queryPool);
+
+void TrackCmdDrawIndirectByteCountEXTHandles(CommandBufferWrapper* wrapper, VkBuffer counterBuffer);
+
+void TrackCmdDrawIndirectCountAMDHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+
+void TrackCmdDrawIndexedIndirectCountAMDHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+
+void TrackCmdBeginConditionalRenderingEXTHandles(CommandBufferWrapper* wrapper, const VkConditionalRenderingBeginInfoEXT* pConditionalRenderingBegin);
+
+void TrackCmdProcessCommandsNVXHandles(CommandBufferWrapper* wrapper, const VkCmdProcessCommandsInfoNVX* pProcessCommandsInfo);
+
+void TrackCmdReserveSpaceForCommandsNVXHandles(CommandBufferWrapper* wrapper, const VkCmdReserveSpaceForCommandsInfoNVX* pReserveSpaceInfo);
+
+void TrackCmdBindShadingRateImageNVHandles(CommandBufferWrapper* wrapper, VkImageView imageView);
+
+void TrackCmdBuildAccelerationStructureNVHandles(CommandBufferWrapper* wrapper, const VkAccelerationStructureInfoNV* pInfo, VkBuffer instanceData, VkAccelerationStructureNV dst, VkAccelerationStructureNV src, VkBuffer scratch);
+
+void TrackCmdCopyAccelerationStructureNVHandles(CommandBufferWrapper* wrapper, VkAccelerationStructureNV dst, VkAccelerationStructureNV src);
+
+void TrackCmdTraceRaysNVHandles(CommandBufferWrapper* wrapper, VkBuffer raygenShaderBindingTableBuffer, VkBuffer missShaderBindingTableBuffer, VkBuffer hitShaderBindingTableBuffer, VkBuffer callableShaderBindingTableBuffer);
+
+void TrackCmdWriteAccelerationStructuresPropertiesNVHandles(CommandBufferWrapper* wrapper, uint32_t accelerationStructureCount, const VkAccelerationStructureNV* pAccelerationStructures, VkQueryPool queryPool);
+
+void TrackCmdWriteBufferMarkerAMDHandles(CommandBufferWrapper* wrapper, VkBuffer dstBuffer);
+
+void TrackCmdDrawMeshTasksIndirectNVHandles(CommandBufferWrapper* wrapper, VkBuffer buffer);
+
+void TrackCmdDrawMeshTasksIndirectCountNVHandles(CommandBufferWrapper* wrapper, VkBuffer buffer, VkBuffer countBuffer);
+
+GFXRECON_END_NAMESPACE(encode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif

--- a/framework/generated/vulkan_generators/codegen.pyproj
+++ b/framework/generated/vulkan_generators/codegen.pyproj
@@ -22,6 +22,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="vulkan_ascii_consumer_body_generator.py" />
+    <Compile Include="vulkan_command_buffer_util_body_generator.py" />
+    <Compile Include="vulkan_command_buffer_util_header_generator.py" />
     <Compile Include="vulkan_consumer_header_generator.py" />
     <Compile Include="vulkan_decoder_body_generator.py" />
     <Compile Include="vulkan_decoder_header_generator.py" />

--- a/framework/generated/vulkan_generators/gencode.py
+++ b/framework/generated/vulkan_generators/gencode.py
@@ -40,6 +40,8 @@ from vulkan_struct_handle_mappers_body_generator import VulkanStructHandleMapper
 # API Call Encoders
 from vulkan_api_call_encoders_body_generator import VulkanApiCallEncodersBodyGenerator,VulkanApiCallEncodersBodyGeneratorOptions
 from vulkan_api_call_encoders_header_generator import VulkanApiCallEncodersHeaderGenerator,VulkanApiCallEncodersHeaderGeneratorOptions
+from vulkan_command_buffer_util_body_generator import VulkanCommandBufferUtilBodyGenerator,VulkanCommandBufferUtilBodyGeneratorOptions
+from vulkan_command_buffer_util_header_generator import VulkanCommandBufferUtilHeaderGenerator,VulkanCommandBufferUtilHeaderGeneratorOptions
 from vulkan_dispatch_table_generator import VulkanDispatchTableGenerator, VulkanDispatchTableGeneratorOptions
 from layer_func_table_generator import LayerFuncTableGenerator,LayerFuncTableGeneratorOptions
 
@@ -298,6 +300,30 @@ def makeGenOpts(args):
           VulkanApiCallEncodersBodyGenerator,
           VulkanApiCallEncodersBodyGeneratorOptions(
             filename          = 'generated_vulkan_api_call_encoders.cpp',
+            directory         = directory,
+            blacklists        = blacklists,
+            platformTypes     = platformTypes,
+            prefixText        = prefixStrings + vkPrefixStrings,
+            protectFile       = False,
+            protectFeature    = False)
+        ]
+
+    genOpts['generated_vulkan_command_buffer_util.h'] = [
+          VulkanCommandBufferUtilHeaderGenerator,
+          VulkanCommandBufferUtilHeaderGeneratorOptions(
+            filename          = 'generated_vulkan_command_buffer_util.h',
+            directory         = directory,
+            blacklists        = blacklists,
+            platformTypes     = platformTypes,
+            prefixText        = prefixStrings + vkPrefixStrings,
+            protectFile       = True,
+            protectFeature    = False)
+        ]
+
+    genOpts['generated_vulkan_command_buffer_util.cpp'] = [
+          VulkanCommandBufferUtilBodyGenerator,
+          VulkanCommandBufferUtilBodyGeneratorOptions(
+            filename          = 'generated_vulkan_command_buffer_util.cpp',
             directory         = directory,
             blacklists        = blacklists,
             platformTypes     = platformTypes,

--- a/framework/generated/vulkan_generators/vulkan_command_buffer_util_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_command_buffer_util_body_generator.py
@@ -1,0 +1,182 @@
+#!/usr/bin/python3 -i
+#
+# Copyright (c) 2018-2019 Valve Corporation
+# Copyright (c) 2018-2019 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os,re,sys
+from base_generator import *
+
+class VulkanCommandBufferUtilBodyGeneratorOptions(BaseGeneratorOptions):
+    """Options for generating a C++ class for Vulkan capture file replay"""
+    def __init__(self,
+                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
+                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+                 filename = None,
+                 directory = '.',
+                 prefixText = '',
+                 protectFile = False,
+                 protectFeature = True):
+        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
+                                      filename, directory, prefixText,
+                                      protectFile, protectFeature)
+
+# VulkanCommandBufferUtilBodyGenerator - subclass of BaseGenerator.
+# Generates C++ member definitions for the VulkanReplayConsumer class responsible for
+# replaying decoded Vulkan API call parameter data.
+class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
+    """Generate a C++ class for Vulkan capture file replay"""
+    def __init__(self,
+                 errFile = sys.stderr,
+                 warnFile = sys.stderr,
+                 diagFile = sys.stdout):
+        BaseGenerator.__init__(self,
+                               processCmds=True, processStructs=True, featureBreak=False,
+                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+
+        # Map of Vulkan structs containing handles to a list values for handle members or struct members
+        # that contain handles (eg. VkGraphicsPipelineCreateInfo contains a VkPipelineShaderStageCreateInfo
+        # member that contains handles).
+        self.structsWithHandles = dict()
+
+    # Method override
+    def beginFile(self, genOpts):
+        BaseGenerator.beginFile(self, genOpts)
+
+        write('#include "generated/generated_vulkan_command_buffer_util.h"', file=self.outFile)
+        self.newline()
+        write('#include "format/format.h"', file=self.outFile)
+        write('#include "format/format_util.h"', file=self.outFile)
+        write('#include "encode/vulkan_state_info.h"', file=self.outFile)
+        self.newline()
+        write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
+        write('GFXRECON_BEGIN_NAMESPACE(encode)', file=self.outFile)
+
+    # Method override
+    def endFile(self):
+        self.newline()
+        write('GFXRECON_END_NAMESPACE(encode)', file=self.outFile)
+        write('GFXRECON_END_NAMESPACE(gfxrecon)', file=self.outFile)
+
+        # Finish processing in superclass
+        BaseGenerator.endFile(self)
+
+    #
+    # Method override
+    def genStruct(self, typeinfo, typename, alias):
+        BaseGenerator.genStruct(self, typeinfo, typename, alias)
+
+        if (typename not in self.STRUCT_BLACKLIST) and not alias:
+            self.checkStructMemberHandles(typename, self.structsWithHandles)
+
+    #
+    # Indicates that the current feature has C++ code to generate.
+    def needFeatureGeneration(self):
+        if self.featureCmdParams:
+            return True
+        return False
+
+    #
+    # Performs C++ code generation for the feature.
+    def generateFeature(self):
+        for cmd in self.featureCmdParams:
+            info = self.featureCmdParams[cmd]
+            returnType = info[0]
+            values = info[2]
+
+            if values and (len(values) > 1) and (values[0].baseType == 'VkCommandBuffer'):
+                # Check for parameters with handle types, ignoring the first VkCommandBuffer parameter.
+                handles = self.getParamListHandles(values[1:])
+
+                if (handles):
+                    # Generate a function to build a list of handle types and values.
+                    cmddef = '\n'
+                    cmddef += 'void Track{}Handles(CommandBufferWrapper* wrapper, {})\n'.format(cmd[2:], self.getArgList(handles))
+                    cmddef += '{\n'
+                    cmddef += '    assert(wrapper != nullptr);\n'
+                    cmddef += '\n'
+                    cmddef += self.makeGetHandleValuesBody(handles)
+                    cmddef += '}'
+
+                    write(cmddef, file=self.outFile)
+
+    #
+    # Create list of parameters that have handle types or are structs that contain handles.
+    def getParamListHandles(self, values):
+        handles = []
+        for value in values:
+            if self.isHandle(value.baseType):
+                handles.append(value)
+            elif self.isStruct(value.baseType) and (value.baseType in self.structsWithHandles):
+                handles.append(value)
+        return handles
+
+    #
+    #
+    def getArgList(self, values):
+        args = []
+        for value in values:
+            if value.arrayLength:
+                args.append('uint32_t {}'.format(value.arrayLength))
+            args.append('{} {}'.format(value.fullType, value.name))
+        return ', '.join(args)
+
+    #
+    #
+    def makeGetHandleValuesBody(self, values):
+        body = ''
+        first = True
+        for value in values:
+            indent = ' ' * self.INDENT_SIZE
+            valueName = value.name
+
+            if value.isPointer or value.isArray:
+                if not first:
+                    body += '\n'
+                body += indent + 'if ({} != nullptr)\n'.format(value.name)
+                body += indent + '{\n'
+                indent += ' ' * self.INDENT_SIZE
+
+                if value.isArray:
+                    body += indent + 'for (uint32_t i = 0; i < {}; ++i)\n'.format(value.arrayLength)
+                    body += indent + '{\n'
+                    indent += ' ' * self.INDENT_SIZE
+                    valueName = '{}[i]'.format(valueName)
+                else:
+                    valueName = '(*{})'.format(valueName)
+
+            if self.isHandle(value.baseType):
+                typeEnumValue = '{}Handle'.format(value.baseType[2:])
+                body += indent + 'wrapper->command_handles[CommandHandleType::{}].insert(format::ToHandleId({}));\n'.format(typeEnumValue, valueName)
+
+            elif self.isStruct(value.baseType) and (value.baseType in self.structsWithHandles):
+                for entry in self.structsWithHandles[value.baseType]:
+                    if self.isHandle(entry.baseType) and not (entry.isPointer or entry.isArray):
+                        typeEnumValue = '{}Handle'.format(entry.baseType[2:])
+                        body += indent + 'wrapper->command_handles[CommandHandleType::{}].insert(format::ToHandleId({}.{}));\n'.format(typeEnumValue, valueName, entry.name)
+
+                    else:
+                        # TODO
+                        pass
+
+            if value.isPointer or value.isArray:
+                indent = indent[0:-self.INDENT_SIZE]
+                body += indent + '}\n'
+                if value.isArray:
+                    indent = indent[0:-self.INDENT_SIZE]
+                    body += indent + '}\n'
+
+            first = False
+
+        return body

--- a/framework/generated/vulkan_generators/vulkan_command_buffer_util_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_command_buffer_util_header_generator.py
@@ -1,0 +1,128 @@
+#!/usr/bin/python3 -i
+#
+# Copyright (c) 2018-2019 Valve Corporation
+# Copyright (c) 2018-2019 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os,re,sys
+from base_generator import *
+
+class VulkanCommandBufferUtilHeaderGeneratorOptions(BaseGeneratorOptions):
+    """Options for generating a C++ class for Vulkan capture file replay"""
+    def __init__(self,
+                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
+                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+                 filename = None,
+                 directory = '.',
+                 prefixText = '',
+                 protectFile = False,
+                 protectFeature = True):
+        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
+                                      filename, directory, prefixText,
+                                      protectFile, protectFeature)
+
+# VulkanCommandBufferUtilBodyGenerator - subclass of BaseGenerator.
+# Generates C++ member definitions for the VulkanReplayConsumer class responsible for
+# replaying decoded Vulkan API call parameter data.
+class VulkanCommandBufferUtilHeaderGenerator(BaseGenerator):
+    """Generate a C++ class for Vulkan capture file replay"""
+    def __init__(self,
+                 errFile = sys.stderr,
+                 warnFile = sys.stderr,
+                 diagFile = sys.stdout):
+        BaseGenerator.__init__(self,
+                               processCmds=True, processStructs=True, featureBreak=False,
+                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+
+        # Map of Vulkan structs containing handles to a list values for handle members or struct members
+        # that contain handles (eg. VkGraphicsPipelineCreateInfo contains a VkPipelineShaderStageCreateInfo
+        # member that contains handles).
+        self.structsWithHandles = dict()
+
+    # Method override
+    def beginFile(self, genOpts):
+        BaseGenerator.beginFile(self, genOpts)
+
+        write('#include "encode/vulkan_handle_wrappers.h"', file=self.outFile)
+        write('#include "util/defines.h"', file=self.outFile)
+        self.newline()
+        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.newline()
+        write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
+        write('GFXRECON_BEGIN_NAMESPACE(encode)', file=self.outFile)
+
+    # Method override
+    def endFile(self):
+        self.newline()
+        write('GFXRECON_END_NAMESPACE(encode)', file=self.outFile)
+        write('GFXRECON_END_NAMESPACE(gfxrecon)', file=self.outFile)
+
+        # Finish processing in superclass
+        BaseGenerator.endFile(self)
+
+    #
+    # Method override
+    def genStruct(self, typeinfo, typename, alias):
+        BaseGenerator.genStruct(self, typeinfo, typename, alias)
+
+        if (typename not in self.STRUCT_BLACKLIST) and not alias:
+            self.checkStructMemberHandles(typename, self.structsWithHandles)
+
+    #
+    # Indicates that the current feature has C++ code to generate.
+    def needFeatureGeneration(self):
+        if self.featureCmdParams:
+            return True
+        return False
+
+    #
+    # Performs C++ code generation for the feature.
+    def generateFeature(self):
+        first = True
+        for cmd in self.featureCmdParams:
+            info = self.featureCmdParams[cmd]
+            returnType = info[0]
+            values = info[2]
+
+            if values and (len(values) > 1) and (values[0].baseType == 'VkCommandBuffer'):
+                # Check for parameters with handle types, ignoring the first VkCommandBuffer parameter.
+                handles = self.getParamListHandles(values[1:])
+
+                if (handles):
+                    # Generate a function to build a list of handle types and values.
+                    cmddef = '\n'
+                    cmddef += 'void Track{}Handles(CommandBufferWrapper* wrapper, {});'.format(cmd[2:], self.getArgList(handles))
+                    write(cmddef, file=self.outFile)
+                    first = False
+
+    #
+    # Create list of parameters that have handle types or are structs that contain handles.
+    def getParamListHandles(self, values):
+        handles = []
+        for value in values:
+            if self.isHandle(value.baseType):
+                handles.append(value)
+            elif self.isStruct(value.baseType) and (value.baseType in self.structsWithHandles):
+                handles.append(value)
+        return handles
+
+    #
+    #
+    def getArgList(self, values):
+        args = []
+        for value in values:
+            if value.arrayLength:
+                args.append('uint32_t {}'.format(value.arrayLength))
+            args.append('{} {}'.format(value.fullType, value.name))
+        return ', '.join(args)


### PR DESCRIPTION
Track values for handles recorded to a command buffer. When writing the state snapshot, if a handle that was recorded to a command buffer has been destroyed, omit the packets for the the tracked commands that were recorded to the command buffer from the snapshot. This fixes a case where handles referenced by a previously executed command buffer have been destroyed, but the command buffer has not been reset prior to start of the trimmed frame.

Handle tracking is currently incomplete, with the code generator not handling some cases (handle within a struct within a struct). To be completed in a future change.