### PR TITLE
Add Query Tracking for Trimming State Snapshot

### DIFF
--- a/framework/encode/custom_encoder_commands.h
+++ b/framework/encode/custom_encoder_commands.h
@@ -481,6 +481,69 @@ struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDestroyDescriptorUpdate
     }
 };
 
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginQuery>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdBeginQuery(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBeginQueryIndexedEXT>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdBeginQueryIndexedEXT(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWriteTimestamp>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdWriteTimestamp(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWriteAccelerationStructuresPropertiesNV>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdWriteAccelerationStructuresPropertiesNV(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdResetQueryPool>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdResetQueryPool(args...);
+    }
+};
+
+#if 0
+// TODO: Need to update header for this function.
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkResetQueryPoolEXT>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkResetQueryPoolEXT(args...);
+    }
+};
+#endif
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -537,7 +537,7 @@ class TraceManager
         {
             assert((state_tracker_ != nullptr) && ((submitCount == 0) || (pSubmits != nullptr)));
 
-            state_tracker_->TrackImageLayoutTransitions(submitCount, pSubmits);
+            state_tracker_->TrackCommandBufferSubmissions(submitCount, pSubmits);
 
             for (uint32_t i = 0; i < submitCount; ++i)
             {
@@ -622,6 +622,78 @@ class TraceManager
         {
             assert(state_tracker_ != nullptr);
             state_tracker_->TrackResetDescriptorPool(descriptorPool);
+        }
+    }
+
+    void PostProcess_vkCmdBeginQuery(VkCommandBuffer     commandBuffer,
+                                     VkQueryPool         queryPool,
+                                     uint32_t            query,
+                                     VkQueryControlFlags flags)
+    {
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackQueryActivation(commandBuffer, queryPool, query, flags, QueryInfo::kInvalidIndex);
+        }
+    }
+
+    void PostProcess_vkCmdBeginQueryIndexedEXT(
+        VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query, VkQueryControlFlags flags, uint32_t index)
+    {
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackQueryActivation(commandBuffer, queryPool, query, flags, index);
+        }
+    }
+
+    void PostProcess_vkCmdWriteTimestamp(VkCommandBuffer         commandBuffer,
+                                         VkPipelineStageFlagBits pipelineStage,
+                                         VkQueryPool             queryPool,
+                                         uint32_t                query)
+    {
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackQueryActivation(commandBuffer, queryPool, query, 0, QueryInfo::kInvalidIndex);
+        }
+    }
+
+    void
+    PostProcess_vkCmdWriteAccelerationStructuresPropertiesNV(VkCommandBuffer commandBuffer,
+                                                             uint32_t        accelerationStructureCount,
+                                                             const VkAccelerationStructureNV* pAccelerationStructures,
+                                                             VkQueryType                      queryType,
+                                                             VkQueryPool                      queryPool,
+                                                             uint32_t                         firstQuery)
+    {
+        GFXRECON_UNREFERENCED_PARAMETER(commandBuffer);
+        GFXRECON_UNREFERENCED_PARAMETER(accelerationStructureCount);
+        GFXRECON_UNREFERENCED_PARAMETER(pAccelerationStructures);
+        GFXRECON_UNREFERENCED_PARAMETER(queryType);
+        GFXRECON_UNREFERENCED_PARAMETER(queryPool);
+        GFXRECON_UNREFERENCED_PARAMETER(firstQuery);
+        // TODO
+    }
+
+    void PostProcess_vkCmdResetQueryPool(VkCommandBuffer commandBuffer,
+                                         VkQueryPool     queryPool,
+                                         uint32_t        firstQuery,
+                                         uint32_t        queryCount)
+    {
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackQueryReset(commandBuffer, queryPool, firstQuery, queryCount);
+        }
+    }
+
+    void PostProcess_vkResetQueryPoolEXT(VkDevice, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount)
+    {
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            assert(state_tracker_ != nullptr);
+            state_tracker_->TrackQueryReset(queryPool, firstQuery, queryCount);
         }
     }
 

--- a/framework/encode/vulkan_state_info.h
+++ b/framework/encode/vulkan_state_info.h
@@ -36,17 +36,16 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 
 typedef std::shared_ptr<util::MemoryOutputStream> CreateParameters;
 
-// Active query state information stored with VkQueryPool handle.
+// Active query state information to be stored with the VkCommandBuffer handle when recorded and transferred to the
+// VkQueryPool handle when the command buffer is submitted for execution.
 struct QueryInfo
 {
     static const uint32_t kInvalidIndex = std::numeric_limits<uint32_t>::max();
 
+    bool                active{ false };
     VkQueryControlFlags flags{ 0 };
-    uint32_t            index{ kInvalidIndex };           // Pool index for active query.
-    VkCommandBuffer     command_buffer{ VK_NULL_HANDLE }; // Command buffer for query begin.
-    format::HandleId    command_buffer_id{ 0 };
-    VkRenderPass        render_pass{ VK_NULL_HANDLE }; // Optional render pass containing query.
-    format::HandleId    render_pass_id{ 0 };
+    uint32_t            query_type_index{ 0 }; // Query type sepcific value (e.g. transform feedback vertex stream).
+    uint32_t            queue_family_index{ kInvalidIndex }; // Queue family index for last command buffer submission.
 };
 
 struct DescriptorBindingInfo

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -309,7 +309,7 @@ class VulkanStateTracker
                             uint32_t                    image_barrier_count,
                             const VkImageMemoryBarrier* image_barriers);
 
-    void TrackImageLayoutTransitions(uint32_t submit_count, const VkSubmitInfo* submits);
+    void TrackCommandBufferSubmissions(uint32_t submit_count, const VkSubmitInfo* submits);
 
     void TrackUpdateDescriptorSets(uint32_t                    write_count,
                                    const VkWriteDescriptorSet* writes,
@@ -321,6 +321,17 @@ class VulkanStateTracker
                                               const void*               data);
 
     void TrackResetDescriptorPool(VkDescriptorPool descriptor_pool);
+
+    void TrackQueryActivation(VkCommandBuffer     command_buffer,
+                              VkQueryPool         query_pool,
+                              uint32_t            query,
+                              VkQueryControlFlags flags,
+                              uint32_t            index);
+
+    void
+    TrackQueryReset(VkCommandBuffer command_buffer, VkQueryPool query_pool, uint32_t first_query, uint32_t query_count);
+
+    void TrackQueryReset(VkQueryPool query_pool, uint32_t first_query, uint32_t query_count);
 
     void TrackSemaphoreSignalState(uint32_t                       wait_count,
                                    const VkSemaphore*             waits,

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -173,6 +173,50 @@ inline void InitializeState<VkDevice, QueueWrapper, void>(VkDevice          pare
 }
 
 template <>
+inline void
+InitializeState<VkDevice, CommandPoolWrapper, VkCommandPoolCreateInfo>(VkDevice                       parent_handle,
+                                                                       CommandPoolWrapper*            wrapper,
+                                                                       const VkCommandPoolCreateInfo* create_info,
+                                                                       format::ApiCallId              create_call_id,
+                                                                       CreateParameters               create_parameters,
+                                                                       VulkanStateTable*              state_table)
+{
+    assert(wrapper != nullptr);
+    assert(create_parameters != nullptr);
+    assert(create_info != nullptr);
+
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+    GFXRECON_UNREFERENCED_PARAMETER(state_table);
+
+    wrapper->create_call_id    = create_call_id;
+    wrapper->create_parameters = std::move(create_parameters);
+
+    wrapper->queue_family_index = create_info->queueFamilyIndex;
+}
+
+template <>
+inline void InitializeState<VkDevice, QueryPoolWrapper, VkQueryPoolCreateInfo>(VkDevice          parent_handle,
+                                                                               QueryPoolWrapper* wrapper,
+                                                                               const VkQueryPoolCreateInfo* create_info,
+                                                                               format::ApiCallId create_call_id,
+                                                                               CreateParameters  create_parameters,
+                                                                               VulkanStateTable* state_table)
+{
+    assert(wrapper != nullptr);
+    assert(create_parameters != nullptr);
+    assert(create_info != nullptr);
+
+    GFXRECON_UNREFERENCED_PARAMETER(state_table);
+
+    wrapper->create_call_id    = create_call_id;
+    wrapper->create_parameters = std::move(create_parameters);
+
+    wrapper->device     = parent_handle;
+    wrapper->query_type = create_info->queryType;
+    wrapper->pending_queries.resize(create_info->queryCount);
+}
+
+template <>
 inline void InitializeState<VkDevice, FenceWrapper, VkFenceCreateInfo>(VkDevice                 parent_handle,
                                                                        FenceWrapper*            wrapper,
                                                                        const VkFenceCreateInfo* create_info,

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -99,6 +99,18 @@ class VulkanStateWriter
         uint32_t                      num_device_local_images{ 0 };
     };
 
+    struct QueryActivationData
+    {
+        VkQueryPool         pool{ VK_NULL_HANDLE };
+        VkQueryType         type{};
+        VkQueryControlFlags flags{ 0 };
+        uint32_t            index{ 0 };
+        uint32_t            type_index{ 0 };
+    };
+
+    typedef std::vector<QueryActivationData>                  QueryActivationList;
+    typedef std::unordered_map<uint32_t, QueryActivationList> QueryActivationQueueFamilyTable;
+
   private:
     void WritePhysicalDeviceState(const VulkanStateTable& state_table);
 
@@ -123,6 +135,8 @@ class VulkanStateWriter
     void WritePipelineState(const VulkanStateTable& state_table);
 
     void WriteDescriptorSetState(const VulkanStateTable& state_table);
+
+    void WriteQueryPoolState(const VulkanStateTable& state_table);
 
     void WriteSurfaceKhrState(const VulkanStateTable& state_table);
 
@@ -247,6 +261,8 @@ class VulkanStateWriter
     void WriteCommandBufferCommands(const CommandBufferWrapper* wrapper, const VulkanStateTable& state_table);
 
     void WriteDescriptorUpdateCommand(VkDevice device, const DescriptorInfo* binding, VkWriteDescriptorSet* write);
+
+    void WriteQueryActivation(VkDevice device, uint32_t queue_family_index, const QueryActivationList& active_queries);
 
     void WriteAcquireNextImage(
         VkDevice device, VkSwapchainKHR swapchain, VkSemaphore semaphore, VkFence fence, uint32_t image_index);


### PR DESCRIPTION
Track active/available state for queries and write begin/end calls to the trimming state snapshot for available queries.  Calls to vkGetQueryPoolResults made by the trimmed frame for these queries will succeed, but the query results will not be valid.  This prevents replay of the trimmed frame from waiting indefinitely for vkGetQueryPoolResults to return VK_SUCCESS.