### PR TITLE
Fix Swapchain Image State Snapshot for Trimming

### DIFF
--- a/framework/encode/vulkan_state_table.h
+++ b/framework/encode/vulkan_state_table.h
@@ -218,6 +218,9 @@ class VulkanStateTable
     EventWrapper*       GetEventWrapper(format::HandleId id)       { return GetWrapper<EventWrapper>(id, event_map_); }
     const EventWrapper* GetEventWrapper(format::HandleId id) const { return GetWrapper<EventWrapper>(id, event_map_); }
 
+    FenceWrapper*       GetFenceWrapper(format::HandleId id)       { return GetWrapper<FenceWrapper>(id, fence_map_); }
+    const FenceWrapper* GetFenceWrapper(format::HandleId id) const { return GetWrapper<FenceWrapper>(id, fence_map_); }
+
     SemaphoreWrapper*       GetSemaphoreWrapper(format::HandleId id)       { return GetWrapper<SemaphoreWrapper>(id, semaphore_map_); }
     const SemaphoreWrapper* GetSemaphoreWrapper(format::HandleId id) const { return GetWrapper<SemaphoreWrapper>(id, semaphore_map_); }
 


### PR DESCRIPTION
The trimming state tracker will keep track of acquired swapchain images and the handles for the semaphore/fence objects specified when acquiring them.  Calls to vkAcquireNextImageKHR will be written to the trimming state snapshot for each image in the acquired state, with the semaphore/fence originally used to acquire them.  This change handles a case where the semaphore/fence associated with an acquired image was destroyed before the state snapshot was written.  This can happen when an application creates a new semaphore/fence before calling vkAcquireNextImageKHR and then destroys the object prior to calling vkQueuePresentKHR. 