### PR TITLE
Add Option to Select Replay Device

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -333,12 +333,14 @@ VkResult VulkanReplayConsumerBase::CreateSurface(VkInstance instance, VkFlags fl
     return result;
 }
 
-VkResult VulkanReplayConsumerBase::OverrideCreateInstance(VkResult                     original_result,
-                                                          const VkInstanceCreateInfo*  pCreateInfo,
-                                                          const VkAllocationCallbacks* pAllocator,
-                                                          VkInstance*                  pInstance)
+VkResult VulkanReplayConsumerBase::OverrideCreateInstance(VkResult                                original_result,
+                                                          const VkInstanceCreateInfo*             pCreateInfo,
+                                                          const VkAllocationCallbacks*            pAllocator,
+                                                          const HandlePointerDecoder<VkInstance>& original_instance,
+                                                          VkInstance*                             pInstance)
 {
     GFXRECON_UNREFERENCED_PARAMETER(original_result);
+    GFXRECON_UNREFERENCED_PARAMETER(original_instance);
 
     if (loader_handle_ == nullptr)
     {
@@ -402,13 +404,15 @@ VkResult VulkanReplayConsumerBase::OverrideCreateInstance(VkResult              
     return result;
 }
 
-VkResult VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                     original_result,
-                                                        VkPhysicalDevice             physicalDevice,
-                                                        const VkDeviceCreateInfo*    pCreateInfo,
-                                                        const VkAllocationCallbacks* pAllocator,
-                                                        VkDevice*                    pDevice)
+VkResult VulkanReplayConsumerBase::OverrideCreateDevice(VkResult                              original_result,
+                                                        VkPhysicalDevice                      physicalDevice,
+                                                        const VkDeviceCreateInfo*             pCreateInfo,
+                                                        const VkAllocationCallbacks*          pAllocator,
+                                                        const HandlePointerDecoder<VkDevice>& original_device,
+                                                        VkDevice*                             pDevice)
 {
     GFXRECON_UNREFERENCED_PARAMETER(original_result);
+    GFXRECON_UNREFERENCED_PARAMETER(original_device);
 
     VkResult                result               = VK_ERROR_INITIALIZATION_FAILED;
     PFN_vkGetDeviceProcAddr get_device_proc_addr = GetDeviceAddrProc(physicalDevice);
@@ -486,17 +490,20 @@ VkResult VulkanReplayConsumerBase::OverrideGetEventStatus(PFN_vkGetEventStatus f
     return result;
 }
 
-VkResult VulkanReplayConsumerBase::OverrideGetQueryPoolResults(PFN_vkGetQueryPoolResults func,
-                                                               VkResult                  original_result,
-                                                               VkDevice                  device,
-                                                               VkQueryPool               queryPool,
-                                                               uint32_t                  firstQuery,
-                                                               uint32_t                  queryCount,
-                                                               size_t                    dataSize,
-                                                               void*                     pData,
-                                                               VkDeviceSize              stride,
-                                                               VkQueryResultFlags        flags)
+VkResult VulkanReplayConsumerBase::OverrideGetQueryPoolResults(PFN_vkGetQueryPoolResults      func,
+                                                               VkResult                       original_result,
+                                                               VkDevice                       device,
+                                                               VkQueryPool                    queryPool,
+                                                               uint32_t                       firstQuery,
+                                                               uint32_t                       queryCount,
+                                                               size_t                         dataSize,
+                                                               const PointerDecoder<uint8_t>& original_data,
+                                                               void*                          pData,
+                                                               VkDeviceSize                   stride,
+                                                               VkQueryResultFlags             flags)
 {
+    GFXRECON_UNREFERENCED_PARAMETER(original_data);
+
     VkResult result;
 
     do
@@ -507,12 +514,16 @@ VkResult VulkanReplayConsumerBase::OverrideGetQueryPoolResults(PFN_vkGetQueryPoo
     return result;
 }
 
-VkResult VulkanReplayConsumerBase::OverrideAllocateCommandBuffers(PFN_vkAllocateCommandBuffers       func,
-                                                                  VkResult                           original_result,
-                                                                  VkDevice                           device,
-                                                                  const VkCommandBufferAllocateInfo* pAllocateInfo,
-                                                                  VkCommandBuffer*                   pCommandBuffers)
+VkResult VulkanReplayConsumerBase::OverrideAllocateCommandBuffers(
+    PFN_vkAllocateCommandBuffers                 func,
+    VkResult                                     original_result,
+    VkDevice                                     device,
+    const VkCommandBufferAllocateInfo*           pAllocateInfo,
+    const HandlePointerDecoder<VkCommandBuffer>& original_command_buffers,
+    VkCommandBuffer*                             pCommandBuffers)
 {
+    GFXRECON_UNREFERENCED_PARAMETER(original_command_buffers);
+
     VkResult result = original_result;
 
     if ((original_result >= 0) || !options_.skip_failed_allocations)
@@ -528,12 +539,16 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateCommandBuffers(PFN_vkAllocate
     return result;
 }
 
-VkResult VulkanReplayConsumerBase::OverrideAllocateDescriptorSets(PFN_vkAllocateDescriptorSets       func,
-                                                                  VkResult                           original_result,
-                                                                  VkDevice                           device,
-                                                                  const VkDescriptorSetAllocateInfo* pAllocateInfo,
-                                                                  VkDescriptorSet*                   pDescriptorSets)
+VkResult VulkanReplayConsumerBase::OverrideAllocateDescriptorSets(
+    PFN_vkAllocateDescriptorSets                 func,
+    VkResult                                     original_result,
+    VkDevice                                     device,
+    const VkDescriptorSetAllocateInfo*           pAllocateInfo,
+    const HandlePointerDecoder<VkDescriptorSet>& original_descriptor_sets,
+    VkDescriptorSet*                             pDescriptorSets)
 {
+    GFXRECON_UNREFERENCED_PARAMETER(original_descriptor_sets);
+
     VkResult result = original_result;
 
     if ((original_result >= 0) || !options_.skip_failed_allocations)
@@ -549,13 +564,16 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateDescriptorSets(PFN_vkAllocate
     return result;
 }
 
-VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(PFN_vkAllocateMemory         func,
-                                                          VkResult                     original_result,
-                                                          VkDevice                     device,
-                                                          const VkMemoryAllocateInfo*  pAllocateInfo,
-                                                          const VkAllocationCallbacks* pAllocator,
-                                                          VkDeviceMemory*              pMemory)
+VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(PFN_vkAllocateMemory                        func,
+                                                          VkResult                                    original_result,
+                                                          VkDevice                                    device,
+                                                          const VkMemoryAllocateInfo*                 pAllocateInfo,
+                                                          const VkAllocationCallbacks*                pAllocator,
+                                                          const HandlePointerDecoder<VkDeviceMemory>& original_memory,
+                                                          VkDeviceMemory*                             pMemory)
 {
+    GFXRECON_UNREFERENCED_PARAMETER(original_memory);
+
     VkResult result = original_result;
 
     if ((original_result >= 0) || !options_.skip_failed_allocations)
@@ -571,16 +589,18 @@ VkResult VulkanReplayConsumerBase::OverrideAllocateMemory(PFN_vkAllocateMemory  
     return result;
 }
 
-VkResult VulkanReplayConsumerBase::OverrideMapMemory(PFN_vkMapMemory  func,
-                                                     VkResult         original_result,
-                                                     VkDevice         device,
-                                                     VkDeviceMemory   memory,
-                                                     VkDeviceSize     offset,
-                                                     VkDeviceSize     size,
-                                                     VkMemoryMapFlags flags,
-                                                     void**           ppData)
+VkResult VulkanReplayConsumerBase::OverrideMapMemory(PFN_vkMapMemory                 func,
+                                                     VkResult                        original_result,
+                                                     VkDevice                        device,
+                                                     VkDeviceMemory                  memory,
+                                                     VkDeviceSize                    offset,
+                                                     VkDeviceSize                    size,
+                                                     VkMemoryMapFlags                flags,
+                                                     const PointerDecoder<uint64_t>& original_data,
+                                                     void**                          ppData)
 {
     GFXRECON_UNREFERENCED_PARAMETER(original_result);
+    GFXRECON_UNREFERENCED_PARAMETER(original_data);
 
     VkResult result = func(device, memory, offset, size, flags, ppData);
 
@@ -610,14 +630,16 @@ void VulkanReplayConsumerBase::OverrideFreeMemory(PFN_vkFreeMemory             f
 }
 
 VkResult VulkanReplayConsumerBase::OverrideCreateDescriptorUpdateTemplate(
-    PFN_vkCreateDescriptorUpdateTemplate        func,
-    VkResult                                    original_result,
-    VkDevice                                    device,
-    const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
-    const VkAllocationCallbacks*                pAllocator,
-    VkDescriptorUpdateTemplate*                 pDescriptorUpdateTemplate)
+    PFN_vkCreateDescriptorUpdateTemplate                    func,
+    VkResult                                                original_result,
+    VkDevice                                                device,
+    const VkDescriptorUpdateTemplateCreateInfo*             pCreateInfo,
+    const VkAllocationCallbacks*                            pAllocator,
+    const HandlePointerDecoder<VkDescriptorUpdateTemplate>& original_update_template,
+    VkDescriptorUpdateTemplate*                             pDescriptorUpdateTemplate)
 {
     GFXRECON_UNREFERENCED_PARAMETER(original_result);
+    GFXRECON_UNREFERENCED_PARAMETER(original_update_template);
 
     if (pCreateInfo != nullptr)
     {
@@ -710,13 +732,18 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDescriptorUpdateTemplate(
     }
 }
 
-VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(PFN_vkCreatePipelineCache        func,
-                                                               VkResult                         original_result,
-                                                               VkDevice                         device,
-                                                               const VkPipelineCacheCreateInfo* pCreateInfo,
-                                                               const VkAllocationCallbacks*     pAllocator,
-                                                               VkPipelineCache*                 pPipelineCache)
+VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(
+    PFN_vkCreatePipelineCache                    func,
+    VkResult                                     original_result,
+    VkDevice                                     device,
+    const VkPipelineCacheCreateInfo*             pCreateInfo,
+    const VkAllocationCallbacks*                 pAllocator,
+    const HandlePointerDecoder<VkPipelineCache>& original_pipeline_cache,
+    VkPipelineCache*                             pPipelineCache)
 {
+    GFXRECON_UNREFERENCED_PARAMETER(original_result);
+    GFXRECON_UNREFERENCED_PARAMETER(original_pipeline_cache);
+
     if (options_.omit_pipeline_cache_data && (pCreateInfo != nullptr))
     {
         // Make a shallow copy of the create info structure and clear the cache data.
@@ -732,29 +759,35 @@ VkResult VulkanReplayConsumerBase::OverrideCreatePipelineCache(PFN_vkCreatePipel
     }
 }
 
-VkResult VulkanReplayConsumerBase::OverrideCreateAndroidSurfaceKHR(PFN_vkCreateAndroidSurfaceKHR        func,
-                                                                   VkResult                             original_result,
-                                                                   VkInstance                           instance,
-                                                                   const VkAndroidSurfaceCreateInfoKHR* pCreateInfo,
-                                                                   const VkAllocationCallbacks*         pAllocator,
-                                                                   VkSurfaceKHR*                        pSurface)
+VkResult
+VulkanReplayConsumerBase::OverrideCreateAndroidSurfaceKHR(PFN_vkCreateAndroidSurfaceKHR             func,
+                                                          VkResult                                  original_result,
+                                                          VkInstance                                instance,
+                                                          const VkAndroidSurfaceCreateInfoKHR*      pCreateInfo,
+                                                          const VkAllocationCallbacks*              pAllocator,
+                                                          const HandlePointerDecoder<VkSurfaceKHR>& original_surface,
+                                                          VkSurfaceKHR*                             pSurface)
 {
     GFXRECON_UNREFERENCED_PARAMETER(func);
     GFXRECON_UNREFERENCED_PARAMETER(original_result);
     GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
+    GFXRECON_UNREFERENCED_PARAMETER(original_surface);
     return CreateSurface(instance, pCreateInfo->flags, pSurface);
 }
 
-VkResult VulkanReplayConsumerBase::OverrideCreateWin32SurfaceKHR(PFN_vkCreateWin32SurfaceKHR        func,
-                                                                 VkResult                           original_result,
-                                                                 VkInstance                         instance,
-                                                                 const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
-                                                                 const VkAllocationCallbacks*       pAllocator,
-                                                                 VkSurfaceKHR*                      pSurface)
+VkResult
+VulkanReplayConsumerBase::OverrideCreateWin32SurfaceKHR(PFN_vkCreateWin32SurfaceKHR               func,
+                                                        VkResult                                  original_result,
+                                                        VkInstance                                instance,
+                                                        const VkWin32SurfaceCreateInfoKHR*        pCreateInfo,
+                                                        const VkAllocationCallbacks*              pAllocator,
+                                                        const HandlePointerDecoder<VkSurfaceKHR>& original_surface,
+                                                        VkSurfaceKHR*                             pSurface)
 {
     GFXRECON_UNREFERENCED_PARAMETER(func);
     GFXRECON_UNREFERENCED_PARAMETER(original_result);
     GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
+    GFXRECON_UNREFERENCED_PARAMETER(original_surface);
     return CreateSurface(instance, pCreateInfo->flags, pSurface);
 }
 
@@ -766,16 +799,19 @@ VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWin32PresentationSup
         GetInstanceTable(physicalDevice), physicalDevice, queueFamilyIndex);
 }
 
-VkResult VulkanReplayConsumerBase::OverrideCreateXcbSurfaceKHR(PFN_vkCreateXcbSurfaceKHR        func,
-                                                               VkResult                         original_result,
-                                                               VkInstance                       instance,
-                                                               const VkXcbSurfaceCreateInfoKHR* pCreateInfo,
-                                                               const VkAllocationCallbacks*     pAllocator,
-                                                               VkSurfaceKHR*                    pSurface)
+VkResult
+VulkanReplayConsumerBase::OverrideCreateXcbSurfaceKHR(PFN_vkCreateXcbSurfaceKHR                 func,
+                                                      VkResult                                  original_result,
+                                                      VkInstance                                instance,
+                                                      const VkXcbSurfaceCreateInfoKHR*          pCreateInfo,
+                                                      const VkAllocationCallbacks*              pAllocator,
+                                                      const HandlePointerDecoder<VkSurfaceKHR>& original_surface,
+                                                      VkSurfaceKHR*                             pSurface)
 {
     GFXRECON_UNREFERENCED_PARAMETER(func);
     GFXRECON_UNREFERENCED_PARAMETER(original_result);
     GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
+    GFXRECON_UNREFERENCED_PARAMETER(original_surface);
     return CreateSurface(instance, pCreateInfo->flags, pSurface);
 }
 
@@ -793,16 +829,19 @@ VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXcbPresentationSuppo
         GetInstanceTable(physicalDevice), physicalDevice, queueFamilyIndex);
 }
 
-VkResult VulkanReplayConsumerBase::OverrideCreateXlibSurfaceKHR(PFN_vkCreateXlibSurfaceKHR        func,
-                                                                VkResult                          original_result,
-                                                                VkInstance                        instance,
-                                                                const VkXlibSurfaceCreateInfoKHR* pCreateInfo,
-                                                                const VkAllocationCallbacks*      pAllocator,
-                                                                VkSurfaceKHR*                     pSurface)
+VkResult
+VulkanReplayConsumerBase::OverrideCreateXlibSurfaceKHR(PFN_vkCreateXlibSurfaceKHR                func,
+                                                       VkResult                                  original_result,
+                                                       VkInstance                                instance,
+                                                       const VkXlibSurfaceCreateInfoKHR*         pCreateInfo,
+                                                       const VkAllocationCallbacks*              pAllocator,
+                                                       const HandlePointerDecoder<VkSurfaceKHR>& original_surface,
+                                                       VkSurfaceKHR*                             pSurface)
 {
     GFXRECON_UNREFERENCED_PARAMETER(func);
     GFXRECON_UNREFERENCED_PARAMETER(original_result);
     GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
+    GFXRECON_UNREFERENCED_PARAMETER(original_surface);
     return CreateSurface(instance, pCreateInfo->flags, pSurface);
 }
 
@@ -820,16 +859,19 @@ VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXlibPresentationSupp
         GetInstanceTable(physicalDevice), physicalDevice, queueFamilyIndex);
 }
 
-VkResult VulkanReplayConsumerBase::OverrideCreateWaylandSurfaceKHR(PFN_vkCreateWaylandSurfaceKHR        func,
-                                                                   VkResult                             original_result,
-                                                                   VkInstance                           instance,
-                                                                   const VkWaylandSurfaceCreateInfoKHR* pCreateInfo,
-                                                                   const VkAllocationCallbacks*         pAllocator,
-                                                                   VkSurfaceKHR*                        pSurface)
+VkResult
+VulkanReplayConsumerBase::OverrideCreateWaylandSurfaceKHR(PFN_vkCreateWaylandSurfaceKHR             func,
+                                                          VkResult                                  original_result,
+                                                          VkInstance                                instance,
+                                                          const VkWaylandSurfaceCreateInfoKHR*      pCreateInfo,
+                                                          const VkAllocationCallbacks*              pAllocator,
+                                                          const HandlePointerDecoder<VkSurfaceKHR>& original_surface,
+                                                          VkSurfaceKHR*                             pSurface)
 {
     GFXRECON_UNREFERENCED_PARAMETER(func);
     GFXRECON_UNREFERENCED_PARAMETER(original_result);
     GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
+    GFXRECON_UNREFERENCED_PARAMETER(original_surface);
     return CreateSurface(instance, pCreateInfo->flags, pSurface);
 }
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -18,6 +18,7 @@
 #ifndef GFXRECON_DECODE_VULKAN_REPLAY_CONSUMER_BASE_H
 #define GFXRECON_DECODE_VULKAN_REPLAY_CONSUMER_BASE_H
 
+#include "decode/handle_pointer_decoder.h"
 #include "decode/pointer_decoder.h"
 #include "decode/vulkan_object_mapper.h"
 #include "decode/vulkan_replay_options.h"
@@ -167,16 +168,18 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     // Replay function overrides provided to the replay consumer code generator with replay_overrides.json
     //
 
-    VkResult OverrideCreateInstance(VkResult                     original_result,
-                                    const VkInstanceCreateInfo*  pCreateInfo,
-                                    const VkAllocationCallbacks* pAllocator,
-                                    VkInstance*                  pInstance);
+    VkResult OverrideCreateInstance(VkResult                                original_result,
+                                    const VkInstanceCreateInfo*             pCreateInfo,
+                                    const VkAllocationCallbacks*            pAllocator,
+                                    const HandlePointerDecoder<VkInstance>& original_instance,
+                                    VkInstance*                             pInstance);
 
-    VkResult OverrideCreateDevice(VkResult                     original_result,
-                                  VkPhysicalDevice             physicalDevice,
-                                  const VkDeviceCreateInfo*    pCreateInfo,
-                                  const VkAllocationCallbacks* pAllocator,
-                                  VkDevice*                    pDevice);
+    VkResult OverrideCreateDevice(VkResult                              original_result,
+                                  VkPhysicalDevice                      physicalDevice,
+                                  const VkDeviceCreateInfo*             pCreateInfo,
+                                  const VkAllocationCallbacks*          pAllocator,
+                                  const HandlePointerDecoder<VkDevice>& original_device,
+                                  VkDevice*                             pDevice);
 
     VkResult OverrideWaitForFences(PFN_vkWaitForFences func,
                                    VkResult            original_result,
@@ -192,44 +195,49 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     VkResult
     OverrideGetEventStatus(PFN_vkGetEventStatus func, VkResult original_result, VkDevice device, VkEvent event);
 
-    VkResult OverrideGetQueryPoolResults(PFN_vkGetQueryPoolResults func,
-                                         VkResult                  original_result,
-                                         VkDevice                  device,
-                                         VkQueryPool               queryPool,
-                                         uint32_t                  firstQuery,
-                                         uint32_t                  queryCount,
-                                         size_t                    dataSize,
-                                         void*                     pData,
-                                         VkDeviceSize              stride,
-                                         VkQueryResultFlags        flags);
+    VkResult OverrideGetQueryPoolResults(PFN_vkGetQueryPoolResults      func,
+                                         VkResult                       original_result,
+                                         VkDevice                       device,
+                                         VkQueryPool                    queryPool,
+                                         uint32_t                       firstQuery,
+                                         uint32_t                       queryCount,
+                                         size_t                         dataSize,
+                                         const PointerDecoder<uint8_t>& original_data,
+                                         void*                          pData,
+                                         VkDeviceSize                   stride,
+                                         VkQueryResultFlags             flags);
 
-    VkResult OverrideAllocateCommandBuffers(PFN_vkAllocateCommandBuffers       func,
-                                            VkResult                           original_result,
-                                            VkDevice                           device,
-                                            const VkCommandBufferAllocateInfo* pAllocateInfo,
-                                            VkCommandBuffer*                   pCommandBuffers);
+    VkResult OverrideAllocateCommandBuffers(PFN_vkAllocateCommandBuffers                 func,
+                                            VkResult                                     original_result,
+                                            VkDevice                                     device,
+                                            const VkCommandBufferAllocateInfo*           pAllocateInfo,
+                                            const HandlePointerDecoder<VkCommandBuffer>& original_command_buffers,
+                                            VkCommandBuffer*                             pCommandBuffers);
 
-    VkResult OverrideAllocateDescriptorSets(PFN_vkAllocateDescriptorSets       func,
-                                            VkResult                           original_result,
-                                            VkDevice                           device,
-                                            const VkDescriptorSetAllocateInfo* pAllocateInfo,
-                                            VkDescriptorSet*                   pDescriptorSets);
+    VkResult OverrideAllocateDescriptorSets(PFN_vkAllocateDescriptorSets                 func,
+                                            VkResult                                     original_result,
+                                            VkDevice                                     device,
+                                            const VkDescriptorSetAllocateInfo*           pAllocateInfo,
+                                            const HandlePointerDecoder<VkDescriptorSet>& original_descriptor_sets,
+                                            VkDescriptorSet*                             pDescriptorSets);
 
-    VkResult OverrideAllocateMemory(PFN_vkAllocateMemory         func,
-                                    VkResult                     original_result,
-                                    VkDevice                     device,
-                                    const VkMemoryAllocateInfo*  pAllocateInfo,
-                                    const VkAllocationCallbacks* pAllocator,
-                                    VkDeviceMemory*              pMemory);
+    VkResult OverrideAllocateMemory(PFN_vkAllocateMemory                        func,
+                                    VkResult                                    original_result,
+                                    VkDevice                                    device,
+                                    const VkMemoryAllocateInfo*                 pAllocateInfo,
+                                    const VkAllocationCallbacks*                pAllocator,
+                                    const HandlePointerDecoder<VkDeviceMemory>& original_memory,
+                                    VkDeviceMemory*                             pMemory);
 
-    VkResult OverrideMapMemory(PFN_vkMapMemory  func,
-                               VkResult         original_result,
-                               VkDevice         device,
-                               VkDeviceMemory   memory,
-                               VkDeviceSize     offset,
-                               VkDeviceSize     size,
-                               VkMemoryMapFlags flags,
-                               void**           ppData);
+    VkResult OverrideMapMemory(PFN_vkMapMemory                 func,
+                               VkResult                        original_result,
+                               VkDevice                        device,
+                               VkDeviceMemory                  memory,
+                               VkDeviceSize                    offset,
+                               VkDeviceSize                    size,
+                               VkMemoryMapFlags                flags,
+                               const PointerDecoder<uint64_t>& original_data,
+                               void**                          ppData);
 
     void OverrideUnmapMemory(PFN_vkUnmapMemory func, VkDevice device, VkDeviceMemory memory);
 
@@ -238,47 +246,53 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                             VkDeviceMemory               memory,
                             const VkAllocationCallbacks* pAllocator);
 
-    VkResult OverrideCreateDescriptorUpdateTemplate(PFN_vkCreateDescriptorUpdateTemplate        func,
-                                                    VkResult                                    original_result,
-                                                    VkDevice                                    device,
-                                                    const VkDescriptorUpdateTemplateCreateInfo* pCreateInfo,
-                                                    const VkAllocationCallbacks*                pAllocator,
-                                                    VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate);
+    VkResult OverrideCreateDescriptorUpdateTemplate(
+        PFN_vkCreateDescriptorUpdateTemplate                    func,
+        VkResult                                                original_result,
+        VkDevice                                                device,
+        const VkDescriptorUpdateTemplateCreateInfo*             pCreateInfo,
+        const VkAllocationCallbacks*                            pAllocator,
+        const HandlePointerDecoder<VkDescriptorUpdateTemplate>& original_update_template,
+        VkDescriptorUpdateTemplate*                             pDescriptorUpdateTemplate);
 
-    VkResult OverrideCreatePipelineCache(PFN_vkCreatePipelineCache        func,
-                                         VkResult                         original_result,
-                                         VkDevice                         device,
-                                         const VkPipelineCacheCreateInfo* pCreateInfo,
-                                         const VkAllocationCallbacks*     pAllocator,
-                                         VkPipelineCache*                 pPipelineCache);
+    VkResult OverrideCreatePipelineCache(PFN_vkCreatePipelineCache                    func,
+                                         VkResult                                     original_result,
+                                         VkDevice                                     device,
+                                         const VkPipelineCacheCreateInfo*             pCreateInfo,
+                                         const VkAllocationCallbacks*                 pAllocator,
+                                         const HandlePointerDecoder<VkPipelineCache>& original_pipeline_cache,
+                                         VkPipelineCache*                             pPipelineCache);
 
     // Window/Surface related overrides, which can transform the window/surface type from the platform
     // specific type found in the trace file to the platform specific type used for replay.
-    VkResult OverrideCreateAndroidSurfaceKHR(PFN_vkCreateAndroidSurfaceKHR        func,
-                                             VkResult                             original_result,
-                                             VkInstance                           instance,
-                                             const VkAndroidSurfaceCreateInfoKHR* pCreateInfo,
-                                             const VkAllocationCallbacks*         pAllocator,
-                                             VkSurfaceKHR*                        pSurface);
+    VkResult OverrideCreateAndroidSurfaceKHR(PFN_vkCreateAndroidSurfaceKHR             func,
+                                             VkResult                                  original_result,
+                                             VkInstance                                instance,
+                                             const VkAndroidSurfaceCreateInfoKHR*      pCreateInfo,
+                                             const VkAllocationCallbacks*              pAllocator,
+                                             const HandlePointerDecoder<VkSurfaceKHR>& original_surface,
+                                             VkSurfaceKHR*                             pSurface);
 
-    VkResult OverrideCreateWin32SurfaceKHR(PFN_vkCreateWin32SurfaceKHR        func,
-                                           VkResult                           original_result,
-                                           VkInstance                         instance,
-                                           const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
-                                           const VkAllocationCallbacks*       pAllocator,
-                                           VkSurfaceKHR*                      pSurface);
+    VkResult OverrideCreateWin32SurfaceKHR(PFN_vkCreateWin32SurfaceKHR               func,
+                                           VkResult                                  original_result,
+                                           VkInstance                                instance,
+                                           const VkWin32SurfaceCreateInfoKHR*        pCreateInfo,
+                                           const VkAllocationCallbacks*              pAllocator,
+                                           const HandlePointerDecoder<VkSurfaceKHR>& original_surface,
+                                           VkSurfaceKHR*                             pSurface);
 
     VkBool32
     OverrideGetPhysicalDeviceWin32PresentationSupportKHR(PFN_vkGetPhysicalDeviceWin32PresentationSupportKHR func,
                                                          VkPhysicalDevice physicalDevice,
                                                          uint32_t         queueFamilyIndex);
 
-    VkResult OverrideCreateXcbSurfaceKHR(PFN_vkCreateXcbSurfaceKHR        func,
-                                         VkResult                         original_result,
-                                         VkInstance                       instance,
-                                         const VkXcbSurfaceCreateInfoKHR* pCreateInfo,
-                                         const VkAllocationCallbacks*     pAllocator,
-                                         VkSurfaceKHR*                    pSurface);
+    VkResult OverrideCreateXcbSurfaceKHR(PFN_vkCreateXcbSurfaceKHR                 func,
+                                         VkResult                                  original_result,
+                                         VkInstance                                instance,
+                                         const VkXcbSurfaceCreateInfoKHR*          pCreateInfo,
+                                         const VkAllocationCallbacks*              pAllocator,
+                                         const HandlePointerDecoder<VkSurfaceKHR>& original_surface,
+                                         VkSurfaceKHR*                             pSurface);
 
     VkBool32 OverrideGetPhysicalDeviceXcbPresentationSupportKHR(PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR func,
                                                                 VkPhysicalDevice  physicalDevice,
@@ -286,12 +300,13 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                                                 xcb_connection_t* connection,
                                                                 xcb_visualid_t    visual_id);
 
-    VkResult OverrideCreateXlibSurfaceKHR(PFN_vkCreateXlibSurfaceKHR        func,
-                                          VkResult                          original_result,
-                                          VkInstance                        instance,
-                                          const VkXlibSurfaceCreateInfoKHR* pCreateInfo,
-                                          const VkAllocationCallbacks*      pAllocator,
-                                          VkSurfaceKHR*                     pSurface);
+    VkResult OverrideCreateXlibSurfaceKHR(PFN_vkCreateXlibSurfaceKHR                func,
+                                          VkResult                                  original_result,
+                                          VkInstance                                instance,
+                                          const VkXlibSurfaceCreateInfoKHR*         pCreateInfo,
+                                          const VkAllocationCallbacks*              pAllocator,
+                                          const HandlePointerDecoder<VkSurfaceKHR>& original_surface,
+                                          VkSurfaceKHR*                             pSurface);
 
     VkBool32 OverrideGetPhysicalDeviceXlibPresentationSupportKHR(PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR func,
                                                                  VkPhysicalDevice physicalDevice,
@@ -299,12 +314,13 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                                                  Display*         dpy,
                                                                  VisualID         visualID);
 
-    VkResult OverrideCreateWaylandSurfaceKHR(PFN_vkCreateWaylandSurfaceKHR        func,
-                                             VkResult                             original_result,
-                                             VkInstance                           instance,
-                                             const VkWaylandSurfaceCreateInfoKHR* pCreateInfo,
-                                             const VkAllocationCallbacks*         pAllocator,
-                                             VkSurfaceKHR*                        pSurface);
+    VkResult OverrideCreateWaylandSurfaceKHR(PFN_vkCreateWaylandSurfaceKHR             func,
+                                             VkResult                                  original_result,
+                                             VkInstance                                instance,
+                                             const VkWaylandSurfaceCreateInfoKHR*      pCreateInfo,
+                                             const VkAllocationCallbacks*              pAllocator,
+                                             const HandlePointerDecoder<VkSurfaceKHR>& original_surface,
+                                             VkSurfaceKHR*                             pSurface);
 
     VkBool32
     OverrideGetPhysicalDeviceWaylandPresentationSupportKHR(PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR func,

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -25,8 +25,9 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 struct ReplayOptions
 {
-    bool skip_failed_allocations{ false };
-    bool omit_pipeline_cache_data{ false };
+    bool    skip_failed_allocations{ false };
+    bool    omit_pipeline_cache_data{ false };
+    int32_t override_gpu_index{ -1 };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -66,7 +66,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDevices(
     uint32_t* out_pPhysicalDeviceCount = &out_pPhysicalDeviceCount_value;
     VkPhysicalDevice* out_pPhysicalDevices = pPhysicalDevices.GetHandlePointer();
 
-    VkResult replay_result = GetInstanceTable(in_instance)->EnumeratePhysicalDevices(in_instance, out_pPhysicalDeviceCount, out_pPhysicalDevices);
+    VkResult replay_result = OverrideEnumeratePhysicalDevices(GetInstanceTable(in_instance)->EnumeratePhysicalDevices, returnValue, in_instance, pPhysicalDeviceCount, out_pPhysicalDeviceCount, pPhysicalDevices, out_pPhysicalDevices);
     CheckResult("vkEnumeratePhysicalDevices", returnValue, replay_result);
 
     AddHandles<VkPhysicalDevice>(pPhysicalDevices.GetPointer(), pPhysicalDevices.GetLength(), out_pPhysicalDevices, out_pPhysicalDeviceCount_value, &VulkanObjectMapper::AddVkPhysicalDevice);
@@ -121,7 +121,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceProperties(
     VkPhysicalDeviceProperties out_pProperties_value = {};
     VkPhysicalDeviceProperties* out_pProperties = &out_pProperties_value;
 
-    GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceProperties(in_physicalDevice, out_pProperties);
+    OverrideGetPhysicalDeviceProperties(GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceProperties, in_physicalDevice, pProperties, out_pProperties);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties(
@@ -2068,7 +2068,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceProperties2(
     VkPhysicalDeviceProperties2 out_pProperties_value = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, nullptr };
     VkPhysicalDeviceProperties2* out_pProperties = &out_pProperties_value;
 
-    GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceProperties2(in_physicalDevice, out_pProperties);
+    OverrideGetPhysicalDeviceProperties2(GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceProperties2, in_physicalDevice, pProperties, out_pProperties);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFormatProperties2(
@@ -2821,7 +2821,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceProperties2KHR(
     VkPhysicalDeviceProperties2 out_pProperties_value = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, nullptr };
     VkPhysicalDeviceProperties2* out_pProperties = &out_pProperties_value;
 
-    GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceProperties2KHR(in_physicalDevice, out_pProperties);
+    OverrideGetPhysicalDeviceProperties2KHR(GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceProperties2KHR, in_physicalDevice, pProperties, out_pProperties);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFormatProperties2KHR(

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -39,7 +39,7 @@ void VulkanReplayConsumer::Process_vkCreateInstance(
     VkInstance out_pInstance_value = static_cast<VkInstance>(0);
     VkInstance* out_pInstance = &out_pInstance_value;
 
-    VkResult replay_result = OverrideCreateInstance(returnValue, in_pCreateInfo, in_pAllocator, out_pInstance);
+    VkResult replay_result = OverrideCreateInstance(returnValue, in_pCreateInfo, in_pAllocator, pInstance, out_pInstance);
     CheckResult("vkCreateInstance", returnValue, replay_result);
 
     AddHandles<VkInstance>(pInstance.GetPointer(), 1, out_pInstance, 1, &VulkanObjectMapper::AddVkInstance);
@@ -164,7 +164,7 @@ void VulkanReplayConsumer::Process_vkCreateDevice(
     VkDevice out_pDevice_value = static_cast<VkDevice>(0);
     VkDevice* out_pDevice = &out_pDevice_value;
 
-    VkResult replay_result = OverrideCreateDevice(returnValue, in_physicalDevice, in_pCreateInfo, in_pAllocator, out_pDevice);
+    VkResult replay_result = OverrideCreateDevice(returnValue, in_physicalDevice, in_pCreateInfo, in_pAllocator, pDevice, out_pDevice);
     CheckResult("vkCreateDevice", returnValue, replay_result);
 
     AddHandles<VkDevice>(pDevice.GetPointer(), 1, out_pDevice, 1, &VulkanObjectMapper::AddVkDevice);
@@ -245,7 +245,7 @@ void VulkanReplayConsumer::Process_vkAllocateMemory(
     VkDeviceMemory out_pMemory_value = static_cast<VkDeviceMemory>(0);
     VkDeviceMemory* out_pMemory = &out_pMemory_value;
 
-    VkResult replay_result = OverrideAllocateMemory(GetDeviceTable(in_device)->AllocateMemory, returnValue, in_device, in_pAllocateInfo, in_pAllocator, out_pMemory);
+    VkResult replay_result = OverrideAllocateMemory(GetDeviceTable(in_device)->AllocateMemory, returnValue, in_device, in_pAllocateInfo, in_pAllocator, pMemory, out_pMemory);
     CheckResult("vkAllocateMemory", returnValue, replay_result);
 
     AddHandles<VkDeviceMemory>(pMemory.GetPointer(), 1, out_pMemory, 1, &VulkanObjectMapper::AddVkDeviceMemory);
@@ -277,7 +277,7 @@ void VulkanReplayConsumer::Process_vkMapMemory(
     void* out_ppData_value = nullptr;
     void** out_ppData = &out_ppData_value;
 
-    VkResult replay_result = OverrideMapMemory(GetDeviceTable(in_device)->MapMemory, returnValue, in_device, in_memory, offset, size, flags, out_ppData);
+    VkResult replay_result = OverrideMapMemory(GetDeviceTable(in_device)->MapMemory, returnValue, in_device, in_memory, offset, size, flags, ppData, out_ppData);
     CheckResult("vkMapMemory", returnValue, replay_result);
 
     PostProcessExternalObject(ppData, out_ppData_value, format::ApiCallId::ApiCall_vkMapMemory, "vkMapMemory");
@@ -660,7 +660,7 @@ void VulkanReplayConsumer::Process_vkGetQueryPoolResults(
     VkQueryPool in_queryPool = GetObjectMapper().MapVkQueryPool(queryPool);
     uint8_t* out_pData = pData.IsNull() ? nullptr : AllocateArray<uint8_t>(dataSize);
 
-    VkResult replay_result = OverrideGetQueryPoolResults(GetDeviceTable(in_device)->GetQueryPoolResults, returnValue, in_device, in_queryPool, firstQuery, queryCount, dataSize, out_pData, stride, flags);
+    VkResult replay_result = OverrideGetQueryPoolResults(GetDeviceTable(in_device)->GetQueryPoolResults, returnValue, in_device, in_queryPool, firstQuery, queryCount, dataSize, pData, out_pData, stride, flags);
     CheckResult("vkGetQueryPoolResults", returnValue, replay_result);
 
     FreeArray<uint8_t>(&out_pData);
@@ -853,7 +853,7 @@ void VulkanReplayConsumer::Process_vkCreatePipelineCache(
     VkPipelineCache out_pPipelineCache_value = static_cast<VkPipelineCache>(0);
     VkPipelineCache* out_pPipelineCache = &out_pPipelineCache_value;
 
-    VkResult replay_result = OverrideCreatePipelineCache(GetDeviceTable(in_device)->CreatePipelineCache, returnValue, in_device, in_pCreateInfo, in_pAllocator, out_pPipelineCache);
+    VkResult replay_result = OverrideCreatePipelineCache(GetDeviceTable(in_device)->CreatePipelineCache, returnValue, in_device, in_pCreateInfo, in_pAllocator, pPipelineCache, out_pPipelineCache);
     CheckResult("vkCreatePipelineCache", returnValue, replay_result);
 
     AddHandles<VkPipelineCache>(pPipelineCache.GetPointer(), 1, out_pPipelineCache, 1, &VulkanObjectMapper::AddVkPipelineCache);
@@ -1113,7 +1113,7 @@ void VulkanReplayConsumer::Process_vkAllocateDescriptorSets(
     MapStructHandles(pAllocateInfo.GetMetaStructPointer(), GetObjectMapper());
     VkDescriptorSet* out_pDescriptorSets = pDescriptorSets.GetHandlePointer();
 
-    VkResult replay_result = OverrideAllocateDescriptorSets(GetDeviceTable(in_device)->AllocateDescriptorSets, returnValue, in_device, in_pAllocateInfo, out_pDescriptorSets);
+    VkResult replay_result = OverrideAllocateDescriptorSets(GetDeviceTable(in_device)->AllocateDescriptorSets, returnValue, in_device, in_pAllocateInfo, pDescriptorSets, out_pDescriptorSets);
     CheckResult("vkAllocateDescriptorSets", returnValue, replay_result);
 
     AddHandles<VkDescriptorSet>(pDescriptorSets.GetPointer(), pDescriptorSets.GetLength(), out_pDescriptorSets, in_pAllocateInfo->descriptorSetCount, &VulkanObjectMapper::AddVkDescriptorSet);
@@ -1282,7 +1282,7 @@ void VulkanReplayConsumer::Process_vkAllocateCommandBuffers(
     MapStructHandles(pAllocateInfo.GetMetaStructPointer(), GetObjectMapper());
     VkCommandBuffer* out_pCommandBuffers = pCommandBuffers.GetHandlePointer();
 
-    VkResult replay_result = OverrideAllocateCommandBuffers(GetDeviceTable(in_device)->AllocateCommandBuffers, returnValue, in_device, in_pAllocateInfo, out_pCommandBuffers);
+    VkResult replay_result = OverrideAllocateCommandBuffers(GetDeviceTable(in_device)->AllocateCommandBuffers, returnValue, in_device, in_pAllocateInfo, pCommandBuffers, out_pCommandBuffers);
     CheckResult("vkAllocateCommandBuffers", returnValue, replay_result);
 
     AddHandles<VkCommandBuffer>(pCommandBuffers.GetPointer(), pCommandBuffers.GetLength(), out_pCommandBuffers, in_pAllocateInfo->commandBufferCount, &VulkanObjectMapper::AddVkCommandBuffer);
@@ -2212,7 +2212,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorUpdateTemplate(
     VkDescriptorUpdateTemplate out_pDescriptorUpdateTemplate_value = static_cast<VkDescriptorUpdateTemplate>(0);
     VkDescriptorUpdateTemplate* out_pDescriptorUpdateTemplate = &out_pDescriptorUpdateTemplate_value;
 
-    VkResult replay_result = OverrideCreateDescriptorUpdateTemplate(GetDeviceTable(in_device)->CreateDescriptorUpdateTemplate, returnValue, in_device, in_pCreateInfo, in_pAllocator, out_pDescriptorUpdateTemplate);
+    VkResult replay_result = OverrideCreateDescriptorUpdateTemplate(GetDeviceTable(in_device)->CreateDescriptorUpdateTemplate, returnValue, in_device, in_pCreateInfo, in_pAllocator, pDescriptorUpdateTemplate, out_pDescriptorUpdateTemplate);
     CheckResult("vkCreateDescriptorUpdateTemplate", returnValue, replay_result);
 
     AddHandles<VkDescriptorUpdateTemplate>(pDescriptorUpdateTemplate.GetPointer(), 1, out_pDescriptorUpdateTemplate, 1, &VulkanObjectMapper::AddVkDescriptorUpdateTemplate);
@@ -2672,7 +2672,7 @@ void VulkanReplayConsumer::Process_vkCreateXlibSurfaceKHR(
     VkSurfaceKHR out_pSurface_value = static_cast<VkSurfaceKHR>(0);
     VkSurfaceKHR* out_pSurface = &out_pSurface_value;
 
-    VkResult replay_result = OverrideCreateXlibSurfaceKHR(GetInstanceTable(in_instance)->CreateXlibSurfaceKHR, returnValue, in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
+    VkResult replay_result = OverrideCreateXlibSurfaceKHR(GetInstanceTable(in_instance)->CreateXlibSurfaceKHR, returnValue, in_instance, in_pCreateInfo, in_pAllocator, pSurface, out_pSurface);
     CheckResult("vkCreateXlibSurfaceKHR", returnValue, replay_result);
 
     AddHandles<VkSurfaceKHR>(pSurface.GetPointer(), 1, out_pSurface, 1, &VulkanObjectMapper::AddVkSurfaceKHR);
@@ -2704,7 +2704,7 @@ void VulkanReplayConsumer::Process_vkCreateXcbSurfaceKHR(
     VkSurfaceKHR out_pSurface_value = static_cast<VkSurfaceKHR>(0);
     VkSurfaceKHR* out_pSurface = &out_pSurface_value;
 
-    VkResult replay_result = OverrideCreateXcbSurfaceKHR(GetInstanceTable(in_instance)->CreateXcbSurfaceKHR, returnValue, in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
+    VkResult replay_result = OverrideCreateXcbSurfaceKHR(GetInstanceTable(in_instance)->CreateXcbSurfaceKHR, returnValue, in_instance, in_pCreateInfo, in_pAllocator, pSurface, out_pSurface);
     CheckResult("vkCreateXcbSurfaceKHR", returnValue, replay_result);
 
     AddHandles<VkSurfaceKHR>(pSurface.GetPointer(), 1, out_pSurface, 1, &VulkanObjectMapper::AddVkSurfaceKHR);
@@ -2736,7 +2736,7 @@ void VulkanReplayConsumer::Process_vkCreateWaylandSurfaceKHR(
     VkSurfaceKHR out_pSurface_value = static_cast<VkSurfaceKHR>(0);
     VkSurfaceKHR* out_pSurface = &out_pSurface_value;
 
-    VkResult replay_result = OverrideCreateWaylandSurfaceKHR(GetInstanceTable(in_instance)->CreateWaylandSurfaceKHR, returnValue, in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
+    VkResult replay_result = OverrideCreateWaylandSurfaceKHR(GetInstanceTable(in_instance)->CreateWaylandSurfaceKHR, returnValue, in_instance, in_pCreateInfo, in_pAllocator, pSurface, out_pSurface);
     CheckResult("vkCreateWaylandSurfaceKHR", returnValue, replay_result);
 
     AddHandles<VkSurfaceKHR>(pSurface.GetPointer(), 1, out_pSurface, 1, &VulkanObjectMapper::AddVkSurfaceKHR);
@@ -2767,7 +2767,7 @@ void VulkanReplayConsumer::Process_vkCreateAndroidSurfaceKHR(
     VkSurfaceKHR out_pSurface_value = static_cast<VkSurfaceKHR>(0);
     VkSurfaceKHR* out_pSurface = &out_pSurface_value;
 
-    VkResult replay_result = OverrideCreateAndroidSurfaceKHR(GetInstanceTable(in_instance)->CreateAndroidSurfaceKHR, returnValue, in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
+    VkResult replay_result = OverrideCreateAndroidSurfaceKHR(GetInstanceTable(in_instance)->CreateAndroidSurfaceKHR, returnValue, in_instance, in_pCreateInfo, in_pAllocator, pSurface, out_pSurface);
     CheckResult("vkCreateAndroidSurfaceKHR", returnValue, replay_result);
 
     AddHandles<VkSurfaceKHR>(pSurface.GetPointer(), 1, out_pSurface, 1, &VulkanObjectMapper::AddVkSurfaceKHR);
@@ -2786,7 +2786,7 @@ void VulkanReplayConsumer::Process_vkCreateWin32SurfaceKHR(
     VkSurfaceKHR out_pSurface_value = static_cast<VkSurfaceKHR>(0);
     VkSurfaceKHR* out_pSurface = &out_pSurface_value;
 
-    VkResult replay_result = OverrideCreateWin32SurfaceKHR(GetInstanceTable(in_instance)->CreateWin32SurfaceKHR, returnValue, in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
+    VkResult replay_result = OverrideCreateWin32SurfaceKHR(GetInstanceTable(in_instance)->CreateWin32SurfaceKHR, returnValue, in_instance, in_pCreateInfo, in_pAllocator, pSurface, out_pSurface);
     CheckResult("vkCreateWin32SurfaceKHR", returnValue, replay_result);
 
     AddHandles<VkSurfaceKHR>(pSurface.GetPointer(), 1, out_pSurface, 1, &VulkanObjectMapper::AddVkSurfaceKHR);
@@ -3140,7 +3140,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorUpdateTemplateKHR(
     VkDescriptorUpdateTemplate out_pDescriptorUpdateTemplate_value = static_cast<VkDescriptorUpdateTemplate>(0);
     VkDescriptorUpdateTemplate* out_pDescriptorUpdateTemplate = &out_pDescriptorUpdateTemplate_value;
 
-    VkResult replay_result = OverrideCreateDescriptorUpdateTemplate(GetDeviceTable(in_device)->CreateDescriptorUpdateTemplateKHR, returnValue, in_device, in_pCreateInfo, in_pAllocator, out_pDescriptorUpdateTemplate);
+    VkResult replay_result = OverrideCreateDescriptorUpdateTemplate(GetDeviceTable(in_device)->CreateDescriptorUpdateTemplateKHR, returnValue, in_device, in_pCreateInfo, in_pAllocator, pDescriptorUpdateTemplate, out_pDescriptorUpdateTemplate);
     CheckResult("vkCreateDescriptorUpdateTemplateKHR", returnValue, replay_result);
 
     AddHandles<VkDescriptorUpdateTemplate>(pDescriptorUpdateTemplate.GetPointer(), 1, out_pDescriptorUpdateTemplate, 1, &VulkanObjectMapper::AddVkDescriptorUpdateTemplate);

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -1,6 +1,10 @@
 { "functions": {
     "vkCreateInstance" : "OverrideCreateInstance",
     "vkCreateDevice" : "OverrideCreateDevice",
+    "vkEnumeratePhysicalDevices" : "OverrideEnumeratePhysicalDevices",
+    "vkGetPhysicalDeviceProperties" : "OverrideGetPhysicalDeviceProperties",
+    "vkGetPhysicalDeviceProperties2" : "OverrideGetPhysicalDeviceProperties2",
+    "vkGetPhysicalDeviceProperties2KHR" : "OverrideGetPhysicalDeviceProperties2KHR",
     "vkWaitForFences" : "OverrideWaitForFences",
     "vkGetFenceStatus" : "OverrideGetFenceStatus",
     "vkGetEventStatus" : "OverrideGetEventStatus",

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -26,6 +26,7 @@
 const char kApplicationName[] = "GFXReconstruct Replay";
 const char kCaptureLayer[]    = "VK_LAYER_LUNARG_gfxreconstruct";
 
+const char kOverrideGpuArgument[]              = "--gpu";
 const char kPausedOption[]                     = "--paused";
 const char kPauseFrameArgument[]               = "--pause-frame";
 const char kSkipFailedAllocationShortOption[]  = "--sfa";
@@ -35,10 +36,9 @@ const char kOmitPipelineCacheDataLongOption[]  = "--omit-pipeline-cache-data";
 
 // TODO: Make this a vector of strings.
 const char kOptions[]   = "--paused,--sfa|--skip-failed-allocations,--opcd|--omit-pipeline-cache-data";
-const char kArguments[] = "--pause-frame";
+const char kArguments[] = "--gpu,--pause-frame";
 
-    static void
-    CheckActiveLayers(const char* env_var)
+static void CheckActiveLayers(const char* env_var)
 {
     std::string result = gfxrecon::util::platform::GetEnv(env_var);
 
@@ -71,6 +71,12 @@ static uint32_t GetPauseFrame(const gfxrecon::util::ArgumentParser& arg_parser)
 static gfxrecon::decode::ReplayOptions GetReplayOptions(const gfxrecon::util::ArgumentParser& arg_parser)
 {
     gfxrecon::decode::ReplayOptions replay_options;
+    std::string                     override_gpu = arg_parser.GetArgumentValue(kOverrideGpuArgument);
+
+    if (!override_gpu.empty())
+    {
+        replay_options.override_gpu_index = std::stoi(override_gpu);
+    }
 
     if (arg_parser.IsOptionSet(kSkipFailedAllocationLongOption) ||
         arg_parser.IsOptionSet(kSkipFailedAllocationShortOption))
@@ -99,12 +105,17 @@ static void PrintUsage(const char* exe_name)
 
     GFXRECON_WRITE_CONSOLE("\n%s - A tool to replay GFXReconstruct capture files.\n", app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");
-    GFXRECON_WRITE_CONSOLE("  %s\t[--pause-frame <N>] [--paused] [--sfa | --skip-failed-allocations]",
-                           app_name.c_str());
+    GFXRECON_WRITE_CONSOLE("  %s\t[--gpu <index>] [--pause-frame <N>] [--paused]", app_name.c_str());
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--sfa | --skip-failed-allocations]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--opcd | --omit-pipeline-cache-data] <file>\n");
     GFXRECON_WRITE_CONSOLE("Required arguments:");
     GFXRECON_WRITE_CONSOLE("  <file>\t\tPath to the capture file to replay");
     GFXRECON_WRITE_CONSOLE("\nOptional arguments:");
+    GFXRECON_WRITE_CONSOLE("  --gpu <index>\t\tUse the specified device for replay, where index");
+    GFXRECON_WRITE_CONSOLE("          \t\tis the zero-based index to the array of physical devices");
+    GFXRECON_WRITE_CONSOLE("          \t\treturned by vkEnumeratePhysicalDevices; replay may fail");
+    GFXRECON_WRITE_CONSOLE("          \t\tif the specified device is not compatible with the");
+    GFXRECON_WRITE_CONSOLE("          \t\toriginal capture devices)");
     GFXRECON_WRITE_CONSOLE("  --pause-frame <N>\tPause after replaying frame number N");
     GFXRECON_WRITE_CONSOLE("  --paused\t\tPause after replaying the first frame (same");
     GFXRECON_WRITE_CONSOLE("          \t\tas --pause-frame 1)");


### PR DESCRIPTION
Add an option to gfxrecon-replay to specify the physical device to use for replay, `--gpu <index>`, where `index` is the zero-based index to the array of physical devices returned by vkEnumeratePhysicalDevices.

The new replay device must be compatible with the capture device for successful replay.   Replay will currently fail if the devices do not have compatible memory heaps/types, or if the replay device does not support the device features and extensions that were enabled during capture.

Addresses #247