### PR TITLE
Code style: add code style checking before compiling

### DIFF
--- a/cmake/CodeStyle.cmake
+++ b/cmake/CodeStyle.cmake
@@ -19,7 +19,7 @@
 
 cmake_minimum_required(VERSION 3.1)
 
-option(APPLY_CPP_CODE_STYLE "Apply C++ code style using clang format" ON)
+option(APPLY_CPP_CODE_STYLE "Apply C++ code style using clang format" OFF)
 option(CHECK_CPP_CODE_STYLE "Check C++ code style using clang format" ON)
 
 find_program(CLANG_FORMAT clang-format DOC "Clang format executable")

--- a/cmake/CodeStyle.cmake
+++ b/cmake/CodeStyle.cmake
@@ -19,9 +19,27 @@
 
 cmake_minimum_required(VERSION 3.1)
 
-option(APPLY_CPP_CODE_STYLE "Apply C++ code style using clang format" OFF)
+option(APPLY_CPP_CODE_STYLE "Apply C++ code style using clang format" ON)
+option(CHECK_CPP_CODE_STYLE "Check C++ code style using clang format" ON)
 
 find_program(CLANG_FORMAT clang-format DOC "Clang format executable")
+
+# Python
+if(CMAKE_HOST_WIN32)
+    find_program(PYTHON "python.exe" PATHS $ENV{PATH} DOC "Python 3 executable")
+    execute_process(COMMAND ${PYTHON} --version OUTPUT_VARIABLE PYTHON_VERSION)
+    string(REPLACE "Python " "" "PYTHON_VERSION" "${PYTHON_VERSION}")
+    if("${PYTHON_VERSION}" VERSION_LESS "3.0.0")
+        message(FATAL_ERROR "Python 3+ is required. Python version ${PYTHON_VERSION} found.")
+    endif()
+else()
+    find_program(PYTHON python3 DOC "Python 3 executable")
+endif()
+
+macro(generate_target_source_files TARGET TARGET_SOURCE_FILES)
+    get_target_property(${TARGET_SOURCE_FILES} ${TARGET} SOURCES)
+    list(FILTER ${TARGET_SOURCE_FILES} EXCLUDE REGEX ".+\.def|generated_.+")
+endmacro()
 
 # Apply code style build directives
 macro(target_code_style_build_directives TARGET)
@@ -29,13 +47,24 @@ macro(target_code_style_build_directives TARGET)
         if(CLANG_FORMAT-NOTFOUND STREQUAL ${CLANG_FORMAT})
             message(FATAL_ERROR "Failed to find clang-format in system path")
         endif()
-        get_target_property(TARGET_SOURCE_FILES ${TARGET} SOURCES)
-        list(FILTER TARGET_SOURCE_FILES EXCLUDE REGEX ".+\.def|generated_.+")
+        # If apply code style is on, turn off check code style
+        set(CHECK_CPP_CODE_STYLE OFF)
+        generate_target_source_files(${TARGET} OUTPUT TARGET_SOURCE_FILES)
         add_custom_target("${TARGET}ClangFormat"
-                COMMAND ${CLANG_FORMAT} -i ${TARGET_SOURCE_FILES}
+                COMMAND ${CLANG_FORMAT} -i ${OUTPUT}
                 WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
                 COMMENT "Run clang format for ${TARGET}"
                 COMMAND_EXPAND_LISTS)
         add_dependencies(${TARGET} "${TARGET}ClangFormat")
+    endif()
+    if(${CHECK_CPP_CODE_STYLE})
+        generate_target_source_files(${TARGET} OUTPUT TARGET_SOURCE_FILES)
+        # Call the script to check formatting
+        add_custom_target("${TARGET}CodeStyleCheck"
+                COMMAND "${PYTHON}" ${GFXReconstruct_SOURCE_DIR}/scripts/check_code_style.py
+                --sourcefile ${OUTPUT}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+                COMMENT "Check code style for ${TARGET}")
+        add_dependencies(${TARGET} "${TARGET}CodeStyleCheck")
     endif()
 endmacro()

--- a/cmake/CodeStyle.cmake
+++ b/cmake/CodeStyle.cmake
@@ -20,9 +20,11 @@
 cmake_minimum_required(VERSION 3.1)
 
 option(APPLY_CPP_CODE_STYLE "Apply C++ code style using clang format" OFF)
-option(CHECK_CPP_CODE_STYLE "Check C++ code style using clang format" ON)
+option(CHECK_CPP_CODE_STYLE "Check C++ code style using clang format" OFF)
 
-find_program(CLANG_FORMAT clang-format DOC "Clang format executable")
+if(${APPLY_CPP_CODE_STYLE} OR ${CHECK_CPP_CODE_STYLE})
+    find_program(CLANG_FORMAT clang-format DOC "Clang format executable")
+endif()
 
 # Python
 if(CMAKE_HOST_WIN32)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -87,6 +87,10 @@ def parse_args():
         action='store_true', default=False,
         help='Apply C++ code style before compiling')
     arg_parser.add_argument(
+        '--skip-check-code-style', dest='skip_check_code_style',
+        action='store_true', default=False,
+        help='Skip checking C++ code style before compiling')
+    arg_parser.add_argument(
         '--static-analysis', dest='static_analysis',
         action='store_true', default=False,
         help='Run static analysis on the code')
@@ -141,6 +145,10 @@ def cmake_generate_options(args):
             generate_options.append('-DAPPLY_CPP_CODE_STYLE=ON')
         else:
             generate_options.append('-DAPPLY_CPP_CODE_STYLE=OFF')
+        if args.skip_check_code_style:
+            generate_options.append('-DCHECK_CPP_CODE_STYLE=OFF')
+        else:
+            generate_options.append('-DCHECK_CPP_CODE_STYLE=ON')
         if args.static_analysis:
             generate_options.append('-DRUN_STATIC_ANALYSIS=ON')
         else:

--- a/scripts/check_code_style.py
+++ b/scripts/check_code_style.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2019 Advanced Micro Devices, Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+GFX reconstruct check code style script
+'''
+
+import subprocess
+import sys
+import argparse
+
+def check_code_style(file):
+    """
+    Run clang format diff on the changed source file(s)
+    against current branch. If branch retrieved failed, 
+    fall back to diff against master branch.
+    :raises Exception: when formatting errors found
+    """
+    git_branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
+    if git_branch == b'':
+        git_branch = "master"
+    cmd = ["git", "diff", "-U0", str(git_branch, 'utf-8'),
+           "--"] + file + ["|", "python", "clang-format-diff.py","-p1","-style=file"]
+    try:
+        cmd_output = subprocess.check_output(cmd)
+        if cmd_output != b'':
+            raise Exception("FORMATTING ERROR!\n" + str(cmd_output, 'utf-8'))
+    except subprocess.CalledProcessError as e:
+        print("ERROR calling clang-format-diff.py [{}]".format(e))
+        sys.exit(1)
+
+# Main entry point
+if '__main__' == __name__:
+    # parse params and run check code style function
+    parser = argparse.ArgumentParser(prog='check_code_style',
+                                     description='Checks if file match the code style specification')
+    parser.add_argument('--sourcefile', nargs='+', dest='file', help="The source file(s)")
+    args = parser.parse_args()
+    check_code_style(args.file)
+    sys.exit(0)

--- a/scripts/clang-format-diff.py
+++ b/scripts/clang-format-diff.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+#
+#===- clang-format-diff.py - ClangFormat Diff Reformatter ----*- python -*--===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===------------------------------------------------------------------------===#
+
+r"""
+ClangFormat Diff Reformatter
+============================
+
+This script reads input from a unified diff and reformats all the changed
+lines. This is useful to reformat all the lines touched by a specific patch.
+Example usage for git/svn users:
+
+  git diff -U0 --no-color HEAD^ | clang-format-diff.py -p1 -i
+  svn diff --diff-cmd=diff -x-U0 | clang-format-diff.py -i
+
+"""
+from __future__ import absolute_import, division, print_function
+
+import argparse
+import difflib
+import re
+import subprocess
+import sys
+
+if sys.version_info.major >= 3:
+    from io import StringIO
+else:
+    from io import BytesIO as StringIO
+
+
+def main():
+  parser = argparse.ArgumentParser(description=
+                                   'Reformat changed lines in diff. Without -i '
+                                   'option just output the diff that would be '
+                                   'introduced.')
+  parser.add_argument('-i', action='store_true', default=False,
+                      help='apply edits to files instead of displaying a diff')
+  parser.add_argument('-p', metavar='NUM', default=0,
+                      help='strip the smallest prefix containing P slashes')
+  parser.add_argument('-regex', metavar='PATTERN', default=None,
+                      help='custom pattern selecting file paths to reformat '
+                      '(case sensitive, overrides -iregex)')
+  parser.add_argument('-iregex', metavar='PATTERN', default=
+                      r'.*\.(cpp|cc|c\+\+|cxx|c|cl|h|hpp|m|mm|inc|js|ts|proto'
+                      r'|protodevel|java)',
+                      help='custom pattern selecting file paths to reformat '
+                      '(case insensitive, overridden by -regex)')
+  parser.add_argument('-sort-includes', action='store_true', default=False,
+                      help='let clang-format sort include blocks')
+  parser.add_argument('-v', '--verbose', action='store_true',
+                      help='be more verbose, ineffective without -i')
+  parser.add_argument('-style',
+                      help='formatting style to apply (LLVM, Google, Chromium, '
+                      'Mozilla, WebKit)')
+  parser.add_argument('-binary', default='clang-format',
+                      help='location of binary to use for clang-format')
+  args = parser.parse_args()
+
+  # Extract changed lines for each file.
+  filename = None
+  lines_by_file = {}
+  for line in sys.stdin:
+    match = re.search(r'^\+\+\+\ (.*?/){%s}(\S*)' % args.p, line)
+    if match:
+      filename = match.group(2)
+    if filename == None:
+      continue
+
+    if args.regex is not None:
+      if not re.match('^%s$' % args.regex, filename):
+        continue
+    else:
+      if not re.match('^%s$' % args.iregex, filename, re.IGNORECASE):
+        continue
+
+    match = re.search(r'^@@.*\+(\d+)(,(\d+))?', line)
+    if match:
+      start_line = int(match.group(1))
+      line_count = 1
+      if match.group(3):
+        line_count = int(match.group(3))
+      if line_count == 0:
+        continue
+      end_line = start_line + line_count - 1
+      lines_by_file.setdefault(filename, []).extend(
+          ['-lines', str(start_line) + ':' + str(end_line)])
+
+  # Reformat files containing changes in place.
+  for filename, lines in lines_by_file.items():
+    if args.i and args.verbose:
+      print('Formatting {}'.format(filename))
+    command = [args.binary, filename]
+    if args.i:
+      command.append('-i')
+    if args.sort_includes:
+      command.append('-sort-includes')
+    command.extend(lines)
+    if args.style:
+      command.extend(['-style', args.style])
+    p = subprocess.Popen(command,
+                         stdout=subprocess.PIPE,
+                         stderr=None,
+                         stdin=subprocess.PIPE,
+                         universal_newlines=True)
+    stdout, stderr = p.communicate()
+    if p.returncode != 0:
+      sys.exit(p.returncode)
+
+    if not args.i:
+      with open(filename) as f:
+        code = f.readlines()
+      formatted_code = StringIO(stdout).readlines()
+      diff = difflib.unified_diff(code, formatted_code,
+                                  filename, filename,
+                                  '(before formatting)', '(after formatting)')
+      diff_string = ''.join(diff)
+      if len(diff_string) > 0:
+        sys.stdout.write(diff_string)
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
- Use clang-format-diff.py which is distributed part of
LLVM project to perform code style checking
- Add check_code_style.py script to be called from CodeStyle.cmake
in order to perform the check
- Code style check can be turned off with option
--skip-check-code-style, it is on by default

SWLGFXREC-7

Change-Id: I374ea940bb81151d6fb3b6451d09524dd521e264