### PR TITLE
Separate Passes for Trimming Resource Create/Bind

### DIFF
--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -120,10 +120,6 @@ class VulkanStateWriter
 
     void WriteSemaphoreState(const VulkanStateTable& state_table);
 
-    void WriteBufferState(const VulkanStateTable& state_table);
-
-    void WriteImageState(const VulkanStateTable& state_table);
-
     void WriteFramebufferState(const VulkanStateTable& state_table);
 
     void WritePipelineLayoutState(const VulkanStateTable& state_table);
@@ -145,6 +141,10 @@ class VulkanStateWriter
     void ProcessImageMemory(const DeviceWrapper*     device_wrapper,
                             const ImageSnapshotData& snapshot_data,
                             const VulkanStateTable&  state_table);
+
+    void WriteBufferMemoryBindState(const VulkanStateTable& state_table);
+
+    void WriteImageMemoryBindState(const VulkanStateTable& state_table);
 
     void WriteMappedMemoryState(const VulkanStateTable& state_table);
 


### PR DESCRIPTION
When writing the trimming state snapshot, splits the buffer/image initialization into separate passes for buffer/image creation and memory bind/upload. Memory allocation had been performed for the trimming state snapshot before buffer/image initialization, which consisted of buffer/image creation, memory binding, and memory content upload. The buffer/image initialization needed to be split into separate passes for buffer/image creation and memory bind/upload to allow memory allocation to be performed after buffer/image creation for cases where valid buffer/image handles are required by memory allocation extensions such as dedicated allocation.
