### PR TITLE
Swapchain image pre-acquire for trim state setup

### DIFF
--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/string_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/struct_pointer_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/struct_pointer_decoder_nvx.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/swapchain_image_tracker.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/value_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_ascii_consumer_base.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_ascii_consumer_base.cpp

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(gfxrecon_decode
                    string_decoder.h
                    struct_pointer_decoder.h
                    struct_pointer_decoder_nvx.h
+                   swapchain_image_tracker.h
                    value_decoder.h
                    vulkan_ascii_consumer_base.h
                    vulkan_ascii_consumer_base.cpp

--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -57,6 +57,13 @@ class ApiDecoder
                                              uint32_t         width,
                                              uint32_t         height)
     {}
+
+    virtual void DispatchSetSwapchainImageStateCommand(format::ThreadId thread_id,
+                                                       format::HandleId device_id,
+                                                       format::HandleId swapchain_id,
+                                                       uint32_t         queue_family_index,
+                                                       const std::vector<format::SwapchainImageStateEntry>& image_state)
+    {}
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/swapchain_image_tracker.h
+++ b/framework/decode/swapchain_image_tracker.h
@@ -1,0 +1,84 @@
+/*
+** Copyright (c) 2019 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef GFXRECON_DECODE_SWAPCHAIN_IMAGE_TRACKER_H
+#define GFXRECON_DECODE_SWAPCHAIN_IMAGE_TRACKER_H
+
+#include "util/defines.h"
+
+#include "vulkan/vulkan.h"
+
+#include <unordered_map>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+class SwapchainImageTracker
+{
+  public:
+    bool TrackPreAcquiredImage(VkSwapchainKHR swapchain, uint32_t image_index, VkSemaphore semaphore, VkFence fence)
+    {
+        auto result = images_[swapchain].emplace(image_index, ImageAcquireResources{ semaphore, fence });
+        return result.second;
+    }
+
+    bool RetrievePreAcquiredImage(VkSwapchainKHR swapchain, uint32_t image_index, VkSemaphore* semaphore, VkFence* fence)
+    {
+        bool found           = false;
+        auto swapchain_entry = images_.find(swapchain);
+
+        if (swapchain_entry != images_.end())
+        {
+            auto image_entry = swapchain_entry->second.find(image_index);
+            if (image_entry != swapchain_entry->second.end())
+            {
+                found = true;
+
+                if (semaphore != nullptr)
+                {
+                    (*semaphore) = image_entry->second.semaphore;
+                }
+
+                if (fence != nullptr)
+                {
+                    (*fence) = image_entry->second.fence;
+                }
+
+                swapchain_entry->second.erase(image_entry);
+            }
+        }
+
+        return found;
+    }
+
+  private:
+    struct ImageAcquireResources
+    {
+        VkSemaphore semaphore;
+        VkFence     fence;
+    };
+
+    typedef std::unordered_map<uint32_t, ImageAcquireResources> PreAcquiredImages;
+    typedef std::unordered_map<VkSwapchainKHR, PreAcquiredImages> SwapchainImages;
+
+  private:
+    SwapchainImages images_;
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_SWAPCHAIN_IMAGE_TRACKER_H

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -44,6 +44,12 @@ class VulkanConsumerBase
 
     virtual void ProcessResizeWindowCommand(format::HandleId surface_id, uint32_t width, uint32_t height) {}
 
+    virtual void ProcessSetSwapchainImageStateCommand(format::HandleId device_id,
+                                                      format::HandleId swapchain_id,
+                                                      uint32_t         queue_family_index,
+                                                      const std::vector<format::SwapchainImageStateEntry>& image_state)
+    {}
+
     virtual void Process_vkUpdateDescriptorSetWithTemplate(format::HandleId device,
                                                            format::HandleId descriptorSet,
                                                            format::HandleId descriptorUpdateTemplate,

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -58,6 +58,21 @@ void VulkanDecoderBase::DispatchResizeWindowCommand(format::ThreadId thread_id,
     }
 }
 
+void VulkanDecoderBase::DispatchSetSwapchainImageStateCommand(
+    format::ThreadId                                     thread_id,
+    format::HandleId                                     device_id,
+    format::HandleId                                     swapchain_id,
+    uint32_t                                             queue_family_index,
+    const std::vector<format::SwapchainImageStateEntry>& image_state)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(thread_id);
+
+    for (auto consumer : consumers_)
+    {
+        consumer->ProcessSetSwapchainImageStateCommand(device_id, swapchain_id, queue_family_index, image_state);
+    }
+}
+
 size_t VulkanDecoderBase::Decode_vkUpdateDescriptorSetWithTemplate(const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -68,6 +68,13 @@ class VulkanDecoderBase : public ApiDecoder
                                              uint32_t         width,
                                              uint32_t         height) override;
 
+    virtual void
+    DispatchSetSwapchainImageStateCommand(format::ThreadId                                     thread_id,
+                                          format::HandleId                                     device_id,
+                                          format::HandleId                                     swapchain_id,
+                                          uint32_t                                             queue_family_index,
+                                          const std::vector<format::SwapchainImageStateEntry>& image_state) override;
+
   protected:
     const std::vector<VulkanConsumer*>& GetConsumers() const { return consumers_; }
 

--- a/framework/decode/vulkan_object_mapper.h
+++ b/framework/decode/vulkan_object_mapper.h
@@ -113,6 +113,30 @@ class VulkanObjectMapper
     VkAccelerationStructureNV     MapVkAccelerationStructureNV(format::HandleId id) const     { return MapObject<VkAccelerationStructureNV>(id, &acceleration_structure_nv_map_); }
     // clang-format on
 
+    void ReplaceSemaphore(VkSemaphore target, VkSemaphore replacement)
+    {
+        for (auto& entry : semaphore_map_)
+        {
+            if (entry.second == target)
+            {
+                entry.second = replacement;
+                break;
+            }
+        }
+    }
+
+    void ReplaceFence(VkFence target, VkFence replacement)
+    {
+        for (auto& entry : fence_map_)
+        {
+            if (entry.second == target)
+            {
+                entry.second = replacement;
+                break;
+            }
+        }
+    }
+
   private:
     template <typename T>
     void AddObject(format::HandleId id, T handle, std::unordered_map<format::HandleId, T>* map)

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -386,8 +386,7 @@ class TraceManager
         if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS))
         {
             assert((state_tracker_ != nullptr) && (index != nullptr));
-            state_tracker_->TrackSemaphoreSignalState(
-                0, nullptr, 1, &semaphore, SemaphoreWrapper::SignalSourceAcquireImage);
+            state_tracker_->TrackSemaphoreSignalState(0, nullptr, 1, &semaphore);
             state_tracker_->TrackAcquireImage(*index, swapchain, semaphore, fence);
         }
     }
@@ -400,8 +399,7 @@ class TraceManager
         if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS))
         {
             assert((state_tracker_ != nullptr) && (pAcquireInfo != nullptr) && (index != nullptr));
-            state_tracker_->TrackSemaphoreSignalState(
-                0, nullptr, 1, &pAcquireInfo->semaphore, SemaphoreWrapper::SignalSourceAcquireImage);
+            state_tracker_->TrackSemaphoreSignalState(0, nullptr, 1, &pAcquireInfo->semaphore);
             state_tracker_->TrackAcquireImage(
                 *index, pAcquireInfo->swapchain, pAcquireInfo->semaphore, pAcquireInfo->fence);
         }
@@ -412,11 +410,8 @@ class TraceManager
         if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS))
         {
             assert((state_tracker_ != nullptr) && (pPresentInfo != nullptr));
-            state_tracker_->TrackSemaphoreSignalState(pPresentInfo->waitSemaphoreCount,
-                                                      pPresentInfo->pWaitSemaphores,
-                                                      0,
-                                                      nullptr,
-                                                      SemaphoreWrapper::SignalSourceQueue);
+            state_tracker_->TrackSemaphoreSignalState(
+                pPresentInfo->waitSemaphoreCount, pPresentInfo->pWaitSemaphores, 0, nullptr);
             state_tracker_->TrackPresentedImages(
                 pPresentInfo->swapchainCount, pPresentInfo->pSwapchains, pPresentInfo->pImageIndices, queue);
         }
@@ -435,8 +430,7 @@ class TraceManager
                 state_tracker_->TrackSemaphoreSignalState(pBindInfo[i].waitSemaphoreCount,
                                                           pBindInfo[i].pWaitSemaphores,
                                                           pBindInfo[i].signalSemaphoreCount,
-                                                          pBindInfo[i].pSignalSemaphores,
-                                                          SemaphoreWrapper::SignalSourceQueue);
+                                                          pBindInfo[i].pSignalSemaphores);
             }
         }
     }
@@ -553,8 +547,7 @@ class TraceManager
                 state_tracker_->TrackSemaphoreSignalState(pSubmits[i].waitSemaphoreCount,
                                                           pSubmits[i].pWaitSemaphores,
                                                           pSubmits[i].signalSemaphoreCount,
-                                                          pSubmits[i].pSignalSemaphores,
-                                                          SemaphoreWrapper::SignalSourceQueue);
+                                                          pSubmits[i].pSignalSemaphores);
             }
         }
     }

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -387,7 +387,7 @@ class TraceManager
         {
             assert((state_tracker_ != nullptr) && (index != nullptr));
             state_tracker_->TrackSemaphoreSignalState(0, nullptr, 1, &semaphore);
-            state_tracker_->TrackAcquireImage(*index, swapchain, semaphore, fence);
+            state_tracker_->TrackAcquireImage(*index, swapchain, semaphore, fence, 0);
         }
     }
 
@@ -400,8 +400,11 @@ class TraceManager
         {
             assert((state_tracker_ != nullptr) && (pAcquireInfo != nullptr) && (index != nullptr));
             state_tracker_->TrackSemaphoreSignalState(0, nullptr, 1, &pAcquireInfo->semaphore);
-            state_tracker_->TrackAcquireImage(
-                *index, pAcquireInfo->swapchain, pAcquireInfo->semaphore, pAcquireInfo->fence);
+            state_tracker_->TrackAcquireImage(*index,
+                                              pAcquireInfo->swapchain,
+                                              pAcquireInfo->semaphore,
+                                              pAcquireInfo->fence,
+                                              pAcquireInfo->deviceMask);
         }
     }
 

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -195,14 +195,7 @@ struct SemaphoreWrapper : public HandleWrapper<VkSemaphore>
     // AcquireNextImageKHR, or AcquireNextImage2KHR as a signal semaphore. State is not signaled when a semaphore is
     // submitted to QueueSubmit, QueueBindSparse, or QueuePresentKHR as a wait semaphore. Initial state after creation
     // is not signaled.
-    enum SignalSource
-    {
-        SignalSourceNone         = 0, // Semaphore is not pending signal.
-        SignalSourceQueue        = 1, // Semaphore is pending signal from a queue operation.
-        SignalSourceAcquireImage = 2  // Semaphore is pending signal from a swapchain acquire image operation.
-    };
-
-    SignalSource   signaled{ SignalSourceNone };
+    bool           signaled{ false };
     DeviceWrapper* device{ nullptr };
 };
 

--- a/framework/encode/vulkan_state_info.h
+++ b/framework/encode/vulkan_state_info.h
@@ -93,6 +93,7 @@ struct ShaderModuleInfo
 struct ImageAcquiredInfo
 {
     bool             is_acquired{ true };
+    uint32_t         acquired_device_mask{ 0 };
     format::HandleId acquired_semaphore_id{ 0 };
     format::HandleId acquired_fence_id{ 0 };
     VkQueue          last_presented_queue{ VK_NULL_HANDLE };

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -832,11 +832,10 @@ void VulkanStateTracker::TrackQueryReset(VkQueryPool query_pool, uint32_t first_
     }
 }
 
-void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t                       wait_count,
-                                                   const VkSemaphore*             waits,
-                                                   uint32_t                       signal_count,
-                                                   const VkSemaphore*             signals,
-                                                   SemaphoreWrapper::SignalSource signal_source)
+void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t           wait_count,
+                                                   const VkSemaphore* waits,
+                                                   uint32_t           signal_count,
+                                                   const VkSemaphore* signals)
 {
     if (((waits != nullptr) && (wait_count > 0)) || ((signals != nullptr) && (signal_count > 0)))
     {
@@ -848,7 +847,7 @@ void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t                     
             {
                 auto wrapper = reinterpret_cast<SemaphoreWrapper*>(waits[i]);
                 assert(wrapper != nullptr);
-                wrapper->signaled = SemaphoreWrapper::SignalSourceNone;
+                wrapper->signaled = false;
             }
         }
 
@@ -858,7 +857,7 @@ void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t                     
             {
                 auto wrapper = reinterpret_cast<SemaphoreWrapper*>(signals[i]);
                 assert(wrapper != nullptr);
-                wrapper->signaled = signal_source;
+                wrapper->signaled = true;
             }
         }
     }

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -863,10 +863,8 @@ void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t           wait_count
     }
 }
 
-void VulkanStateTracker::TrackAcquireImage(uint32_t       image_index,
-                                           VkSwapchainKHR swapchain,
-                                           VkSemaphore    semaphore,
-                                           VkFence        fence)
+void VulkanStateTracker::TrackAcquireImage(
+    uint32_t image_index, VkSwapchainKHR swapchain, VkSemaphore semaphore, VkFence fence, uint32_t deviceMask)
 {
     assert(swapchain != VK_NULL_HANDLE);
 
@@ -875,6 +873,7 @@ void VulkanStateTracker::TrackAcquireImage(uint32_t       image_index,
     auto wrapper = reinterpret_cast<SwapchainKHRWrapper*>(swapchain);
 
     wrapper->image_acquired_info[image_index].is_acquired           = true;
+    wrapper->image_acquired_info[image_index].acquired_device_mask  = deviceMask;
     wrapper->image_acquired_info[image_index].acquired_semaphore_id = GetWrappedId(semaphore);
     wrapper->image_acquired_info[image_index].acquired_fence_id     = GetWrappedId(fence);
 }

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -306,11 +306,10 @@ class VulkanStateTracker
 
     void TrackQueryReset(VkQueryPool query_pool, uint32_t first_query, uint32_t query_count);
 
-    void TrackSemaphoreSignalState(uint32_t                       wait_count,
-                                   const VkSemaphore*             waits,
-                                   uint32_t                       signal_count,
-                                   const VkSemaphore*             signals,
-                                   SemaphoreWrapper::SignalSource signal_source);
+    void TrackSemaphoreSignalState(uint32_t           wait_count,
+                                   const VkSemaphore* waits,
+                                   uint32_t           signal_count,
+                                   const VkSemaphore* signals);
 
     void TrackAcquireImage(uint32_t image_index, VkSwapchainKHR swapchain, VkSemaphore semaphore, VkFence fence);
 

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -311,7 +311,8 @@ class VulkanStateTracker
                                    uint32_t           signal_count,
                                    const VkSemaphore* signals);
 
-    void TrackAcquireImage(uint32_t image_index, VkSwapchainKHR swapchain, VkSemaphore semaphore, VkFence fence);
+    void TrackAcquireImage(
+        uint32_t image_index, VkSwapchainKHR swapchain, VkSemaphore semaphore, VkFence fence, uint32_t deviceMask);
 
     void TrackPresentedImages(uint32_t              count,
                               const VkSwapchainKHR* swapchains,

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -277,7 +277,7 @@ void VulkanStateWriter::WriteSemaphoreState(const VulkanStateTable& state_table)
         // Write event creation call.
         WriteFunctionCall(wrapper->create_call_id, wrapper->create_parameters.get());
 
-        if (wrapper->signaled != SemaphoreWrapper::SignalSourceNone)
+        if (wrapper->signaled)
         {
             signaled[wrapper->device].push_back(wrapper->handle_id);
         }

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1444,7 +1444,8 @@ void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_t
 
             if (wrapper->image_acquired_info[i].is_acquired)
             {
-                entry.acquired = true;
+                entry.acquired            = true;
+                entry.acquire_device_mask = wrapper->image_acquired_info[i].acquired_device_mask;
 
                 // Only provide sync object IDs if the objects have not been destroyed between now and image acquire.
                 const SemaphoreWrapper* semaphore_wrapper =
@@ -1460,9 +1461,6 @@ void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_t
                 {
                     entry.acquire_fence_id = wrapper->image_acquired_info[i].acquired_fence_id;
                 }
-
-                // TODO: Track vkAcquireNexteImage2KHR device mask.
-                entry.acquire_device_mask = 0;
             }
             else
             {

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -64,16 +64,15 @@ enum BlockType : uint32_t
 
 enum MetaDataType : uint32_t
 {
-    kUnknownMetaDataType      = 0,
+    kUnknownMetaDataType = 0,
 
     // Platform independent metadata commands.
-    kDisplayMessageCommand    = 1,
-    kFillMemoryCommand        = 2,
-    kResizeWindowCommand      = 3,
+    kDisplayMessageCommand = 1,
+    kFillMemoryCommand     = 2,
+    kResizeWindowCommand   = 3,
 
-    // Vulkan specific metadata.
-    kVulkanPhysicalDeviceInfo = 4,
-    kVulkanMemoryInfo         = 5
+    // Commands for trimmed frame state setup.
+    kSetSwapchainImageStateCommand = 4
 };
 
 enum CompressionType : uint32_t
@@ -196,6 +195,28 @@ struct ResizeWindowCommand
     HandleId         surface_id;
     uint32_t         width;
     uint32_t         height;
+};
+
+struct SetSwapchainImageStateCommandHeader
+{
+    MetaDataHeader   meta_header;
+    format::ThreadId thread_id;
+    format::HandleId device_id;
+    format::HandleId swapchain_id;
+    uint32_t         queue_family_index;
+    uint32_t         image_entry_count;
+};
+
+struct SwapchainImageStateEntry
+{
+    format::HandleId image_id;
+    uint32_t         image_index;
+    uint32_t         image_layout;
+    uint32_t         acquired;
+    uint32_t         acquire_device_mask;
+    format::HandleId acquire_semaphore_id;
+    format::HandleId acquire_fence_id;
+    format::HandleId last_presented_queue_id;
 };
 
 #pragma pack(pop)

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -2433,7 +2433,7 @@ void VulkanReplayConsumer::Process_vkAcquireNextImageKHR(
     uint32_t out_pImageIndex_value = static_cast<uint32_t>(0);
     uint32_t* out_pImageIndex = &out_pImageIndex_value;
 
-    VkResult replay_result = GetDeviceTable(in_device)->AcquireNextImageKHR(in_device, in_swapchain, timeout, in_semaphore, in_fence, out_pImageIndex);
+    VkResult replay_result = OverrideAcquireNextImageKHR(GetDeviceTable(in_device)->AcquireNextImageKHR, returnValue, in_device, in_swapchain, timeout, in_semaphore, in_fence, pImageIndex, out_pImageIndex);
     CheckResult("vkAcquireNextImageKHR", returnValue, replay_result);
 }
 
@@ -2509,7 +2509,7 @@ void VulkanReplayConsumer::Process_vkAcquireNextImage2KHR(
     uint32_t out_pImageIndex_value = static_cast<uint32_t>(0);
     uint32_t* out_pImageIndex = &out_pImageIndex_value;
 
-    VkResult replay_result = GetDeviceTable(in_device)->AcquireNextImage2KHR(in_device, in_pAcquireInfo, out_pImageIndex);
+    VkResult replay_result = OverrideAcquireNextImage2KHR(GetDeviceTable(in_device)->AcquireNextImage2KHR, returnValue, in_device, in_pAcquireInfo, pImageIndex, out_pImageIndex);
     CheckResult("vkAcquireNextImage2KHR", returnValue, replay_result);
 }
 

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -20,6 +20,8 @@
     "vkCreateDescriptorUpdateTemplateKHR" : "OverrideCreateDescriptorUpdateTemplate",
     "vkDestroyDescriptorUpdateTemplate" : "OverrideDestroyDescriptorUpdateTemplate",
     "vkDestroyDescriptorUpdateTemplateKHR" : "OverrideDestroyDescriptorUpdateTemplate",
+    "vkAcquireNextImageKHR" : "OverrideAcquireNextImageKHR",
+    "vkAcquireNextImage2KHR" : "OverrideAcquireNextImage2KHR",
     "vkCreateAndroidSurfaceKHR" : "OverrideCreateAndroidSurfaceKHR",
     "vkCreateWin32SurfaceKHR" : "OverrideCreateWin32SurfaceKHR",
     "vkGetPhysicalDeviceWin32PresentationSupportKHR" : "OverrideGetPhysicalDeviceWin32PresentationSupportKHR",


### PR DESCRIPTION
When initializing API state for replay of a trimmed frame, pre-acquire
all swapchain images and transition them to the layout specified in the
state snapshot. Changes the existing swapchain image setup behavior from
a pattern that acquires, transitions, and presents images to a pattern
of acquire, transition, and store the image until first use. This avoids
multiple queue present operations at state setup, which would lead to
the screenshot layer generating invalid image files.

Includes the following:
- Adds a new packet type to describe swapchain image state. This
  replaces Vulkan calls to acquire and transition swapchain images in
  the state snapshot.
- Modifies capture and replay to use the new packet for swapchain image
  state initialization.
- Modifies semaphore state snapshot data such that the signaled state is
  written for all semaphores. Previous behavior did not write signal
  state for semaphores to be signaled by an image acquire.