### PR TITLE
Add markers for trim state snapshot begin/end

### DIFF
--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -46,6 +46,10 @@ class ApiDecoder
                                     const uint8_t*     buffer,
                                     size_t             buffer_size) = 0;
 
+    virtual void DispatchStateBeginMarker(uint64_t frame_number) {}
+
+    virtual void DispatchStateEndMarker(uint64_t frame_number) {}
+
     virtual void DispatchDisplayMessageCommand(format::ThreadId thread_id, const std::string& message) {}
 
     virtual void DispatchFillMemoryCommand(

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -104,6 +104,8 @@ class FileProcessor
 
     bool ProcessMetaData(const format::BlockHeader& block_header, format::MetaDataType meta_type);
 
+    bool ProcessStateMarker(const format::BlockHeader& block_header, format::MarkerType marker_type);
+
     bool IsFrameDelimiter(format::ApiCallId call_id) const;
 
     bool IsFileHeaderValid() const { return (file_header_.fourcc == GFXRECON_FOURCC); }

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -38,6 +38,10 @@ class VulkanConsumerBase
 
     virtual ~VulkanConsumerBase() {}
 
+    virtual void ProcessStateBeginMarker(uint64_t frame_number) {}
+
+    virtual void ProcessStateEndMarker(uint64_t frame_number) {}
+
     virtual void ProcessDisplayMessageCommand(const std::string& message) {}
 
     virtual void ProcessFillMemoryCommand(uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data) {}

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -24,6 +24,22 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
+void VulkanDecoderBase::DispatchStateBeginMarker(uint64_t frame_number)
+{
+    for (auto consumer : consumers_)
+    {
+        consumer->ProcessStateBeginMarker(frame_number);
+    }
+}
+
+void VulkanDecoderBase::DispatchStateEndMarker(uint64_t frame_number)
+{
+    for (auto consumer : consumers_)
+    {
+        consumer->ProcessStateEndMarker(frame_number);
+    }
+}
+
 void VulkanDecoderBase::DispatchDisplayMessageCommand(format::ThreadId thread_id, const std::string& message)
 {
     GFXRECON_UNREFERENCED_PARAMETER(thread_id);

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -58,6 +58,10 @@ class VulkanDecoderBase : public ApiDecoder
                                     const uint8_t*     parameter_buffer,
                                     size_t             buffer_size) override;
 
+    virtual void DispatchStateBeginMarker(uint64_t frame_number) override;
+
+    virtual void DispatchStateEndMarker(uint64_t frame_number) override;
+
     virtual void DispatchDisplayMessageCommand(format::ThreadId thread_id, const std::string& message) override;
 
     virtual void DispatchFillMemoryCommand(

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -71,6 +71,16 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
     }
 }
 
+void VulkanReplayConsumerBase::ProcessStateBeginMarker(uint64_t frame_number)
+{
+    GFXRECON_LOG_INFO("Loading state for captured frame %" PRId64, frame_number)
+}
+
+void VulkanReplayConsumerBase::ProcessStateEndMarker(uint64_t frame_number)
+{
+    GFXRECON_LOG_INFO("Finished loading state for captured frame %" PRId64, frame_number)
+}
+
 void VulkanReplayConsumerBase::ProcessDisplayMessageCommand(const std::string& message)
 {
     GFXRECON_LOG_INFO("Trace Message: %s", message.c_str());

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -51,6 +51,10 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     void SetFatalErrorHandler(std::function<void(const char*)> handler) { fatal_error_handler_ = handler; }
 
+    virtual void ProcessStateBeginMarker(uint64_t frame_number) override;
+
+    virtual void ProcessStateEndMarker(uint64_t frame_number) override;
+
     virtual void ProcessDisplayMessageCommand(const std::string& message) override;
 
     virtual void

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -453,7 +453,8 @@ bool TraceManager::CreateCaptureFile(const std::string& base_filename)
 
 void TraceManager::ActivateTrimming()
 {
-    bool success = CreateCaptureFile(CreateTrimFilename(base_filename_, trim_ranges_[trim_current_range_]));
+    const CaptureSettings::TrimRange& trim_range = trim_ranges_[trim_current_range_];
+    bool                              success    = CreateCaptureFile(CreateTrimFilename(base_filename_, trim_range));
     if (success)
     {
         capture_mode_ |= kModeWrite;
@@ -462,7 +463,7 @@ void TraceManager::ActivateTrimming()
         assert(thread_data != nullptr);
 
         VulkanStateWriter state_writer(file_stream_.get(), compressor_.get(), thread_data->thread_id_);
-        state_tracker_->WriteState(&state_writer);
+        state_tracker_->WriteState(&state_writer, trim_range.first);
     }
     else
     {

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -45,12 +45,12 @@ class VulkanStateTracker
 
     ~VulkanStateTracker();
 
-    void WriteState(VulkanStateWriter* writer)
+    void WriteState(VulkanStateWriter* writer, uint64_t frame_number)
     {
         if (writer != nullptr)
         {
             std::unique_lock<std::mutex> lock(mutex_);
-            writer->WriteState(state_table_);
+            writer->WriteState(state_table_, frame_number);
         }
     }
 

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -49,9 +49,16 @@ VulkanStateWriter::VulkanStateWriter(util::FileOutputStream* output_stream,
 
 VulkanStateWriter::~VulkanStateWriter() {}
 
-void VulkanStateWriter::WriteState(const VulkanStateTable& state_table)
+void VulkanStateWriter::WriteState(const VulkanStateTable& state_table, uint64_t frame_number)
 {
     // clang-format off
+
+    format::Marker marker;
+    marker.header.size = sizeof(marker.marker_type) + sizeof(marker.frame_number);
+    marker.header.type = format::kStateMarkerBlock;
+    marker.marker_type = format::kBeginMarker;
+    marker.frame_number = frame_number;
+    output_stream_->Write(&marker, sizeof(marker));
 
     // Instance, device, and queue creation.
     StandardCreateWrite<InstanceWrapper>(state_table);
@@ -119,6 +126,9 @@ void VulkanStateWriter::WriteState(const VulkanStateTable& state_table)
 
     // Process swapchain image acquire.
     WriteSwapchainImageState(state_table);
+
+    marker.marker_type = format::kEndMarker;
+    output_stream_->Write(&marker, sizeof(marker));
 
     // clang-format on
 }

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -43,7 +43,7 @@ class VulkanStateWriter
     ~VulkanStateWriter();
 
     // Returns number of bytes written to the output_stream.
-    void WriteState(const VulkanStateTable& state_table);
+    void WriteState(const VulkanStateTable& state_table, uint64_t frame_number);
 
   private:
     // Data structures for processing resource memory snapshots.

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -54,12 +54,19 @@ constexpr uint32_t MakeCompressedBlockType(uint32_t block_type)
 enum BlockType : uint32_t
 {
     kUnknownBlock                = 0,
-    kFrameBlock                  = 1,
-    kStateBlock                  = 2, // A group of metadata and apicall blocks representing the initial state for a trimmed file.
+    kFrameMarkerBlock            = 1, // Marker to denote frame status, such as the start or end of a frame.
+    kStateMarkerBlock            = 2, // Marker to denote state snapshot status, such as the start or end of a state snapshot.
     kMetaDataBlock               = 3,
     kFunctionCallBlock           = 4,
     kCompressedMetaDataBlock     = MakeCompressedBlockType(kMetaDataBlock),
     kCompressedFunctionCallBlock = MakeCompressedBlockType(kFunctionCallBlock)
+};
+
+enum MarkerType : uint32_t
+{
+    kUnknownMarker = 0,
+    kBeginMarker   = 1,
+    kEndMarker     = 2
 };
 
 enum MetaDataType : uint32_t
@@ -134,6 +141,13 @@ struct BlockHeader
 {
     uint64_t  size;
     BlockType type;
+};
+
+struct Marker
+{
+    BlockHeader header;
+    MarkerType  marker_type;
+    uint64_t    frame_number;
 };
 
 struct FunctionCallHeader


### PR DESCRIPTION
Write markers to the capture file before and after the trimming state
snapshot data. Markers are used at replay to distinguish between API
calls that are part of the state setup for the first frame to be rendered
and API calls that are part of frame rendering process. The marker data
includes the number of the first frame from the trim range associated
with the state snapshot.
