### PR TITLE
Workaround XCB window resize issue

### DIFF
--- a/framework/application/xcb_window.cpp
+++ b/framework/application/xcb_window.cpp
@@ -22,6 +22,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <limits>
+#include <unistd.h>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
@@ -253,6 +254,11 @@ void XcbWindow::SetSize(const uint32_t width, const uint32_t height)
             {
                 GFXRECON_LOG_ERROR("Failed to resize window with error %u", xcb_application_->GetLastErrorCode());
             }
+            else
+            {
+                // Sleep to ensure window resize has completed.
+                usleep(50000); // 0.05 seconds (same as vktrace)
+            }
         }
     }
 }
@@ -307,6 +313,9 @@ void XcbWindow::SetFullscreen(bool fullscreen)
                                     &bypass);
                 xcb_flush(connection);
             }
+
+            // Sleep to ensure window resize has completed.
+            usleep(50000); // 0.05 seconds (same as vktrace)
         }
         else
         {


### PR DESCRIPTION
Add a 0.05 second delay after resizing an XCB window with xcb_configure_window() and waiting for the XCB_CONFIGURE_NOTIFY event generated for the associated cookie, to prevent a swapchain creation failure observed with some window managers. This should serve as a workaround for the problem until a better solution can be found.
