### PR TITLE
Update Swapchain Image Init for Trim Replay

### DIFF
--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -62,9 +62,10 @@ class ApiDecoder
                                              uint32_t         height)
     {}
 
-    virtual void DispatchSetSwapchainImageStateCommand(format::ThreadId                                    thread_id,
-                                                       format::HandleId                                    device_id,
-                                                       format::HandleId                                    swapchain_id,
+    virtual void DispatchSetSwapchainImageStateCommand(format::ThreadId thread_id,
+                                                       format::HandleId device_id,
+                                                       format::HandleId swapchain_id,
+                                                       uint32_t         last_presented_image,
                                                        const std::vector<format::SwapchainImageStateInfo>& image_state)
     {}
 

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -551,6 +551,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
         success = ReadBytes(&header.thread_id, sizeof(header.thread_id));
         success = success && ReadBytes(&header.device_id, sizeof(header.device_id));
         success = success && ReadBytes(&header.swapchain_id, sizeof(header.swapchain_id));
+        success = success && ReadBytes(&header.last_presented_image, sizeof(header.last_presented_image));
         success = success && ReadBytes(&header.image_info_count, sizeof(header.image_info_count));
 
         if (success)
@@ -575,7 +576,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                 for (auto decoder : decoders_)
                 {
                     decoder->DispatchSetSwapchainImageStateCommand(
-                        header.thread_id, header.device_id, header.swapchain_id, entries);
+                        header.thread_id, header.device_id, header.swapchain_id, header.last_presented_image, entries);
                 }
             }
             else

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -48,8 +48,9 @@ class VulkanConsumerBase
 
     virtual void ProcessResizeWindowCommand(format::HandleId surface_id, uint32_t width, uint32_t height) {}
 
-    virtual void ProcessSetSwapchainImageStateCommand(format::HandleId                                    device_id,
-                                                      format::HandleId                                    swapchain_id,
+    virtual void ProcessSetSwapchainImageStateCommand(format::HandleId device_id,
+                                                      format::HandleId swapchain_id,
+                                                      uint32_t         last_presented_image,
                                                       const std::vector<format::SwapchainImageStateInfo>& image_state)
     {}
 

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -78,13 +78,14 @@ void VulkanDecoderBase::DispatchSetSwapchainImageStateCommand(
     format::ThreadId                                    thread_id,
     format::HandleId                                    device_id,
     format::HandleId                                    swapchain_id,
+    uint32_t                                            last_presented_image,
     const std::vector<format::SwapchainImageStateInfo>& image_state)
 {
     GFXRECON_UNREFERENCED_PARAMETER(thread_id);
 
     for (auto consumer : consumers_)
     {
-        consumer->ProcessSetSwapchainImageStateCommand(device_id, swapchain_id, image_state);
+        consumer->ProcessSetSwapchainImageStateCommand(device_id, swapchain_id, last_presented_image, image_state);
     }
 }
 

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -76,6 +76,7 @@ class VulkanDecoderBase : public ApiDecoder
     DispatchSetSwapchainImageStateCommand(format::ThreadId                                    thread_id,
                                           format::HandleId                                    device_id,
                                           format::HandleId                                    swapchain_id,
+                                          uint32_t                                            last_presented_image,
                                           const std::vector<format::SwapchainImageStateInfo>& image_state) override;
 
     virtual void DispatchBeginResourceInitCommand(format::ThreadId thread_id,

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1422,7 +1422,8 @@ void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_t
         // Initialize standard block header.
         header.meta_header.block_header.size = sizeof(header.meta_header.meta_data_type) + sizeof(header.thread_id) +
                                                sizeof(header.device_id) + sizeof(header.swapchain_id) +
-                                               sizeof(header.image_info_count) + (image_count * sizeof(info));
+                                               sizeof(header.last_presented_image) + sizeof(header.image_info_count) +
+                                               (image_count * sizeof(info));
         header.meta_header.block_header.type = format::kMetaDataBlock;
 
         // Initialize block data for set-swapchain-image-state meta-data command.
@@ -1430,6 +1431,7 @@ void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_t
         header.thread_id                  = thread_id_;
         header.device_id                  = device_wrapper->handle_id;
         header.swapchain_id               = wrapper->handle_id;
+        header.last_presented_image       = wrapper->last_presented_image;
         header.image_info_count           = static_cast<uint32_t>(wrapper->child_images.size());
 
         output_stream_->Write(&header, sizeof(header));

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -221,6 +221,7 @@ struct SetSwapchainImageStateCommandHeader
     format::ThreadId thread_id;
     format::HandleId device_id;
     format::HandleId swapchain_id;
+    uint32_t         last_presented_image;
     uint32_t         image_info_count;
 };
 


### PR DESCRIPTION
When initializing swapchain image state for replay of a trimmed file, handle the case where it is not possible to acquire all swapchain images at the same time.
