### PR TITLE
Add Capture Layer to Replay APK

### DIFF
--- a/android/tools/replay/build.gradle
+++ b/android/tools/replay/build.gradle
@@ -35,4 +35,5 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation project(':layer')
 }


### PR DESCRIPTION
Add the capture layer to the replay tool's APK to use for trimming
files during replay.
