### PR TITLE
Trimming State Tracking/Initialization Fixes

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1271,7 +1271,8 @@ void VulkanReplayConsumerBase::ProcessInitImageCommand(format::HandleId         
                     }
                 }
 
-                if (layout != old_layout)
+                if ((layout != old_layout) && (layout != VK_IMAGE_LAYOUT_UNDEFINED) &&
+                    (layout != VK_IMAGE_LAYOUT_PREINITIALIZED))
                 {
                     memory_barrier.srcAccessMask = src_access;
                     memory_barrier.dstAccessMask = 0;

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -383,7 +383,7 @@ class TraceManager
                                            VkFence     fence,
                                            uint32_t*   index)
     {
-        if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS))
+        if (((capture_mode_ & kModeTrack) == kModeTrack) && ((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR)))
         {
             assert((state_tracker_ != nullptr) && (index != nullptr));
             state_tracker_->TrackSemaphoreSignalState(0, nullptr, 1, &semaphore);
@@ -396,7 +396,7 @@ class TraceManager
                                             const VkAcquireNextImageInfoKHR* pAcquireInfo,
                                             uint32_t*                        index)
     {
-        if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS))
+        if (((capture_mode_ & kModeTrack) == kModeTrack) && ((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR)))
         {
             assert((state_tracker_ != nullptr) && (pAcquireInfo != nullptr) && (index != nullptr));
             state_tracker_->TrackSemaphoreSignalState(0, nullptr, 1, &pAcquireInfo->semaphore);
@@ -410,7 +410,7 @@ class TraceManager
 
     void PostProcess_vkQueuePresentKHR(VkResult result, VkQueue queue, const VkPresentInfoKHR* pPresentInfo)
     {
-        if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS))
+        if (((capture_mode_ & kModeTrack) == kModeTrack) && ((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR)))
         {
             assert((state_tracker_ != nullptr) && (pPresentInfo != nullptr));
             state_tracker_->TrackSemaphoreSignalState(

--- a/framework/encode/vulkan_state_info.h
+++ b/framework/encode/vulkan_state_info.h
@@ -92,7 +92,7 @@ struct ShaderModuleInfo
 
 struct ImageAcquiredInfo
 {
-    bool             is_acquired{ true };
+    bool             is_acquired{ false };
     uint32_t         acquired_device_mask{ 0 };
     format::HandleId acquired_semaphore_id{ 0 };
     format::HandleId acquired_fence_id{ 0 };

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1477,7 +1477,7 @@ void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_t
 
             if (wrapper->image_acquired_info[i].is_acquired)
             {
-                info.acquired            = true;
+                info.acquired            = 1;
                 info.acquire_device_mask = wrapper->image_acquired_info[i].acquired_device_mask;
 
                 // Only provide sync object IDs if the objects have not been destroyed between now and image
@@ -1488,6 +1488,10 @@ void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_t
                 {
                     info.acquire_semaphore_id = wrapper->image_acquired_info[i].acquired_semaphore_id;
                 }
+                else
+                {
+                    info.acquire_semaphore_id = 0;
+                }
 
                 const FenceWrapper* fence_wrapper =
                     state_table.GetFenceWrapper(wrapper->image_acquired_info[i].acquired_fence_id);
@@ -1495,10 +1499,14 @@ void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_t
                 {
                     info.acquire_fence_id = wrapper->image_acquired_info[i].acquired_fence_id;
                 }
+                else
+                {
+                    info.acquire_fence_id = 0;
+                }
             }
             else
             {
-                info.acquired             = false;
+                info.acquired             = 0;
                 info.acquire_device_mask  = 0;
                 info.acquire_semaphore_id = 0;
                 info.acquire_fence_id     = 0;

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2186,7 +2186,7 @@ bool VulkanStateWriter::FindMemoryTypeIndex(const DeviceWrapper*    device_wrapp
 
                 if (found_flags != nullptr)
                 {
-                    (*found_flags) = physical_device_wrapper->memory_types[i].propertyFlags;
+                    (*found_flags) = properties.memoryTypes[i].propertyFlags;
                 }
 
                 break;

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2339,7 +2339,7 @@ VkResult VulkanStateWriter::CreateStagingBuffer(const DeviceWrapper*    device_w
     create_info.pNext                 = nullptr;
     create_info.flags                 = 0;
     create_info.size                  = size;
-    create_info.usage                 = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+    create_info.usage                 = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     create_info.sharingMode           = VK_SHARING_MODE_EXCLUSIVE;
     create_info.queueFamilyIndexCount = 0;
     create_info.pQueueFamilyIndices   = nullptr;

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1011,6 +1011,8 @@ void VulkanStateWriter::ProcessImageMemory(const DeviceWrapper*                 
                                                        copy_regions.data());
 
                     if ((image_wrapper->samples == VK_SAMPLE_COUNT_1_BIT) &&
+                        (image_wrapper->current_layout != VK_IMAGE_LAYOUT_UNDEFINED) &&
+                        (image_wrapper->current_layout != VK_IMAGE_LAYOUT_PREINITIALIZED) &&
                         (image_wrapper->current_layout != VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL))
                     {
                         memory_barrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;


### PR DESCRIPTION
Miscellaneous fixes for trim state write at capture and initialization at replay:
* Fix potential null pointer dereference during resource snapshot, if the application had not previously called vkGetPhysicalDeviceMemoryProperties().
* Skip image layout transitions when processing images with the UNDEFINED or PREINITIALIZED layouts.
* Cleanup value initialization for swapchain image state tracking and state snapshot write.
* Treat a return value of VK_SUBOPTIMAL_KHR as success for tracking swapchain image acquired state.
