### PR TITLE
Fix Python 3.7 Warning

### DIFF
--- a/framework/generated/vulkan_generators/gencode.py
+++ b/framework/generated/vulkan_generators/gencode.py
@@ -57,12 +57,13 @@ startTime = None
 
 def startTimer(timeit):
     global startTime
-    startTime = time.clock()
+    if timeit:
+        startTime = time.process_time()
 
 def endTimer(timeit, msg):
     global startTime
-    endTime = time.clock()
-    if (timeit):
+    if timeit:
+        endTime = time.process_time()
         write(msg, endTime - startTime, file=sys.stderr)
         startTime = None
 


### PR DESCRIPTION
Change time.clock() to time.process_time() to address the following
deprecation warning:
  DeprecationWarning: time.clock has been deprecated in Python 3.3 and
   will be removed from Python 3.8: use time.perf_counter or
   time.process_time instead