### PR TITLE
Mapped Memory Tracking Updates

### DIFF
--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -67,6 +67,12 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 #define MEMORY_TRACKING_MODE_UPPER          "MEMORY_TRACKING_MODE"
 #define CAPTURE_FRAMES_LOWER                "capture_frames"
 #define CAPTURE_FRAMES_UPPER                "CAPTURE_FRAMES"
+#define PAGE_GUARD_COPY_ON_MAP_LOWER        "page_guard_copy_on_map"
+#define PAGE_GUARD_COPY_ON_MAP_UPPER        "PAGE_GUARD_COPY_ON_MAP"
+#define PAGE_GUARD_LAZY_COPY_LOWER          "page_guard_lazy_copy"
+#define PAGE_GUARD_LAZY_COPY_UPPER          "PAGE_GUARD_LAZY_COPY"
+#define PAGE_GUARD_EXTERNAL_MEMORY_LOWER    "page_guard_external_memory"
+#define PAGE_GUARD_EXTERNAL_MEMORY_UPPER    "PAGE_GUARD_EXTERNAL_MEMORY"
 // clang-format on
 
 #if defined(__ANDROID__)
@@ -91,34 +97,41 @@ const char kLogOutputToConsoleEnvVar[]       = GFXRECON_ENV_VAR_PREFIX LOG_OUTPU
 const char kLogOutputToOsDebugStringEnvVar[] = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_OS_DEBUG_STRING_LOWER;
 const char kMemoryTrackingModeEnvVar[]       = GFXRECON_ENV_VAR_PREFIX MEMORY_TRACKING_MODE_LOWER;
 const char kCaptureFramesEnvVar[]            = GFXRECON_ENV_VAR_PREFIX CAPTURE_FRAMES_LOWER;
+const char kPageGuardCopyOnMapEnvVar[]       = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_COPY_ON_MAP_LOWER;
+const char kPageGuardLazyCopyEnvVar[]        = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_LAZY_COPY_LOWER;
+const char kPageGuardExternalMemoryEnvVar[]  = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_EXTERNAL_MEMORY_LOWER;
 
 #else
 const char CaptureSettings::kDefaultCaptureFileName[] = "gfxrecon_capture" GFXRECON_FILE_EXTENSION;
 
 // Desktop environment settings
 #define GFXRECON_ENV_VAR_PREFIX "GFXRECON_"
-const char kCaptureCompressionTypeEnvVar[]   = GFXRECON_ENV_VAR_PREFIX CAPTURE_COMPRESSION_TYPE_UPPER;
-const char kCaptureFileFlushEnvVar[]         = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_FLUSH_UPPER;
-const char kCaptureFileNameEnvVar[]          = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_NAME_UPPER;
-const char kCaptureFileUseTimestampEnvVar[]  = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_USE_TIMESTAMP_UPPER;
-const char kLogAllowIndentsEnvVar[]          = GFXRECON_ENV_VAR_PREFIX LOG_ALLOW_INDENTS_UPPER;
-const char kLogBreakOnErrorEnvVar[]          = GFXRECON_ENV_VAR_PREFIX LOG_BREAK_ON_ERROR_UPPER;
-const char kLogDetailedEnvVar[]              = GFXRECON_ENV_VAR_PREFIX LOG_DETAILED_UPPER;
-const char kLogErrorsToStderrEnvVar[]        = GFXRECON_ENV_VAR_PREFIX LOG_ERRORS_TO_STDERR_UPPER;
-const char kLogFileNameEnvVar[]              = GFXRECON_ENV_VAR_PREFIX LOG_FILE_NAME_UPPER;
-const char kLogFileCreateNewEnvVar[]         = GFXRECON_ENV_VAR_PREFIX LOG_FILE_CREATE_NEW_UPPER;
-const char kLogFileFlushAfterWriteEnvVar[]   = GFXRECON_ENV_VAR_PREFIX LOG_FILE_FLUSH_AFTER_WRITE_UPPER;
-const char kLogFileKeepFileOpenEnvVar[]      = GFXRECON_ENV_VAR_PREFIX LOG_FILE_KEEP_OPEN_UPPER;
-const char kLogLevelEnvVar[]                 = GFXRECON_ENV_VAR_PREFIX LOG_LEVEL_UPPER;
-const char kLogOutputToConsoleEnvVar[]       = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_CONSOLE_UPPER;
-const char kLogOutputToOsDebugStringEnvVar[] = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_OS_DEBUG_STRING_UPPER;
-const char kMemoryTrackingModeEnvVar[]       = GFXRECON_ENV_VAR_PREFIX MEMORY_TRACKING_MODE_UPPER;
-const char kCaptureFramesEnvVar[]            = GFXRECON_ENV_VAR_PREFIX CAPTURE_FRAMES_UPPER;
+const char kCaptureCompressionTypeEnvVar[]            = GFXRECON_ENV_VAR_PREFIX CAPTURE_COMPRESSION_TYPE_UPPER;
+const char kCaptureFileFlushEnvVar[]                  = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_FLUSH_UPPER;
+const char kCaptureFileNameEnvVar[]                   = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_NAME_UPPER;
+const char kCaptureFileUseTimestampEnvVar[]           = GFXRECON_ENV_VAR_PREFIX CAPTURE_FILE_USE_TIMESTAMP_UPPER;
+const char kLogAllowIndentsEnvVar[]                   = GFXRECON_ENV_VAR_PREFIX LOG_ALLOW_INDENTS_UPPER;
+const char kLogBreakOnErrorEnvVar[]                   = GFXRECON_ENV_VAR_PREFIX LOG_BREAK_ON_ERROR_UPPER;
+const char kLogDetailedEnvVar[]                       = GFXRECON_ENV_VAR_PREFIX LOG_DETAILED_UPPER;
+const char kLogErrorsToStderrEnvVar[]                 = GFXRECON_ENV_VAR_PREFIX LOG_ERRORS_TO_STDERR_UPPER;
+const char kLogFileNameEnvVar[]                       = GFXRECON_ENV_VAR_PREFIX LOG_FILE_NAME_UPPER;
+const char kLogFileCreateNewEnvVar[]                  = GFXRECON_ENV_VAR_PREFIX LOG_FILE_CREATE_NEW_UPPER;
+const char kLogFileFlushAfterWriteEnvVar[]            = GFXRECON_ENV_VAR_PREFIX LOG_FILE_FLUSH_AFTER_WRITE_UPPER;
+const char kLogFileKeepFileOpenEnvVar[]               = GFXRECON_ENV_VAR_PREFIX LOG_FILE_KEEP_OPEN_UPPER;
+const char kLogLevelEnvVar[]                          = GFXRECON_ENV_VAR_PREFIX LOG_LEVEL_UPPER;
+const char kLogOutputToConsoleEnvVar[]                = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_CONSOLE_UPPER;
+const char kLogOutputToOsDebugStringEnvVar[]          = GFXRECON_ENV_VAR_PREFIX LOG_OUTPUT_TO_OS_DEBUG_STRING_UPPER;
+const char kMemoryTrackingModeEnvVar[]                = GFXRECON_ENV_VAR_PREFIX MEMORY_TRACKING_MODE_UPPER;
+const char kCaptureFramesEnvVar[]                     = GFXRECON_ENV_VAR_PREFIX CAPTURE_FRAMES_UPPER;
+const char kPageGuardCopyOnMapEnvVar[]                = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_COPY_ON_MAP_UPPER;
+const char kPageGuardLazyCopyEnvVar[]                 = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_LAZY_COPY_UPPER;
+const char kPageGuardExternalMemoryEnvVar[]           = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_EXTERNAL_MEMORY_UPPER;
 #endif
 
 // Capture options for settings file.
 // clang-format off
 const char kSettingsFilter[] = "lunarg_gfxrecon.";
+
 const std::string kOptionKeyCaptureCompressionType   = std::string(kSettingsFilter) + std::string(CAPTURE_COMPRESSION_TYPE_LOWER);
 const std::string kOptionKeyCaptureFile              = std::string(kSettingsFilter) + std::string(CAPTURE_FILE_NAME_LOWER);
 const std::string kOptionKeyCaptureFileForceFlush    = std::string(kSettingsFilter) + std::string(CAPTURE_FILE_FLUSH_LOWER);
@@ -136,6 +149,9 @@ const std::string kOptionKeyLogOutputToConsole       = std::string(kSettingsFilt
 const std::string kOptionKeyLogOutputToOsDebugString = std::string(kSettingsFilter) + std::string(LOG_OUTPUT_TO_OS_DEBUG_STRING_LOWER);
 const std::string kOptionKeyMemoryTrackingMode       = std::string(kSettingsFilter) + std::string(MEMORY_TRACKING_MODE_LOWER);
 const std::string kOptionKeyCaptureFrames            = std::string(kSettingsFilter) + std::string(CAPTURE_FRAMES_LOWER);
+const std::string kOptionKeyPageGuardCopyOnMap       = std::string(kSettingsFilter) + std::string(PAGE_GUARD_COPY_ON_MAP_LOWER);
+const std::string kOptionKeyPageGuardLazyCopy        = std::string(kSettingsFilter) + std::string(PAGE_GUARD_LAZY_COPY_LOWER);
+const std::string kOptionKeyPageGuardExternalMemory  = std::string(kSettingsFilter) + std::string(PAGE_GUARD_EXTERNAL_MEMORY_LOWER);
 // clang-format on
 
 #if defined(ENABLE_LZ4_COMPRESSION)
@@ -214,6 +230,11 @@ void CaptureSettings::LoadOptionsEnvVar(OptionsMap* options)
 
     // Trimming environment variables
     LoadSingleOptionEnvVar(options, kCaptureFramesEnvVar, kOptionKeyCaptureFrames);
+
+    // Page guard environment variables
+    LoadSingleOptionEnvVar(options, kPageGuardCopyOnMapEnvVar, kOptionKeyPageGuardCopyOnMap);
+    LoadSingleOptionEnvVar(options, kPageGuardLazyCopyEnvVar, kOptionKeyPageGuardLazyCopy);
+    LoadSingleOptionEnvVar(options, kPageGuardExternalMemoryEnvVar, kOptionKeyPageGuardExternalMemory);
 }
 
 void CaptureSettings::LoadOptionsFile(OptionsMap* options)
@@ -259,6 +280,14 @@ void CaptureSettings::ProcessOptions(OptionsMap* options, CaptureSettings* setti
 
     // Trimming options
     ParseTrimRangeString(FindOption(options, kOptionKeyCaptureFrames), &settings->trace_settings_.trim_ranges);
+
+    // Page guard environment variables
+    settings->trace_settings_.page_guard_copy_on_map = ParseBoolString(
+        FindOption(options, kOptionKeyPageGuardCopyOnMap), settings->trace_settings_.page_guard_copy_on_map);
+    settings->trace_settings_.page_guard_lazy_copy = ParseBoolString(FindOption(options, kOptionKeyPageGuardLazyCopy),
+                                                                     settings->trace_settings_.page_guard_lazy_copy);
+    settings->trace_settings_.page_guard_external_memory = ParseBoolString(
+        FindOption(options, kOptionKeyPageGuardExternalMemory), settings->trace_settings_.page_guard_external_memory);
 
     // Log options
     settings->log_settings_.use_indent =

--- a/framework/encode/capture_settings.h
+++ b/framework/encode/capture_settings.h
@@ -20,6 +20,7 @@
 
 #include "format/format.h"
 #include "util/logging.h"
+#include "util/page_guard_manager.h"
 
 #include <string>
 #include <unordered_map>
@@ -41,7 +42,7 @@ class CaptureSettings
         // Assume the application will always flush after writing to mapped memory, so only write mapped memory data on
         // flush.
         kAssisted = 1,
-        // Use pageguard to determine which regions of memory to write on unmap and queue submit.  This mode replaces
+        // Use guard pages to determine which regions of memory to write on unmap and queue submit.  This mode replaces
         // the mapped memory value returned by the driver with a shadow allocation that the capture layer can monitor
         // to determine which regions of memory have been modified by the application.
         kPageGuard = 2
@@ -61,8 +62,10 @@ class CaptureSettings
         bool                   force_flush{ false };
         MemoryTrackingMode     memory_tracking_mode{ kPageGuard };
         std::vector<TrimRange> trim_ranges;
+        bool                   page_guard_copy_on_map{ util::PageGuardManager::kDefaultEnableCopyOnMap };
+        bool                   page_guard_lazy_copy{ util::PageGuardManager::kDefaultEnableLazyCopy };
 
-        // An optimization for the pageguard memory tracking mode that eliminates the need for shadow memory by
+        // An optimization for the page_guard memory tracking mode that eliminates the need for shadow memory by
         // overriding vkAllocateMemory so that all host visible allocations use the external memory extension with a
         // memory allocation that the capture layer can monitor to determine which regions of memory have been modified
         // by the application.

--- a/framework/encode/capture_settings.h
+++ b/framework/encode/capture_settings.h
@@ -38,10 +38,12 @@ class CaptureSettings
     {
         // Assume the application does not flush, so write all mapped data on unmap and queue submit.
         kUnassisted = 0,
-        // Assume the application will always flush after writing to mapped memory, so only write on flush.
+        // Assume the application will always flush after writing to mapped memory, so only write mapped memory data on
+        // flush.
         kAssisted = 1,
-        // Use pageguard to determine which regions of memory to wrtie on unmap and queue submit.  This
-        // mode shadows uncached memory.
+        // Use pageguard to determine which regions of memory to write on unmap and queue submit.  This mode replaces
+        // the mapped memory value returned by the driver with a shadow allocation that the capture layer can monitor
+        // to determine which regions of memory have been modified by the application.
         kPageGuard = 2
     };
 
@@ -59,6 +61,12 @@ class CaptureSettings
         bool                   force_flush{ false };
         MemoryTrackingMode     memory_tracking_mode{ kPageGuard };
         std::vector<TrimRange> trim_ranges;
+
+        // An optimization for the pageguard memory tracking mode that eliminates the need for shadow memory by
+        // overriding vkAllocateMemory so that all host visible allocations use the external memory extension with a
+        // memory allocation that the capture layer can monitor to determine which regions of memory have been modified
+        // by the application.
+        bool page_guard_external_memory{ false };
     };
 
   public:

--- a/framework/encode/custom_encoder_commands.h
+++ b/framework/encode/custom_encoder_commands.h
@@ -211,16 +211,6 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueuePresentKHR>
 };
 
 template <>
-struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkAllocateMemory>
-{
-    template <typename... Args>
-    static void Dispatch(TraceManager* manager, VkResult result, Args... args)
-    {
-        manager->PostProcess_vkAllocateMemory(result, args...);
-    }
-};
-
-template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkBindBufferMemory>
 {
     template <typename... Args>

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -253,8 +253,8 @@ bool TraceManager::Initialize(std::string base_filename, const CaptureSettings::
         if (memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kPageGuard)
         {
             util::PageGuardManager::Create(!page_guard_external_memory_,
-                                           util::PageGuardManager::kDefaultEnableCopyOnMap,
-                                           util::PageGuardManager::kDefaultEnableLazyCopy,
+                                           trace_settings.page_guard_copy_on_map,
+                                           trace_settings.page_guard_lazy_copy,
                                            util::PageGuardManager::kDefaultEnableReadWriteSamePage);
         }
 

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -245,7 +245,10 @@ bool TraceManager::Initialize(std::string base_filename, const CaptureSettings::
     {
         if (memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kPageGuard)
         {
-            util::PageGuardManager::Create(true, true, true);
+            util::PageGuardManager::Create(util::PageGuardManager::kDefaultEnableShadowMemory,
+                                           util::PageGuardManager::kDefaultEnableCopyOnMap,
+                                           util::PageGuardManager::kDefaultEnableLazyCopy,
+                                           util::PageGuardManager::kDefaultEnableReadWriteSamePage);
         }
 
         if ((capture_mode_ & kModeTrack) == kModeTrack)

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -245,7 +245,7 @@ bool TraceManager::Initialize(std::string base_filename, const CaptureSettings::
     {
         if (memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kPageGuard)
         {
-            util::PageGuardManager::Create(true, false, true, true, true, true);
+            util::PageGuardManager::Create(true, true, true);
         }
 
         if ((capture_mode_ & kModeTrack) == kModeTrack)
@@ -813,7 +813,7 @@ void TraceManager::PostProcess_vkMapMemory(VkResult         result,
 
                     // Return the pointer provided by the pageguard manager, which may be a pointer to shadow memory,
                     // not the mapped memory.
-                    (*ppData) = manager->AddMemory(wrapper->handle_id, (*ppData), static_cast<size_t>(size), false);
+                    (*ppData) = manager->AddMemory(wrapper->handle_id, (*ppData), static_cast<size_t>(size));
                 }
             }
             else if (memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kUnassisted)

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -256,6 +256,15 @@ class TraceManager
     bool GetDescriptorUpdateTemplateInfo(VkDescriptorUpdateTemplate update_template,
                                          const UpdateTemplateInfo** info) const;
 
+    static VkResult OverrideCreateInstance(const VkInstanceCreateInfo*  pCreateInfo,
+                                           const VkAllocationCallbacks* pAllocator,
+                                           VkInstance*                  pInstance);
+
+    VkResult OverrideCreateDevice(VkPhysicalDevice             physicalDevice,
+                                  const VkDeviceCreateInfo*    pCreateInfo,
+                                  const VkAllocationCallbacks* pAllocator,
+                                  VkDevice*                    pDevice);
+
     void PostProcess_vkGetPhysicalDeviceMemoryProperties(VkPhysicalDevice                  physicalDevice,
                                                          VkPhysicalDeviceMemoryProperties* pMemoryProperties)
     {

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -264,6 +264,10 @@ class TraceManager
                                   const VkDeviceCreateInfo*    pCreateInfo,
                                   const VkAllocationCallbacks* pAllocator,
                                   VkDevice*                    pDevice);
+    VkResult OverrideAllocateMemory(VkDevice                     device,
+                                    const VkMemoryAllocateInfo*  pAllocateInfo,
+                                    const VkAllocationCallbacks* pAllocator,
+                                    VkDeviceMemory*              pMemory);
 
     void PostProcess_vkGetPhysicalDeviceMemoryProperties(VkPhysicalDevice                  physicalDevice,
                                                          VkPhysicalDeviceMemoryProperties* pMemoryProperties)
@@ -377,12 +381,6 @@ class TraceManager
                                       const VkSwapchainCreateInfoKHR* pCreateInfo,
                                       const VkAllocationCallbacks*    pAllocator,
                                       VkSwapchainKHR*                 pSwapchain);
-
-    void PostProcess_vkAllocateMemory(VkResult                     result,
-                                      VkDevice                     device,
-                                      const VkMemoryAllocateInfo*  pAllocateInfo,
-                                      const VkAllocationCallbacks* pAllocator,
-                                      VkDeviceMemory*              pMemory);
 
     void PostProcess_vkAcquireNextImageKHR(VkResult result,
                                            VkDevice,
@@ -822,6 +820,8 @@ class TraceManager
                                               VkDescriptorUpdateTemplate update_templat,
                                               const void*                data);
 
+    VkMemoryPropertyFlags GetMemoryProperties(DeviceWrapper* device_wrapper, uint32_t memory_type_index);
+
   private:
     static TraceManager*                            instance_;
     static uint32_t                                 instance_count_;
@@ -838,6 +838,7 @@ class TraceManager
     uint64_t                                        bytes_written_;
     std::unique_ptr<util::Compressor>               compressor_;
     CaptureSettings::MemoryTrackingMode             memory_tracking_mode_;
+    bool                                            page_guard_external_memory_;
     std::mutex                                      mapped_memory_lock_;
     std::set<DeviceMemoryWrapper*>                  mapped_memory_; // Track mapped memory for unassisted tracking mode.
     bool                                            trim_enabled_;

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -147,6 +147,7 @@ struct DeviceMemoryWrapper : public HandleWrapper<VkDeviceMemory>
     VkDeviceSize     mapped_offset{ 0 };
     VkDeviceSize     mapped_size{ 0 };
     VkMemoryMapFlags mapped_flags{ 0 };
+    void*            external_allocation{ nullptr };
 };
 
 struct BufferWrapper : public HandleWrapper<VkBuffer>

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -444,17 +444,8 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateMemory(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkAllocateMemory>::Dispatch(TraceManager::Get(), device, pAllocateInfo, pAllocator, pMemory);
 
-    auto handle_unwrap_memory = TraceManager::Get()->GetHandleUnwrapMemory();
-    VkDevice device_unwrapped = GetWrappedHandle<VkDevice>(device);
-    const VkMemoryAllocateInfo* pAllocateInfo_unwrapped = UnwrapStructPtrHandles(pAllocateInfo, handle_unwrap_memory);
-
-    VkResult result = GetDeviceTable(device)->AllocateMemory(device_unwrapped, pAllocateInfo_unwrapped, pAllocator, pMemory);
-
-    if (result >= 0)
-    {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, DeviceMemoryWrapper>(device, NoParentWrapper::kHandleValue, pMemory, TraceManager::GetUniqueId);
-    }
-    else
+    VkResult result = TraceManager::Get()->OverrideAllocateMemory(device, pAllocateInfo, pAllocator, pMemory);
+    if (result < 0)
     {
         omit_output_data = true;
     }

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -47,7 +47,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateInstance>::Dispatch(TraceManager::Get(), pCreateInfo, pAllocator, pInstance);
 
-    VkResult result = TraceManager::GetLayerTable()->CreateInstance(pCreateInfo, pAllocator, pInstance);
+    VkResult result = TraceManager::OverrideCreateInstance(pCreateInfo, pAllocator, pInstance);
     if (result < 0)
     {
         omit_output_data = true;
@@ -287,11 +287,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateDevice>::Dispatch(TraceManager::Get(), physicalDevice, pCreateInfo, pAllocator, pDevice);
 
-    auto handle_unwrap_memory = TraceManager::Get()->GetHandleUnwrapMemory();
-    VkPhysicalDevice physicalDevice_unwrapped = GetWrappedHandle<VkPhysicalDevice>(physicalDevice);
-    const VkDeviceCreateInfo* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
-
-    VkResult result = TraceManager::GetLayerTable()->CreateDevice(physicalDevice_unwrapped, pCreateInfo_unwrapped, pAllocator, pDevice);
+    VkResult result = TraceManager::Get()->OverrideCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice);
     if (result < 0)
     {
         omit_output_data = true;

--- a/framework/generated/vulkan_generators/capture_overrides.json
+++ b/framework/generated/vulkan_generators/capture_overrides.json
@@ -1,0 +1,6 @@
+{
+  "functions": {
+    "vkCreateInstance": "TraceManager::OverrideCreateInstance",
+    "vkCreateDevice": "TraceManager::Get()->OverrideCreateDevice"
+  }
+}

--- a/framework/generated/vulkan_generators/capture_overrides.json
+++ b/framework/generated/vulkan_generators/capture_overrides.json
@@ -1,6 +1,7 @@
 {
   "functions": {
     "vkCreateInstance": "TraceManager::OverrideCreateInstance",
-    "vkCreateDevice": "TraceManager::Get()->OverrideCreateDevice"
+    "vkCreateDevice": "TraceManager::Get()->OverrideCreateDevice",
+    "vkAllocateMemory": "TraceManager::Get()->OverrideAllocateMemory"
   }
 }

--- a/framework/generated/vulkan_generators/gencode.py
+++ b/framework/generated/vulkan_generators/gencode.py
@@ -71,6 +71,7 @@ def endTimer(timeit, msg):
 defaultBlacklists = 'blacklists.json'
 defaultPlatformTypes = 'platform_types.json'
 defaultReplayOverrides = 'replay_overrides.json'
+defaultCaptureOverrides = 'capture_overrides.json'
 
 # Returns a directory of [ generator function, generator options ] indexed
 # by specified short names. The generator options incorporate the following
@@ -88,6 +89,7 @@ def makeGenOpts(args):
     blacklists = os.path.join(args.configs, defaultBlacklists)
     platformTypes = os.path.join(args.configs, defaultPlatformTypes)
     replayOverrides = os.path.join(args.configs, defaultReplayOverrides)
+    captureOverrides = os.path.join(args.configs, defaultCaptureOverrides)
 
     # Copyright text prefixing all headers (list of strings).
     prefixStrings = [
@@ -308,6 +310,7 @@ def makeGenOpts(args):
             filename          = 'generated_vulkan_api_call_encoders.cpp',
             directory         = directory,
             blacklists        = blacklists,
+            captureOverrides  = captureOverrides,
             platformTypes     = platformTypes,
             prefixText        = prefixStrings + vkPrefixStrings,
             protectFile       = False,

--- a/framework/util/page_guard_manager.h
+++ b/framework/util/page_guard_manager.h
@@ -36,7 +36,7 @@ class PageGuardManager
   public:
     static const bool kDefaultEnableShadowMemory         = true;
     static const bool kDefaultEnableCopyOnMap            = true;
-    static const bool kDefaultEnableLazyCopy             = true;
+    static const bool kDefaultEnableLazyCopy             = false;
     static const bool kDefaultEnableReadWriteSamePage    = true;
 
   public:

--- a/framework/util/page_guard_manager.h
+++ b/framework/util/page_guard_manager.h
@@ -63,6 +63,12 @@ class PageGuardManager
 
     bool HandleGuardPageViolation(void* address, bool is_write, bool clear_guard);
 
+    size_t GetAlignedSize(size_t size) const;
+
+    void* AllocateMemory(size_t aligned_size);
+
+    void FreeMemory(void* pMemory, size_t aligned_size);
+
   protected:
     PageGuardManager();
 
@@ -113,10 +119,6 @@ class PageGuardManager
 
   private:
     size_t GetSystemPageSize() const;
-    size_t GetAdjustedSize(size_t size) const;
-
-    void* AllocateShadowMemory(size_t size);
-    void  FreeShadowMemory(void* pMemory, size_t size);
 
     void AddExceptionHandler();
     void RemoveExceptionHandler();


### PR DESCRIPTION
Updates for the "page guard" memory tracking mode:
* Remove unused experimental and debug options
* Add an experimental option using VK_EXT_external_memory_host to eliminate the need for shadow memory to detect write access to mapped memory.  The current implementation only works reliably on Windows with AMD GPUs.
* Add settings file/environment variable options for controlling page guard behavior:
  - GFXRECON_PAGE_GUARD_COPY_ON_MAP to enable/disable copy from mapped
    memory to shadow memory after map.
  - GFXRECON_PAGE_GUARD_LAZY_COPY to change the copy on map behavior
    such that the copy is performed for individual pages on first access.
  - GFXRECON_PAGE_GUARD_EXTERNAL_MEMORY to enable the experimental
    feature that eliminates the need for shadow allocations.

Closes #205 