### PR TITLE
Additional Resource Dependency Tracking

### DIFF
--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -182,9 +182,12 @@ struct ImageViewWrapper : public HandleWrapper<VkImageView>
 
 struct FramebufferWrapper : public HandleWrapper<VkFramebuffer>
 {
+    // Creation info for objects used to create the framebuffer, which may have been destroyed after creation.
     format::HandleId  render_pass_id{ 0 };
     format::ApiCallId render_pass_create_call_id{ format::ApiCallId::ApiCall_Unknown };
     CreateParameters  render_pass_create_parameters;
+
+    std::vector<format::HandleId> image_view_ids;
 
     // Track handles of image attachments for processing render pass layout transitions.
     std::vector<ImageWrapper*> attachments;
@@ -255,7 +258,7 @@ struct PipelineLayoutWrapper : public HandleWrapper<VkPipelineLayout>
 struct PipelineWrapper : public HandleWrapper<VkPipeline>
 {
     // Creation info for objects used to create the pipeline, which may have been destroyed after pipeline creation.
-    std::vector<ShaderModuleInfo> shader_modules;
+    std::vector<CreateDependencyInfo> shader_modules;
 
     format::HandleId  render_pass_id{ 0 };
     format::ApiCallId render_pass_create_call_id{ format::ApiCallId::ApiCall_Unknown };

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -60,7 +60,6 @@ struct HandleWrapper
 //
 
 // clang-format off
-struct BufferViewWrapper                    : public HandleWrapper<VkBufferView> {};
 struct ShaderModuleWrapper                  : public HandleWrapper<VkShaderModule> {};
 struct PipelineCacheWrapper                 : public HandleWrapper<VkPipelineCache> {};
 struct SamplerWrapper                       : public HandleWrapper<VkSampler> {};
@@ -174,10 +173,15 @@ struct ImageWrapper : public HandleWrapper<VkImage>
     VkImageLayout         current_layout{ VK_IMAGE_LAYOUT_UNDEFINED };
 };
 
+struct BufferViewWrapper : public HandleWrapper<VkBufferView>
+{
+    format::HandleId buffer_id{ 0 };
+};
+
 struct ImageViewWrapper : public HandleWrapper<VkImageView>
 {
-    // Store handle to associated image for tracking render pass layout transitions.
-    ImageWrapper* image{ nullptr };
+    format::HandleId image_id{ 0 };
+    ImageWrapper*    image{ nullptr };
 };
 
 struct FramebufferWrapper : public HandleWrapper<VkFramebuffer>

--- a/framework/encode/vulkan_state_info.h
+++ b/framework/encode/vulkan_state_info.h
@@ -67,8 +67,7 @@ struct DescriptorInfo
     std::unique_ptr<VkBufferView[]>           texel_buffer_views;
 };
 
-// VkDescriptorSetLayout create info stored with VkPipelineLayout handle.
-struct DescriptorSetLayoutInfo
+struct CreateDependencyInfo
 {
     format::HandleId  handle_id{ 0 };
     format::ApiCallId create_call_id{ format::ApiCallId::ApiCall_Unknown };
@@ -79,15 +78,7 @@ struct DescriptorSetLayoutInfo
 // Referenced with a shared pointer by VkPipelineLayout and VkPipeline handles.
 struct PipelineLayoutDependencies
 {
-    std::vector<DescriptorSetLayoutInfo> layouts;
-};
-
-// VkShaderModule create info stored with VkPipeline handle.
-struct ShaderModuleInfo
-{
-    format::HandleId  handle_id{ 0 };
-    format::ApiCallId create_call_id{ format::ApiCallId::ApiCall_Unknown };
-    CreateParameters  create_parameters;
+    std::vector<CreateDependencyInfo> layouts;
 };
 
 struct ImageAcquiredInfo

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -571,6 +571,27 @@ inline void InitializeGroupObjectState<VkDevice, VkSwapchainKHR, ImageWrapper, v
 }
 
 template <>
+inline void
+InitializeState<VkDevice, BufferViewWrapper, VkBufferViewCreateInfo>(VkDevice                      parent_handle,
+                                                                     BufferViewWrapper*            wrapper,
+                                                                     const VkBufferViewCreateInfo* create_info,
+                                                                     format::ApiCallId             create_call_id,
+                                                                     CreateParameters              create_parameters)
+{
+    assert(wrapper != nullptr);
+    assert(create_info != nullptr);
+    assert(create_parameters != nullptr);
+
+    GFXRECON_UNREFERENCED_PARAMETER(parent_handle);
+
+    wrapper->create_call_id    = create_call_id;
+    wrapper->create_parameters = std::move(create_parameters);
+
+    auto buffer        = reinterpret_cast<BufferWrapper*>(create_info->buffer);
+    wrapper->buffer_id = buffer->handle_id;
+}
+
+template <>
 inline void InitializeState<VkDevice, ImageViewWrapper, VkImageViewCreateInfo>(VkDevice          parent_handle,
                                                                                ImageViewWrapper* wrapper,
                                                                                const VkImageViewCreateInfo* create_info,
@@ -586,7 +607,9 @@ inline void InitializeState<VkDevice, ImageViewWrapper, VkImageViewCreateInfo>(V
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->image = reinterpret_cast<ImageWrapper*>(create_info->image);
+    auto image        = reinterpret_cast<ImageWrapper*>(create_info->image);
+    wrapper->image_id = image->handle_id;
+    wrapper->image    = image;
 }
 
 template <>

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -128,7 +128,7 @@ inline void InitializeState<VkDevice, PipelineLayoutWrapper, VkPipelineLayoutCre
         assert(create_info->pSetLayouts[i] != VK_NULL_HANDLE);
 
         auto layout_wrapper = reinterpret_cast<DescriptorSetLayoutWrapper*>(create_info->pSetLayouts[i]);
-        DescriptorSetLayoutInfo info;
+        CreateDependencyInfo info;
         info.handle_id         = layout_wrapper->handle_id;
         info.create_call_id    = layout_wrapper->create_call_id;
         info.create_parameters = layout_wrapper->create_parameters;
@@ -265,6 +265,8 @@ InitializeState<VkDevice, FramebufferWrapper, VkFramebufferCreateInfo>(VkDevice 
         {
             auto image_view_wrapper = reinterpret_cast<ImageViewWrapper*>(create_info->pAttachments[i]);
             assert(image_view_wrapper != nullptr);
+
+            wrapper->image_view_ids.push_back(image_view_wrapper->handle_id);
             wrapper->attachments.push_back(image_view_wrapper->image);
         }
     }
@@ -322,7 +324,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
         auto shader_wrapper = reinterpret_cast<ShaderModuleWrapper*>(create_info->pStages[i].module);
         assert(shader_wrapper != nullptr);
 
-        ShaderModuleInfo info;
+        CreateDependencyInfo info;
         info.handle_id         = shader_wrapper->handle_id;
         info.create_call_id    = shader_wrapper->create_call_id;
         info.create_parameters = shader_wrapper->create_parameters;
@@ -370,7 +372,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
     auto shader_wrapper = reinterpret_cast<ShaderModuleWrapper*>(create_info->stage.module);
     assert(shader_wrapper != nullptr);
 
-    ShaderModuleInfo info;
+    CreateDependencyInfo info;
     info.handle_id         = shader_wrapper->handle_id;
     info.create_call_id    = shader_wrapper->create_call_id;
     info.create_parameters = shader_wrapper->create_parameters;
@@ -412,7 +414,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
         auto shader_wrapper = reinterpret_cast<ShaderModuleWrapper*>(create_info->pStages[i].module);
         assert(shader_wrapper != nullptr);
 
-        ShaderModuleInfo info;
+        CreateDependencyInfo info;
         info.handle_id         = shader_wrapper->handle_id;
         info.create_call_id    = shader_wrapper->create_call_id;
         info.create_parameters = shader_wrapper->create_parameters;

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -100,6 +100,10 @@ class VulkanStateWriter
 
     void WriteSemaphoreState(const VulkanStateTable& state_table);
 
+    void WriteBufferViewState(const VulkanStateTable& state_table);
+
+    void WriteImageViewState(const VulkanStateTable& state_table);
+
     void WriteFramebufferState(const VulkanStateTable& state_table);
 
     void WritePipelineLayoutState(const VulkanStateTable& state_table);


### PR DESCRIPTION
Adds trimming state tracking for the following:
* Track IDs for image views specified for framebuffer creation and omit  framebuffers from the trimming state snapshot if any of their associated image views have been destroyed.
* Track IDs for buffers used for buffer view creation and omit buffer views from the trimming state snapshot if their associated buffer has been destroyed.
* Track IDs for images used for image view creation and omit image views from the trimming state snapshot if their associated image has been destroyed.