### PR TITLE
Fix Image Acquire Semaphore Tracking

### DIFF
--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -393,7 +393,7 @@ class TraceManager
         if (((capture_mode_ & kModeTrack) == kModeTrack) && ((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR)))
         {
             assert((state_tracker_ != nullptr) && (index != nullptr));
-            state_tracker_->TrackSemaphoreSignalState(0, nullptr, 1, &semaphore);
+            state_tracker_->TrackSemaphoreSignalState(semaphore);
             state_tracker_->TrackAcquireImage(*index, swapchain, semaphore, fence, 0);
         }
     }
@@ -406,7 +406,7 @@ class TraceManager
         if (((capture_mode_ & kModeTrack) == kModeTrack) && ((result == VK_SUCCESS) || (result == VK_SUBOPTIMAL_KHR)))
         {
             assert((state_tracker_ != nullptr) && (pAcquireInfo != nullptr) && (index != nullptr));
-            state_tracker_->TrackSemaphoreSignalState(0, nullptr, 1, &pAcquireInfo->semaphore);
+            state_tracker_->TrackSemaphoreSignalState(pAcquireInfo->semaphore);
             state_tracker_->TrackAcquireImage(*index,
                                               pAcquireInfo->swapchain,
                                               pAcquireInfo->semaphore,

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -850,6 +850,18 @@ void VulkanStateTracker::TrackQueryReset(VkQueryPool query_pool, uint32_t first_
     }
 }
 
+void VulkanStateTracker::TrackSemaphoreSignalState(VkSemaphore signal)
+{
+    if (signal != VK_NULL_HANDLE)
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+
+        auto wrapper = reinterpret_cast<SemaphoreWrapper*>(signal);
+        assert(wrapper != nullptr);
+        wrapper->signaled = true;
+    }
+}
+
 void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t           wait_count,
                                                    const VkSemaphore* waits,
                                                    uint32_t           signal_count,

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -306,6 +306,8 @@ class VulkanStateTracker
 
     void TrackQueryReset(VkQueryPool query_pool, uint32_t first_query, uint32_t query_count);
 
+    void TrackSemaphoreSignalState(VkSemaphore signal);
+
     void TrackSemaphoreSignalState(uint32_t           wait_count,
                                    const VkSemaphore* waits,
                                    uint32_t           signal_count,


### PR DESCRIPTION
The trimming state tracker was treating the semaphore parameter of vkAcquireNextImageKHR/vkAckquireNextImage2KHR as a VkSemaphore array of size 1, and was not correctly handle the case where the value of semaphore was VK_NULL_HANDLE.
