### PR TITLE
PageGuard Improvements for Android/Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ add_library(windows_specific INTERFACE)
 target_compile_definitions(windows_specific INTERFACE WIN32_LEAN_AND_MEAN NOMINMAX VK_USE_PLATFORM_WIN32_KHR)
 
 add_library(linux_specific INTERFACE)
-target_compile_definitions(linux_specific INTERFACE _FILE_OFFSET_BITS=64 PAGE_GUARD_ENABLE_X86_64_UCONTEXT
+target_compile_definitions(linux_specific INTERFACE _FILE_OFFSET_BITS=64 PAGE_GUARD_ENABLE_UCONTEXT_WRITE_DETECTION
     $<$<BOOL:${X11_FOUND}>:VK_USE_PLATFORM_XLIB_KHR>
     $<$<BOOL:${X11_Xrandr_FOUND}>:VK_USE_PLATFORM_XLIB_XRANDR_EXT>
     $<$<BOOL:${XCB_FOUND}>:VK_USE_PLATFORM_XCB_KHR>

--- a/android/framework/cmake-config/PlatformConfig.cmake
+++ b/android/framework/cmake-config/PlatformConfig.cmake
@@ -1,5 +1,5 @@
 add_library(platform_specific INTERFACE)
-target_compile_definitions(platform_specific INTERFACE _FILE_OFFSET_BITS=64 VK_USE_PLATFORM_ANDROID_KHR)
+target_compile_definitions(platform_specific INTERFACE _FILE_OFFSET_BITS=64 PAGE_GUARD_ENABLE_UCONTEXT_WRITE_DETECTION VK_USE_PLATFORM_ANDROID_KHR)
 
 add_library(vulkan_registry INTERFACE)
 target_include_directories(vulkan_registry INTERFACE ${GFXRECON_SOURCE_DIR}/external/Vulkan-Headers/include)

--- a/framework/util/page_guard_manager.cpp
+++ b/framework/util/page_guard_manager.cpp
@@ -151,19 +151,17 @@ static void PageGuardExceptionHandler(int id, siginfo_t* info, void* data)
     {
         // This was not a SIGSEGV signal for an address that was protected with mprotect().
         // Raise the original signal handler for this case.
-        if ((s_old_sigaction.sa_flags & SA_SIGINFO) == SA_SIGINFO)
+        if (((s_old_sigaction.sa_flags & SA_SIGINFO) == SA_SIGINFO) && (s_old_sigaction.sa_sigaction != nullptr))
         {
-            if (s_old_sigaction.sa_sigaction != nullptr)
-            {
-                s_old_sigaction.sa_sigaction(id, info, data);
-            }
+            s_old_sigaction.sa_sigaction(id, info, data);
+        }
+        else if (((s_old_sigaction.sa_flags & SA_SIGINFO) != SA_SIGINFO) && (s_old_sigaction.sa_handler != nullptr))
+        {
+            s_old_sigaction.sa_handler(id);
         }
         else
         {
-            if (s_old_sigaction.sa_handler != nullptr)
-            {
-                s_old_sigaction.sa_handler(id);
-            }
+            abort();
         }
     }
 }

--- a/framework/util/page_guard_manager.h
+++ b/framework/util/page_guard_manager.h
@@ -156,7 +156,7 @@ class PageGuardManager
     bool                     enable_copy_on_map_;
     bool                     enable_lazy_copy_;
 
-    // Only applies to WIN32 builds and Linux builds with PAGE_GUARD_ENABLE_X86_64_UCONTEXT defined.
+    // Only applies to WIN32 builds and Linux/Android builds with PAGE_GUARD_ENABLE_UCONTEXT_WRITE_DETECTION defined.
     bool enable_read_write_same_page_;
 };
 


### PR DESCRIPTION
Adds the following to the Android and Desktop Linux "page guard" implementation:
* The page guard signal handler for ARM will now check the WnR bit of the ESR register value provided through the signal handler's ucontext parameter to determine if the SIGSEGV signal was generated by a read or a write.  Makes the Android page guard behavior equivalent to the Desktop behavior.
* The Linux and Android signal handlers will now call abort(), instead of hanging, when receiving a SIGSEGV signal that was not generated by a read or write access to memory that the page guard implementation has protected with mprotect().