### PR TITLE
Fix Capture Issue with Duplicate vkMapMemory Calls

### DIFF
--- a/framework/util/page_guard_manager.cpp
+++ b/framework/util/page_guard_manager.cpp
@@ -559,6 +559,30 @@ void PageGuardManager::ProcessActiveRange(uint64_t           memory_id,
     }
 }
 
+bool PageGuardManager::GetMemory(uint64_t memory_id, void** memory)
+{
+    assert(memory != nullptr);
+
+    std::lock_guard<std::mutex> lock(tracked_memory_lock_);
+
+    auto entry = memory_info_.find(memory_id);
+    if (entry != memory_info_.end())
+    {
+        if (entry->second.shadow_memory != nullptr)
+        {
+            (*memory) = entry->second.shadow_memory;
+        }
+        else
+        {
+            (*memory) = entry->second.mapped_memory;
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
 void* PageGuardManager::AddMemory(uint64_t memory_id, void* mapped_memory, size_t size)
 {
     void*  aligned_address   = nullptr;

--- a/framework/util/page_guard_manager.h
+++ b/framework/util/page_guard_manager.h
@@ -53,6 +53,8 @@ class PageGuardManager
 
     static PageGuardManager* Get() { return instance_; }
 
+    bool GetMemory(uint64_t memory_id, void** memory);
+
     void* AddMemory(uint64_t memory_id, void* mapped_memory, size_t size);
 
     void RemoveMemory(uint64_t memory_id);


### PR DESCRIPTION
Update the capture layer to handle the case where the same VkDeviceMemory object is mapped more than once. In its vkMapMemory implementation, when the page guard memory tracking mode is enabled, the layer was correctly skipping the page guard initialization for the second vkMapMemory call, but was returning the real pointer returned by vkMapMemory instead of the pointer to the shadow memory allocation used for detecting memory modifications. As a result, no data written to mapped memory was recorded to the capture file. The layer now returns the pointer to the shadow allocation from the duplicate vkMapMemory call.

This case had been handled correctly before the trimming feature was implemented, but was lost with the changes for the trimming state tracking.
