### PR TITLE
Fixes for Trimming Memory/Resource Handling

### DIFF
--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -1236,20 +1236,23 @@ void TraceManager::PreProcess_vkFreeMemory(VkDevice                     device,
     GFXRECON_UNREFERENCED_PARAMETER(device);
     GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
 
-    auto wrapper = reinterpret_cast<DeviceMemoryWrapper*>(memory);
-    assert(wrapper != nullptr);
-
-    if ((memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kPageGuard) && (wrapper->mapped_data != nullptr))
+    if (memory != VK_NULL_HANDLE)
     {
-        util::PageGuardManager* manager = util::PageGuardManager::Get();
-        assert(manager != nullptr);
+        auto wrapper = reinterpret_cast<DeviceMemoryWrapper*>(memory);
 
-        manager->RemoveMemory(wrapper->handle_id);
-
-        if (page_guard_external_memory_)
+        if ((memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kPageGuard) &&
+            (wrapper->mapped_data != nullptr))
         {
-            size_t external_memory_size = manager->GetAlignedSize(static_cast<size_t>(wrapper->allocation_size));
-            manager->FreeMemory(wrapper->external_allocation, external_memory_size);
+            util::PageGuardManager* manager = util::PageGuardManager::Get();
+            assert(manager != nullptr);
+
+            manager->RemoveMemory(wrapper->handle_id);
+
+            if (page_guard_external_memory_)
+            {
+                size_t external_memory_size = manager->GetAlignedSize(static_cast<size_t>(wrapper->allocation_size));
+                manager->FreeMemory(wrapper->external_allocation, external_memory_size);
+            }
         }
     }
 }

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -151,17 +151,17 @@ struct DeviceMemoryWrapper : public HandleWrapper<VkDeviceMemory>
 
 struct BufferWrapper : public HandleWrapper<VkBuffer>
 {
-    DeviceWrapper*       bind_device{ nullptr };
-    DeviceMemoryWrapper* bind_memory{ nullptr };
-    VkDeviceSize         bind_offset{ 0 };
-    uint32_t             queue_family_index{ 0 };
-    VkDeviceSize         created_size{ 0 };
+    DeviceWrapper*   bind_device{ nullptr };
+    format::HandleId bind_memory_id{ 0 };
+    VkDeviceSize     bind_offset{ 0 };
+    uint32_t         queue_family_index{ 0 };
+    VkDeviceSize     created_size{ 0 };
 };
 
 struct ImageWrapper : public HandleWrapper<VkImage>
 {
     DeviceWrapper*        bind_device{ nullptr };
-    DeviceMemoryWrapper*  bind_memory{ nullptr };
+    format::HandleId      bind_memory_id{ 0 };
     VkDeviceSize          bind_offset{ 0 };
     uint32_t              queue_family_index{ 0 };
     VkImageType           image_type{ VK_IMAGE_TYPE_2D };

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -220,10 +220,10 @@ void VulkanStateTracker::TrackBufferMemoryBinding(VkDevice       device,
 
     std::unique_lock<std::mutex> lock(mutex_);
 
-    auto wrapper         = reinterpret_cast<BufferWrapper*>(buffer);
-    wrapper->bind_device = reinterpret_cast<DeviceWrapper*>(device);
-    wrapper->bind_memory = reinterpret_cast<DeviceMemoryWrapper*>(memory);
-    wrapper->bind_offset = memoryOffset;
+    auto wrapper            = reinterpret_cast<BufferWrapper*>(buffer);
+    wrapper->bind_device    = reinterpret_cast<DeviceWrapper*>(device);
+    wrapper->bind_memory_id = GetWrappedId(memory);
+    wrapper->bind_offset    = memoryOffset;
 }
 
 void VulkanStateTracker::TrackImageMemoryBinding(VkDevice       device,
@@ -235,10 +235,10 @@ void VulkanStateTracker::TrackImageMemoryBinding(VkDevice       device,
 
     std::unique_lock<std::mutex> lock(mutex_);
 
-    auto wrapper         = reinterpret_cast<ImageWrapper*>(image);
-    wrapper->bind_device = reinterpret_cast<DeviceWrapper*>(device);
-    wrapper->bind_memory = reinterpret_cast<DeviceMemoryWrapper*>(memory);
-    wrapper->bind_offset = memoryOffset;
+    auto wrapper            = reinterpret_cast<ImageWrapper*>(image);
+    wrapper->bind_device    = reinterpret_cast<DeviceWrapper*>(device);
+    wrapper->bind_memory_id = GetWrappedId(memory);
+    wrapper->bind_offset    = memoryOffset;
 }
 
 void VulkanStateTracker::TrackMappedMemory(VkDevice         device,

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -302,6 +302,18 @@ class VulkanStateWriter
 
     bool CheckDescriptorStatus(const DescriptorInfo* descriptor, uint32_t index, const VulkanStateTable& state_table);
 
+    bool IsBufferValid(format::HandleId buffer_id, const VulkanStateTable& state_table);
+
+    bool IsBufferViewValid(format::HandleId view_id, const VulkanStateTable& state_table);
+
+    bool IsImageValid(format::HandleId image_id, const VulkanStateTable& state_table);
+
+    bool IsImageViewValid(format::HandleId view_id, const VulkanStateTable& state_table);
+
+    bool IsFramebufferValid(format::HandleId framebuffer_id, const VulkanStateTable& state_table);
+
+    bool IsFramebufferValid(const FramebufferWrapper* framebuffer_wrapper, const VulkanStateTable& state_table);
+
   private:
     util::FileOutputStream*  output_stream_;
     util::Compressor*        compressor_;


### PR DESCRIPTION
* When writing resource data to the trimming state snapshot, omit data from uninitialized images.
* When writing object initialization commands to the trimming state snapshot, handle the case where a VkMemory object has been destroyed, but VkImage and VkBuffer objects bound to that memory object have not been destroyed.
* When tracking mapped memory, ignore calls to vkFreeMemory with a null handle.