### PR TITLE
Fix Surface Handle Unwrap Issue

### DIFF
--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -754,7 +754,7 @@ void VulkanStateWriter::WriteSwapchainKhrState(const VulkanStateTable& state_tab
     state_table.VisitWrappers([&](const SwapchainKHRWrapper* wrapper) {
         assert(wrapper != nullptr);
 
-        WriteResizeWindowCmd(GetWrappedId(wrapper->surface), wrapper->extent.width, wrapper->extent.height);
+        WriteResizeWindowCmd(wrapper->surface->handle_id, wrapper->extent.width, wrapper->extent.height);
 
         // Write swapchain creation call.
         WriteFunctionCall(wrapper->create_call_id, wrapper->create_parameters.get());


### PR DESCRIPTION
When writing a window resize command to the trimming state snapshot, a pointer to a SurfaceWrapper struct was incorrectly treated as a wrapped VkSurfaceKHR handle and was being unwrapped. The type casting performed for unwrapping produced a valid result with 64-bit builds where the size of a pointer matches the size of a Vulkan handle, but produced an invalid result with 32-bit address sizes.