### PR TITLE
Fix Physical Device Group Handle Tracking

### DIFF
--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -200,13 +200,12 @@ class TraceManager
             auto thread_data = GetThreadData();
             assert(thread_data != nullptr);
 
-            state_tracker_->AddStructGroupEntry<ParentHandle, Wrapper, HandleStruct>(
-                parent_handle,
-                count,
-                handle_structs,
-                unwrap_struct_handle,
-                thread_data->call_id_,
-                thread_data->parameter_buffer_.get());
+            state_tracker_->AddStructGroupEntry(parent_handle,
+                                                count,
+                                                handle_structs,
+                                                unwrap_struct_handle,
+                                                thread_data->call_id_,
+                                                thread_data->parameter_buffer_.get());
         }
 
         EndApiCallTrace(encoder);


### PR DESCRIPTION
Fix trimming state tracking issue with handles retrieved through vkEnumeratePhysicalDeviceGroups:
- Remove explicit template argument specification from AddStructGroupEntry invocation to allow for non-template function overloads.
- Refactor AddStructGroupEntry to avoid attempting to acquire the same lock twice.
