### PR TITLE
Detect Modified Pages with GetWriteWatch

### DIFF
--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -203,7 +203,13 @@ bool TraceManager::Initialize(std::string base_filename, const CaptureSettings::
 
     if (memory_tracking_mode_ == CaptureSettings::kPageGuard)
     {
+#if defined(WIN32)
         page_guard_external_memory_ = trace_settings.page_guard_external_memory;
+#else
+        GFXRECON_LOG_WARNING(
+            "Ignoring page guard external memory option on unsupported platform (Only Windows is currently supported)")
+        page_guard_external_memory_ = false;
+#endif
     }
     else
     {


### PR DESCRIPTION
When capturing with GFXRECON_PAGE_GUARD_EXTERNAL_MEMORY=1 on Windows, use the Win32 GetWriteWatch() function to obtain a list of modified pages.  Replaces use of VirtualProtect() to generate exceptions on page write to detect modifications to mapped memory.