### PR TITLE
Add Page Guard Option for Separate Read/Write Tracking

### DIFF
--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -71,6 +71,8 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 #define PAGE_GUARD_COPY_ON_MAP_UPPER        "PAGE_GUARD_COPY_ON_MAP"
 #define PAGE_GUARD_LAZY_COPY_LOWER          "page_guard_lazy_copy"
 #define PAGE_GUARD_LAZY_COPY_UPPER          "PAGE_GUARD_LAZY_COPY"
+#define PAGE_GUARD_SEPARATE_READ_LOWER      "page_guard_separate_read"
+#define PAGE_GUARD_SEPARATE_READ_UPPER      "PAGE_GUARD_SEPARATE_READ"
 #define PAGE_GUARD_EXTERNAL_MEMORY_LOWER    "page_guard_external_memory"
 #define PAGE_GUARD_EXTERNAL_MEMORY_UPPER    "PAGE_GUARD_EXTERNAL_MEMORY"
 // clang-format on
@@ -99,6 +101,7 @@ const char kMemoryTrackingModeEnvVar[]       = GFXRECON_ENV_VAR_PREFIX MEMORY_TR
 const char kCaptureFramesEnvVar[]            = GFXRECON_ENV_VAR_PREFIX CAPTURE_FRAMES_LOWER;
 const char kPageGuardCopyOnMapEnvVar[]       = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_COPY_ON_MAP_LOWER;
 const char kPageGuardLazyCopyEnvVar[]        = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_LAZY_COPY_LOWER;
+const char kPageGuardSeparateReadEnvVar[]    = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_SEPARATE_READ_LOWER;
 const char kPageGuardExternalMemoryEnvVar[]  = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_EXTERNAL_MEMORY_LOWER;
 
 #else
@@ -125,6 +128,7 @@ const char kMemoryTrackingModeEnvVar[]                = GFXRECON_ENV_VAR_PREFIX 
 const char kCaptureFramesEnvVar[]                     = GFXRECON_ENV_VAR_PREFIX CAPTURE_FRAMES_UPPER;
 const char kPageGuardCopyOnMapEnvVar[]                = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_COPY_ON_MAP_UPPER;
 const char kPageGuardLazyCopyEnvVar[]                 = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_LAZY_COPY_UPPER;
+const char kPageGuardSeparateReadEnvVar[]             = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_SEPARATE_READ_UPPER;
 const char kPageGuardExternalMemoryEnvVar[]           = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_EXTERNAL_MEMORY_UPPER;
 #endif
 
@@ -151,6 +155,7 @@ const std::string kOptionKeyMemoryTrackingMode       = std::string(kSettingsFilt
 const std::string kOptionKeyCaptureFrames            = std::string(kSettingsFilter) + std::string(CAPTURE_FRAMES_LOWER);
 const std::string kOptionKeyPageGuardCopyOnMap       = std::string(kSettingsFilter) + std::string(PAGE_GUARD_COPY_ON_MAP_LOWER);
 const std::string kOptionKeyPageGuardLazyCopy        = std::string(kSettingsFilter) + std::string(PAGE_GUARD_LAZY_COPY_LOWER);
+const std::string kOptionKeyPageGuardSeparateRead    = std::string(kSettingsFilter) + std::string(PAGE_GUARD_SEPARATE_READ_LOWER);
 const std::string kOptionKeyPageGuardExternalMemory  = std::string(kSettingsFilter) + std::string(PAGE_GUARD_EXTERNAL_MEMORY_LOWER);
 // clang-format on
 
@@ -234,6 +239,7 @@ void CaptureSettings::LoadOptionsEnvVar(OptionsMap* options)
     // Page guard environment variables
     LoadSingleOptionEnvVar(options, kPageGuardCopyOnMapEnvVar, kOptionKeyPageGuardCopyOnMap);
     LoadSingleOptionEnvVar(options, kPageGuardLazyCopyEnvVar, kOptionKeyPageGuardLazyCopy);
+    LoadSingleOptionEnvVar(options, kPageGuardSeparateReadEnvVar, kOptionKeyPageGuardSeparateRead);
     LoadSingleOptionEnvVar(options, kPageGuardExternalMemoryEnvVar, kOptionKeyPageGuardExternalMemory);
 }
 
@@ -286,6 +292,8 @@ void CaptureSettings::ProcessOptions(OptionsMap* options, CaptureSettings* setti
         FindOption(options, kOptionKeyPageGuardCopyOnMap), settings->trace_settings_.page_guard_copy_on_map);
     settings->trace_settings_.page_guard_lazy_copy = ParseBoolString(FindOption(options, kOptionKeyPageGuardLazyCopy),
                                                                      settings->trace_settings_.page_guard_lazy_copy);
+    settings->trace_settings_.page_guard_separate_read = ParseBoolString(
+        FindOption(options, kOptionKeyPageGuardSeparateRead), settings->trace_settings_.page_guard_separate_read);
     settings->trace_settings_.page_guard_external_memory = ParseBoolString(
         FindOption(options, kOptionKeyPageGuardExternalMemory), settings->trace_settings_.page_guard_external_memory);
 

--- a/framework/encode/capture_settings.h
+++ b/framework/encode/capture_settings.h
@@ -64,6 +64,7 @@ class CaptureSettings
         std::vector<TrimRange> trim_ranges;
         bool                   page_guard_copy_on_map{ util::PageGuardManager::kDefaultEnableCopyOnMap };
         bool                   page_guard_lazy_copy{ util::PageGuardManager::kDefaultEnableLazyCopy };
+        bool                   page_guard_separate_read{ util::PageGuardManager::kDefaultEnableSeparateRead };
 
         // An optimization for the page_guard memory tracking mode that eliminates the need for shadow memory by
         // overriding vkAllocateMemory so that all host visible allocations use the external memory extension with a

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -206,9 +206,12 @@ bool TraceManager::Initialize(std::string base_filename, const CaptureSettings::
 #if defined(WIN32)
         page_guard_external_memory_ = trace_settings.page_guard_external_memory;
 #else
-        GFXRECON_LOG_WARNING(
-            "Ignoring page guard external memory option on unsupported platform (Only Windows is currently supported)")
         page_guard_external_memory_ = false;
+        if (trace_settings.page_guard_external_memory)
+        {
+            GFXRECON_LOG_WARNING("Ignoring page guard external memory option on unsupported platform (Only Windows is "
+                                 "currently supported)")
+        }
 #endif
     }
     else
@@ -261,6 +264,7 @@ bool TraceManager::Initialize(std::string base_filename, const CaptureSettings::
             util::PageGuardManager::Create(!page_guard_external_memory_,
                                            trace_settings.page_guard_copy_on_map,
                                            trace_settings.page_guard_lazy_copy,
+                                           trace_settings.page_guard_separate_read,
                                            util::PageGuardManager::kDefaultEnableReadWriteSamePage);
         }
 

--- a/framework/util/page_guard_manager.h
+++ b/framework/util/page_guard_manager.h
@@ -38,6 +38,7 @@ class PageGuardManager
     static const bool kDefaultEnableShadowMemory      = true;
     static const bool kDefaultEnableCopyOnMap         = true;
     static const bool kDefaultEnableLazyCopy          = false;
+    static const bool kDefaultEnableSeparateRead      = true;
     static const bool kDefaultEnableReadWriteSamePage = true;
 
   public:
@@ -47,12 +48,17 @@ class PageGuardManager
     typedef std::function<void(uint64_t, void*, size_t, size_t)> ModifiedMemoryFunc;
 
   public:
-    static void
-    Create(bool enable_shadow_memory, bool enable_copy_on_map, bool enable_lazy_copy, bool expect_read_write_same_page);
+    static void Create(bool enable_shadow_memory,
+                       bool enable_copy_on_map,
+                       bool enable_lazy_copy,
+                       bool enable_separate_read,
+                       bool expect_read_write_same_page);
 
     static void Destroy();
 
     static PageGuardManager* Get() { return instance_; }
+
+    bool UseSeparateRead() const { return enable_separate_read_; }
 
     bool GetMemory(uint64_t memory_id, void** memory);
 
@@ -78,6 +84,7 @@ class PageGuardManager
     PageGuardManager(bool enable_shadow_memory,
                      bool enable_copy_on_map,
                      bool enable_lazy_copy,
+                     bool enable_separate_read,
                      bool expect_read_write_same_page);
 
     ~PageGuardManager();
@@ -168,12 +175,13 @@ class PageGuardManager
     void*                    exception_handler_;
     uint32_t                 exception_handler_count_;
     const size_t             system_page_size_;
-    bool                     enable_shadow_memory_;
-    bool                     enable_copy_on_map_;
-    bool                     enable_lazy_copy_;
+    const bool               enable_shadow_memory_;
+    const bool               enable_copy_on_map_;
+    const bool               enable_lazy_copy_;
+    const bool               enable_separate_read_;
 
     // Only applies to WIN32 builds and Linux/Android builds with PAGE_GUARD_ENABLE_UCONTEXT_WRITE_DETECTION defined.
-    bool enable_read_write_same_page_;
+    const bool enable_read_write_same_page_;
 };
 
 GFXRECON_END_NAMESPACE(util)


### PR DESCRIPTION
Add an option to enable/disable page guard support for tracking read and write memory accesses separately. When enabled, the accessed page will be copied from the mapped memory to shadow memory on every read. The option is enabled by default.
