### PR TITLE
Reset Query Pool After Creation at Trim State Setup

### DIFF
--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -212,6 +212,7 @@ struct QueryPoolWrapper : public HandleWrapper<VkQueryPool>
 {
     DeviceWrapper*         device{ nullptr };
     VkQueryType            query_type{};
+    uint32_t               query_count{ 0 };
     std::vector<QueryInfo> pending_queries;
 };
 

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -173,8 +173,9 @@ inline void InitializeState<VkDevice, QueryPoolWrapper, VkQueryPoolCreateInfo>(V
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device     = reinterpret_cast<DeviceWrapper*>(parent_handle);
-    wrapper->query_type = create_info->queryType;
+    wrapper->device      = reinterpret_cast<DeviceWrapper*>(parent_handle);
+    wrapper->query_type  = create_info->queryType;
+    wrapper->query_count = create_info->queryCount;
     wrapper->pending_queries.resize(create_info->queryCount);
 }
 

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -208,6 +208,9 @@ class VulkanStateWriter
                                       const DescriptorInfo* binding,
                                       VkWriteDescriptorSet* write);
 
+    void WriteQueryPoolReset(format::HandleId                            device_id,
+                             const std::vector<const QueryPoolWrapper*>& query_pool_wrappers);
+
     void WriteQueryActivation(format::HandleId           device_id,
                               uint32_t                   queue_family_index,
                               const QueryActivationList& active_queries);


### PR DESCRIPTION
Reset query pools after creation during state setup for trimmed file replay.
