### PR TITLE
arg parsing: Fix crash when arg has long string for value

### DIFF
--- a/framework/util/argument_parser.cpp
+++ b/framework/util/argument_parser.cpp
@@ -230,7 +230,7 @@ void ArgumentParser::Init(std::vector<std::string> command_line_args,
                             {
                                 argument_value.erase(0, 1);
                             }
-                            if (current_argument[argument_value.size() - 1] == '\"')
+                            if (argument_value[argument_value.size() - 1] == '\"')
                             {
                                 argument_value.erase(argument_value.size() - 1);
                             }


### PR DESCRIPTION
Change-Id: Idc0ef10d0903be333518fc4579b100228183bae7