### PR TITLE
Fix debug report callback override

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2151,7 +2151,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDebugReportCallbackEXT(
         GFXRECON_LOG_WARNING("The vkCreateDebugReportCallbackEXT parameter pCreateInfo is NULL.");
     }
 
-    return func(instance, pCreateInfo, pAllocator, pCallback);
+    return func(instance, &modified_create_info, pAllocator, pCallback);
 }
 
 VkResult VulkanReplayConsumerBase::OverrideCreateDebugUtilsMessengerEXT(


### PR DESCRIPTION
Make sure that the replay override for vkCreateDebugReportCallbackEXT uses the modified VkDebuReportCallbackDreateInfoEXT struct that references the replay tool's debug callback function.
