### PR TITLE
Tell clang-format to ignore generated directory

### DIFF
--- a/framework/generated/.clang-format
+++ b/framework/generated/.clang-format
@@ -1,0 +1,6 @@
+---
+# Disable clang-format for generated code
+DisableFormat: true
+# C-F has a bug in which it insists on sorting includes even if disabled
+SortIncludes: false
+...


### PR DESCRIPTION
This should allow running `git clang-format` without it modifying the generated files.  .clang-format file copied from KhronosGroup/Vulkan-ValidationLayers which has a similar need.