### PR TITLE
Fixes for clang-tidy issues from util code

### DIFF
--- a/framework/decode/struct_pointer_decoder_nvx.h
+++ b/framework/decode/struct_pointer_decoder_nvx.h
@@ -121,8 +121,8 @@ class StructPointerDecoder<Decoded_VkObjectTableEntryNVX> : public PointerDecode
                             new Decoded_VkObjectTableDescriptorSetEntryNVX;
                         VkObjectTableDescriptorSetEntryNVX* value = new VkObjectTableDescriptorSetEntryNVX;
 
-                        decoded_structs_[i] = reinterpret_cast<Decoded_VkObjectTableEntryNVX*>(wrapper);
-                        struct_memory_[i]   = reinterpret_cast<VkObjectTableEntryNVX*>(value);
+                        decoded_structs_[i]    = reinterpret_cast<Decoded_VkObjectTableEntryNVX*>(wrapper);
+                        struct_memory_[i]      = reinterpret_cast<VkObjectTableEntryNVX*>(value);
                         wrapper->decoded_value = value;
 
                         bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper);
@@ -132,8 +132,8 @@ class StructPointerDecoder<Decoded_VkObjectTableEntryNVX> : public PointerDecode
                         Decoded_VkObjectTablePipelineEntryNVX* wrapper = new Decoded_VkObjectTablePipelineEntryNVX;
                         VkObjectTablePipelineEntryNVX*         value   = new VkObjectTablePipelineEntryNVX;
 
-                        decoded_structs_[i] = reinterpret_cast<Decoded_VkObjectTableEntryNVX*>(wrapper);
-                        struct_memory_[i]   = reinterpret_cast<VkObjectTableEntryNVX*>(value);
+                        decoded_structs_[i]    = reinterpret_cast<Decoded_VkObjectTableEntryNVX*>(wrapper);
+                        struct_memory_[i]      = reinterpret_cast<VkObjectTableEntryNVX*>(value);
                         wrapper->decoded_value = value;
 
                         bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper);
@@ -144,8 +144,8 @@ class StructPointerDecoder<Decoded_VkObjectTableEntryNVX> : public PointerDecode
                             new Decoded_VkObjectTableIndexBufferEntryNVX;
                         VkObjectTableIndexBufferEntryNVX* value = new VkObjectTableIndexBufferEntryNVX;
 
-                        decoded_structs_[i] = reinterpret_cast<Decoded_VkObjectTableEntryNVX*>(wrapper);
-                        struct_memory_[i]   = reinterpret_cast<VkObjectTableEntryNVX*>(value);
+                        decoded_structs_[i]    = reinterpret_cast<Decoded_VkObjectTableEntryNVX*>(wrapper);
+                        struct_memory_[i]      = reinterpret_cast<VkObjectTableEntryNVX*>(value);
                         wrapper->decoded_value = value;
 
                         bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper);
@@ -156,8 +156,8 @@ class StructPointerDecoder<Decoded_VkObjectTableEntryNVX> : public PointerDecode
                             new Decoded_VkObjectTableVertexBufferEntryNVX;
                         VkObjectTableVertexBufferEntryNVX* value = new VkObjectTableVertexBufferEntryNVX;
 
-                        decoded_structs_[i] = reinterpret_cast<Decoded_VkObjectTableEntryNVX*>(wrapper);
-                        struct_memory_[i]   = reinterpret_cast<VkObjectTableEntryNVX*>(value);
+                        decoded_structs_[i]    = reinterpret_cast<Decoded_VkObjectTableEntryNVX*>(wrapper);
+                        struct_memory_[i]      = reinterpret_cast<VkObjectTableEntryNVX*>(value);
                         wrapper->decoded_value = value;
 
                         bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper);
@@ -168,8 +168,8 @@ class StructPointerDecoder<Decoded_VkObjectTableEntryNVX> : public PointerDecode
                             new Decoded_VkObjectTablePushConstantEntryNVX;
                         VkObjectTablePushConstantEntryNVX* value = new VkObjectTablePushConstantEntryNVX;
 
-                        decoded_structs_[i] = reinterpret_cast<Decoded_VkObjectTableEntryNVX*>(wrapper);
-                        struct_memory_[i]   = reinterpret_cast<VkObjectTableEntryNVX*>(value);
+                        decoded_structs_[i]    = reinterpret_cast<Decoded_VkObjectTableEntryNVX*>(wrapper);
+                        struct_memory_[i]      = reinterpret_cast<VkObjectTableEntryNVX*>(value);
                         wrapper->decoded_value = value;
 
                         bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper);

--- a/framework/util/argument_parser.cpp
+++ b/framework/util/argument_parser.cpp
@@ -122,7 +122,7 @@ void ArgumentParser::Init(std::vector<std::string> command_line_args,
     std::string              sub_string2;
 
     uint32_t option_index = 0;
-    if (options.size() > 0)
+    if (!options.empty())
     {
         std::stringstream option_strstr(options);
         while (option_strstr.good())
@@ -152,7 +152,7 @@ void ArgumentParser::Init(std::vector<std::string> command_line_args,
     options_present_.resize(option_index);
 
     uint32_t argument_index = 0;
-    if (arguments.size() > 0)
+    if (!arguments.empty())
     {
         std::stringstream arguments_strstr(arguments);
         while (arguments_strstr.good())
@@ -188,17 +188,17 @@ void ArgumentParser::Init(std::vector<std::string> command_line_args,
 
         // Strip off any quotes surrounding the whole string
         std::string current_argument = command_line_args[cur_arg];
-        if (current_argument[0] == '\"')
+        if (current_argument.front() == '\"')
         {
-            current_argument.erase(0, 1);
+            current_argument.erase(current_argument.begin());
         }
-        if (current_argument[current_argument.size() - 1] == '\"')
+        if (current_argument.back() == '\"')
         {
-            current_argument.erase(current_argument.size() - 1);
+            current_argument.pop_back();
         }
 
         // Optional option/argument
-        if (current_argument[0] == '-')
+        if (current_argument.front() == '-')
         {
             for (const auto& cur_option : options_indices_)
             {
@@ -226,13 +226,13 @@ void ArgumentParser::Init(std::vector<std::string> command_line_args,
                         {
                             // Get the next value and strip off any quotes surrounding the whole string
                             std::string argument_value = command_line_args[++cur_arg];
-                            if (argument_value[0] == '\"')
+                            if (argument_value.front() == '\"')
                             {
-                                argument_value.erase(0, 1);
+                                argument_value.erase(argument_value.begin());
                             }
-                            if (argument_value[argument_value.size() - 1] == '\"')
+                            if (argument_value.back() == '\"')
                             {
-                                argument_value.erase(argument_value.size() - 1);
+                                argument_value.pop_back();
                             }
                             argument_values_[cur_argument.second] = argument_value;
                         }

--- a/framework/util/file_path.cpp
+++ b/framework/util/file_path.cpp
@@ -142,7 +142,7 @@ std::string Join(const std::string& lhs, const std::string& rhs)
     return joined;
 }
 
-std::string InsertFilenamePostfix(const std::string& filename, const std::string postfix)
+std::string InsertFilenamePostfix(const std::string& filename, const std::string& postfix)
 {
     std::string file_extension;
     std::string file_part;

--- a/framework/util/file_path.h
+++ b/framework/util/file_path.h
@@ -34,7 +34,7 @@ bool IsDirectory(const std::string& path);
 
 std::string Join(const std::string& lhs, const std::string& rhs);
 
-std::string InsertFilenamePostfix(const std::string& filename, const std::string postfix);
+std::string InsertFilenamePostfix(const std::string& filename, const std::string& postfix);
 
 std::string GenerateTimestampedFilename(const std::string& filename, bool use_gmt = false);
 

--- a/framework/util/memory_output_stream.cpp
+++ b/framework/util/memory_output_stream.cpp
@@ -34,7 +34,8 @@ MemoryOutputStream::MemoryOutputStream(size_t initial_size)
 
 MemoryOutputStream::MemoryOutputStream(const void* initial_data, size_t initial_data_size)
 {
-    Write(initial_data, initial_data_size);
+    const uint8_t* bytes = reinterpret_cast<const uint8_t*>(initial_data);
+    buffer_.insert(buffer_.end(), bytes, bytes + initial_data_size);
 }
 
 MemoryOutputStream::~MemoryOutputStream() {}

--- a/framework/util/memory_output_stream.h
+++ b/framework/util/memory_output_stream.h
@@ -37,7 +37,7 @@ class MemoryOutputStream : public OutputStream
 
     MemoryOutputStream(size_t initial_size);
 
-    MemoryOutputStream(const void* initial_data, size_t initial_size);
+    MemoryOutputStream(const void* initial_data, size_t initial_data_size);
 
     virtual ~MemoryOutputStream() override;
 

--- a/framework/util/page_guard_manager.cpp
+++ b/framework/util/page_guard_manager.cpp
@@ -500,7 +500,9 @@ void PageGuardManager::LoadActiveWriteStates(MemoryInfo* memory_info)
 #endif
 }
 
-void PageGuardManager::ProcessEntry(uint64_t memory_id, MemoryInfo* memory_info, ModifiedMemoryFunc handle_modified)
+void PageGuardManager::ProcessEntry(uint64_t                  memory_id,
+                                    MemoryInfo*               memory_info,
+                                    const ModifiedMemoryFunc& handle_modified)
 {
     assert(memory_info != nullptr);
 
@@ -558,11 +560,11 @@ void PageGuardManager::ProcessEntry(uint64_t memory_id, MemoryInfo* memory_info,
     }
 }
 
-void PageGuardManager::ProcessActiveRange(uint64_t           memory_id,
-                                          MemoryInfo*        memory_info,
-                                          size_t             start_index,
-                                          size_t             end_index,
-                                          ModifiedMemoryFunc handle_modified)
+void PageGuardManager::ProcessActiveRange(uint64_t                  memory_id,
+                                          MemoryInfo*               memory_info,
+                                          size_t                    start_index,
+                                          size_t                    end_index,
+                                          const ModifiedMemoryFunc& handle_modified)
 {
     assert((memory_info != nullptr) && (memory_info->aligned_address != nullptr));
     assert(end_index > start_index);
@@ -751,7 +753,7 @@ void PageGuardManager::RemoveMemory(uint64_t memory_id)
     }
 }
 
-void PageGuardManager::ProcessMemoryEntry(uint64_t memory_id, ModifiedMemoryFunc handle_modified)
+void PageGuardManager::ProcessMemoryEntry(uint64_t memory_id, const ModifiedMemoryFunc& handle_modified)
 {
     std::lock_guard<std::mutex> lock(tracked_memory_lock_);
 
@@ -775,7 +777,7 @@ void PageGuardManager::ProcessMemoryEntry(uint64_t memory_id, ModifiedMemoryFunc
     }
 }
 
-void PageGuardManager::ProcessMemoryEntries(ModifiedMemoryFunc handle_modified)
+void PageGuardManager::ProcessMemoryEntries(const ModifiedMemoryFunc& handle_modified)
 {
     std::lock_guard<std::mutex> lock(tracked_memory_lock_);
 

--- a/framework/util/page_guard_manager.h
+++ b/framework/util/page_guard_manager.h
@@ -66,9 +66,9 @@ class PageGuardManager
 
     void RemoveMemory(uint64_t memory_id);
 
-    void ProcessMemoryEntry(uint64_t memory_id, ModifiedMemoryFunc handle_modified);
+    void ProcessMemoryEntry(uint64_t memory_id, const ModifiedMemoryFunc& handle_modified);
 
-    void ProcessMemoryEntries(ModifiedMemoryFunc handle_modified);
+    void ProcessMemoryEntries(const ModifiedMemoryFunc& handle_modified);
 
     bool HandleGuardPageViolation(void* address, bool is_write, bool clear_guard);
 
@@ -110,7 +110,7 @@ class PageGuardManager
 #if defined(WIN32)
             if (shadow_memory == nullptr)
             {
-                modified_addresses = std::make_unique<void* []>(total_pages);
+                modified_addresses = std::make_unique<void*[]>(total_pages);
             }
 #endif
         }
@@ -133,7 +133,7 @@ class PageGuardManager
 
 #if defined(WIN32)
         // Memory for retrieving modified pages with GetWriteWatch.
-        std::unique_ptr<void* []> modified_addresses;
+        std::unique_ptr<void*[]> modified_addresses;
 #endif
     };
 
@@ -151,12 +151,12 @@ class PageGuardManager
     bool   FindMemory(void* address, MemoryInfo** watched_memory_info);
     bool   SetMemoryProtection(void* protect_address, size_t protect_size, uint32_t protect_mask);
     void   LoadActiveWriteStates(MemoryInfo* memory_info);
-    void   ProcessEntry(uint64_t memory_id, MemoryInfo* memory_info, ModifiedMemoryFunc handle_modified);
-    void   ProcessActiveRange(uint64_t           memory_id,
-                              MemoryInfo*        memory_info,
-                              size_t             start_index,
-                              size_t             end_index,
-                              ModifiedMemoryFunc handle_modified);
+    void   ProcessEntry(uint64_t memory_id, MemoryInfo* memory_info, const ModifiedMemoryFunc& handle_modified);
+    void   ProcessActiveRange(uint64_t                  memory_id,
+                              MemoryInfo*               memory_info,
+                              size_t                    start_index,
+                              size_t                    end_index,
+                              const ModifiedMemoryFunc& handle_modified);
 
     size_t GetOffsetFromPageStart(void* address) const
     {

--- a/framework/util/settings_loader.cpp
+++ b/framework/util/settings_loader.cpp
@@ -50,6 +50,8 @@ const char kSettingsEnvVar[] = "VK_LAYER_SETTINGS_PATH";
 const char kSettingsFilename[] = "vk_layer_settings.txt";
 const char kCommentDelimiter   = '#';
 
+const size_t kDefaultTokenSize = 512;
+
 std::string RemoveQuotes(const std::string& source)
 {
     size_t start_index = 0;
@@ -213,8 +215,8 @@ int32_t LoadLayerSettingsFile(const std::string&                            file
 
     if (file.good())
     {
-        char        key[512]   = { '\0' };
-        char        value[512] = { '\0' };
+        char        key[kDefaultTokenSize]   = { '\0' };
+        char        value[kDefaultTokenSize] = { '\0' };
         std::string line;
 
         std::getline(file, line);
@@ -230,7 +232,12 @@ int32_t LoadLayerSettingsFile(const std::string&                            file
 
             // This is the same format string that the Vulkan validation layers use.
 #if defined(WIN32)
-            if (sscanf_s(line.c_str(), " %511[^\r\n\t =] = %511[^\r\n \t]", key, 512, value, 512) == 2)
+            if (sscanf_s(line.c_str(),
+                         " %511[^\r\n\t =] = %511[^\r\n \t]",
+                         key,
+                         kDefaultTokenSize,
+                         value,
+                         kDefaultTokenSize) == 2)
 #else
             if (sscanf(line.c_str(), " %511[^\r\n\t =] = %511[^\r\n \t]", key, value) == 2)
 #endif


### PR DESCRIPTION
Fixes for simple issues reported by clang-tidy for the util library code on Linux, with some additional cleanup.
