### PR TITLE
Fix compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ endif(UNIX)
 
 add_library(windows_specific INTERFACE)
 target_compile_definitions(windows_specific INTERFACE WIN32_LEAN_AND_MEAN NOMINMAX VK_USE_PLATFORM_WIN32_KHR)
+target_compile_options(windows_specific INTERFACE /WX)
 
 add_library(linux_specific INTERFACE)
 target_compile_definitions(linux_specific INTERFACE _FILE_OFFSET_BITS=64 PAGE_GUARD_ENABLE_UCONTEXT_WRITE_DETECTION
@@ -99,6 +100,7 @@ target_compile_definitions(linux_specific INTERFACE _FILE_OFFSET_BITS=64 PAGE_GU
     $<$<BOOL:${X11_Xrandr_FOUND}>:VK_USE_PLATFORM_XLIB_XRANDR_EXT>
     $<$<BOOL:${XCB_FOUND}>:VK_USE_PLATFORM_XCB_KHR>
     $<$<BOOL:${WAYLAND_FOUND}>:VK_USE_PLATFORM_WAYLAND_KHR>)
+target_compile_options(linux_specific INTERFACE -Werror)
 
 add_library(platform_specific INTERFACE)
 target_link_libraries(platform_specific INTERFACE

--- a/framework/decode/vulkan_resource_initializer.cpp
+++ b/framework/decode/vulkan_resource_initializer.cpp
@@ -72,7 +72,9 @@ VulkanResourceInitializer::LoadData(VkDeviceMemory memory, VkDeviceSize offset, 
 
     if (result == VK_SUCCESS)
     {
-        util::platform::MemoryCopy(mapped_memory, size, data, size);
+        GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, size);
+        size_t copy_size = static_cast<size_t>(size);
+        util::platform::MemoryCopy(mapped_memory, copy_size, data, copy_size);
         device_table_->UnmapMemory(device_, memory);
     }
 

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -623,12 +623,13 @@ const Handle* UnwrapHandles(const Handle* handles, uint32_t len, HandleUnwrapMem
     {
         assert(unwrap_memory != nullptr);
 
-        const uint8_t* bytes     = reinterpret_cast<const uint8_t*>(handles);
-        size_t         num_bytes = len * sizeof(Handle);
+        size_t num_bytes         = len * sizeof(Handle);
+        auto   unwrapped_handles = reinterpret_cast<Handle*>(unwrap_memory->GetBuffer(num_bytes));
 
-        // Copy and transform handles.
-        auto unwrapped_handles = reinterpret_cast<Handle*>(unwrap_memory->GetFilledBuffer(bytes, num_bytes));
-        std::transform(unwrapped_handles, unwrapped_handles + len, unwrapped_handles, GetWrappedHandle<Handle>);
+        for (uint32_t i = 0; i < len; ++i)
+        {
+            unwrapped_handles[i] = GetWrappedHandle<Handle>(handles[i]);
+        }
 
         return unwrapped_handles;
     }

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -3346,7 +3346,7 @@ VKAPI_ATTR void VKAPI_CALL CmdUpdateBuffer(
         encoder->EncodeHandleValue(dstBuffer);
         encoder->EncodeVkDeviceSizeValue(dstOffset);
         encoder->EncodeVkDeviceSizeValue(dataSize);
-        encoder->EncodeVoidArray(pData, dataSize);
+        encoder->EncodeVoidArray(pData, static_cast<size_t>(dataSize));
         TraceManager::Get()->EndCommandApiCallTrace(commandBuffer, encoder, TrackCmdUpdateBufferHandles, dstBuffer);
     }
 

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -818,7 +818,10 @@ class BaseGenerator(OutputGenerator):
             if lengthValue and lengthValue.isPointer:
                 args.append('({name} != nullptr) ? (*{name}) : 0'.format(name=prefixedName))
             elif lengthName in paramNames:
-                args.append(prefixedName)
+                if lengthValue and (lengthValue.baseType == 'VkDeviceSize'):
+                    args.append('static_cast<size_t>({})'.format(prefixedName))
+                else:
+                    args.append(prefixedName)
             else:
                 args.append(lengthExpr)     # Length is a constant value, not a parameter
         elif isStruct:

--- a/framework/util/settings_loader.cpp
+++ b/framework/util/settings_loader.cpp
@@ -235,9 +235,9 @@ int32_t LoadLayerSettingsFile(const std::string&                            file
             if (sscanf_s(line.c_str(),
                          " %511[^\r\n\t =] = %511[^\r\n \t]",
                          key,
-                         kDefaultTokenSize,
+                         static_cast<uint32_t>(kDefaultTokenSize),
                          value,
-                         kDefaultTokenSize) == 2)
+                         static_cast<uint32_t>(kDefaultTokenSize)) == 2)
 #else
             if (sscanf(line.c_str(), " %511[^\r\n\t =] = %511[^\r\n \t]", key, value) == 2)
 #endif


### PR DESCRIPTION
* Fix warnings generated for size_t comparison/conversion.
* Fix std::transform warning generated by VS2015.
* Enable warnings as errors.