### PR TITLE
Update Xcb Event Wait

### DIFF
--- a/framework/application/xcb_window.cpp
+++ b/framework/application/xcb_window.cpp
@@ -421,7 +421,7 @@ void XcbWindow::InitializeAtoms()
 
 void XcbWindow::CheckEventStatus(uint32_t sequence, uint32_t type)
 {
-    if ((sequence == pending_event_.sequence) && (type == pending_event_.type))
+    if ((sequence >= pending_event_.sequence) && (type == pending_event_.type))
     {
         pending_event_.complete = true;
     }


### PR DESCRIPTION
Change comparison operation for sequence numbers returned by Xcb requests and sequence numbers received with events from == to >=, so that we handle cases where we never receive an event with a sequence number that is equal to the one generated by the request, but do receive an event with a sequence number that is greater than the one generated by the request.
