### PR TITLE
Warn for VK_INCOMPLETE on replay

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1166,22 +1166,11 @@ void VulkanReplayConsumerBase::CheckResult(const char* func_name, VkResult origi
 
             RaiseFatalError(enumutil::GetResultDescription(replay));
         }
-        else if (replay == VK_INCOMPLETE)
-        {
-            // VK_INCOMPLETE is generated when replaying a 'vkGet' function with a size value read from the capture file
-            // that is smaller than the size expected by the replay device.  Replay does not make use of the values
-            // retrieved by this function, so the error should be safe to ignore.  Log this case as a debug message
-            // until replay is modified to adjust sizes used when replaying.
-            GFXRECON_LOG_DEBUG("API call %s returned value VK_INCOMPLETE that does not match return value from "
-                               "capture file: %s.  This may be caused by platform differences.",
-                               func_name,
-                               enumutil::GetResultValueString(original));
-        }
         else if (!((replay == VK_SUCCESS) &&
                    ((original == VK_TIMEOUT) || (original == VK_NOT_READY) || (original == VK_ERROR_OUT_OF_DATE_KHR))))
         {
             // Report differences between replay result and capture result, unless the replay results indicates
-            // that a wait operation completed before the original or a WSI function succeded when the original failed.
+            // that a wait operation completed before the original or a WSI function succeeded when the original failed.
             GFXRECON_LOG_WARNING(
                 "API call %s returned value %s that does not match return value from capture file: %s.",
                 func_name,

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -932,11 +932,11 @@ void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t           wait_count
 void VulkanStateTracker::TrackAcquireImage(
     uint32_t image_index, VkSwapchainKHR swapchain, VkSemaphore semaphore, VkFence fence, uint32_t deviceMask)
 {
-    assert(swapchain != VK_NULL_HANDLE);
-
     std::unique_lock<std::mutex> lock(mutex_);
 
     auto wrapper = reinterpret_cast<SwapchainKHRWrapper*>(swapchain);
+
+    assert((wrapper != nullptr) && (image_index < wrapper->image_acquired_info.size()));
 
     wrapper->image_acquired_info[image_index].is_acquired           = true;
     wrapper->image_acquired_info[image_index].acquired_device_mask  = deviceMask;
@@ -955,10 +955,11 @@ void VulkanStateTracker::TrackPresentedImages(uint32_t              count,
 
     for (uint32_t i = 0; i < count; ++i)
     {
-        auto wrapper = reinterpret_cast<SwapchainKHRWrapper*>(swapchains[i]);
-        assert(wrapper != nullptr);
+        auto     wrapper     = reinterpret_cast<SwapchainKHRWrapper*>(swapchains[i]);
+        uint32_t image_index = image_indices[i];
 
-        uint32_t image_index                                           = image_indices[i];
+        assert((wrapper != nullptr) && (image_index < wrapper->image_acquired_info.size()));
+
         wrapper->last_presented_image                                  = image_index;
         wrapper->image_acquired_info[image_index].is_acquired          = false;
         wrapper->image_acquired_info[image_index].last_presented_queue = queue;


### PR DESCRIPTION
- For replay, change log level for VK_INCOMPLETE return values from Debug to Warning.
- For capture, add assertion checks for index values used with the vector of swapchain image info structs maintained by the trimming state tracker. When vkGetSwapchainImagesKHR returns VK_INCOMPLETE, the index can be outside of the expected range. Primarily intended to detect the case where trimming a replay will fail when the image count read from the capture file is smaller than the image count generated for replay.
