### PR TITLE
Use Non-streaming LZ4 Functions

### DIFF
--- a/framework/util/lz4_compressor.cpp
+++ b/framework/util/lz4_compressor.cpp
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018,2020 Valve Corporation
+** Copyright (c) 2018,2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -37,8 +37,6 @@ size_t Lz4Compressor::Compress(const size_t          uncompressed_size,
             return 0;
         }
 
-        LZ4_stream_t lz4_stream;
-        LZ4_resetStream(&lz4_stream);
         size_t lz4_compressed_size = LZ4_COMPRESSBOUND(uncompressed_size);
 
         if (lz4_compressed_size > compressed_data->size())
@@ -46,13 +44,11 @@ size_t Lz4Compressor::Compress(const size_t          uncompressed_size,
             compressed_data->resize(lz4_compressed_size);
         }
 
-        const size_t compressed_size_generated =
-            LZ4_compress_fast_continue(&lz4_stream,
-                                       reinterpret_cast<const char*>(uncompressed_data),
-                                       reinterpret_cast<char*>(compressed_data->data()),
-                                       static_cast<const int32_t>(uncompressed_size),
-                                       static_cast<int32_t>(lz4_compressed_size),
-                                       1);
+        int compressed_size_generated = LZ4_compress_fast(reinterpret_cast<const char*>(uncompressed_data),
+                                                          reinterpret_cast<char*>(compressed_data->data()),
+                                                          static_cast<const int32_t>(uncompressed_size),
+                                                          static_cast<int32_t>(lz4_compressed_size),
+                                                          1);
 
         if (compressed_size_generated > 0)
         {
@@ -79,14 +75,10 @@ size_t Lz4Compressor::Decompress(const size_t                compressed_size,
             return 0;
         }
 
-        LZ4_streamDecode_t lz4_stream_decode;
-        LZ4_setStreamDecode(&lz4_stream_decode, NULL, 0);
-        const int uncompressed_size_generated =
-            LZ4_decompress_safe_continue(&lz4_stream_decode,
-                                         reinterpret_cast<const char*>(compressed_data.data()),
-                                         reinterpret_cast<char*>(uncompressed_data->data()),
-                                         static_cast<int32_t>(compressed_size),
-                                         static_cast<int32_t>(expected_uncompressed_size));
+        int uncompressed_size_generated = LZ4_decompress_safe(reinterpret_cast<const char*>(compressed_data.data()),
+                                                              reinterpret_cast<char*>(uncompressed_data->data()),
+                                                              static_cast<int32_t>(compressed_size),
+                                                              static_cast<int32_t>(expected_uncompressed_size));
 
         if (uncompressed_size_generated > 0)
         {

--- a/framework/util/lz4_compressor.cpp
+++ b/framework/util/lz4_compressor.cpp
@@ -30,33 +30,28 @@ size_t Lz4Compressor::Compress(const size_t          uncompressed_size,
 {
     size_t copy_size = 0;
 
-    try
+    if (nullptr == compressed_data)
     {
-        if (nullptr == compressed_data)
-        {
-            return 0;
-        }
-
-        size_t lz4_compressed_size = LZ4_COMPRESSBOUND(uncompressed_size);
-
-        if (lz4_compressed_size > compressed_data->size())
-        {
-            compressed_data->resize(lz4_compressed_size);
-        }
-
-        int compressed_size_generated = LZ4_compress_fast(reinterpret_cast<const char*>(uncompressed_data),
-                                                          reinterpret_cast<char*>(compressed_data->data()),
-                                                          static_cast<const int32_t>(uncompressed_size),
-                                                          static_cast<int32_t>(lz4_compressed_size),
-                                                          1);
-
-        if (compressed_size_generated > 0)
-        {
-            copy_size = compressed_size_generated;
-        }
+        return 0;
     }
-    catch (...)
-    {}
+
+    size_t lz4_compressed_size = LZ4_COMPRESSBOUND(uncompressed_size);
+
+    if (lz4_compressed_size > compressed_data->size())
+    {
+        compressed_data->resize(lz4_compressed_size);
+    }
+
+    int compressed_size_generated = LZ4_compress_fast(reinterpret_cast<const char*>(uncompressed_data),
+                                                      reinterpret_cast<char*>(compressed_data->data()),
+                                                      static_cast<const int32_t>(uncompressed_size),
+                                                      static_cast<int32_t>(lz4_compressed_size),
+                                                      1);
+
+    if (compressed_size_generated > 0)
+    {
+        copy_size = compressed_size_generated;
+    }
 
     return copy_size;
 }
@@ -68,25 +63,20 @@ size_t Lz4Compressor::Decompress(const size_t                compressed_size,
 {
     size_t copy_size = 0;
 
-    try
+    if (nullptr == uncompressed_data)
     {
-        if (nullptr == uncompressed_data)
-        {
-            return 0;
-        }
-
-        int uncompressed_size_generated = LZ4_decompress_safe(reinterpret_cast<const char*>(compressed_data.data()),
-                                                              reinterpret_cast<char*>(uncompressed_data->data()),
-                                                              static_cast<int32_t>(compressed_size),
-                                                              static_cast<int32_t>(expected_uncompressed_size));
-
-        if (uncompressed_size_generated > 0)
-        {
-            copy_size = uncompressed_size_generated;
-        }
+        return 0;
     }
-    catch (...)
-    {}
+
+    int uncompressed_size_generated = LZ4_decompress_safe(reinterpret_cast<const char*>(compressed_data.data()),
+                                                          reinterpret_cast<char*>(uncompressed_data->data()),
+                                                          static_cast<int32_t>(compressed_size),
+                                                          static_cast<int32_t>(expected_uncompressed_size));
+
+    if (uncompressed_size_generated > 0)
+    {
+        copy_size = uncompressed_size_generated;
+    }
 
     return copy_size;
 }

--- a/framework/util/zlib_compressor.cpp
+++ b/framework/util/zlib_compressor.cpp
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018-2019 Valve Corporation
-** Copyright (c) 2018-2019 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -30,41 +30,36 @@ size_t ZlibCompressor::Compress(const size_t          uncompressed_size,
 {
     size_t copy_size = 0;
 
-    try
+    if (nullptr == compressed_data)
     {
-        if (nullptr == compressed_data)
-        {
-            return 0;
-        }
-
-        if (compressed_data->size() < uncompressed_size)
-        {
-            compressed_data->resize(uncompressed_size);
-        }
-
-        z_stream compress_stream = {};
-        compress_stream.zalloc   = Z_NULL;
-        compress_stream.zfree    = Z_NULL;
-        compress_stream.opaque   = Z_NULL;
-
-        GFXRECON_CHECK_CONVERSION_DATA_LOSS(uInt, uncompressed_size);
-        compress_stream.avail_in = static_cast<uInt>(uncompressed_size);
-        compress_stream.next_in  = const_cast<Bytef*>(uncompressed_data);
-
-        GFXRECON_CHECK_CONVERSION_DATA_LOSS(uInt, compressed_data->size());
-        compress_stream.avail_out = static_cast<uInt>(compressed_data->size());
-        compress_stream.next_out  = compressed_data->data();
-
-        // Perform the compression (deflate the data).
-        deflateInit(&compress_stream, Z_BEST_COMPRESSION);
-        deflate(&compress_stream, Z_FINISH);
-        deflateEnd(&compress_stream);
-
-        // Determine the size of data from the stream
-        copy_size = compress_stream.total_out;
+        return 0;
     }
-    catch (...)
-    {}
+
+    if (compressed_data->size() < uncompressed_size)
+    {
+        compressed_data->resize(uncompressed_size);
+    }
+
+    z_stream compress_stream = {};
+    compress_stream.zalloc   = Z_NULL;
+    compress_stream.zfree    = Z_NULL;
+    compress_stream.opaque   = Z_NULL;
+
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(uInt, uncompressed_size);
+    compress_stream.avail_in = static_cast<uInt>(uncompressed_size);
+    compress_stream.next_in  = const_cast<Bytef*>(uncompressed_data);
+
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(uInt, compressed_data->size());
+    compress_stream.avail_out = static_cast<uInt>(compressed_data->size());
+    compress_stream.next_out  = compressed_data->data();
+
+    // Perform the compression (deflate the data).
+    deflateInit(&compress_stream, Z_BEST_COMPRESSION);
+    deflate(&compress_stream, Z_FINISH);
+    deflateEnd(&compress_stream);
+
+    // Determine the size of data from the stream
+    copy_size = compress_stream.total_out;
 
     return copy_size;
 }
@@ -76,36 +71,31 @@ size_t ZlibCompressor::Decompress(const size_t                compressed_size,
 {
     size_t copy_size = 0;
 
-    try
+    if (nullptr == uncompressed_data)
     {
-        if (nullptr == uncompressed_data)
-        {
-            return 0;
-        }
-
-        z_stream decompress_stream = {};
-        decompress_stream.zalloc   = Z_NULL;
-        decompress_stream.zfree    = Z_NULL;
-        decompress_stream.opaque   = Z_NULL;
-
-        GFXRECON_CHECK_CONVERSION_DATA_LOSS(uInt, compressed_size);
-        decompress_stream.avail_in = static_cast<uInt>(compressed_size);
-        decompress_stream.next_in  = const_cast<Bytef*>(compressed_data.data());
-
-        GFXRECON_CHECK_CONVERSION_DATA_LOSS(uInt, expected_uncompressed_size);
-        decompress_stream.avail_out = static_cast<uInt>(expected_uncompressed_size);
-        decompress_stream.next_out  = uncompressed_data->data();
-
-        // Perform the decompression (inflate the data).
-        inflateInit(&decompress_stream);
-        inflate(&decompress_stream, Z_NO_FLUSH);
-        inflateEnd(&decompress_stream);
-
-        // Determine the size of data from the stream
-        copy_size = decompress_stream.total_out;
+        return 0;
     }
-    catch (...)
-    {}
+
+    z_stream decompress_stream = {};
+    decompress_stream.zalloc   = Z_NULL;
+    decompress_stream.zfree    = Z_NULL;
+    decompress_stream.opaque   = Z_NULL;
+
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(uInt, compressed_size);
+    decompress_stream.avail_in = static_cast<uInt>(compressed_size);
+    decompress_stream.next_in  = const_cast<Bytef*>(compressed_data.data());
+
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(uInt, expected_uncompressed_size);
+    decompress_stream.avail_out = static_cast<uInt>(expected_uncompressed_size);
+    decompress_stream.next_out  = uncompressed_data->data();
+
+    // Perform the decompression (inflate the data).
+    inflateInit(&decompress_stream);
+    inflate(&decompress_stream, Z_NO_FLUSH);
+    inflateEnd(&decompress_stream);
+
+    // Determine the size of data from the stream
+    copy_size = decompress_stream.total_out;
 
     return copy_size;
 }


### PR DESCRIPTION
* Use LZ4_compress_fast() and LZ4_decompress_safe() instead of LZ4_compress_fast_continue() and LZ4_decompress_safe_continue() when compressing/decompressing capture packets.
* Remove try-catch statements with empty catch blocks from compression code.