### PR TITLE
Add Replay Support for the FullScreen Exclusive WIN32 Extension

### DIFF
--- a/framework/application/android_window.cpp
+++ b/framework/application/android_window.cpp
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018,2020 Valve Corporation
+** Copyright (c) 2018,2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -71,13 +71,13 @@ void AndroidWindow::SetSize(const uint32_t width, const uint32_t height)
     }
 }
 
-bool AndroidWindow::GetNativeHandle(uint32_t id, void** handle)
+bool AndroidWindow::GetNativeHandle(HandleType type, void** handle)
 {
     assert(handle != nullptr);
 
-    switch (id)
+    switch (type)
     {
-        case AndroidWindow::kNativeWindow:
+        case Window::kAndroidNativeWindow:
             *handle = reinterpret_cast<void*>(window_);
             return true;
         default:

--- a/framework/application/android_window.h
+++ b/framework/application/android_window.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018,2020 Valve Corporation
+** Copyright (c) 2018,2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -31,12 +31,6 @@ GFXRECON_BEGIN_NAMESPACE(application)
 class AndroidWindow : public decode::Window
 {
   public:
-    enum HandleId : uint32_t
-    {
-        kNativeWindow = 0
-    };
-
-  public:
     AndroidWindow(AndroidApplication* application, ANativeWindow* window);
 
     virtual ~AndroidWindow() override {}
@@ -58,7 +52,7 @@ class AndroidWindow : public decode::Window
 
     virtual void SetForeground() override {}
 
-    virtual bool GetNativeHandle(uint32_t id, void** handle) override;
+    virtual bool GetNativeHandle(HandleType type, void** handle) override;
 
     virtual VkResult CreateSurface(const encode::InstanceTable* table,
                                    VkInstance                   instance,

--- a/framework/application/wayland_window.cpp
+++ b/framework/application/wayland_window.cpp
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018,2020 Valve Corporation
+** Copyright (c) 2018,2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -127,15 +127,15 @@ void WaylandWindow::SetVisibility(bool show)
 
 void WaylandWindow::SetForeground() {}
 
-bool WaylandWindow::GetNativeHandle(uint32_t id, void** handle)
+bool WaylandWindow::GetNativeHandle(HandleType type, void** handle)
 {
     assert(handle != nullptr);
-    switch (id)
+    switch (type)
     {
-        case WaylandWindow::kDisplay:
+        case Window::kWaylandDisplay:
             *handle = reinterpret_cast<void*>(wayland_application_->GetDisplay());
             return true;
-        case WaylandWindow::kSurface:
+        case Window::kWaylandSurface:
             *handle = reinterpret_cast<void*>(surface_);
             return true;
         default:

--- a/framework/application/wayland_window.h
+++ b/framework/application/wayland_window.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018,2020 Valve Corporation
+** Copyright (c) 2018,2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -30,13 +30,6 @@ GFXRECON_BEGIN_NAMESPACE(application)
 class WaylandWindow : public decode::Window
 {
   public:
-    enum HandleId : uint32_t
-    {
-        kDisplay = 0,
-        kSurface = 1
-    };
-
-  public:
     WaylandWindow(WaylandApplication* application);
 
     virtual ~WaylandWindow() override;
@@ -63,7 +56,7 @@ class WaylandWindow : public decode::Window
 
     virtual void SetForeground() override;
 
-    virtual bool GetNativeHandle(uint32_t id, void** handle) override;
+    virtual bool GetNativeHandle(HandleType type, void** handle) override;
 
     virtual VkResult CreateSurface(const encode::InstanceTable* table,
                                    VkInstance                   instance,

--- a/framework/application/win32_window.cpp
+++ b/framework/application/win32_window.cpp
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018,2020 Valve Corporation
+** Copyright (c) 2018,2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -231,15 +231,15 @@ void Win32Window::SetForeground()
     SetForegroundWindow(hwnd_);
 }
 
-bool Win32Window::GetNativeHandle(uint32_t id, void** handle)
+bool Win32Window::GetNativeHandle(HandleType type, void** handle)
 {
     assert(handle != nullptr);
-    switch (id)
+    switch (type)
     {
-        case Win32Window::kHInstance:
+        case Window::kWin32HInstance:
             *handle = reinterpret_cast<void*>(hinstance_);
             return true;
-        case Win32Window::kHWnd:
+        case Window::kWin32HWnd:
             *handle = reinterpret_cast<void*>(hwnd_);
             return true;
         default:

--- a/framework/application/win32_window.h
+++ b/framework/application/win32_window.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018,2020 Valve Corporation
+** Copyright (c) 2018,2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -31,13 +31,6 @@ GFXRECON_BEGIN_NAMESPACE(application)
 class Win32Window : public decode::Window
 {
   public:
-    enum HandleId : uint32_t
-    {
-        kHInstance = 0,
-        kHWnd      = 1
-    };
-
-  public:
     Win32Window(Win32Application* application);
 
     virtual ~Win32Window() override;
@@ -60,7 +53,7 @@ class Win32Window : public decode::Window
 
     virtual void SetForeground() override;
 
-    virtual bool GetNativeHandle(uint32_t id, void** handle) override;
+    virtual bool GetNativeHandle(HandleType type, void** handle) override;
 
     virtual VkResult CreateSurface(const encode::InstanceTable* table,
                                    VkInstance                   instance,

--- a/framework/application/xcb_window.cpp
+++ b/framework/application/xcb_window.cpp
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018,2020 Valve Corporation
+** Copyright (c) 2018,2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -362,15 +362,15 @@ void XcbWindow::SetForeground()
     xcb_flush(connection);
 }
 
-bool XcbWindow::GetNativeHandle(uint32_t id, void** handle)
+bool XcbWindow::GetNativeHandle(HandleType type, void** handle)
 {
     assert(handle != nullptr);
-    switch (id)
+    switch (type)
     {
-        case XcbWindow::kConnection:
+        case Window::kXcbConnection:
             *handle = reinterpret_cast<void*>(xcb_application_->GetConnection());
             return true;
-        case XcbWindow::kWindow:
+        case Window::kXcbWindow:
             *handle = reinterpret_cast<void*>(window_);
             return true;
         default:

--- a/framework/application/xcb_window.h
+++ b/framework/application/xcb_window.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018,2020 Valve Corporation
+** Copyright (c) 2018,2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -29,13 +29,6 @@ GFXRECON_BEGIN_NAMESPACE(application)
 
 class XcbWindow : public decode::Window
 {
-  public:
-    enum HandleId : uint32_t
-    {
-        kConnection = 0,
-        kWindow     = 1
-    };
-
   public:
     XcbWindow(XcbApplication* application);
 
@@ -78,7 +71,7 @@ class XcbWindow : public decode::Window
 
     virtual void SetForeground() override;
 
-    virtual bool GetNativeHandle(uint32_t id, void** handle) override;
+    virtual bool GetNativeHandle(HandleType type, void** handle) override;
 
     virtual VkResult CreateSurface(const encode::InstanceTable* table,
                                    VkInstance                   instance,

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018-2019 Valve Corporation
-** Copyright (c) 2018-2019 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -554,6 +554,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                                   uint32_t       queue_family_index,
                                                   uint32_t       last_presented_image,
                                                   const std::vector<format::SwapchainImageStateInfo>& image_info);
+
+    void ProcessSwapchainFullScreenExclusiveInfo(Decoded_VkSwapchainCreateInfoKHR* swapchain_info);
 
   private:
     struct InstanceDevices

--- a/framework/decode/window.h
+++ b/framework/decode/window.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018,2020 Valve Corporation
+** Copyright (c) 2018,2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -31,6 +31,20 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 class Window
 {
   public:
+    enum HandleType
+    {
+        kAndroidNativeWindow,
+        kXcbConnection,
+        kXcbWindow,
+        kXlibDisplay,
+        kXlibWindow,
+        kWaylandDisplay,
+        kWaylandSurface,
+        kWin32HInstance,
+        kWin32HWnd
+    };
+
+  public:
     Window() {}
 
     virtual ~Window() {}
@@ -53,7 +67,7 @@ class Window
 
     virtual void SetForeground() = 0;
 
-    virtual bool GetNativeHandle(uint32_t id, void** handle) = 0;
+    virtual bool GetNativeHandle(HandleType type, void** handle) = 0;
 
     virtual VkResult
     CreateSurface(const encode::InstanceTable* table, VkInstance instance, VkFlags flags, VkSurfaceKHR* pSurface) = 0;


### PR DESCRIPTION
Set VkFullScreenExclusiveWin32InfoEXT::hmonitor to a valid value when replaying a capture on the WIN32 platform.
