### PR TITLE
Add Capture/Replay Support for AHardwareBuffer

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -220,7 +220,7 @@ For build systems that support ccache, enable it with the CMake
  * The latest version of [Android Studio](https://developer.android.com/studio/) with additional items:
    * The [Android Platform tools](https://developer.android.com/studio/releases/platform-tools) for your specific platform
    * The [Android NDK](https://developer.android.com/ndk/guides/)
-   * [Android SDK 24 (7.0 Nougat) or newer](https://guides.codepath.com/android/installing-android-sdk-tools)
+   * [Android SDK 26 (8.0 Oreo) or newer](https://guides.codepath.com/android/installing-android-sdk-tools)
  * Set the following `ANDROID_*` environment variables appropriately in your user environment if building outside of Android Studio:
    * `ANDROID_NDK_HOME`
    * `ANDROID_SDK_HOME`

--- a/android/framework/encode/CMakeLists.txt
+++ b/android/framework/encode/CMakeLists.txt
@@ -40,4 +40,4 @@ target_include_directories(gfxrecon_encode
                            PUBLIC
                                ${GFXRECON_SOURCE_DIR}/framework)
 
-target_link_libraries(gfxrecon_encode gfxrecon_format gfxrecon_util vulkan_registry platform_specific)
+target_link_libraries(gfxrecon_encode gfxrecon_format gfxrecon_util vulkan_registry platform_specific android)

--- a/android/layer/CMakeLists.txt
+++ b/android/layer/CMakeLists.txt
@@ -27,4 +27,5 @@ target_link_libraries(VkLayer_gfxreconstruct
                       gfxrecon_util
                       vulkan_registry
                       platform_specific
+                      android
                       log)

--- a/android/layer/build.gradle
+++ b/android/layer/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 27
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 26
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"

--- a/android/tools/replay/build.gradle
+++ b/android/tools/replay/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 27
     defaultConfig {
         applicationId "com.lunarg.gfxreconstruct.replay"
-        minSdkVersion 24
+        minSdkVersion 26
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"

--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -61,6 +61,20 @@ class ApiDecoder
                                              uint32_t         width,
                                              uint32_t         height)
     {}
+
+    virtual void DispatchCreateHardwareBufferCommand(format::ThreadId                                    thread_id,
+                                                     format::HandleId                                    memory_id,
+                                                     uint64_t                                            buffer_id,
+                                                     uint32_t                                            format,
+                                                     uint32_t                                            width,
+                                                     uint32_t                                            height,
+                                                     uint32_t                                            stride,
+                                                     uint32_t                                            usage,
+                                                     uint32_t                                            layers,
+                                                     const std::vector<format::HardwareBufferPlaneInfo>& plane_info)
+    {}
+
+    virtual void DispatchDestroyHardwareBufferCommand(format::ThreadId thread_id, uint64_t buffer_id) {}
 
     virtual void DispatchSetSwapchainImageStateCommand(format::ThreadId thread_id,
                                                        format::HandleId device_id,

--- a/framework/decode/custom_vulkan_struct_decoders.h
+++ b/framework/decode/custom_vulkan_struct_decoders.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -34,6 +34,19 @@
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
+
+// TODO: This is currently used when mapping external object IDs to object handles that are created on replay. This
+// functionality could instead be provided through the replay consumer's PreProcessExternalObject and
+// PostProcessExternalObject methods if they were moved to the VulkanObjectInfo table, which would make them available
+// to the struct decoders.
+struct Decoded_VkBaseOutStructure
+{
+    using struct_type = VkBaseOutStructure;
+
+    VkBaseOutStructure* decoded_value{ nullptr };
+
+    std::unique_ptr<PNextNode> pNext;
+};
 
 // Decoded union wrappers.
 struct Decoded_VkClearColorValue

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -47,6 +47,19 @@ class VulkanConsumerBase
     virtual void ProcessFillMemoryCommand(uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data) {}
 
     virtual void ProcessResizeWindowCommand(format::HandleId surface_id, uint32_t width, uint32_t height) {}
+
+    virtual void ProcessCreateHardwareBufferCommand(format::HandleId                                    memory_id,
+                                                    uint64_t                                            buffer_id,
+                                                    uint32_t                                            format,
+                                                    uint32_t                                            width,
+                                                    uint32_t                                            height,
+                                                    uint32_t                                            stride,
+                                                    uint32_t                                            usage,
+                                                    uint32_t                                            layers,
+                                                    const std::vector<format::HardwareBufferPlaneInfo>& plane_info)
+    {}
+
+    virtual void ProcessDestroyHardwareBufferCommand(uint64_t buffer_id) {}
 
     virtual void ProcessSetSwapchainImageStateCommand(format::HandleId device_id,
                                                       format::HandleId swapchain_id,

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -71,6 +71,37 @@ void VulkanDecoderBase::DispatchResizeWindowCommand(format::ThreadId thread_id,
     for (auto consumer : consumers_)
     {
         consumer->ProcessResizeWindowCommand(surface_id, width, height);
+    }
+}
+
+void VulkanDecoderBase::DispatchCreateHardwareBufferCommand(
+    format::ThreadId                                    thread_id,
+    format::HandleId                                    memory_id,
+    uint64_t                                            buffer_id,
+    uint32_t                                            format,
+    uint32_t                                            width,
+    uint32_t                                            height,
+    uint32_t                                            stride,
+    uint32_t                                            usage,
+    uint32_t                                            layers,
+    const std::vector<format::HardwareBufferPlaneInfo>& plane_info)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(thread_id);
+
+    for (auto consumer : consumers_)
+    {
+        consumer->ProcessCreateHardwareBufferCommand(
+            memory_id, buffer_id, format, width, height, stride, usage, layers, plane_info);
+    }
+}
+
+void VulkanDecoderBase::DispatchDestroyHardwareBufferCommand(format::ThreadId thread_id, uint64_t buffer_id)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(thread_id);
+
+    for (auto consumer : consumers_)
+    {
+        consumer->ProcessDestroyHardwareBufferCommand(buffer_id);
     }
 }
 

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -71,6 +71,20 @@ class VulkanDecoderBase : public ApiDecoder
                                              format::HandleId surface_id,
                                              uint32_t         width,
                                              uint32_t         height) override;
+
+    virtual void
+    DispatchCreateHardwareBufferCommand(format::ThreadId                                    thread_id,
+                                        format::HandleId                                    memory_id,
+                                        uint64_t                                            buffer_id,
+                                        uint32_t                                            format,
+                                        uint32_t                                            width,
+                                        uint32_t                                            height,
+                                        uint32_t                                            stride,
+                                        uint32_t                                            usage,
+                                        uint32_t                                            layers,
+                                        const std::vector<format::HardwareBufferPlaneInfo>& plane_info) override;
+
+    virtual void DispatchDestroyHardwareBufferCommand(format::ThreadId thread_id, uint64_t buffer_id) override;
 
     virtual void
     DispatchSetSwapchainImageStateCommand(format::ThreadId                                    thread_id,

--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -78,6 +78,8 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 #define PAGE_GUARD_PERSISTENT_MEMORY_UPPER  "PAGE_GUARD_PERSISTENT_MEMORY"
 #define PAGE_GUARD_ALIGN_BUFFER_SIZES_LOWER "page_guard_align_buffer_sizes"
 #define PAGE_GUARD_ALIGN_BUFFER_SIZES_UPPER "PAGE_GUARD_ALIGN_BUFFER_SIZES"
+#define PAGE_GUARD_TRACK_AHB_MEMORY_LOWER   "page_guard_track_ahb_memory"
+#define PAGE_GUARD_TRACK_AHB_MEMORY_UPPER   "PAGE_GUARD_TRACK_AHB_MEMORY"
 #define PAGE_GUARD_EXTERNAL_MEMORY_LOWER    "page_guard_external_memory"
 #define PAGE_GUARD_EXTERNAL_MEMORY_UPPER    "PAGE_GUARD_EXTERNAL_MEMORY"
 // clang-format on
@@ -109,6 +111,7 @@ const char kPageGuardCopyOnMapEnvVar[]        = GFXRECON_ENV_VAR_PREFIX PAGE_GUA
 const char kPageGuardSeparateReadEnvVar[]     = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_SEPARATE_READ_LOWER;
 const char kPageGuardPersistentMemoryEnvVar[] = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_PERSISTENT_MEMORY_LOWER;
 const char kPageGuardAlignBufferSizesEnvVar[] = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_ALIGN_BUFFER_SIZES_LOWER;
+const char kPageGuardTrackAhbMemoryEnvVar[]   = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_TRACK_AHB_MEMORY_LOWER;
 const char kPageGuardExternalMemoryEnvVar[]   = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_EXTERNAL_MEMORY_LOWER;
 
 #else
@@ -137,6 +140,7 @@ const char kPageGuardCopyOnMapEnvVar[]        = GFXRECON_ENV_VAR_PREFIX PAGE_GUA
 const char kPageGuardSeparateReadEnvVar[]     = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_SEPARATE_READ_UPPER;
 const char kPageGuardPersistentMemoryEnvVar[] = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_PERSISTENT_MEMORY_UPPER;
 const char kPageGuardAlignBufferSizesEnvVar[] = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_ALIGN_BUFFER_SIZES_UPPER;
+const char kPageGuardTrackAhbMemoryEnvVar[]           = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_TRACK_AHB_MEMORY_UPPER;
 const char kPageGuardExternalMemoryEnvVar[]   = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_EXTERNAL_MEMORY_UPPER;
 const char kCaptureTriggerEnvVar[]            = GFXRECON_ENV_VAR_PREFIX CAPTURE_TRIGGER_UPPER;
 #endif
@@ -167,6 +171,7 @@ const std::string kOptionKeyPageGuardCopyOnMap        = std::string(kSettingsFil
 const std::string kOptionKeyPageGuardSeparateRead     = std::string(kSettingsFilter) + std::string(PAGE_GUARD_SEPARATE_READ_LOWER);
 const std::string kOptionKeyPageGuardPersistentMemory = std::string(kSettingsFilter) + std::string(PAGE_GUARD_PERSISTENT_MEMORY_LOWER);
 const std::string kOptionKeyPageGuardAlignBufferSizes = std::string(kSettingsFilter) + std::string(PAGE_GUARD_ALIGN_BUFFER_SIZES_LOWER);
+const std::string kOptionKeyPageGuardTrackAhbMemory   = std::string(kSettingsFilter) + std::string(PAGE_GUARD_TRACK_AHB_MEMORY_LOWER);
 const std::string kOptionKeyPageGuardExternalMemory   = std::string(kSettingsFilter) + std::string(PAGE_GUARD_EXTERNAL_MEMORY_LOWER);
 // clang-format on
 
@@ -253,6 +258,7 @@ void CaptureSettings::LoadOptionsEnvVar(OptionsMap* options)
     LoadSingleOptionEnvVar(options, kPageGuardSeparateReadEnvVar, kOptionKeyPageGuardSeparateRead);
     LoadSingleOptionEnvVar(options, kPageGuardPersistentMemoryEnvVar, kOptionKeyPageGuardPersistentMemory);
     LoadSingleOptionEnvVar(options, kPageGuardAlignBufferSizesEnvVar, kOptionKeyPageGuardAlignBufferSizes);
+    LoadSingleOptionEnvVar(options, kPageGuardTrackAhbMemoryEnvVar, kOptionKeyPageGuardTrackAhbMemory);
     LoadSingleOptionEnvVar(options, kPageGuardExternalMemoryEnvVar, kOptionKeyPageGuardExternalMemory);
 }
 
@@ -326,6 +332,8 @@ void CaptureSettings::ProcessOptions(OptionsMap* options, CaptureSettings* setti
     settings->trace_settings_.page_guard_align_buffer_sizes =
         ParseBoolString(FindOption(options, kOptionKeyPageGuardAlignBufferSizes),
                         settings->trace_settings_.page_guard_align_buffer_sizes);
+    settings->trace_settings_.page_guard_track_ahb_memory = ParseBoolString(
+        FindOption(options, kOptionKeyPageGuardTrackAhbMemory), settings->trace_settings_.page_guard_track_ahb_memory);
     settings->trace_settings_.page_guard_external_memory = ParseBoolString(
         FindOption(options, kOptionKeyPageGuardExternalMemory), settings->trace_settings_.page_guard_external_memory);
 

--- a/framework/encode/capture_settings.h
+++ b/framework/encode/capture_settings.h
@@ -68,6 +68,7 @@ class CaptureSettings
         bool                   page_guard_separate_read{ util::PageGuardManager::kDefaultEnableSeparateRead };
         bool                   page_guard_persistent_memory{ util::PageGuardManager::kDefaultEnablePersistentMemory };
         bool                   page_guard_align_buffer_sizes{ false };
+        bool                   page_guard_track_ahb_memory{ false };
 
         // An optimization for the page_guard memory tracking mode that eliminates the need for shadow memory by
         // overriding vkAllocateMemory so that all host visible allocations use the external memory extension with a

--- a/framework/encode/custom_encoder_commands.h
+++ b/framework/encode/custom_encoder_commands.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 ** Copyright (c) 2019 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
@@ -379,6 +379,16 @@ struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkFreeMemory>
     static void Dispatch(TraceManager* manager, Args... args)
     {
         manager->PreProcess_vkFreeMemory(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkFreeMemory>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PostProcess_vkFreeMemory(args...);
     }
 };
 

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -1447,7 +1447,8 @@ void TraceManager::ProcessImportAndroidHardwareBuffer(VkDevice         device,
             ahb_info.memory_id           = memory_id;
             ahb_info.reference_count     = 1;
 
-            memory_wrapper->hardware_buffer = hardware_buffer;
+            memory_wrapper->hardware_buffer           = hardware_buffer;
+            memory_wrapper->hardware_buffer_memory_id = memory_id;
 
             WriteCreateHardwareBufferCmd(memory_id, hardware_buffer, plane_info);
             WriteFillMemoryCmd(memory_id, 0, memory_wrapper->allocation_size, data);

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019 LunarG, Inc.
+** Copyright (c) 2019-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -147,6 +147,7 @@ struct DeviceMemoryWrapper : public HandleWrapper<VkDeviceMemory>
     VkDeviceSize     mapped_size{ 0 };
     VkMemoryMapFlags mapped_flags{ 0 };
     void*            external_allocation{ nullptr };
+    AHardwareBuffer* hardware_buffer{ nullptr };
 };
 
 struct BufferWrapper : public HandleWrapper<VkBuffer>

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -148,6 +148,7 @@ struct DeviceMemoryWrapper : public HandleWrapper<VkDeviceMemory>
     VkMemoryMapFlags mapped_flags{ 0 };
     void*            external_allocation{ nullptr };
     AHardwareBuffer* hardware_buffer{ nullptr };
+    format::HandleId hardware_buffer_memory_id{ 0 };
 };
 
 struct BufferWrapper : public HandleWrapper<VkBuffer>

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019 LunarG, Inc.
+** Copyright (c) 2019-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 #include "encode/vulkan_handle_wrappers.h"
 #include "encode/vulkan_state_table.h"
 #include "format/format.h"
+#include "format/platform_types.h"
 #include "generated/generated_vulkan_dispatch_table.h"
 #include "util/compressor.h"
 #include "util/defines.h"
@@ -117,6 +118,11 @@ class VulkanStateWriter
     void WriteSurfaceKhrState(const VulkanStateTable& state_table);
 
     void WriteSwapchainKhrState(const VulkanStateTable& state_table);
+
+    void WriteDeviceMemoryState(const VulkanStateTable& state_table);
+
+    void
+    ProcessHardwareBuffer(format::HandleId memory_id, AHardwareBuffer* hardware_buffer, VkDeviceSize allocation_size);
 
     void ProcessBufferMemory(const DeviceWrapper*                   device_wrapper,
                              const std::vector<BufferSnapshotInfo>& buffer_snapshot_info,
@@ -233,6 +239,10 @@ class VulkanStateWriter
     void WriteFillMemoryCmd(format::HandleId memory_id, VkDeviceSize offset, VkDeviceSize size, const void* data);
 
     void WriteResizeWindowCmd(format::HandleId surface_id, uint32_t width, uint32_t height);
+
+    void WriteCreateHardwareBufferCmd(format::HandleId                                    memory_id,
+                                      AHardwareBuffer*                                    hardware_buffer,
+                                      const std::vector<format::HardwareBufferPlaneInfo>& plane_info);
 
     template <typename Wrapper>
     void StandardCreateWrite(const VulkanStateTable& state_table)

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018-2019 Valve Corporation
-** Copyright (c) 2018-2019 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -71,19 +71,17 @@ enum MarkerType : uint32_t
 
 enum MetaDataType : uint32_t
 {
-    kUnknownMetaDataType = 0,
-
-    // Platform independent metadata commands.
-    kDisplayMessageCommand = 1,
-    kFillMemoryCommand     = 2,
-    kResizeWindowCommand   = 3,
-
-    // Commands for trimmed frame state setup.
+    kUnknownMetaDataType           = 0,
+    kDisplayMessageCommand         = 1,
+    kFillMemoryCommand             = 2,
+    kResizeWindowCommand           = 3,
     kSetSwapchainImageStateCommand = 4,
     kBeginResourceInitCommand      = 5,
     kEndResourceInitCommand        = 6,
     kInitBufferCommand             = 7,
-    kInitImageCommand              = 8
+    kInitImageCommand              = 8,
+    kCreateHardwareBufferCommand   = 9,
+    kDestroyHardwareBufferCommand  = 10
 };
 
 enum CompressionType : uint32_t
@@ -95,9 +93,9 @@ enum CompressionType : uint32_t
 
 enum FileOption : uint32_t
 {
-    kUnknownFileOption     = 0,
-    kCompressionType       = 1, // One of the CompressionType values defining the compression algorithm used with parameter
-                                // encoding. Default = CompressionType::kNone.
+    kUnknownFileOption = 0,
+    kCompressionType   = 1, // One of the CompressionType values defining the compression algorithm used with parameter
+                            // encoding. Default = CompressionType::kNone.
 };
 
 enum PointerAttributes : uint32_t
@@ -213,6 +211,38 @@ struct ResizeWindowCommand
     HandleId         surface_id;
     uint32_t         width;
     uint32_t         height;
+};
+
+struct CreateHardwareBufferCommandHeader
+{
+    MetaDataHeader meta_header;
+    ThreadId       thread_id;
+    HandleId       memory_id; // Globally unique ID assigned to the buffer for tracking memory modifications.
+    uint64_t       buffer_id; // Address of the buffer object.
+    uint32_t       format;
+    uint32_t       width;
+    uint32_t       height;
+    uint32_t       stride; // Size of a row in pixels.
+    uint32_t       usage;
+    uint32_t       layers;
+    uint32_t       planes; // When additional multi-plane data is available, header is followed by 'planes' count
+                           // HardwareBufferLayerInfo records.  When unavailable, 'planes' is zero.
+};
+
+struct HardwareBufferPlaneInfo
+{
+    uint64_t offset;       // Offset from the start of the memory allocation in bytes.
+    uint32_t pixel_stride; // Bytes between pixels.
+    uint32_t row_pitch;    // Size of a row in bytes.
+};
+
+// Not a header because this command does not include a variable length data payload.
+// All of the command data is present in the struct.
+struct DestroyHardwareBufferCommand
+{
+    MetaDataHeader meta_header;
+    ThreadId       thread_id;
+    uint64_t       buffer_id;
 };
 
 struct SetSwapchainImageStateCommandHeader


### PR DESCRIPTION
* For capture, add support for recording description info and content for AHardwareBuffer objects referenced by VkImportAndroidHardwareBufferInfoANDROID.
* For replay, add support for creating and writing data to AHardwareBuffer objects referenced by VkImportAndroidHardwareBufferInfoANDROID.