### PR TITLE
Remove Persistent Shadow Memory Table

### DIFF
--- a/framework/encode/capture_settings.h
+++ b/framework/encode/capture_settings.h
@@ -66,7 +66,7 @@ class CaptureSettings
         std::string            trim_key;
         bool                   page_guard_copy_on_map{ util::PageGuardManager::kDefaultEnableCopyOnMap };
         bool                   page_guard_separate_read{ util::PageGuardManager::kDefaultEnableSeparateRead };
-        bool                   page_guard_persistent_memory{ util::PageGuardManager::kDefaultEnablePersistentMemory };
+        bool                   page_guard_persistent_memory{ false };
         bool                   page_guard_align_buffer_sizes{ false };
         bool                   page_guard_track_ahb_memory{ false };
 

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -853,6 +853,14 @@ class TraceManager
         kModeWriteAndTrack = (kModeWrite | kModeTrack)
     };
 
+    enum PageGuardMemoryMode : uint32_t
+    {
+        kMemoryModeDisabled,
+        kMemoryModeShadowInternal,   // Internally managed shadow memory allocations.
+        kMemoryModeShadowPersistent, // Externally managed shadow memory allocations.
+        kMemoryModeExternal          // Imported host memory without shadow allocations.
+    };
+
     typedef uint32_t CaptureMode;
 
     class ThreadData
@@ -947,8 +955,8 @@ class TraceManager
     std::unique_ptr<util::Compressor>               compressor_;
     CaptureSettings::MemoryTrackingMode             memory_tracking_mode_;
     bool                                            page_guard_align_buffer_sizes_;
-    bool                                            page_guard_external_memory_;
     bool                                            page_guard_track_ahb_memory_;
+    PageGuardMemoryMode                             page_guard_memory_mode_;
     std::mutex                                      mapped_memory_lock_;
     std::set<DeviceMemoryWrapper*>                  mapped_memory_; // Track mapped memory for unassisted tracking mode.
     bool                                            trim_enabled_;

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -23,6 +23,7 @@
 #include "generated/generated_vulkan_dispatch_table.h"
 #include "util/defines.h"
 #include "util/memory_output_stream.h"
+#include "util/page_guard_manager.h"
 
 #include "vulkan/vulkan.h"
 
@@ -147,6 +148,7 @@ struct DeviceMemoryWrapper : public HandleWrapper<VkDeviceMemory>
     VkDeviceSize     mapped_size{ 0 };
     VkMemoryMapFlags mapped_flags{ 0 };
     void*            external_allocation{ nullptr };
+    uintptr_t        shadow_allocation{ util::PageGuardManager::kNullShadowHandle };
     AHardwareBuffer* hardware_buffer{ nullptr };
     format::HandleId hardware_buffer_memory_id{ 0 };
 };


### PR DESCRIPTION
Removes the data structure and lock used to track persistent shadow memory allocations.  These allocations are now stored in the VkDeviceMemory handle wrapper.
