### PR TITLE
Add a gfxrecon-info command line utility

### DIFF
--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -91,18 +91,21 @@ class VulkanConsumerBase
     virtual void Process_vkUpdateDescriptorSetWithTemplate(format::HandleId device,
                                                            format::HandleId descriptorSet,
                                                            format::HandleId descriptorUpdateTemplate,
-                                                           const DescriptorUpdateTemplateDecoder& pData) = 0;
+                                                           const DescriptorUpdateTemplateDecoder& pData)
+    {}
 
     virtual void Process_vkCmdPushDescriptorSetWithTemplateKHR(format::HandleId commandBuffer,
                                                                format::HandleId descriptorUpdateTemplate,
                                                                format::HandleId layout,
                                                                uint32_t         set,
-                                                               const DescriptorUpdateTemplateDecoder& pData) = 0;
+                                                               const DescriptorUpdateTemplateDecoder& pData)
+    {}
 
     virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(format::HandleId device,
                                                               format::HandleId descriptorSet,
                                                               format::HandleId descriptorUpdateTemplate,
-                                                              const DescriptorUpdateTemplateDecoder& pData) = 0;
+                                                              const DescriptorUpdateTemplateDecoder& pData)
+    {}
 
     virtual void
     Process_vkRegisterObjectsNVX(VkResult                                                   returnValue,
@@ -110,7 +113,8 @@ class VulkanConsumerBase
                                  format::HandleId                                           objectTable,
                                  uint32_t                                                   objectCount,
                                  const StructPointerDecoder<Decoded_VkObjectTableEntryNVX>& ppObjectTableEntries,
-                                 const PointerDecoder<uint32_t>&                            pObjectIndices) = 0;
+                                 const PointerDecoder<uint32_t>&                            pObjectIndices)
+    {}
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/generated_vulkan_consumer.h
+++ b/framework/generated/generated_vulkan_consumer.h
@@ -42,26 +42,26 @@ class VulkanConsumer : public VulkanConsumerBase
         VkResult                                    returnValue,
         const StructPointerDecoder<Decoded_VkInstanceCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkInstance>*           pInstance) = 0;
+        HandlePointerDecoder<VkInstance>*           pInstance) {}
 
     virtual void Process_vkDestroyInstance(
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkEnumeratePhysicalDevices(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         PointerDecoder<uint32_t>*                   pPhysicalDeviceCount,
-        HandlePointerDecoder<VkPhysicalDevice>*     pPhysicalDevices) = 0;
+        HandlePointerDecoder<VkPhysicalDevice>*     pPhysicalDevices) {}
 
     virtual void Process_vkGetPhysicalDeviceFeatures(
         format::HandleId                            physicalDevice,
-        StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures>* pFeatures) = 0;
+        StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures>* pFeatures) {}
 
     virtual void Process_vkGetPhysicalDeviceFormatProperties(
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
-        StructPointerDecoder<Decoded_VkFormatProperties>* pFormatProperties) = 0;
+        StructPointerDecoder<Decoded_VkFormatProperties>* pFormatProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties(
         VkResult                                    returnValue,
@@ -71,64 +71,64 @@ class VulkanConsumer : public VulkanConsumerBase
         VkImageTiling                               tiling,
         VkImageUsageFlags                           usage,
         VkImageCreateFlags                          flags,
-        StructPointerDecoder<Decoded_VkImageFormatProperties>* pImageFormatProperties) = 0;
+        StructPointerDecoder<Decoded_VkImageFormatProperties>* pImageFormatProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceProperties(
         format::HandleId                            physicalDevice,
-        StructPointerDecoder<Decoded_VkPhysicalDeviceProperties>* pProperties) = 0;
+        StructPointerDecoder<Decoded_VkPhysicalDeviceProperties>* pProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties(
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
-        StructPointerDecoder<Decoded_VkQueueFamilyProperties>* pQueueFamilyProperties) = 0;
+        StructPointerDecoder<Decoded_VkQueueFamilyProperties>* pQueueFamilyProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceMemoryProperties(
         format::HandleId                            physicalDevice,
-        StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties>* pMemoryProperties) = 0;
+        StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties>* pMemoryProperties) {}
 
     virtual void Process_vkCreateDevice(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         const StructPointerDecoder<Decoded_VkDeviceCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkDevice>*             pDevice) = 0;
+        HandlePointerDecoder<VkDevice>*             pDevice) {}
 
     virtual void Process_vkDestroyDevice(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkGetDeviceQueue(
         format::HandleId                            device,
         uint32_t                                    queueFamilyIndex,
         uint32_t                                    queueIndex,
-        HandlePointerDecoder<VkQueue>*              pQueue) = 0;
+        HandlePointerDecoder<VkQueue>*              pQueue) {}
 
     virtual void Process_vkQueueSubmit(
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    submitCount,
         const StructPointerDecoder<Decoded_VkSubmitInfo>& pSubmits,
-        format::HandleId                            fence) = 0;
+        format::HandleId                            fence) {}
 
     virtual void Process_vkQueueWaitIdle(
         VkResult                                    returnValue,
-        format::HandleId                            queue) = 0;
+        format::HandleId                            queue) {}
 
     virtual void Process_vkDeviceWaitIdle(
         VkResult                                    returnValue,
-        format::HandleId                            device) = 0;
+        format::HandleId                            device) {}
 
     virtual void Process_vkAllocateMemory(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkMemoryAllocateInfo>& pAllocateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkDeviceMemory>*       pMemory) = 0;
+        HandlePointerDecoder<VkDeviceMemory>*       pMemory) {}
 
     virtual void Process_vkFreeMemory(
         format::HandleId                            device,
         format::HandleId                            memory,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkMapMemory(
         VkResult                                    returnValue,
@@ -137,58 +137,58 @@ class VulkanConsumer : public VulkanConsumerBase
         VkDeviceSize                                offset,
         VkDeviceSize                                size,
         VkMemoryMapFlags                            flags,
-        PointerDecoder<uint64_t, void*>*            ppData) = 0;
+        PointerDecoder<uint64_t, void*>*            ppData) {}
 
     virtual void Process_vkUnmapMemory(
         format::HandleId                            device,
-        format::HandleId                            memory) = 0;
+        format::HandleId                            memory) {}
 
     virtual void Process_vkFlushMappedMemoryRanges(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    memoryRangeCount,
-        const StructPointerDecoder<Decoded_VkMappedMemoryRange>& pMemoryRanges) = 0;
+        const StructPointerDecoder<Decoded_VkMappedMemoryRange>& pMemoryRanges) {}
 
     virtual void Process_vkInvalidateMappedMemoryRanges(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    memoryRangeCount,
-        const StructPointerDecoder<Decoded_VkMappedMemoryRange>& pMemoryRanges) = 0;
+        const StructPointerDecoder<Decoded_VkMappedMemoryRange>& pMemoryRanges) {}
 
     virtual void Process_vkGetDeviceMemoryCommitment(
         format::HandleId                            device,
         format::HandleId                            memory,
-        PointerDecoder<VkDeviceSize>*               pCommittedMemoryInBytes) = 0;
+        PointerDecoder<VkDeviceSize>*               pCommittedMemoryInBytes) {}
 
     virtual void Process_vkBindBufferMemory(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            buffer,
         format::HandleId                            memory,
-        VkDeviceSize                                memoryOffset) = 0;
+        VkDeviceSize                                memoryOffset) {}
 
     virtual void Process_vkBindImageMemory(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            image,
         format::HandleId                            memory,
-        VkDeviceSize                                memoryOffset) = 0;
+        VkDeviceSize                                memoryOffset) {}
 
     virtual void Process_vkGetBufferMemoryRequirements(
         format::HandleId                            device,
         format::HandleId                            buffer,
-        StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements) = 0;
+        StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements) {}
 
     virtual void Process_vkGetImageMemoryRequirements(
         format::HandleId                            device,
         format::HandleId                            image,
-        StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements) = 0;
+        StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements) {}
 
     virtual void Process_vkGetImageSparseMemoryRequirements(
         format::HandleId                            device,
         format::HandleId                            image,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
-        StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements>* pSparseMemoryRequirements) = 0;
+        StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements>* pSparseMemoryRequirements) {}
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties(
         format::HandleId                            physicalDevice,
@@ -198,37 +198,37 @@ class VulkanConsumer : public VulkanConsumerBase
         VkImageUsageFlags                           usage,
         VkImageTiling                               tiling,
         PointerDecoder<uint32_t>*                   pPropertyCount,
-        StructPointerDecoder<Decoded_VkSparseImageFormatProperties>* pProperties) = 0;
+        StructPointerDecoder<Decoded_VkSparseImageFormatProperties>* pProperties) {}
 
     virtual void Process_vkQueueBindSparse(
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    bindInfoCount,
         const StructPointerDecoder<Decoded_VkBindSparseInfo>& pBindInfo,
-        format::HandleId                            fence) = 0;
+        format::HandleId                            fence) {}
 
     virtual void Process_vkCreateFence(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkFenceCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkFence>*              pFence) = 0;
+        HandlePointerDecoder<VkFence>*              pFence) {}
 
     virtual void Process_vkDestroyFence(
         format::HandleId                            device,
         format::HandleId                            fence,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkResetFences(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    fenceCount,
-        const HandlePointerDecoder<VkFence>&        pFences) = 0;
+        const HandlePointerDecoder<VkFence>&        pFences) {}
 
     virtual void Process_vkGetFenceStatus(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        format::HandleId                            fence) = 0;
+        format::HandleId                            fence) {}
 
     virtual void Process_vkWaitForFences(
         VkResult                                    returnValue,
@@ -236,58 +236,58 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    fenceCount,
         const HandlePointerDecoder<VkFence>&        pFences,
         VkBool32                                    waitAll,
-        uint64_t                                    timeout) = 0;
+        uint64_t                                    timeout) {}
 
     virtual void Process_vkCreateSemaphore(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkSemaphoreCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSemaphore>*          pSemaphore) = 0;
+        HandlePointerDecoder<VkSemaphore>*          pSemaphore) {}
 
     virtual void Process_vkDestroySemaphore(
         format::HandleId                            device,
         format::HandleId                            semaphore,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkCreateEvent(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkEventCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkEvent>*              pEvent) = 0;
+        HandlePointerDecoder<VkEvent>*              pEvent) {}
 
     virtual void Process_vkDestroyEvent(
         format::HandleId                            device,
         format::HandleId                            event,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkGetEventStatus(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        format::HandleId                            event) = 0;
+        format::HandleId                            event) {}
 
     virtual void Process_vkSetEvent(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        format::HandleId                            event) = 0;
+        format::HandleId                            event) {}
 
     virtual void Process_vkResetEvent(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        format::HandleId                            event) = 0;
+        format::HandleId                            event) {}
 
     virtual void Process_vkCreateQueryPool(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkQueryPoolCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkQueryPool>*          pQueryPool) = 0;
+        HandlePointerDecoder<VkQueryPool>*          pQueryPool) {}
 
     virtual void Process_vkDestroyQueryPool(
         format::HandleId                            device,
         format::HandleId                            queryPool,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkGetQueryPoolResults(
         VkResult                                    returnValue,
@@ -298,99 +298,99 @@ class VulkanConsumer : public VulkanConsumerBase
         size_t                                      dataSize,
         PointerDecoder<uint8_t>*                    pData,
         VkDeviceSize                                stride,
-        VkQueryResultFlags                          flags) = 0;
+        VkQueryResultFlags                          flags) {}
 
     virtual void Process_vkCreateBuffer(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkBufferCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkBuffer>*             pBuffer) = 0;
+        HandlePointerDecoder<VkBuffer>*             pBuffer) {}
 
     virtual void Process_vkDestroyBuffer(
         format::HandleId                            device,
         format::HandleId                            buffer,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkCreateBufferView(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkBufferViewCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkBufferView>*         pView) = 0;
+        HandlePointerDecoder<VkBufferView>*         pView) {}
 
     virtual void Process_vkDestroyBufferView(
         format::HandleId                            device,
         format::HandleId                            bufferView,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkCreateImage(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkImageCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkImage>*              pImage) = 0;
+        HandlePointerDecoder<VkImage>*              pImage) {}
 
     virtual void Process_vkDestroyImage(
         format::HandleId                            device,
         format::HandleId                            image,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkGetImageSubresourceLayout(
         format::HandleId                            device,
         format::HandleId                            image,
         const StructPointerDecoder<Decoded_VkImageSubresource>& pSubresource,
-        StructPointerDecoder<Decoded_VkSubresourceLayout>* pLayout) = 0;
+        StructPointerDecoder<Decoded_VkSubresourceLayout>* pLayout) {}
 
     virtual void Process_vkCreateImageView(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkImageViewCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkImageView>*          pView) = 0;
+        HandlePointerDecoder<VkImageView>*          pView) {}
 
     virtual void Process_vkDestroyImageView(
         format::HandleId                            device,
         format::HandleId                            imageView,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkCreateShaderModule(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkShaderModule>*       pShaderModule) = 0;
+        HandlePointerDecoder<VkShaderModule>*       pShaderModule) {}
 
     virtual void Process_vkDestroyShaderModule(
         format::HandleId                            device,
         format::HandleId                            shaderModule,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkCreatePipelineCache(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkPipelineCache>*      pPipelineCache) = 0;
+        HandlePointerDecoder<VkPipelineCache>*      pPipelineCache) {}
 
     virtual void Process_vkDestroyPipelineCache(
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkGetPipelineCacheData(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
         PointerDecoder<size_t>*                     pDataSize,
-        PointerDecoder<uint8_t>*                    pData) = 0;
+        PointerDecoder<uint8_t>*                    pData) {}
 
     virtual void Process_vkMergePipelineCaches(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            dstCache,
         uint32_t                                    srcCacheCount,
-        const HandlePointerDecoder<VkPipelineCache>& pSrcCaches) = 0;
+        const HandlePointerDecoder<VkPipelineCache>& pSrcCaches) {}
 
     virtual void Process_vkCreateGraphicsPipelines(
         VkResult                                    returnValue,
@@ -399,7 +399,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    createInfoCount,
         const StructPointerDecoder<Decoded_VkGraphicsPipelineCreateInfo>& pCreateInfos,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkPipeline>*           pPipelines) = 0;
+        HandlePointerDecoder<VkPipeline>*           pPipelines) {}
 
     virtual void Process_vkCreateComputePipelines(
         VkResult                                    returnValue,
@@ -408,210 +408,210 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    createInfoCount,
         const StructPointerDecoder<Decoded_VkComputePipelineCreateInfo>& pCreateInfos,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkPipeline>*           pPipelines) = 0;
+        HandlePointerDecoder<VkPipeline>*           pPipelines) {}
 
     virtual void Process_vkDestroyPipeline(
         format::HandleId                            device,
         format::HandleId                            pipeline,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkCreatePipelineLayout(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkPipelineLayoutCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkPipelineLayout>*     pPipelineLayout) = 0;
+        HandlePointerDecoder<VkPipelineLayout>*     pPipelineLayout) {}
 
     virtual void Process_vkDestroyPipelineLayout(
         format::HandleId                            device,
         format::HandleId                            pipelineLayout,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkCreateSampler(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkSamplerCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSampler>*            pSampler) = 0;
+        HandlePointerDecoder<VkSampler>*            pSampler) {}
 
     virtual void Process_vkDestroySampler(
         format::HandleId                            device,
         format::HandleId                            sampler,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkCreateDescriptorSetLayout(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkDescriptorSetLayout>* pSetLayout) = 0;
+        HandlePointerDecoder<VkDescriptorSetLayout>* pSetLayout) {}
 
     virtual void Process_vkDestroyDescriptorSetLayout(
         format::HandleId                            device,
         format::HandleId                            descriptorSetLayout,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkCreateDescriptorPool(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkDescriptorPool>*     pDescriptorPool) = 0;
+        HandlePointerDecoder<VkDescriptorPool>*     pDescriptorPool) {}
 
     virtual void Process_vkDestroyDescriptorPool(
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkResetDescriptorPool(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
-        VkDescriptorPoolResetFlags                  flags) = 0;
+        VkDescriptorPoolResetFlags                  flags) {}
 
     virtual void Process_vkAllocateDescriptorSets(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>& pAllocateInfo,
-        HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) = 0;
+        HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) {}
 
     virtual void Process_vkFreeDescriptorSets(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
         uint32_t                                    descriptorSetCount,
-        const HandlePointerDecoder<VkDescriptorSet>& pDescriptorSets) = 0;
+        const HandlePointerDecoder<VkDescriptorSet>& pDescriptorSets) {}
 
     virtual void Process_vkUpdateDescriptorSets(
         format::HandleId                            device,
         uint32_t                                    descriptorWriteCount,
         const StructPointerDecoder<Decoded_VkWriteDescriptorSet>& pDescriptorWrites,
         uint32_t                                    descriptorCopyCount,
-        const StructPointerDecoder<Decoded_VkCopyDescriptorSet>& pDescriptorCopies) = 0;
+        const StructPointerDecoder<Decoded_VkCopyDescriptorSet>& pDescriptorCopies) {}
 
     virtual void Process_vkCreateFramebuffer(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkFramebufferCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkFramebuffer>*        pFramebuffer) = 0;
+        HandlePointerDecoder<VkFramebuffer>*        pFramebuffer) {}
 
     virtual void Process_vkDestroyFramebuffer(
         format::HandleId                            device,
         format::HandleId                            framebuffer,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkCreateRenderPass(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkRenderPassCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkRenderPass>*         pRenderPass) = 0;
+        HandlePointerDecoder<VkRenderPass>*         pRenderPass) {}
 
     virtual void Process_vkDestroyRenderPass(
         format::HandleId                            device,
         format::HandleId                            renderPass,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkGetRenderAreaGranularity(
         format::HandleId                            device,
         format::HandleId                            renderPass,
-        StructPointerDecoder<Decoded_VkExtent2D>*   pGranularity) = 0;
+        StructPointerDecoder<Decoded_VkExtent2D>*   pGranularity) {}
 
     virtual void Process_vkCreateCommandPool(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkCommandPool>*        pCommandPool) = 0;
+        HandlePointerDecoder<VkCommandPool>*        pCommandPool) {}
 
     virtual void Process_vkDestroyCommandPool(
         format::HandleId                            device,
         format::HandleId                            commandPool,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkResetCommandPool(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            commandPool,
-        VkCommandPoolResetFlags                     flags) = 0;
+        VkCommandPoolResetFlags                     flags) {}
 
     virtual void Process_vkAllocateCommandBuffers(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>& pAllocateInfo,
-        HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) = 0;
+        HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) {}
 
     virtual void Process_vkFreeCommandBuffers(
         format::HandleId                            device,
         format::HandleId                            commandPool,
         uint32_t                                    commandBufferCount,
-        const HandlePointerDecoder<VkCommandBuffer>& pCommandBuffers) = 0;
+        const HandlePointerDecoder<VkCommandBuffer>& pCommandBuffers) {}
 
     virtual void Process_vkBeginCommandBuffer(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>& pBeginInfo) = 0;
+        const StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>& pBeginInfo) {}
 
     virtual void Process_vkEndCommandBuffer(
         VkResult                                    returnValue,
-        format::HandleId                            commandBuffer) = 0;
+        format::HandleId                            commandBuffer) {}
 
     virtual void Process_vkResetCommandBuffer(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        VkCommandBufferResetFlags                   flags) = 0;
+        VkCommandBufferResetFlags                   flags) {}
 
     virtual void Process_vkCmdBindPipeline(
         format::HandleId                            commandBuffer,
         VkPipelineBindPoint                         pipelineBindPoint,
-        format::HandleId                            pipeline) = 0;
+        format::HandleId                            pipeline) {}
 
     virtual void Process_vkCmdSetViewport(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
-        const StructPointerDecoder<Decoded_VkViewport>& pViewports) = 0;
+        const StructPointerDecoder<Decoded_VkViewport>& pViewports) {}
 
     virtual void Process_vkCmdSetScissor(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstScissor,
         uint32_t                                    scissorCount,
-        const StructPointerDecoder<Decoded_VkRect2D>& pScissors) = 0;
+        const StructPointerDecoder<Decoded_VkRect2D>& pScissors) {}
 
     virtual void Process_vkCmdSetLineWidth(
         format::HandleId                            commandBuffer,
-        float                                       lineWidth) = 0;
+        float                                       lineWidth) {}
 
     virtual void Process_vkCmdSetDepthBias(
         format::HandleId                            commandBuffer,
         float                                       depthBiasConstantFactor,
         float                                       depthBiasClamp,
-        float                                       depthBiasSlopeFactor) = 0;
+        float                                       depthBiasSlopeFactor) {}
 
     virtual void Process_vkCmdSetBlendConstants(
         format::HandleId                            commandBuffer,
-        const PointerDecoder<float>&                blendConstants) = 0;
+        const PointerDecoder<float>&                blendConstants) {}
 
     virtual void Process_vkCmdSetDepthBounds(
         format::HandleId                            commandBuffer,
         float                                       minDepthBounds,
-        float                                       maxDepthBounds) = 0;
+        float                                       maxDepthBounds) {}
 
     virtual void Process_vkCmdSetStencilCompareMask(
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
-        uint32_t                                    compareMask) = 0;
+        uint32_t                                    compareMask) {}
 
     virtual void Process_vkCmdSetStencilWriteMask(
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
-        uint32_t                                    writeMask) = 0;
+        uint32_t                                    writeMask) {}
 
     virtual void Process_vkCmdSetStencilReference(
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
-        uint32_t                                    reference) = 0;
+        uint32_t                                    reference) {}
 
     virtual void Process_vkCmdBindDescriptorSets(
         format::HandleId                            commandBuffer,
@@ -621,27 +621,27 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    descriptorSetCount,
         const HandlePointerDecoder<VkDescriptorSet>& pDescriptorSets,
         uint32_t                                    dynamicOffsetCount,
-        const PointerDecoder<uint32_t>&             pDynamicOffsets) = 0;
+        const PointerDecoder<uint32_t>&             pDynamicOffsets) {}
 
     virtual void Process_vkCmdBindIndexBuffer(
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
-        VkIndexType                                 indexType) = 0;
+        VkIndexType                                 indexType) {}
 
     virtual void Process_vkCmdBindVertexBuffers(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
         const HandlePointerDecoder<VkBuffer>&       pBuffers,
-        const PointerDecoder<VkDeviceSize>&         pOffsets) = 0;
+        const PointerDecoder<VkDeviceSize>&         pOffsets) {}
 
     virtual void Process_vkCmdDraw(
         format::HandleId                            commandBuffer,
         uint32_t                                    vertexCount,
         uint32_t                                    instanceCount,
         uint32_t                                    firstVertex,
-        uint32_t                                    firstInstance) = 0;
+        uint32_t                                    firstInstance) {}
 
     virtual void Process_vkCmdDrawIndexed(
         format::HandleId                            commandBuffer,
@@ -649,39 +649,39 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    instanceCount,
         uint32_t                                    firstIndex,
         int32_t                                     vertexOffset,
-        uint32_t                                    firstInstance) = 0;
+        uint32_t                                    firstInstance) {}
 
     virtual void Process_vkCmdDrawIndirect(
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
         uint32_t                                    drawCount,
-        uint32_t                                    stride) = 0;
+        uint32_t                                    stride) {}
 
     virtual void Process_vkCmdDrawIndexedIndirect(
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
         uint32_t                                    drawCount,
-        uint32_t                                    stride) = 0;
+        uint32_t                                    stride) {}
 
     virtual void Process_vkCmdDispatch(
         format::HandleId                            commandBuffer,
         uint32_t                                    groupCountX,
         uint32_t                                    groupCountY,
-        uint32_t                                    groupCountZ) = 0;
+        uint32_t                                    groupCountZ) {}
 
     virtual void Process_vkCmdDispatchIndirect(
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
-        VkDeviceSize                                offset) = 0;
+        VkDeviceSize                                offset) {}
 
     virtual void Process_vkCmdCopyBuffer(
         format::HandleId                            commandBuffer,
         format::HandleId                            srcBuffer,
         format::HandleId                            dstBuffer,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkBufferCopy>& pRegions) = 0;
+        const StructPointerDecoder<Decoded_VkBufferCopy>& pRegions) {}
 
     virtual void Process_vkCmdCopyImage(
         format::HandleId                            commandBuffer,
@@ -690,7 +690,7 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            dstImage,
         VkImageLayout                               dstImageLayout,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkImageCopy>& pRegions) = 0;
+        const StructPointerDecoder<Decoded_VkImageCopy>& pRegions) {}
 
     virtual void Process_vkCmdBlitImage(
         format::HandleId                            commandBuffer,
@@ -700,7 +700,7 @@ class VulkanConsumer : public VulkanConsumerBase
         VkImageLayout                               dstImageLayout,
         uint32_t                                    regionCount,
         const StructPointerDecoder<Decoded_VkImageBlit>& pRegions,
-        VkFilter                                    filter) = 0;
+        VkFilter                                    filter) {}
 
     virtual void Process_vkCmdCopyBufferToImage(
         format::HandleId                            commandBuffer,
@@ -708,7 +708,7 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            dstImage,
         VkImageLayout                               dstImageLayout,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkBufferImageCopy>& pRegions) = 0;
+        const StructPointerDecoder<Decoded_VkBufferImageCopy>& pRegions) {}
 
     virtual void Process_vkCmdCopyImageToBuffer(
         format::HandleId                            commandBuffer,
@@ -716,21 +716,21 @@ class VulkanConsumer : public VulkanConsumerBase
         VkImageLayout                               srcImageLayout,
         format::HandleId                            dstBuffer,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkBufferImageCopy>& pRegions) = 0;
+        const StructPointerDecoder<Decoded_VkBufferImageCopy>& pRegions) {}
 
     virtual void Process_vkCmdUpdateBuffer(
         format::HandleId                            commandBuffer,
         format::HandleId                            dstBuffer,
         VkDeviceSize                                dstOffset,
         VkDeviceSize                                dataSize,
-        const PointerDecoder<uint8_t>&              pData) = 0;
+        const PointerDecoder<uint8_t>&              pData) {}
 
     virtual void Process_vkCmdFillBuffer(
         format::HandleId                            commandBuffer,
         format::HandleId                            dstBuffer,
         VkDeviceSize                                dstOffset,
         VkDeviceSize                                size,
-        uint32_t                                    data) = 0;
+        uint32_t                                    data) {}
 
     virtual void Process_vkCmdClearColorImage(
         format::HandleId                            commandBuffer,
@@ -738,7 +738,7 @@ class VulkanConsumer : public VulkanConsumerBase
         VkImageLayout                               imageLayout,
         const StructPointerDecoder<Decoded_VkClearColorValue>& pColor,
         uint32_t                                    rangeCount,
-        const StructPointerDecoder<Decoded_VkImageSubresourceRange>& pRanges) = 0;
+        const StructPointerDecoder<Decoded_VkImageSubresourceRange>& pRanges) {}
 
     virtual void Process_vkCmdClearDepthStencilImage(
         format::HandleId                            commandBuffer,
@@ -746,14 +746,14 @@ class VulkanConsumer : public VulkanConsumerBase
         VkImageLayout                               imageLayout,
         const StructPointerDecoder<Decoded_VkClearDepthStencilValue>& pDepthStencil,
         uint32_t                                    rangeCount,
-        const StructPointerDecoder<Decoded_VkImageSubresourceRange>& pRanges) = 0;
+        const StructPointerDecoder<Decoded_VkImageSubresourceRange>& pRanges) {}
 
     virtual void Process_vkCmdClearAttachments(
         format::HandleId                            commandBuffer,
         uint32_t                                    attachmentCount,
         const StructPointerDecoder<Decoded_VkClearAttachment>& pAttachments,
         uint32_t                                    rectCount,
-        const StructPointerDecoder<Decoded_VkClearRect>& pRects) = 0;
+        const StructPointerDecoder<Decoded_VkClearRect>& pRects) {}
 
     virtual void Process_vkCmdResolveImage(
         format::HandleId                            commandBuffer,
@@ -762,17 +762,17 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            dstImage,
         VkImageLayout                               dstImageLayout,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkImageResolve>& pRegions) = 0;
+        const StructPointerDecoder<Decoded_VkImageResolve>& pRegions) {}
 
     virtual void Process_vkCmdSetEvent(
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
-        VkPipelineStageFlags                        stageMask) = 0;
+        VkPipelineStageFlags                        stageMask) {}
 
     virtual void Process_vkCmdResetEvent(
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
-        VkPipelineStageFlags                        stageMask) = 0;
+        VkPipelineStageFlags                        stageMask) {}
 
     virtual void Process_vkCmdWaitEvents(
         format::HandleId                            commandBuffer,
@@ -785,7 +785,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    bufferMemoryBarrierCount,
         const StructPointerDecoder<Decoded_VkBufferMemoryBarrier>& pBufferMemoryBarriers,
         uint32_t                                    imageMemoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkImageMemoryBarrier>& pImageMemoryBarriers) = 0;
+        const StructPointerDecoder<Decoded_VkImageMemoryBarrier>& pImageMemoryBarriers) {}
 
     virtual void Process_vkCmdPipelineBarrier(
         format::HandleId                            commandBuffer,
@@ -797,30 +797,30 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    bufferMemoryBarrierCount,
         const StructPointerDecoder<Decoded_VkBufferMemoryBarrier>& pBufferMemoryBarriers,
         uint32_t                                    imageMemoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkImageMemoryBarrier>& pImageMemoryBarriers) = 0;
+        const StructPointerDecoder<Decoded_VkImageMemoryBarrier>& pImageMemoryBarriers) {}
 
     virtual void Process_vkCmdBeginQuery(
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    query,
-        VkQueryControlFlags                         flags) = 0;
+        VkQueryControlFlags                         flags) {}
 
     virtual void Process_vkCmdEndQuery(
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
-        uint32_t                                    query) = 0;
+        uint32_t                                    query) {}
 
     virtual void Process_vkCmdResetQueryPool(
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery,
-        uint32_t                                    queryCount) = 0;
+        uint32_t                                    queryCount) {}
 
     virtual void Process_vkCmdWriteTimestamp(
         format::HandleId                            commandBuffer,
         VkPipelineStageFlagBits                     pipelineStage,
         format::HandleId                            queryPool,
-        uint32_t                                    query) = 0;
+        uint32_t                                    query) {}
 
     virtual void Process_vkCmdCopyQueryPoolResults(
         format::HandleId                            commandBuffer,
@@ -830,7 +830,7 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            dstBuffer,
         VkDeviceSize                                dstOffset,
         VkDeviceSize                                stride,
-        VkQueryResultFlags                          flags) = 0;
+        VkQueryResultFlags                          flags) {}
 
     virtual void Process_vkCmdPushConstants(
         format::HandleId                            commandBuffer,
@@ -838,47 +838,47 @@ class VulkanConsumer : public VulkanConsumerBase
         VkShaderStageFlags                          stageFlags,
         uint32_t                                    offset,
         uint32_t                                    size,
-        const PointerDecoder<uint8_t>&              pValues) = 0;
+        const PointerDecoder<uint8_t>&              pValues) {}
 
     virtual void Process_vkCmdBeginRenderPass(
         format::HandleId                            commandBuffer,
         const StructPointerDecoder<Decoded_VkRenderPassBeginInfo>& pRenderPassBegin,
-        VkSubpassContents                           contents) = 0;
+        VkSubpassContents                           contents) {}
 
     virtual void Process_vkCmdNextSubpass(
         format::HandleId                            commandBuffer,
-        VkSubpassContents                           contents) = 0;
+        VkSubpassContents                           contents) {}
 
     virtual void Process_vkCmdEndRenderPass(
-        format::HandleId                            commandBuffer) = 0;
+        format::HandleId                            commandBuffer) {}
 
     virtual void Process_vkCmdExecuteCommands(
         format::HandleId                            commandBuffer,
         uint32_t                                    commandBufferCount,
-        const HandlePointerDecoder<VkCommandBuffer>& pCommandBuffers) = 0;
+        const HandlePointerDecoder<VkCommandBuffer>& pCommandBuffers) {}
 
     virtual void Process_vkBindBufferMemory2(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>& pBindInfos) = 0;
+        const StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>& pBindInfos) {}
 
     virtual void Process_vkBindImageMemory2(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>& pBindInfos) = 0;
+        const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>& pBindInfos) {}
 
     virtual void Process_vkGetDeviceGroupPeerMemoryFeatures(
         format::HandleId                            device,
         uint32_t                                    heapIndex,
         uint32_t                                    localDeviceIndex,
         uint32_t                                    remoteDeviceIndex,
-        PointerDecoder<VkPeerMemoryFeatureFlags>*   pPeerMemoryFeatures) = 0;
+        PointerDecoder<VkPeerMemoryFeatureFlags>*   pPeerMemoryFeatures) {}
 
     virtual void Process_vkCmdSetDeviceMask(
         format::HandleId                            commandBuffer,
-        uint32_t                                    deviceMask) = 0;
+        uint32_t                                    deviceMask) {}
 
     virtual void Process_vkCmdDispatchBase(
         format::HandleId                            commandBuffer,
@@ -887,168 +887,168 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    baseGroupZ,
         uint32_t                                    groupCountX,
         uint32_t                                    groupCountY,
-        uint32_t                                    groupCountZ) = 0;
+        uint32_t                                    groupCountZ) {}
 
     virtual void Process_vkEnumeratePhysicalDeviceGroups(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         PointerDecoder<uint32_t>*                   pPhysicalDeviceGroupCount,
-        StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties) = 0;
+        StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties) {}
 
     virtual void Process_vkGetImageMemoryRequirements2(
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>& pInfo,
-        StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) = 0;
+        StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkGetBufferMemoryRequirements2(
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>& pInfo,
-        StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) = 0;
+        StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkGetImageSparseMemoryRequirements2(
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>& pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
-        StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) = 0;
+        StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) {}
 
     virtual void Process_vkGetPhysicalDeviceFeatures2(
         format::HandleId                            physicalDevice,
-        StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures) = 0;
+        StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures) {}
 
     virtual void Process_vkGetPhysicalDeviceProperties2(
         format::HandleId                            physicalDevice,
-        StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties) = 0;
+        StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceFormatProperties2(
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
-        StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties) = 0;
+        StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties2(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         const StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>& pImageFormatInfo,
-        StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties) = 0;
+        StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties2(
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
-        StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties) = 0;
+        StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceMemoryProperties2(
         format::HandleId                            physicalDevice,
-        StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties) = 0;
+        StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties2(
         format::HandleId                            physicalDevice,
         const StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>& pFormatInfo,
         PointerDecoder<uint32_t>*                   pPropertyCount,
-        StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties) = 0;
+        StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties) {}
 
     virtual void Process_vkTrimCommandPool(
         format::HandleId                            device,
         format::HandleId                            commandPool,
-        VkCommandPoolTrimFlags                      flags) = 0;
+        VkCommandPoolTrimFlags                      flags) {}
 
     virtual void Process_vkGetDeviceQueue2(
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkDeviceQueueInfo2>& pQueueInfo,
-        HandlePointerDecoder<VkQueue>*              pQueue) = 0;
+        HandlePointerDecoder<VkQueue>*              pQueue) {}
 
     virtual void Process_vkCreateSamplerYcbcrConversion(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion) = 0;
+        HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion) {}
 
     virtual void Process_vkDestroySamplerYcbcrConversion(
         format::HandleId                            device,
         format::HandleId                            ycbcrConversion,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkCreateDescriptorUpdateTemplate(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate) = 0;
+        HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate) {}
 
     virtual void Process_vkDestroyDescriptorUpdateTemplate(
         format::HandleId                            device,
         format::HandleId                            descriptorUpdateTemplate,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalBufferProperties(
         format::HandleId                            physicalDevice,
         const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>& pExternalBufferInfo,
-        StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties) = 0;
+        StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalFenceProperties(
         format::HandleId                            physicalDevice,
         const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>& pExternalFenceInfo,
-        StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties) = 0;
+        StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalSemaphoreProperties(
         format::HandleId                            physicalDevice,
         const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>& pExternalSemaphoreInfo,
-        StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties) = 0;
+        StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties) {}
 
     virtual void Process_vkGetDescriptorSetLayoutSupport(
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>& pCreateInfo,
-        StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport) = 0;
+        StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport) {}
 
     virtual void Process_vkDestroySurfaceKHR(
         format::HandleId                            instance,
         format::HandleId                            surface,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfaceSupportKHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
         format::HandleId                            surface,
-        PointerDecoder<VkBool32>*                   pSupported) = 0;
+        PointerDecoder<VkBool32>*                   pSupported) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
-        StructPointerDecoder<Decoded_VkSurfaceCapabilitiesKHR>* pSurfaceCapabilities) = 0;
+        StructPointerDecoder<Decoded_VkSurfaceCapabilitiesKHR>* pSurfaceCapabilities) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
         PointerDecoder<uint32_t>*                   pSurfaceFormatCount,
-        StructPointerDecoder<Decoded_VkSurfaceFormatKHR>* pSurfaceFormats) = 0;
+        StructPointerDecoder<Decoded_VkSurfaceFormatKHR>* pSurfaceFormats) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
         PointerDecoder<uint32_t>*                   pPresentModeCount,
-        PointerDecoder<VkPresentModeKHR>*           pPresentModes) = 0;
+        PointerDecoder<VkPresentModeKHR>*           pPresentModes) {}
 
     virtual void Process_vkCreateSwapchainKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSwapchainKHR>*       pSwapchain) = 0;
+        HandlePointerDecoder<VkSwapchainKHR>*       pSwapchain) {}
 
     virtual void Process_vkDestroySwapchainKHR(
         format::HandleId                            device,
         format::HandleId                            swapchain,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkGetSwapchainImagesKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
         PointerDecoder<uint32_t>*                   pSwapchainImageCount,
-        HandlePointerDecoder<VkImage>*              pSwapchainImages) = 0;
+        HandlePointerDecoder<VkImage>*              pSwapchainImages) {}
 
     virtual void Process_vkAcquireNextImageKHR(
         VkResult                                    returnValue,
@@ -1057,62 +1057,62 @@ class VulkanConsumer : public VulkanConsumerBase
         uint64_t                                    timeout,
         format::HandleId                            semaphore,
         format::HandleId                            fence,
-        PointerDecoder<uint32_t>*                   pImageIndex) = 0;
+        PointerDecoder<uint32_t>*                   pImageIndex) {}
 
     virtual void Process_vkQueuePresentKHR(
         VkResult                                    returnValue,
         format::HandleId                            queue,
-        const StructPointerDecoder<Decoded_VkPresentInfoKHR>& pPresentInfo) = 0;
+        const StructPointerDecoder<Decoded_VkPresentInfoKHR>& pPresentInfo) {}
 
     virtual void Process_vkGetDeviceGroupPresentCapabilitiesKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        StructPointerDecoder<Decoded_VkDeviceGroupPresentCapabilitiesKHR>* pDeviceGroupPresentCapabilities) = 0;
+        StructPointerDecoder<Decoded_VkDeviceGroupPresentCapabilitiesKHR>* pDeviceGroupPresentCapabilities) {}
 
     virtual void Process_vkGetDeviceGroupSurfacePresentModesKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            surface,
-        PointerDecoder<VkDeviceGroupPresentModeFlagsKHR>* pModes) = 0;
+        PointerDecoder<VkDeviceGroupPresentModeFlagsKHR>* pModes) {}
 
     virtual void Process_vkGetPhysicalDevicePresentRectanglesKHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
         PointerDecoder<uint32_t>*                   pRectCount,
-        StructPointerDecoder<Decoded_VkRect2D>*     pRects) = 0;
+        StructPointerDecoder<Decoded_VkRect2D>*     pRects) {}
 
     virtual void Process_vkAcquireNextImage2KHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>& pAcquireInfo,
-        PointerDecoder<uint32_t>*                   pImageIndex) = 0;
+        PointerDecoder<uint32_t>*                   pImageIndex) {}
 
     virtual void Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
-        StructPointerDecoder<Decoded_VkDisplayPropertiesKHR>* pProperties) = 0;
+        StructPointerDecoder<Decoded_VkDisplayPropertiesKHR>* pProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
-        StructPointerDecoder<Decoded_VkDisplayPlanePropertiesKHR>* pProperties) = 0;
+        StructPointerDecoder<Decoded_VkDisplayPlanePropertiesKHR>* pProperties) {}
 
     virtual void Process_vkGetDisplayPlaneSupportedDisplaysKHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    planeIndex,
         PointerDecoder<uint32_t>*                   pDisplayCount,
-        HandlePointerDecoder<VkDisplayKHR>*         pDisplays) = 0;
+        HandlePointerDecoder<VkDisplayKHR>*         pDisplays) {}
 
     virtual void Process_vkGetDisplayModePropertiesKHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display,
         PointerDecoder<uint32_t>*                   pPropertyCount,
-        StructPointerDecoder<Decoded_VkDisplayModePropertiesKHR>* pProperties) = 0;
+        StructPointerDecoder<Decoded_VkDisplayModePropertiesKHR>* pProperties) {}
 
     virtual void Process_vkCreateDisplayModeKHR(
         VkResult                                    returnValue,
@@ -1120,21 +1120,21 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            display,
         const StructPointerDecoder<Decoded_VkDisplayModeCreateInfoKHR>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkDisplayModeKHR>*     pMode) = 0;
+        HandlePointerDecoder<VkDisplayModeKHR>*     pMode) {}
 
     virtual void Process_vkGetDisplayPlaneCapabilitiesKHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            mode,
         uint32_t                                    planeIndex,
-        StructPointerDecoder<Decoded_VkDisplayPlaneCapabilitiesKHR>* pCapabilities) = 0;
+        StructPointerDecoder<Decoded_VkDisplayPlaneCapabilitiesKHR>* pCapabilities) {}
 
     virtual void Process_vkCreateDisplayPlaneSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         const StructPointerDecoder<Decoded_VkDisplaySurfaceCreateInfoKHR>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) = 0;
+        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCreateSharedSwapchainsKHR(
         VkResult                                    returnValue,
@@ -1142,112 +1142,112 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    swapchainCount,
         const StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>& pCreateInfos,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains) = 0;
+        HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains) {}
 
     virtual void Process_vkCreateXlibSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         const StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) = 0;
+        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
         uint64_t                                    dpy,
-        size_t                                      visualID) = 0;
+        size_t                                      visualID) {}
 
     virtual void Process_vkCreateXcbSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         const StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) = 0;
+        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
         uint64_t                                    connection,
-        uint32_t                                    visual_id) = 0;
+        uint32_t                                    visual_id) {}
 
     virtual void Process_vkCreateWaylandSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         const StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) = 0;
+        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceWaylandPresentationSupportKHR(
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
-        uint64_t                                    display) = 0;
+        uint64_t                                    display) {}
 
     virtual void Process_vkCreateAndroidSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         const StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) = 0;
+        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCreateWin32SurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         const StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) = 0;
+        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceWin32PresentationSupportKHR(
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
-        uint32_t                                    queueFamilyIndex) = 0;
+        uint32_t                                    queueFamilyIndex) {}
 
     virtual void Process_vkGetPhysicalDeviceFeatures2KHR(
         format::HandleId                            physicalDevice,
-        StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures) = 0;
+        StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures) {}
 
     virtual void Process_vkGetPhysicalDeviceProperties2KHR(
         format::HandleId                            physicalDevice,
-        StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties) = 0;
+        StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceFormatProperties2KHR(
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
-        StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties) = 0;
+        StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         const StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>& pImageFormatInfo,
-        StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties) = 0;
+        StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
-        StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties) = 0;
+        StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceMemoryProperties2KHR(
         format::HandleId                            physicalDevice,
-        StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties) = 0;
+        StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(
         format::HandleId                            physicalDevice,
         const StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>& pFormatInfo,
         PointerDecoder<uint32_t>*                   pPropertyCount,
-        StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties) = 0;
+        StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties) {}
 
     virtual void Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(
         format::HandleId                            device,
         uint32_t                                    heapIndex,
         uint32_t                                    localDeviceIndex,
         uint32_t                                    remoteDeviceIndex,
-        PointerDecoder<VkPeerMemoryFeatureFlags>*   pPeerMemoryFeatures) = 0;
+        PointerDecoder<VkPeerMemoryFeatureFlags>*   pPeerMemoryFeatures) {}
 
     virtual void Process_vkCmdSetDeviceMaskKHR(
         format::HandleId                            commandBuffer,
-        uint32_t                                    deviceMask) = 0;
+        uint32_t                                    deviceMask) {}
 
     virtual void Process_vkCmdDispatchBaseKHR(
         format::HandleId                            commandBuffer,
@@ -1256,76 +1256,76 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    baseGroupZ,
         uint32_t                                    groupCountX,
         uint32_t                                    groupCountY,
-        uint32_t                                    groupCountZ) = 0;
+        uint32_t                                    groupCountZ) {}
 
     virtual void Process_vkTrimCommandPoolKHR(
         format::HandleId                            device,
         format::HandleId                            commandPool,
-        VkCommandPoolTrimFlags                      flags) = 0;
+        VkCommandPoolTrimFlags                      flags) {}
 
     virtual void Process_vkEnumeratePhysicalDeviceGroupsKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         PointerDecoder<uint32_t>*                   pPhysicalDeviceGroupCount,
-        StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties) = 0;
+        StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR(
         format::HandleId                            physicalDevice,
         const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>& pExternalBufferInfo,
-        StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties) = 0;
+        StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties) {}
 
     virtual void Process_vkGetMemoryWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkMemoryGetWin32HandleInfoKHR>& pGetWin32HandleInfo,
-        PointerDecoder<uint64_t, void*>*            pHandle) = 0;
+        PointerDecoder<uint64_t, void*>*            pHandle) {}
 
     virtual void Process_vkGetMemoryWin32HandlePropertiesKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkExternalMemoryHandleTypeFlagBits          handleType,
         uint64_t                                    handle,
-        StructPointerDecoder<Decoded_VkMemoryWin32HandlePropertiesKHR>* pMemoryWin32HandleProperties) = 0;
+        StructPointerDecoder<Decoded_VkMemoryWin32HandlePropertiesKHR>* pMemoryWin32HandleProperties) {}
 
     virtual void Process_vkGetMemoryFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkMemoryGetFdInfoKHR>& pGetFdInfo,
-        PointerDecoder<int>*                        pFd) = 0;
+        PointerDecoder<int>*                        pFd) {}
 
     virtual void Process_vkGetMemoryFdPropertiesKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkExternalMemoryHandleTypeFlagBits          handleType,
         int                                         fd,
-        StructPointerDecoder<Decoded_VkMemoryFdPropertiesKHR>* pMemoryFdProperties) = 0;
+        StructPointerDecoder<Decoded_VkMemoryFdPropertiesKHR>* pMemoryFdProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(
         format::HandleId                            physicalDevice,
         const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>& pExternalSemaphoreInfo,
-        StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties) = 0;
+        StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties) {}
 
     virtual void Process_vkImportSemaphoreWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>& pImportSemaphoreWin32HandleInfo) = 0;
+        const StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>& pImportSemaphoreWin32HandleInfo) {}
 
     virtual void Process_vkGetSemaphoreWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>& pGetWin32HandleInfo,
-        PointerDecoder<uint64_t, void*>*            pHandle) = 0;
+        PointerDecoder<uint64_t, void*>*            pHandle) {}
 
     virtual void Process_vkImportSemaphoreFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>& pImportSemaphoreFdInfo) = 0;
+        const StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>& pImportSemaphoreFdInfo) {}
 
     virtual void Process_vkGetSemaphoreFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkSemaphoreGetFdInfoKHR>& pGetFdInfo,
-        PointerDecoder<int>*                        pFd) = 0;
+        PointerDecoder<int>*                        pFd) {}
 
     virtual void Process_vkCmdPushDescriptorSetKHR(
         format::HandleId                            commandBuffer,
@@ -1333,155 +1333,155 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            layout,
         uint32_t                                    set,
         uint32_t                                    descriptorWriteCount,
-        const StructPointerDecoder<Decoded_VkWriteDescriptorSet>& pDescriptorWrites) = 0;
+        const StructPointerDecoder<Decoded_VkWriteDescriptorSet>& pDescriptorWrites) {}
 
     virtual void Process_vkCreateDescriptorUpdateTemplateKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate) = 0;
+        HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate) {}
 
     virtual void Process_vkDestroyDescriptorUpdateTemplateKHR(
         format::HandleId                            device,
         format::HandleId                            descriptorUpdateTemplate,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkCreateRenderPass2KHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkRenderPassCreateInfo2KHR>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkRenderPass>*         pRenderPass) = 0;
+        HandlePointerDecoder<VkRenderPass>*         pRenderPass) {}
 
     virtual void Process_vkCmdBeginRenderPass2KHR(
         format::HandleId                            commandBuffer,
         const StructPointerDecoder<Decoded_VkRenderPassBeginInfo>& pRenderPassBegin,
-        const StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>& pSubpassBeginInfo) = 0;
+        const StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>& pSubpassBeginInfo) {}
 
     virtual void Process_vkCmdNextSubpass2KHR(
         format::HandleId                            commandBuffer,
         const StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>& pSubpassBeginInfo,
-        const StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>& pSubpassEndInfo) = 0;
+        const StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>& pSubpassEndInfo) {}
 
     virtual void Process_vkCmdEndRenderPass2KHR(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>& pSubpassEndInfo) = 0;
+        const StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>& pSubpassEndInfo) {}
 
     virtual void Process_vkGetSwapchainStatusKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        format::HandleId                            swapchain) = 0;
+        format::HandleId                            swapchain) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(
         format::HandleId                            physicalDevice,
         const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>& pExternalFenceInfo,
-        StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties) = 0;
+        StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties) {}
 
     virtual void Process_vkImportFenceWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImportFenceWin32HandleInfoKHR>& pImportFenceWin32HandleInfo) = 0;
+        const StructPointerDecoder<Decoded_VkImportFenceWin32HandleInfoKHR>& pImportFenceWin32HandleInfo) {}
 
     virtual void Process_vkGetFenceWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkFenceGetWin32HandleInfoKHR>& pGetWin32HandleInfo,
-        PointerDecoder<uint64_t, void*>*            pHandle) = 0;
+        PointerDecoder<uint64_t, void*>*            pHandle) {}
 
     virtual void Process_vkImportFenceFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImportFenceFdInfoKHR>& pImportFenceFdInfo) = 0;
+        const StructPointerDecoder<Decoded_VkImportFenceFdInfoKHR>& pImportFenceFdInfo) {}
 
     virtual void Process_vkGetFenceFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkFenceGetFdInfoKHR>& pGetFdInfo,
-        PointerDecoder<int>*                        pFd) = 0;
+        PointerDecoder<int>*                        pFd) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
-        StructPointerDecoder<Decoded_VkSurfaceCapabilities2KHR>* pSurfaceCapabilities) = 0;
+        StructPointerDecoder<Decoded_VkSurfaceCapabilities2KHR>* pSurfaceCapabilities) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
         PointerDecoder<uint32_t>*                   pSurfaceFormatCount,
-        StructPointerDecoder<Decoded_VkSurfaceFormat2KHR>* pSurfaceFormats) = 0;
+        StructPointerDecoder<Decoded_VkSurfaceFormat2KHR>* pSurfaceFormats) {}
 
     virtual void Process_vkGetPhysicalDeviceDisplayProperties2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
-        StructPointerDecoder<Decoded_VkDisplayProperties2KHR>* pProperties) = 0;
+        StructPointerDecoder<Decoded_VkDisplayProperties2KHR>* pProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
-        StructPointerDecoder<Decoded_VkDisplayPlaneProperties2KHR>* pProperties) = 0;
+        StructPointerDecoder<Decoded_VkDisplayPlaneProperties2KHR>* pProperties) {}
 
     virtual void Process_vkGetDisplayModeProperties2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display,
         PointerDecoder<uint32_t>*                   pPropertyCount,
-        StructPointerDecoder<Decoded_VkDisplayModeProperties2KHR>* pProperties) = 0;
+        StructPointerDecoder<Decoded_VkDisplayModeProperties2KHR>* pProperties) {}
 
     virtual void Process_vkGetDisplayPlaneCapabilities2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         const StructPointerDecoder<Decoded_VkDisplayPlaneInfo2KHR>& pDisplayPlaneInfo,
-        StructPointerDecoder<Decoded_VkDisplayPlaneCapabilities2KHR>* pCapabilities) = 0;
+        StructPointerDecoder<Decoded_VkDisplayPlaneCapabilities2KHR>* pCapabilities) {}
 
     virtual void Process_vkGetImageMemoryRequirements2KHR(
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>& pInfo,
-        StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) = 0;
+        StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkGetBufferMemoryRequirements2KHR(
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>& pInfo,
-        StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) = 0;
+        StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkGetImageSparseMemoryRequirements2KHR(
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>& pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
-        StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) = 0;
+        StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) {}
 
     virtual void Process_vkCreateSamplerYcbcrConversionKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion) = 0;
+        HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion) {}
 
     virtual void Process_vkDestroySamplerYcbcrConversionKHR(
         format::HandleId                            device,
         format::HandleId                            ycbcrConversion,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkBindBufferMemory2KHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>& pBindInfos) = 0;
+        const StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>& pBindInfos) {}
 
     virtual void Process_vkBindImageMemory2KHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>& pBindInfos) = 0;
+        const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>& pBindInfos) {}
 
     virtual void Process_vkGetDescriptorSetLayoutSupportKHR(
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>& pCreateInfo,
-        StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport) = 0;
+        StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport) {}
 
     virtual void Process_vkCmdDrawIndirectCountKHR(
         format::HandleId                            commandBuffer,
@@ -1490,7 +1490,7 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            countBuffer,
         VkDeviceSize                                countBufferOffset,
         uint32_t                                    maxDrawCount,
-        uint32_t                                    stride) = 0;
+        uint32_t                                    stride) {}
 
     virtual void Process_vkCmdDrawIndexedIndirectCountKHR(
         format::HandleId                            commandBuffer,
@@ -1499,57 +1499,57 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            countBuffer,
         VkDeviceSize                                countBufferOffset,
         uint32_t                                    maxDrawCount,
-        uint32_t                                    stride) = 0;
+        uint32_t                                    stride) {}
 
     virtual void Process_vkGetSemaphoreCounterValueKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            semaphore,
-        PointerDecoder<uint64_t>*                   pValue) = 0;
+        PointerDecoder<uint64_t>*                   pValue) {}
 
     virtual void Process_vkWaitSemaphoresKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkSemaphoreWaitInfoKHR>& pWaitInfo,
-        uint64_t                                    timeout) = 0;
+        uint64_t                                    timeout) {}
 
     virtual void Process_vkSignalSemaphoreKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSemaphoreSignalInfoKHR>& pSignalInfo) = 0;
+        const StructPointerDecoder<Decoded_VkSemaphoreSignalInfoKHR>& pSignalInfo) {}
 
     virtual void Process_vkGetPipelineExecutablePropertiesKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkPipelineInfoKHR>& pPipelineInfo,
         PointerDecoder<uint32_t>*                   pExecutableCount,
-        StructPointerDecoder<Decoded_VkPipelineExecutablePropertiesKHR>* pProperties) = 0;
+        StructPointerDecoder<Decoded_VkPipelineExecutablePropertiesKHR>* pProperties) {}
 
     virtual void Process_vkGetPipelineExecutableStatisticsKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>& pExecutableInfo,
         PointerDecoder<uint32_t>*                   pStatisticCount,
-        StructPointerDecoder<Decoded_VkPipelineExecutableStatisticKHR>* pStatistics) = 0;
+        StructPointerDecoder<Decoded_VkPipelineExecutableStatisticKHR>* pStatistics) {}
 
     virtual void Process_vkGetPipelineExecutableInternalRepresentationsKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>& pExecutableInfo,
         PointerDecoder<uint32_t>*                   pInternalRepresentationCount,
-        StructPointerDecoder<Decoded_VkPipelineExecutableInternalRepresentationKHR>* pInternalRepresentations) = 0;
+        StructPointerDecoder<Decoded_VkPipelineExecutableInternalRepresentationKHR>* pInternalRepresentations) {}
 
     virtual void Process_vkCreateDebugReportCallbackEXT(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         const StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkDebugReportCallbackEXT>* pCallback) = 0;
+        HandlePointerDecoder<VkDebugReportCallbackEXT>* pCallback) {}
 
     virtual void Process_vkDestroyDebugReportCallbackEXT(
         format::HandleId                            instance,
         format::HandleId                            callback,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkDebugReportMessageEXT(
         format::HandleId                            instance,
@@ -1559,28 +1559,28 @@ class VulkanConsumer : public VulkanConsumerBase
         size_t                                      location,
         int32_t                                     messageCode,
         const StringDecoder&                        pLayerPrefix,
-        const StringDecoder&                        pMessage) = 0;
+        const StringDecoder&                        pMessage) {}
 
     virtual void Process_vkDebugMarkerSetObjectTagEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDebugMarkerObjectTagInfoEXT>& pTagInfo) = 0;
+        const StructPointerDecoder<Decoded_VkDebugMarkerObjectTagInfoEXT>& pTagInfo) {}
 
     virtual void Process_vkDebugMarkerSetObjectNameEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDebugMarkerObjectNameInfoEXT>& pNameInfo) = 0;
+        const StructPointerDecoder<Decoded_VkDebugMarkerObjectNameInfoEXT>& pNameInfo) {}
 
     virtual void Process_vkCmdDebugMarkerBeginEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>& pMarkerInfo) = 0;
+        const StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>& pMarkerInfo) {}
 
     virtual void Process_vkCmdDebugMarkerEndEXT(
-        format::HandleId                            commandBuffer) = 0;
+        format::HandleId                            commandBuffer) {}
 
     virtual void Process_vkCmdDebugMarkerInsertEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>& pMarkerInfo) = 0;
+        const StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>& pMarkerInfo) {}
 
     virtual void Process_vkCmdBindTransformFeedbackBuffersEXT(
         format::HandleId                            commandBuffer,
@@ -1588,34 +1588,34 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    bindingCount,
         const HandlePointerDecoder<VkBuffer>&       pBuffers,
         const PointerDecoder<VkDeviceSize>&         pOffsets,
-        const PointerDecoder<VkDeviceSize>&         pSizes) = 0;
+        const PointerDecoder<VkDeviceSize>&         pSizes) {}
 
     virtual void Process_vkCmdBeginTransformFeedbackEXT(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstCounterBuffer,
         uint32_t                                    counterBufferCount,
         const HandlePointerDecoder<VkBuffer>&       pCounterBuffers,
-        const PointerDecoder<VkDeviceSize>&         pCounterBufferOffsets) = 0;
+        const PointerDecoder<VkDeviceSize>&         pCounterBufferOffsets) {}
 
     virtual void Process_vkCmdEndTransformFeedbackEXT(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstCounterBuffer,
         uint32_t                                    counterBufferCount,
         const HandlePointerDecoder<VkBuffer>&       pCounterBuffers,
-        const PointerDecoder<VkDeviceSize>&         pCounterBufferOffsets) = 0;
+        const PointerDecoder<VkDeviceSize>&         pCounterBufferOffsets) {}
 
     virtual void Process_vkCmdBeginQueryIndexedEXT(
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    query,
         VkQueryControlFlags                         flags,
-        uint32_t                                    index) = 0;
+        uint32_t                                    index) {}
 
     virtual void Process_vkCmdEndQueryIndexedEXT(
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    query,
-        uint32_t                                    index) = 0;
+        uint32_t                                    index) {}
 
     virtual void Process_vkCmdDrawIndirectByteCountEXT(
         format::HandleId                            commandBuffer,
@@ -1624,12 +1624,12 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            counterBuffer,
         VkDeviceSize                                counterBufferOffset,
         uint32_t                                    counterOffset,
-        uint32_t                                    vertexStride) = 0;
+        uint32_t                                    vertexStride) {}
 
     virtual void Process_vkGetImageViewHandleNVX(
         uint32_t                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>& pInfo) = 0;
+        const StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>& pInfo) {}
 
     virtual void Process_vkCmdDrawIndirectCountAMD(
         format::HandleId                            commandBuffer,
@@ -1638,7 +1638,7 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            countBuffer,
         VkDeviceSize                                countBufferOffset,
         uint32_t                                    maxDrawCount,
-        uint32_t                                    stride) = 0;
+        uint32_t                                    stride) {}
 
     virtual void Process_vkCmdDrawIndexedIndirectCountAMD(
         format::HandleId                            commandBuffer,
@@ -1647,7 +1647,7 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            countBuffer,
         VkDeviceSize                                countBufferOffset,
         uint32_t                                    maxDrawCount,
-        uint32_t                                    stride) = 0;
+        uint32_t                                    stride) {}
 
     virtual void Process_vkGetShaderInfoAMD(
         VkResult                                    returnValue,
@@ -1656,14 +1656,14 @@ class VulkanConsumer : public VulkanConsumerBase
         VkShaderStageFlagBits                       shaderStage,
         VkShaderInfoTypeAMD                         infoType,
         PointerDecoder<size_t>*                     pInfoSize,
-        PointerDecoder<uint8_t>*                    pInfo) = 0;
+        PointerDecoder<uint8_t>*                    pInfo) {}
 
     virtual void Process_vkCreateStreamDescriptorSurfaceGGP(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         const StructPointerDecoder<Decoded_VkStreamDescriptorSurfaceCreateInfoGGP>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) = 0;
+        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(
         VkResult                                    returnValue,
@@ -1674,60 +1674,60 @@ class VulkanConsumer : public VulkanConsumerBase
         VkImageUsageFlags                           usage,
         VkImageCreateFlags                          flags,
         VkExternalMemoryHandleTypeFlagsNV           externalHandleType,
-        StructPointerDecoder<Decoded_VkExternalImageFormatPropertiesNV>* pExternalImageFormatProperties) = 0;
+        StructPointerDecoder<Decoded_VkExternalImageFormatPropertiesNV>* pExternalImageFormatProperties) {}
 
     virtual void Process_vkGetMemoryWin32HandleNV(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            memory,
         VkExternalMemoryHandleTypeFlagsNV           handleType,
-        PointerDecoder<uint64_t, void*>*            pHandle) = 0;
+        PointerDecoder<uint64_t, void*>*            pHandle) {}
 
     virtual void Process_vkCreateViSurfaceNN(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         const StructPointerDecoder<Decoded_VkViSurfaceCreateInfoNN>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) = 0;
+        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCmdBeginConditionalRenderingEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>& pConditionalRenderingBegin) = 0;
+        const StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>& pConditionalRenderingBegin) {}
 
     virtual void Process_vkCmdEndConditionalRenderingEXT(
-        format::HandleId                            commandBuffer) = 0;
+        format::HandleId                            commandBuffer) {}
 
     virtual void Process_vkCmdProcessCommandsNVX(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkCmdProcessCommandsInfoNVX>& pProcessCommandsInfo) = 0;
+        const StructPointerDecoder<Decoded_VkCmdProcessCommandsInfoNVX>& pProcessCommandsInfo) {}
 
     virtual void Process_vkCmdReserveSpaceForCommandsNVX(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkCmdReserveSpaceForCommandsInfoNVX>& pReserveSpaceInfo) = 0;
+        const StructPointerDecoder<Decoded_VkCmdReserveSpaceForCommandsInfoNVX>& pReserveSpaceInfo) {}
 
     virtual void Process_vkCreateIndirectCommandsLayoutNVX(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkIndirectCommandsLayoutCreateInfoNVX>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkIndirectCommandsLayoutNVX>* pIndirectCommandsLayout) = 0;
+        HandlePointerDecoder<VkIndirectCommandsLayoutNVX>* pIndirectCommandsLayout) {}
 
     virtual void Process_vkDestroyIndirectCommandsLayoutNVX(
         format::HandleId                            device,
         format::HandleId                            indirectCommandsLayout,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkCreateObjectTableNVX(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkObjectTableCreateInfoNVX>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkObjectTableNVX>*     pObjectTable) = 0;
+        HandlePointerDecoder<VkObjectTableNVX>*     pObjectTable) {}
 
     virtual void Process_vkDestroyObjectTableNVX(
         format::HandleId                            device,
         format::HandleId                            objectTable,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkUnregisterObjectsNVX(
         VkResult                                    returnValue,
@@ -1735,55 +1735,55 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            objectTable,
         uint32_t                                    objectCount,
         const PointerDecoder<VkObjectEntryTypeNVX>& pObjectEntryTypes,
-        const PointerDecoder<uint32_t>&             pObjectIndices) = 0;
+        const PointerDecoder<uint32_t>&             pObjectIndices) {}
 
     virtual void Process_vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX(
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkDeviceGeneratedCommandsFeaturesNVX>* pFeatures,
-        StructPointerDecoder<Decoded_VkDeviceGeneratedCommandsLimitsNVX>* pLimits) = 0;
+        StructPointerDecoder<Decoded_VkDeviceGeneratedCommandsLimitsNVX>* pLimits) {}
 
     virtual void Process_vkCmdSetViewportWScalingNV(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
-        const StructPointerDecoder<Decoded_VkViewportWScalingNV>& pViewportWScalings) = 0;
+        const StructPointerDecoder<Decoded_VkViewportWScalingNV>& pViewportWScalings) {}
 
     virtual void Process_vkReleaseDisplayEXT(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        format::HandleId                            display) = 0;
+        format::HandleId                            display) {}
 
     virtual void Process_vkAcquireXlibDisplayEXT(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint64_t                                    dpy,
-        format::HandleId                            display) = 0;
+        format::HandleId                            display) {}
 
     virtual void Process_vkGetRandROutputDisplayEXT(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint64_t                                    dpy,
         size_t                                      rrOutput,
-        HandlePointerDecoder<VkDisplayKHR>*         pDisplay) = 0;
+        HandlePointerDecoder<VkDisplayKHR>*         pDisplay) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
-        StructPointerDecoder<Decoded_VkSurfaceCapabilities2EXT>* pSurfaceCapabilities) = 0;
+        StructPointerDecoder<Decoded_VkSurfaceCapabilities2EXT>* pSurfaceCapabilities) {}
 
     virtual void Process_vkDisplayPowerControlEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            display,
-        const StructPointerDecoder<Decoded_VkDisplayPowerInfoEXT>& pDisplayPowerInfo) = 0;
+        const StructPointerDecoder<Decoded_VkDisplayPowerInfoEXT>& pDisplayPowerInfo) {}
 
     virtual void Process_vkRegisterDeviceEventEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkDeviceEventInfoEXT>& pDeviceEventInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkFence>*              pFence) = 0;
+        HandlePointerDecoder<VkFence>*              pFence) {}
 
     virtual void Process_vkRegisterDisplayEventEXT(
         VkResult                                    returnValue,
@@ -1791,196 +1791,196 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            display,
         const StructPointerDecoder<Decoded_VkDisplayEventInfoEXT>& pDisplayEventInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkFence>*              pFence) = 0;
+        HandlePointerDecoder<VkFence>*              pFence) {}
 
     virtual void Process_vkGetSwapchainCounterEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
         VkSurfaceCounterFlagBitsEXT                 counter,
-        PointerDecoder<uint64_t>*                   pCounterValue) = 0;
+        PointerDecoder<uint64_t>*                   pCounterValue) {}
 
     virtual void Process_vkGetRefreshCycleDurationGOOGLE(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
-        StructPointerDecoder<Decoded_VkRefreshCycleDurationGOOGLE>* pDisplayTimingProperties) = 0;
+        StructPointerDecoder<Decoded_VkRefreshCycleDurationGOOGLE>* pDisplayTimingProperties) {}
 
     virtual void Process_vkGetPastPresentationTimingGOOGLE(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
         PointerDecoder<uint32_t>*                   pPresentationTimingCount,
-        StructPointerDecoder<Decoded_VkPastPresentationTimingGOOGLE>* pPresentationTimings) = 0;
+        StructPointerDecoder<Decoded_VkPastPresentationTimingGOOGLE>* pPresentationTimings) {}
 
     virtual void Process_vkCmdSetDiscardRectangleEXT(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstDiscardRectangle,
         uint32_t                                    discardRectangleCount,
-        const StructPointerDecoder<Decoded_VkRect2D>& pDiscardRectangles) = 0;
+        const StructPointerDecoder<Decoded_VkRect2D>& pDiscardRectangles) {}
 
     virtual void Process_vkSetHdrMetadataEXT(
         format::HandleId                            device,
         uint32_t                                    swapchainCount,
         const HandlePointerDecoder<VkSwapchainKHR>& pSwapchains,
-        const StructPointerDecoder<Decoded_VkHdrMetadataEXT>& pMetadata) = 0;
+        const StructPointerDecoder<Decoded_VkHdrMetadataEXT>& pMetadata) {}
 
     virtual void Process_vkCreateIOSSurfaceMVK(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         const StructPointerDecoder<Decoded_VkIOSSurfaceCreateInfoMVK>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) = 0;
+        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCreateMacOSSurfaceMVK(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         const StructPointerDecoder<Decoded_VkMacOSSurfaceCreateInfoMVK>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) = 0;
+        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkSetDebugUtilsObjectNameEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>& pNameInfo) = 0;
+        const StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>& pNameInfo) {}
 
     virtual void Process_vkSetDebugUtilsObjectTagEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>& pTagInfo) = 0;
+        const StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>& pTagInfo) {}
 
     virtual void Process_vkQueueBeginDebugUtilsLabelEXT(
         format::HandleId                            queue,
-        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) = 0;
+        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) {}
 
     virtual void Process_vkQueueEndDebugUtilsLabelEXT(
-        format::HandleId                            queue) = 0;
+        format::HandleId                            queue) {}
 
     virtual void Process_vkQueueInsertDebugUtilsLabelEXT(
         format::HandleId                            queue,
-        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) = 0;
+        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) {}
 
     virtual void Process_vkCmdBeginDebugUtilsLabelEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) = 0;
+        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) {}
 
     virtual void Process_vkCmdEndDebugUtilsLabelEXT(
-        format::HandleId                            commandBuffer) = 0;
+        format::HandleId                            commandBuffer) {}
 
     virtual void Process_vkCmdInsertDebugUtilsLabelEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) = 0;
+        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) {}
 
     virtual void Process_vkCreateDebugUtilsMessengerEXT(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         const StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkDebugUtilsMessengerEXT>* pMessenger) = 0;
+        HandlePointerDecoder<VkDebugUtilsMessengerEXT>* pMessenger) {}
 
     virtual void Process_vkDestroyDebugUtilsMessengerEXT(
         format::HandleId                            instance,
         format::HandleId                            messenger,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkSubmitDebugUtilsMessageEXT(
         format::HandleId                            instance,
         VkDebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,
         VkDebugUtilsMessageTypeFlagsEXT             messageTypes,
-        const StructPointerDecoder<Decoded_VkDebugUtilsMessengerCallbackDataEXT>& pCallbackData) = 0;
+        const StructPointerDecoder<Decoded_VkDebugUtilsMessengerCallbackDataEXT>& pCallbackData) {}
 
     virtual void Process_vkGetAndroidHardwareBufferPropertiesANDROID(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint64_t                                    buffer,
-        StructPointerDecoder<Decoded_VkAndroidHardwareBufferPropertiesANDROID>* pProperties) = 0;
+        StructPointerDecoder<Decoded_VkAndroidHardwareBufferPropertiesANDROID>* pProperties) {}
 
     virtual void Process_vkGetMemoryAndroidHardwareBufferANDROID(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID>& pInfo,
-        PointerDecoder<uint64_t, void*>*            pBuffer) = 0;
+        PointerDecoder<uint64_t, void*>*            pBuffer) {}
 
     virtual void Process_vkCmdSetSampleLocationsEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkSampleLocationsInfoEXT>& pSampleLocationsInfo) = 0;
+        const StructPointerDecoder<Decoded_VkSampleLocationsInfoEXT>& pSampleLocationsInfo) {}
 
     virtual void Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(
         format::HandleId                            physicalDevice,
         VkSampleCountFlagBits                       samples,
-        StructPointerDecoder<Decoded_VkMultisamplePropertiesEXT>* pMultisampleProperties) = 0;
+        StructPointerDecoder<Decoded_VkMultisamplePropertiesEXT>* pMultisampleProperties) {}
 
     virtual void Process_vkGetImageDrmFormatModifierPropertiesEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            image,
-        StructPointerDecoder<Decoded_VkImageDrmFormatModifierPropertiesEXT>* pProperties) = 0;
+        StructPointerDecoder<Decoded_VkImageDrmFormatModifierPropertiesEXT>* pProperties) {}
 
     virtual void Process_vkCreateValidationCacheEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkValidationCacheCreateInfoEXT>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkValidationCacheEXT>* pValidationCache) = 0;
+        HandlePointerDecoder<VkValidationCacheEXT>* pValidationCache) {}
 
     virtual void Process_vkDestroyValidationCacheEXT(
         format::HandleId                            device,
         format::HandleId                            validationCache,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkMergeValidationCachesEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            dstCache,
         uint32_t                                    srcCacheCount,
-        const HandlePointerDecoder<VkValidationCacheEXT>& pSrcCaches) = 0;
+        const HandlePointerDecoder<VkValidationCacheEXT>& pSrcCaches) {}
 
     virtual void Process_vkGetValidationCacheDataEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            validationCache,
         PointerDecoder<size_t>*                     pDataSize,
-        PointerDecoder<uint8_t>*                    pData) = 0;
+        PointerDecoder<uint8_t>*                    pData) {}
 
     virtual void Process_vkCmdBindShadingRateImageNV(
         format::HandleId                            commandBuffer,
         format::HandleId                            imageView,
-        VkImageLayout                               imageLayout) = 0;
+        VkImageLayout                               imageLayout) {}
 
     virtual void Process_vkCmdSetViewportShadingRatePaletteNV(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
-        const StructPointerDecoder<Decoded_VkShadingRatePaletteNV>& pShadingRatePalettes) = 0;
+        const StructPointerDecoder<Decoded_VkShadingRatePaletteNV>& pShadingRatePalettes) {}
 
     virtual void Process_vkCmdSetCoarseSampleOrderNV(
         format::HandleId                            commandBuffer,
         VkCoarseSampleOrderTypeNV                   sampleOrderType,
         uint32_t                                    customSampleOrderCount,
-        const StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>& pCustomSampleOrders) = 0;
+        const StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>& pCustomSampleOrders) {}
 
     virtual void Process_vkCreateAccelerationStructureNV(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoNV>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructure) = 0;
+        HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructure) {}
 
     virtual void Process_vkDestroyAccelerationStructureNV(
         format::HandleId                            device,
         format::HandleId                            accelerationStructure,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) = 0;
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
 
     virtual void Process_vkGetAccelerationStructureMemoryRequirementsNV(
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkAccelerationStructureMemoryRequirementsInfoNV>& pInfo,
-        StructPointerDecoder<Decoded_VkMemoryRequirements2KHR>* pMemoryRequirements) = 0;
+        StructPointerDecoder<Decoded_VkMemoryRequirements2KHR>* pMemoryRequirements) {}
 
     virtual void Process_vkBindAccelerationStructureMemoryNV(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindAccelerationStructureMemoryInfoNV>& pBindInfos) = 0;
+        const StructPointerDecoder<Decoded_VkBindAccelerationStructureMemoryInfoNV>& pBindInfos) {}
 
     virtual void Process_vkCmdBuildAccelerationStructureNV(
         format::HandleId                            commandBuffer,
@@ -1991,13 +1991,13 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            dst,
         format::HandleId                            src,
         format::HandleId                            scratch,
-        VkDeviceSize                                scratchOffset) = 0;
+        VkDeviceSize                                scratchOffset) {}
 
     virtual void Process_vkCmdCopyAccelerationStructureNV(
         format::HandleId                            commandBuffer,
         format::HandleId                            dst,
         format::HandleId                            src,
-        VkCopyAccelerationStructureModeNV           mode) = 0;
+        VkCopyAccelerationStructureModeNV           mode) {}
 
     virtual void Process_vkCmdTraceRaysNV(
         format::HandleId                            commandBuffer,
@@ -2014,7 +2014,7 @@ class VulkanConsumer : public VulkanConsumerBase
         VkDeviceSize                                callableShaderBindingStride,
         uint32_t                                    width,
         uint32_t                                    height,
-        uint32_t                                    depth) = 0;
+        uint32_t                                    depth) {}
 
     virtual void Process_vkCreateRayTracingPipelinesNV(
         VkResult                                    returnValue,
@@ -2023,7 +2023,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    createInfoCount,
         const StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoNV>& pCreateInfos,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkPipeline>*           pPipelines) = 0;
+        HandlePointerDecoder<VkPipeline>*           pPipelines) {}
 
     virtual void Process_vkGetRayTracingShaderGroupHandlesNV(
         VkResult                                    returnValue,
@@ -2032,14 +2032,14 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    firstGroup,
         uint32_t                                    groupCount,
         size_t                                      dataSize,
-        PointerDecoder<uint8_t>*                    pData) = 0;
+        PointerDecoder<uint8_t>*                    pData) {}
 
     virtual void Process_vkGetAccelerationStructureHandleNV(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            accelerationStructure,
         size_t                                      dataSize,
-        PointerDecoder<uint8_t>*                    pData) = 0;
+        PointerDecoder<uint8_t>*                    pData) {}
 
     virtual void Process_vkCmdWriteAccelerationStructuresPropertiesNV(
         format::HandleId                            commandBuffer,
@@ -2047,33 +2047,33 @@ class VulkanConsumer : public VulkanConsumerBase
         const HandlePointerDecoder<VkAccelerationStructureNV>& pAccelerationStructures,
         VkQueryType                                 queryType,
         format::HandleId                            queryPool,
-        uint32_t                                    firstQuery) = 0;
+        uint32_t                                    firstQuery) {}
 
     virtual void Process_vkCompileDeferredNV(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
-        uint32_t                                    shader) = 0;
+        uint32_t                                    shader) {}
 
     virtual void Process_vkGetMemoryHostPointerPropertiesEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkExternalMemoryHandleTypeFlagBits          handleType,
         uint64_t                                    pHostPointer,
-        StructPointerDecoder<Decoded_VkMemoryHostPointerPropertiesEXT>* pMemoryHostPointerProperties) = 0;
+        StructPointerDecoder<Decoded_VkMemoryHostPointerPropertiesEXT>* pMemoryHostPointerProperties) {}
 
     virtual void Process_vkCmdWriteBufferMarkerAMD(
         format::HandleId                            commandBuffer,
         VkPipelineStageFlagBits                     pipelineStage,
         format::HandleId                            dstBuffer,
         VkDeviceSize                                dstOffset,
-        uint32_t                                    marker) = 0;
+        uint32_t                                    marker) {}
 
     virtual void Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pTimeDomainCount,
-        PointerDecoder<VkTimeDomainEXT>*            pTimeDomains) = 0;
+        PointerDecoder<VkTimeDomainEXT>*            pTimeDomains) {}
 
     virtual void Process_vkGetCalibratedTimestampsEXT(
         VkResult                                    returnValue,
@@ -2081,19 +2081,19 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    timestampCount,
         const StructPointerDecoder<Decoded_VkCalibratedTimestampInfoEXT>& pTimestampInfos,
         PointerDecoder<uint64_t>*                   pTimestamps,
-        PointerDecoder<uint64_t>*                   pMaxDeviation) = 0;
+        PointerDecoder<uint64_t>*                   pMaxDeviation) {}
 
     virtual void Process_vkCmdDrawMeshTasksNV(
         format::HandleId                            commandBuffer,
         uint32_t                                    taskCount,
-        uint32_t                                    firstTask) = 0;
+        uint32_t                                    firstTask) {}
 
     virtual void Process_vkCmdDrawMeshTasksIndirectNV(
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
         uint32_t                                    drawCount,
-        uint32_t                                    stride) = 0;
+        uint32_t                                    stride) {}
 
     virtual void Process_vkCmdDrawMeshTasksIndirectCountNV(
         format::HandleId                            commandBuffer,
@@ -2102,144 +2102,144 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            countBuffer,
         VkDeviceSize                                countBufferOffset,
         uint32_t                                    maxDrawCount,
-        uint32_t                                    stride) = 0;
+        uint32_t                                    stride) {}
 
     virtual void Process_vkCmdSetExclusiveScissorNV(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstExclusiveScissor,
         uint32_t                                    exclusiveScissorCount,
-        const StructPointerDecoder<Decoded_VkRect2D>& pExclusiveScissors) = 0;
+        const StructPointerDecoder<Decoded_VkRect2D>& pExclusiveScissors) {}
 
     virtual void Process_vkCmdSetCheckpointNV(
         format::HandleId                            commandBuffer,
-        uint64_t                                    pCheckpointMarker) = 0;
+        uint64_t                                    pCheckpointMarker) {}
 
     virtual void Process_vkGetQueueCheckpointDataNV(
         format::HandleId                            queue,
         PointerDecoder<uint32_t>*                   pCheckpointDataCount,
-        StructPointerDecoder<Decoded_VkCheckpointDataNV>* pCheckpointData) = 0;
+        StructPointerDecoder<Decoded_VkCheckpointDataNV>* pCheckpointData) {}
 
     virtual void Process_vkInitializePerformanceApiINTEL(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkInitializePerformanceApiInfoINTEL>& pInitializeInfo) = 0;
+        const StructPointerDecoder<Decoded_VkInitializePerformanceApiInfoINTEL>& pInitializeInfo) {}
 
     virtual void Process_vkUninitializePerformanceApiINTEL(
-        format::HandleId                            device) = 0;
+        format::HandleId                            device) {}
 
     virtual void Process_vkCmdSetPerformanceMarkerINTEL(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkPerformanceMarkerInfoINTEL>& pMarkerInfo) = 0;
+        const StructPointerDecoder<Decoded_VkPerformanceMarkerInfoINTEL>& pMarkerInfo) {}
 
     virtual void Process_vkCmdSetPerformanceStreamMarkerINTEL(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkPerformanceStreamMarkerInfoINTEL>& pMarkerInfo) = 0;
+        const StructPointerDecoder<Decoded_VkPerformanceStreamMarkerInfoINTEL>& pMarkerInfo) {}
 
     virtual void Process_vkCmdSetPerformanceOverrideINTEL(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkPerformanceOverrideInfoINTEL>& pOverrideInfo) = 0;
+        const StructPointerDecoder<Decoded_VkPerformanceOverrideInfoINTEL>& pOverrideInfo) {}
 
     virtual void Process_vkAcquirePerformanceConfigurationINTEL(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkPerformanceConfigurationAcquireInfoINTEL>& pAcquireInfo,
-        HandlePointerDecoder<VkPerformanceConfigurationINTEL>* pConfiguration) = 0;
+        HandlePointerDecoder<VkPerformanceConfigurationINTEL>* pConfiguration) {}
 
     virtual void Process_vkReleasePerformanceConfigurationINTEL(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        format::HandleId                            configuration) = 0;
+        format::HandleId                            configuration) {}
 
     virtual void Process_vkQueueSetPerformanceConfigurationINTEL(
         VkResult                                    returnValue,
         format::HandleId                            queue,
-        format::HandleId                            configuration) = 0;
+        format::HandleId                            configuration) {}
 
     virtual void Process_vkGetPerformanceParameterINTEL(
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkPerformanceParameterTypeINTEL             parameter,
-        StructPointerDecoder<Decoded_VkPerformanceValueINTEL>* pValue) = 0;
+        StructPointerDecoder<Decoded_VkPerformanceValueINTEL>* pValue) {}
 
     virtual void Process_vkSetLocalDimmingAMD(
         format::HandleId                            device,
         format::HandleId                            swapChain,
-        VkBool32                                    localDimmingEnable) = 0;
+        VkBool32                                    localDimmingEnable) {}
 
     virtual void Process_vkCreateImagePipeSurfaceFUCHSIA(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         const StructPointerDecoder<Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) = 0;
+        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCreateMetalSurfaceEXT(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         const StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) = 0;
+        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetBufferDeviceAddressEXT(
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkBufferDeviceAddressInfoEXT>& pInfo) = 0;
+        const StructPointerDecoder<Decoded_VkBufferDeviceAddressInfoEXT>& pInfo) {}
 
     virtual void Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
-        StructPointerDecoder<Decoded_VkCooperativeMatrixPropertiesNV>* pProperties) = 0;
+        StructPointerDecoder<Decoded_VkCooperativeMatrixPropertiesNV>* pProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pCombinationCount,
-        StructPointerDecoder<Decoded_VkFramebufferMixedSamplesCombinationNV>* pCombinations) = 0;
+        StructPointerDecoder<Decoded_VkFramebufferMixedSamplesCombinationNV>* pCombinations) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
         PointerDecoder<uint32_t>*                   pPresentModeCount,
-        PointerDecoder<VkPresentModeKHR>*           pPresentModes) = 0;
+        PointerDecoder<VkPresentModeKHR>*           pPresentModes) {}
 
     virtual void Process_vkAcquireFullScreenExclusiveModeEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        format::HandleId                            swapchain) = 0;
+        format::HandleId                            swapchain) {}
 
     virtual void Process_vkReleaseFullScreenExclusiveModeEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        format::HandleId                            swapchain) = 0;
+        format::HandleId                            swapchain) {}
 
     virtual void Process_vkGetDeviceGroupSurfacePresentModes2EXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
         const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
-        PointerDecoder<VkDeviceGroupPresentModeFlagsKHR>* pModes) = 0;
+        PointerDecoder<VkDeviceGroupPresentModeFlagsKHR>* pModes) {}
 
     virtual void Process_vkCreateHeadlessSurfaceEXT(
         VkResult                                    returnValue,
         format::HandleId                            instance,
         const StructPointerDecoder<Decoded_VkHeadlessSurfaceCreateInfoEXT>& pCreateInfo,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
-        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) = 0;
+        HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCmdSetLineStippleEXT(
         format::HandleId                            commandBuffer,
         uint32_t                                    lineStippleFactor,
-        uint16_t                                    lineStipplePattern) = 0;
+        uint16_t                                    lineStipplePattern) {}
 
     virtual void Process_vkResetQueryPoolEXT(
         format::HandleId                            device,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery,
-        uint32_t                                    queryCount) = 0;
+        uint32_t                                    queryCount) {}
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/vulkan_generators/vulkan_consumer_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_consumer_header_generator.py
@@ -110,7 +110,7 @@ class VulkanConsumerHeaderGenerator(BaseGenerator):
             if self.genOpts.isOverride:
                 cmddef += self.indent('virtual ' + decl + ' override;', self.INDENT_SIZE)
             else:
-                cmddef += self.indent('virtual ' + decl + ' = 0;', self.INDENT_SIZE)
+                cmddef += self.indent('virtual ' + decl + ' {}', self.INDENT_SIZE)
 
             write(cmddef, file=self.outFile)
             first = False

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_subdirectory(replay)
 add_subdirectory(toascii)
 add_subdirectory(compress)
+add_subdirectory(info)
+

--- a/tools/info/CMakeLists.txt
+++ b/tools/info/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_executable(gfxrecon-info "")
+
+target_sources(gfxrecon-info
+               PRIVATE
+                   main.cpp
+              )
+
+target_include_directories(gfxrecon-info PUBLIC ${CMAKE_BINARY_DIR})
+
+target_link_libraries(gfxrecon-info gfxrecon_decode gfxrecon_format gfxrecon_util platform_specific)
+
+common_build_directives(gfxrecon-info)

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -1,0 +1,515 @@
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include "project_version.h"
+
+#include "decode/file_processor.h"
+#include "format/format.h"
+#include "generated/generated_vulkan_consumer.h"
+#include "generated/generated_vulkan_decoder.h"
+#include "util/argument_parser.h"
+#include "util/logging.h"
+
+#include "vulkan/vulkan.h"
+
+#include <limits>
+#include <set>
+#include <string>
+#include <unordered_map>
+
+const char kVersionOption[] = "--version";
+
+static bool PrintVersion(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
+{
+    if (arg_parser.IsOptionSet(kVersionOption))
+    {
+        std::string app_name     = exe_name;
+        size_t      dir_location = app_name.find_last_of("/\\");
+
+        if (dir_location >= 0)
+        {
+            app_name.replace(0, dir_location + 1, "");
+        }
+
+        GFXRECON_WRITE_CONSOLE("%s version info:", app_name.c_str());
+        GFXRECON_WRITE_CONSOLE("  GFXReconstruct Version %s", GFXRECON_PROJECT_VERSION_STRING);
+        GFXRECON_WRITE_CONSOLE("  Vulkan Header Version 1.1.%u", VK_HEADER_VERSION);
+
+        return true;
+    }
+
+    return false;
+}
+
+static void PrintUsage(const char* exe_name)
+{
+    std::string app_name     = exe_name;
+    size_t      dir_location = app_name.find_last_of("/\\");
+    if (dir_location >= 0)
+    {
+        app_name.replace(0, dir_location + 1, "");
+    }
+    GFXRECON_WRITE_CONSOLE("\n%s - Print statistics for a GFXReconstruct capture file.\n", app_name.c_str());
+    GFXRECON_WRITE_CONSOLE("Usage:");
+    GFXRECON_WRITE_CONSOLE("  %s [--version] <file>\n", app_name.c_str());
+    GFXRECON_WRITE_CONSOLE("Required arguments:");
+    GFXRECON_WRITE_CONSOLE("  <file>\t\tThe GFXReconstruct capture file to be processed.");
+    GFXRECON_WRITE_CONSOLE("\nOptional arguments:");
+    GFXRECON_WRITE_CONSOLE("  --version\t\tPrint version information and exit.");
+}
+
+static std::string GetVersionString(uint32_t api_version)
+{
+    uint32_t major = api_version >> 22;
+    uint32_t minor = (api_version >> 12) & 0x3ff;
+    uint32_t patch = api_version & 0xfff;
+
+    return std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch);
+}
+
+class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
+{
+  public:
+    uint32_t           GetTrimmedStartFrame() const { return trimmed_frame_; }
+    const std::string& GetAppName() const { return app_name_; }
+    uint32_t           GetAppVersion() const { return app_version_; }
+    const std::string& GetEngineName() const { return engine_name_; }
+    uint32_t           GetEngineVersion() const { return engine_version_; }
+    uint32_t           GetApiVersion() const { return api_version_; }
+    uint64_t           GetGraphicsPipelineCount() const { return graphics_pipelines_; }
+    uint64_t           GetComputePipelineCount() const { return compute_pipelines_; }
+    uint64_t           GetDrawCount() const { return draw_count_; }
+    uint64_t           GetDispatchCount() const { return dispatch_count_; }
+    uint64_t           GetAllocationCount() const { return allocation_count_; }
+    uint64_t           GetMinAllocationSize() const { return min_allocation_size_; }
+    uint64_t           GetMaxAllocationSize() const { return max_allocation_size_; }
+
+    const std::set<gfxrecon::format::HandleId>& GetInstantiatedDevices() const { return used_physical_devices_; }
+    const VkPhysicalDeviceProperties*           GetDeviceProperties(gfxrecon::format::HandleId id) const
+    {
+        auto entry = physical_device_properties_.find(id);
+        if (entry != physical_device_properties_.end())
+        {
+            return &entry->second;
+        }
+
+        return nullptr;
+    }
+
+    virtual void ProcessStateBeginMarker(uint64_t frame_number) override
+    {
+        // Theres should only be one of these in a capture file.
+        trimmed_frame_ = static_cast<uint32_t>(frame_number);
+    }
+
+    virtual void Process_vkCreateInstance(
+        VkResult                                                                                      returnValue,
+        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkInstanceCreateInfo>& pCreateInfo,
+        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>&,
+        gfxrecon::decode::HandlePointerDecoder<VkInstance>*) override
+    {
+        if ((returnValue >= 0) && !pCreateInfo.IsNull())
+        {
+            auto create_info = pCreateInfo.GetPointer();
+            auto app_info    = create_info->pApplicationInfo;
+            if (app_info != nullptr)
+            {
+                app_name_       = app_info->pApplicationName;
+                app_version_    = app_info->applicationVersion;
+                engine_name_    = app_info->pEngineName;
+                engine_version_ = app_info->engineVersion;
+                api_version_    = app_info->apiVersion;
+            }
+        }
+    }
+
+    virtual void Process_vkGetPhysicalDeviceProperties(
+        gfxrecon::format::HandleId                                                                    physicalDevice,
+        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkPhysicalDeviceProperties>* pProperties)
+        override
+    {
+        if ((pProperties != nullptr) && !pProperties->IsNull())
+        {
+            physical_device_properties_[physicalDevice] = *pProperties->GetPointer();
+        }
+    }
+
+    virtual void Process_vkGetPhysicalDeviceProperties2(
+        gfxrecon::format::HandleId                                                                     physicalDevice,
+        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkPhysicalDeviceProperties2>* pProperties)
+        override
+    {
+        if ((pProperties != nullptr) && !pProperties->IsNull())
+        {
+            auto properties2                            = pProperties->GetPointer();
+            physical_device_properties_[physicalDevice] = properties2->properties;
+        }
+    }
+
+    virtual void Process_vkGetPhysicalDeviceProperties2KHR(
+        gfxrecon::format::HandleId                                                                     physicalDevice,
+        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkPhysicalDeviceProperties2>* pProperties)
+        override
+    {
+        if ((pProperties != nullptr) && !pProperties->IsNull())
+        {
+            auto properties2                            = pProperties->GetPointer();
+            physical_device_properties_[physicalDevice] = properties2->properties;
+        }
+    }
+
+    virtual void Process_vkCreateDevice(
+        VkResult                   returnValue,
+        gfxrecon::format::HandleId physicalDevice,
+        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkDeviceCreateInfo>&,
+        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>&,
+        gfxrecon::decode::HandlePointerDecoder<VkDevice>*) override
+    {
+        if (returnValue >= 0)
+        {
+            used_physical_devices_.insert(physicalDevice);
+        }
+    }
+
+    virtual void Process_vkCreateGraphicsPipelines(
+        VkResult returnValue,
+        gfxrecon::format::HandleId,
+        gfxrecon::format::HandleId,
+        uint32_t createInfoCount,
+        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkGraphicsPipelineCreateInfo>&,
+        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>&,
+        gfxrecon::decode::HandlePointerDecoder<VkPipeline>*) override
+    {
+        if (returnValue >= 0)
+        {
+            graphics_pipelines_ += createInfoCount;
+        }
+    }
+
+    virtual void Process_vkCreateComputePipelines(
+        VkResult returnValue,
+        gfxrecon::format::HandleId,
+        gfxrecon::format::HandleId,
+        uint32_t createInfoCount,
+        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkComputePipelineCreateInfo>&,
+        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>&,
+        gfxrecon::decode::HandlePointerDecoder<VkPipeline>*) override
+    {
+        if (returnValue >= 0)
+        {
+            compute_pipelines_ += createInfoCount;
+        }
+    }
+
+    virtual void Process_vkCmdDraw(gfxrecon::format::HandleId, uint32_t, uint32_t, uint32_t, uint32_t) override
+    {
+        ++draw_count_;
+    }
+
+    virtual void
+        Process_vkCmdDrawIndexed(gfxrecon::format::HandleId, uint32_t, uint32_t, uint32_t, int32_t, uint32_t) override
+    {
+        ++draw_count_;
+    }
+
+    virtual void Process_vkCmdDrawIndirect(
+        gfxrecon::format::HandleId, gfxrecon::format::HandleId, VkDeviceSize, uint32_t, uint32_t) override
+    {
+        ++draw_count_;
+    }
+
+    virtual void Process_vkCmdDrawIndexedIndirect(
+        gfxrecon::format::HandleId, gfxrecon::format::HandleId, VkDeviceSize, uint32_t, uint32_t) override
+    {
+        ++draw_count_;
+    }
+
+    virtual void Process_vkCmdDrawIndirectCountKHR(gfxrecon::format::HandleId,
+                                                   gfxrecon::format::HandleId,
+                                                   VkDeviceSize,
+                                                   gfxrecon::format::HandleId,
+                                                   VkDeviceSize,
+                                                   uint32_t,
+                                                   uint32_t) override
+    {
+        ++draw_count_;
+    }
+
+    virtual void Process_vkCmdDrawIndexedIndirectCountKHR(gfxrecon::format::HandleId,
+                                                          gfxrecon::format::HandleId,
+                                                          VkDeviceSize,
+                                                          gfxrecon::format::HandleId,
+                                                          VkDeviceSize,
+                                                          uint32_t,
+                                                          uint32_t) override
+    {
+        ++draw_count_;
+    }
+
+    virtual void Process_vkCmdDrawIndirectByteCountEXT(gfxrecon::format::HandleId,
+                                                       uint32_t,
+                                                       uint32_t,
+                                                       gfxrecon::format::HandleId,
+                                                       VkDeviceSize,
+                                                       uint32_t,
+                                                       uint32_t) override
+    {
+        ++draw_count_;
+    }
+
+    virtual void Process_vkCmdDrawIndirectCountAMD(gfxrecon::format::HandleId,
+                                                   gfxrecon::format::HandleId,
+                                                   VkDeviceSize,
+                                                   gfxrecon::format::HandleId,
+                                                   VkDeviceSize,
+                                                   uint32_t,
+                                                   uint32_t) override
+    {
+        ++draw_count_;
+    }
+
+    virtual void Process_vkCmdDrawIndexedIndirectCountAMD(gfxrecon::format::HandleId,
+                                                          gfxrecon::format::HandleId,
+                                                          VkDeviceSize,
+                                                          gfxrecon::format::HandleId,
+                                                          VkDeviceSize,
+                                                          uint32_t,
+                                                          uint32_t) override
+    {
+        ++draw_count_;
+    }
+
+    virtual void Process_vkCmdDrawMeshTasksNV(gfxrecon::format::HandleId, uint32_t, uint32_t) override
+    {
+        ++draw_count_;
+    }
+
+    virtual void Process_vkCmdDrawMeshTasksIndirectNV(
+        gfxrecon::format::HandleId, gfxrecon::format::HandleId, VkDeviceSize, uint32_t, uint32_t) override
+    {
+        ++draw_count_;
+    }
+
+    virtual void Process_vkCmdDrawMeshTasksIndirectCountNV(gfxrecon::format::HandleId,
+                                                           gfxrecon::format::HandleId,
+                                                           VkDeviceSize,
+                                                           gfxrecon::format::HandleId,
+                                                           VkDeviceSize,
+                                                           uint32_t,
+                                                           uint32_t) override
+    {
+        ++draw_count_;
+    }
+
+    virtual void Process_vkCmdDispatch(gfxrecon::format::HandleId, uint32_t, uint32_t, uint32_t) override
+    {
+        ++dispatch_count_;
+    }
+
+    virtual void
+        Process_vkCmdDispatchIndirect(gfxrecon::format::HandleId, gfxrecon::format::HandleId, VkDeviceSize) override
+    {
+        ++dispatch_count_;
+    }
+
+    virtual void Process_vkCmdDispatchBase(
+        gfxrecon::format::HandleId, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t) override
+    {
+        ++dispatch_count_;
+    }
+
+    virtual void Process_vkCmdDispatchBaseKHR(
+        gfxrecon::format::HandleId, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t) override
+    {
+        ++dispatch_count_;
+    }
+
+    virtual void Process_vkAllocateMemory(
+        VkResult returnValue,
+        gfxrecon::format::HandleId,
+        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkMemoryAllocateInfo>& pAllocateInfo,
+        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>&,
+        gfxrecon::decode::HandlePointerDecoder<VkDeviceMemory>*) override
+    {
+        if (returnValue >= 0)
+        {
+            ++allocation_count_;
+
+            if (!pAllocateInfo.IsNull())
+            {
+                auto allocate_info = pAllocateInfo.GetPointer();
+
+                if (allocate_info->allocationSize < min_allocation_size_)
+                {
+                    min_allocation_size_ = allocate_info->allocationSize;
+                }
+
+                if (allocate_info->allocationSize > max_allocation_size_)
+                {
+                    max_allocation_size_ = allocate_info->allocationSize;
+                }
+            }
+        }
+    }
+
+  private:
+    uint32_t trimmed_frame_{ 0 };
+
+    // Application info.
+    std::string app_name_;
+    uint32_t    app_version_{ 0 };
+    std::string engine_name_;
+    uint32_t    engine_version_{ 0 };
+    uint32_t    api_version_{ 0 };
+
+    // Physical device info.
+    std::set<gfxrecon::format::HandleId>                                       used_physical_devices_;
+    std::unordered_map<gfxrecon::format::HandleId, VkPhysicalDeviceProperties> physical_device_properties_;
+
+    // Total pipeline counts by type.
+    uint64_t graphics_pipelines_{ 0 };
+    uint64_t compute_pipelines_{ 0 };
+
+    // Total draw/dispatch counts.
+    uint64_t draw_count_{ 0 };
+    uint64_t dispatch_count_{ 0 };
+
+    // Memory allocation info.
+    uint64_t allocation_count_{ 0 };
+    uint64_t min_allocation_size_{ std::numeric_limits<uint64_t>::max() };
+    uint64_t max_allocation_size_{ 0 };
+};
+
+int main(int argc, const char** argv)
+{
+    std::string                    input_filename;
+    gfxrecon::util::ArgumentParser arg_parser(argc, argv, kVersionOption, "");
+
+    gfxrecon::util::Log::Init();
+
+    if (PrintVersion(argv[0], arg_parser))
+    {
+        exit(0);
+    }
+    else if (arg_parser.IsInvalid() || (arg_parser.GetPositionalArgumentsCount() != 1))
+    {
+        PrintUsage(argv[0]);
+        gfxrecon::util::Log::Release();
+        exit(-1);
+    }
+    else
+    {
+        const std::vector<std::string>& positional_arguments = arg_parser.GetPositionalArguments();
+        input_filename                                       = positional_arguments[0];
+    }
+
+    gfxrecon::decode::FileProcessor file_processor;
+    if (file_processor.Initialize(input_filename))
+    {
+        gfxrecon::decode::VulkanDecoder decoder;
+        VulkanStatsConsumer             stats_consumer;
+
+        decoder.AddConsumer(&stats_consumer);
+
+        file_processor.AddDecoder(&decoder);
+        file_processor.ProcessAllFrames();
+
+        if ((file_processor.GetCurrentFrameNumber() > 0) &&
+            (file_processor.GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone))
+        {
+            // Frame counts.
+            uint32_t trim_start_frame = stats_consumer.GetTrimmedStartFrame();
+            uint32_t frame_count      = file_processor.GetCurrentFrameNumber();
+
+            if (trim_start_frame == 0)
+            {
+                // Not a trimmed file.
+                GFXRECON_WRITE_CONSOLE("Total frames: %u", frame_count);
+            }
+            else
+            {
+                // Include the frame range for trimmed files.
+                GFXRECON_WRITE_CONSOLE("Total frames: %u (trimmed frame range %u-%u)",
+                                       frame_count,
+                                       trim_start_frame,
+                                       trim_start_frame + frame_count - 1);
+            }
+
+            // Application info.
+            uint32_t api_version = stats_consumer.GetApiVersion();
+            GFXRECON_WRITE_CONSOLE("\nApplication info:");
+            GFXRECON_WRITE_CONSOLE("\tApplication name: %s", stats_consumer.GetAppName().c_str());
+            GFXRECON_WRITE_CONSOLE("\tApplication version: %u", stats_consumer.GetAppVersion());
+            GFXRECON_WRITE_CONSOLE("\tEngine name: %s", stats_consumer.GetEngineName().c_str());
+            GFXRECON_WRITE_CONSOLE("\tEngine version: %u", stats_consumer.GetEngineVersion());
+            GFXRECON_WRITE_CONSOLE("\tTarget API version: %u (%s)", api_version, GetVersionString(api_version).c_str());
+
+            // Properties for physical devices used to create logical devices.
+            std::vector<const VkPhysicalDeviceProperties*> used_device_properties;
+            auto                                           used_devices = stats_consumer.GetInstantiatedDevices();
+            for (auto entry : used_devices)
+            {
+                auto properties = stats_consumer.GetDeviceProperties(entry);
+                if (properties != nullptr)
+                {
+                    used_device_properties.push_back(properties);
+                }
+            }
+
+            // Don't print anything if no queries were made for VkPhysicalDeviceProperties.
+            if (!used_device_properties.empty())
+            {
+                for (auto entry : used_device_properties)
+                {
+                    GFXRECON_WRITE_CONSOLE("\nPhysical device info:");
+                    GFXRECON_WRITE_CONSOLE("\tDevice name: %s", entry->deviceName);
+                    GFXRECON_WRITE_CONSOLE("\tDevice ID: 0x%x", entry->deviceID);
+                    GFXRECON_WRITE_CONSOLE("\tVendor ID: 0x%x", entry->vendorID);
+                    GFXRECON_WRITE_CONSOLE("\tDriver version: %u (0x%x)", entry->driverVersion, entry->driverVersion);
+                    GFXRECON_WRITE_CONSOLE(
+                        "\tAPI version: %u (%s)", entry->apiVersion, GetVersionString(entry->apiVersion).c_str());
+                }
+            }
+
+            GFXRECON_WRITE_CONSOLE("\nDevice memory allocation info:");
+            GFXRECON_WRITE_CONSOLE("\tTotal allocations: %" PRIu64, stats_consumer.GetAllocationCount());
+            GFXRECON_WRITE_CONSOLE("\tMin allocation size: %" PRIu64, stats_consumer.GetMinAllocationSize());
+            GFXRECON_WRITE_CONSOLE("\tMax allocation size: %" PRIu64, stats_consumer.GetMaxAllocationSize());
+
+            GFXRECON_WRITE_CONSOLE("\nPipeline info:");
+            GFXRECON_WRITE_CONSOLE("\tTotal graphics pipelines: %" PRIu64, stats_consumer.GetGraphicsPipelineCount());
+            GFXRECON_WRITE_CONSOLE("\tTotal compute pipelines: %" PRIu64, stats_consumer.GetComputePipelineCount());
+
+            // TODO: This is the number of recorded draw calls, which will not reflect the number of draw calls executed
+            // when recorded once to a command buffer that is submitted/replayed more than once.
+            // GFXRECON_WRITE_CONSOLE("\nDraw/dispatch call info:");
+            // GFXRECON_WRITE_CONSOLE("\tTotal draw calls: %" PRIu64, stats_consumer.GetDrawCount());
+            // GFXRECON_WRITE_CONSOLE("\tTotal dispatch calls: %" PRIu64, stats_consumer.GetDispatchCount());
+        }
+        else if (file_processor.GetErrorState() != gfxrecon::decode::FileProcessor::kErrorNone)
+        {
+            GFXRECON_WRITE_CONSOLE("A failure has occurred during file processing");
+            exit(-1);
+        }
+        else
+        {
+            GFXRECON_WRITE_CONSOLE("File did not contain any frames");
+        }
+    }
+
+    gfxrecon::util::Log::Release();
+    return 0;
+}


### PR DESCRIPTION
Adds a new command line utility to print statistics for a capture file, including:
- Total frame count
- Application info
- Physical device info
- Total number of memory allocations, with min and max sizes.
- Total number of created pipelines

Fixes #329 