### PR TITLE
Add Trimming Support for vkBindBufferMemory2 and vkBindImageMemory2

### DIFF
--- a/framework/encode/custom_encoder_commands.h
+++ b/framework/encode/custom_encoder_commands.h
@@ -263,12 +263,52 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkBindBufferMemory>
 };
 
 template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkBindBufferMemory2>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkBindBufferMemory2(result, args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkBindBufferMemory2KHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkBindBufferMemory2(result, args...);
+    }
+};
+
+template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkBindImageMemory>
 {
     template <typename... Args>
     static void Dispatch(TraceManager* manager, VkResult result, Args... args)
     {
         manager->PostProcess_vkBindImageMemory(result, args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkBindImageMemory2>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkBindImageMemory2(result, args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkBindImageMemory2KHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkBindImageMemory2(result, args...);
     }
 };
 

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -542,6 +542,23 @@ class TraceManager
         }
     }
 
+    void PostProcess_vkBindBufferMemory2(VkResult                      result,
+                                         VkDevice                      device,
+                                         uint32_t                      bindInfoCount,
+                                         const VkBindBufferMemoryInfo* pBindInfos)
+    {
+        if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS) && (pBindInfos != nullptr))
+        {
+            assert(state_tracker_ != nullptr);
+
+            for (uint32_t i = 0; i < bindInfoCount; ++i)
+            {
+                state_tracker_->TrackBufferMemoryBinding(
+                    device, pBindInfos[i].buffer, pBindInfos[i].memory, pBindInfos[i].memoryOffset);
+            }
+        }
+    }
+
     void PostProcess_vkBindImageMemory(
         VkResult result, VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset)
     {
@@ -549,6 +566,23 @@ class TraceManager
         {
             assert(state_tracker_ != nullptr);
             state_tracker_->TrackImageMemoryBinding(device, image, memory, memoryOffset);
+        }
+    }
+
+    void PostProcess_vkBindImageMemory2(VkResult                     result,
+                                        VkDevice                     device,
+                                        uint32_t                     bindInfoCount,
+                                        const VkBindImageMemoryInfo* pBindInfos)
+    {
+        if (((capture_mode_ & kModeTrack) == kModeTrack) && (result == VK_SUCCESS) && (pBindInfos != nullptr))
+        {
+            assert(state_tracker_ != nullptr);
+
+            for (uint32_t i = 0; i < bindInfoCount; ++i)
+            {
+                state_tracker_->TrackImageMemoryBinding(
+                    device, pBindInfos[i].image, pBindInfos[i].memory, pBindInfos[i].memoryOffset);
+            }
         }
     }
 


### PR DESCRIPTION
Add support to the trimming state tracker for tracking buffer and image memory bindings performed with the following:
- vkBindBufferMemory2
- vkBindBufferMemory2KHR
- vkBindImageMemory2
- vkBindImageMemory2KHR

Does not currently track extensions structures provided to these calls. #273 will be updated to track the current state of trimming support for the BindMemory2 calls.
