### PR TITLE
Shader replace feature

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -461,6 +461,13 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                                  const DescriptorUpdateTemplateInfo*   descriptor_update_template_info,
                                                  const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator);
 
+    VkResult OverrideCreateShaderModule(PFN_vkCreateShaderModule                                      func,
+                                        VkResult                                                      original_result,
+                                        const DeviceInfo*                                             device_info,
+                                        const StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>& pCreateInfo,
+                                        const StructPointerDecoder<Decoded_VkAllocationCallbacks>&    pAllocator,
+                                        HandlePointerDecoder<VkShaderModule>*                         pShaderModule);
+
     VkResult OverrideCreatePipelineCache(PFN_vkCreatePipelineCache                                      func,
                                          VkResult                                                       original_result,
                                          const DeviceInfo*                                              device_info,
@@ -623,6 +630,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     void ProcessSwapchainFullScreenExclusiveInfo(Decoded_VkSwapchainCreateInfoKHR* swapchain_info);
 
     void ProcessImportAndroidHardwareBufferInfo(Decoded_VkMemoryAllocateInfo* allocate_info);
+
+    uint32_t CheckSum(const uint32_t* pCode, size_t pSize);
 
   private:
     struct InstanceDevices

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -21,6 +21,8 @@
 #include "decode/vulkan_resource_allocator.h"
 #include "util/defines.h"
 
+#include <string>
+
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
@@ -32,6 +34,7 @@ struct ReplayOptions
     bool                    omit_pipeline_cache_data{ false };
     int32_t                 override_gpu_index{ -1 };
     CreateResourceAllocator create_resource_allocator{ nullptr };
+    std::string             replace_dir{};
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -32,6 +32,7 @@
     "vkCreateImage": "OverrideCreateImage",
     "vkDestroyImage": "OverrideDestroyImage",
     "vkGetImageSubresourceLayout" : "OverrideGetImageSubresourceLayout",
+    "vkCreateShaderModule": "OverrideCreateShaderModule",
     "vkCreatePipelineCache": "OverrideCreatePipelineCache",
     "vkCreateDescriptorUpdateTemplate": "OverrideCreateDescriptorUpdateTemplate",
     "vkCreateDescriptorUpdateTemplateKHR": "OverrideCreateDescriptorUpdateTemplate",

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -44,9 +44,10 @@ const char kOmitPipelineCacheDataShortOption[] = "--opcd";
 const char kOmitPipelineCacheDataLongOption[]  = "--omit-pipeline-cache-data";
 const char kMemoryPortabilityShortOption[]     = "-m";
 const char kMemoryPortabilityLongOption[]      = "--memory-translation";
+const char kShaderReplaceArgument[]            = "--replace-shaders";
 
 const char kOptions[]   = "--version,--paused,--sfa|--skip-failed-allocations,--opcd|--omit-pipeline-cache-data";
-const char kArguments[] = "--gpu,--pause-frame,-m|--memory-translation";
+const char kArguments[] = "--gpu,--pause-frame,-m|--memory-translation,--replace-shaders";
 
 const char kMemoryTranslationNone[]   = "none";
 const char kMemoryTranslationRemap[]  = "remap";
@@ -147,6 +148,7 @@ static gfxrecon::decode::ReplayOptions GetReplayOptions(const gfxrecon::util::Ar
     }
 
     replay_options.create_resource_allocator = GetCreateResourceAllocatorFunc(arg_parser);
+    replay_options.replace_dir               = arg_parser.GetArgumentValue(kShaderReplaceArgument);
 
     return replay_options;
 }
@@ -187,6 +189,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("Usage:");
     GFXRECON_WRITE_CONSOLE("  %s\t[--version] [--gpu <index>] [--pause-frame <N>]", app_name.c_str());
     GFXRECON_WRITE_CONSOLE("\t\t\t[--paused] [--sfa | --skip-failed-allocations]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--replace-shaders <dir>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--opcd | --omit-pipeline-cache-data]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[-m <mode> | --memory-translation <mode>] <file>\n");
     GFXRECON_WRITE_CONSOLE("Required arguments:");
@@ -204,6 +207,9 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("  --sfa\t\t\tSkip vkAllocateMemory, vkAllocateCommandBuffers, and");
     GFXRECON_WRITE_CONSOLE("       \t\t\tvkAllocateDescriptorSets calls that failed during");
     GFXRECON_WRITE_CONSOLE("       \t\t\tcapture (same as --skip-failed-allocations).");
+    GFXRECON_WRITE_CONSOLE("  --replace-shaders <dir> Replace the shader code in each CreateShaderModule");
+    GFXRECON_WRITE_CONSOLE("       \t\t\twith the contents of the file <dir>/sh<hash> if found, where ");
+    GFXRECON_WRITE_CONSOLE("       \t\t\t<hash> is the xor sum of the original shader code.");
     GFXRECON_WRITE_CONSOLE("  --opcd\t\tOmit pipeline cache data from calls to");
     GFXRECON_WRITE_CONSOLE("        \t\tvkCreatePipelineCache (same as --omit-pipeline-cache-data).");
     GFXRECON_WRITE_CONSOLE("  -m <mode>\t\tEnable memory translation for replay on GPUs with memory");


### PR DESCRIPTION
This creates a command line option --replace-shaders <dir> which replaces the shader code in a CreateShaderModule call with the contents of the file <dir>/sh<hash> if present, where <hash> is the xor sum of the original shader contents.

This feature is designed to work along with a shader extraction feature which creates a baseline shader set for a trace.
