### PR TITLE
Allow linux replay WSI selection at run time

### DIFF
--- a/cmake/FindWAYLAND.cmake
+++ b/cmake/FindWAYLAND.cmake
@@ -1,9 +1,9 @@
 # Helper to try to find installed Wayland libraries and headers
 # This should generate 3 items of use when looking for Wayland in CMake:
-#   WAYLAND_FOUND : indicates that it found XCB libraries and headers
-#               installed on the local system.
-#   WAYLAND_INCLUDE_DIR : The location of xcb/xcb.h
-#   WAYLAND_LIBRARY : The location of the xcb library.
+#   WAYLAND_FOUND : indicates that it found Wayland libraries and headers
+#                   installed on the local system.
+#   WAYLAND_INCLUDE_DIR : The location of wayland-client.h
+#   WAYLAND_LIBRARY : The location of the wayland library.
 
 FIND_PATH(WAYLAND_INCLUDE_DIR
           NAMES wayland-client.h)

--- a/framework/application/CMakeLists.txt
+++ b/framework/application/CMakeLists.txt
@@ -28,8 +28,6 @@ target_link_libraries(gfxrecon_application
                       gfxrecon_util
                       vulkan_registry
                       platform_specific
-                      $<$<BOOL:${XCB_FOUND}>:${XCB_LIBRARIES}>
-                      $<$<BOOL:${WAYLAND_FOUND}>:${WAYLAND_LIBRARY}>
                      )
 
 common_build_directives(gfxrecon_application)

--- a/framework/application/wayland_application.cpp
+++ b/framework/application/wayland_application.cpp
@@ -106,7 +106,7 @@ bool WaylandApplication::Initialize(decode::FileProcessor* file_processor)
         display_ = wl.display_connect(nullptr);
         if (display_ == nullptr)
         {
-            GFXRECON_LOG_ERROR("Failed to connect to the Wayland display server");
+            GFXRECON_LOG_DEBUG("Failed to connect to a Wayland display server");
             success = false;
         }
     }

--- a/framework/application/wayland_application.h
+++ b/framework/application/wayland_application.h
@@ -20,8 +20,7 @@
 
 #include "application/application.h"
 #include "util/defines.h"
-
-#include <wayland-client.h>
+#include "util/wayland_loader.h"
 
 #include <unordered_map>
 
@@ -36,6 +35,8 @@ class WaylandApplication : public Application
     WaylandApplication(const std::string& name);
 
     virtual ~WaylandApplication() override;
+
+    const util::WaylandLoader::FunctionTable& GetWaylandFunctionTable() const { return wayland_loader_.GetFunctionTable(); }
 
     struct wl_display* GetDisplay() const { return display_; }
 
@@ -114,6 +115,7 @@ class WaylandApplication : public Application
     struct wl_surface*                 current_keyboard_surface_;
     struct wl_surface*                 current_pointer_surface_;
     WaylandWindowMap                   wayland_windows_;
+    util::WaylandLoader                wayland_loader_;
 };
 
 GFXRECON_END_NAMESPACE(application)

--- a/framework/application/xcb_application.cpp
+++ b/framework/application/xcb_application.cpp
@@ -49,7 +49,7 @@ bool XcbApplication::Initialize(decode::FileProcessor* file_processor)
 
     if (xcb.connection_has_error(connection_))
     {
-        GFXRECON_LOG_ERROR("Failed to connect to X server");
+        GFXRECON_LOG_DEBUG("Failed to connect to an X server");
         return false;
     }
 

--- a/framework/application/xcb_application.h
+++ b/framework/application/xcb_application.h
@@ -20,8 +20,7 @@
 
 #include "application/application.h"
 #include "util/defines.h"
-
-#include <xcb/xcb.h>
+#include "util/xcb_loader.h"
 
 #include <unordered_map>
 
@@ -36,6 +35,8 @@ class XcbApplication : public Application
     XcbApplication(const std::string& name);
 
     virtual ~XcbApplication() override;
+
+    const util::XcbLoader::FunctionTable& GetXcbFunctionTable() const { return xcb_loader_.GetFunctionTable(); }
 
     xcb_connection_t* GetConnection() const { return connection_; }
 
@@ -68,6 +69,7 @@ class XcbApplication : public Application
     uint32_t          last_error_sequence_;
     uint8_t           last_error_code_;
     XcbWindowMap      xcb_windows_;
+    util::XcbLoader   xcb_loader_;
 };
 
 GFXRECON_END_NAMESPACE(application)

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -28,6 +28,10 @@ target_sources(gfxrecon_util
                    platform.h
                    settings_loader.h
                    settings_loader.cpp
+                   $<$<BOOL:${XCB_FOUND}>:xcb_loader.h>
+                   $<$<BOOL:${XCB_FOUND}>:xcb_loader.cpp>
+                   $<$<BOOL:${WAYLAND_FOUND}>:wayland_loader.h>
+                   $<$<BOOL:${WAYLAND_FOUND}>:wayland_loader.cpp>
               )
 
 target_include_directories(gfxrecon_util

--- a/framework/util/wayland_loader.cpp
+++ b/framework/util/wayland_loader.cpp
@@ -90,7 +90,7 @@ bool WaylandLoader::Initialize()
         }
         else
         {
-            GFXRECON_LOG_ERROR("Failed to load libwayland-client.so");
+            GFXRECON_LOG_DEBUG("Failed to load libwayland-client.so");
             success = false;
         }
     }

--- a/framework/util/wayland_loader.cpp
+++ b/framework/util/wayland_loader.cpp
@@ -1,0 +1,102 @@
+/*
+** Copyright (c) 2020 Valve Corporation
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include "util/wayland_loader.h"
+
+#include "util/logging.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+WaylandLoader::WaylandLoader() : libwayland_(nullptr), function_table_{} {}
+
+WaylandLoader::~WaylandLoader()
+{
+    if (libwayland_)
+    {
+        util::platform::CloseLibrary(libwayland_);
+        libwayland_ = nullptr;
+    }
+}
+
+bool WaylandLoader::Initialize()
+{
+    bool success = true;
+
+    // Guard against double initialization
+    if (!libwayland_)
+    {
+        libwayland_ = util::platform::OpenLibrary("libwayland-client.so");
+        if (libwayland_)
+        {
+            // Client functions
+            function_table_.display_connect = reinterpret_cast<decltype(wl_display_connect)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_display_connect"));
+            function_table_.display_disconnect = reinterpret_cast<decltype(wl_display_disconnect)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_display_disconnect"));
+            function_table_.display_dispatch = reinterpret_cast<decltype(wl_display_dispatch)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_display_dispatch"));
+            function_table_.display_dispatch_pending = reinterpret_cast<decltype(wl_display_dispatch_pending)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_display_dispatch_pending"));
+            function_table_.display_flush = reinterpret_cast<decltype(wl_display_flush)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_display_flush"));
+            function_table_.display_roundtrip = reinterpret_cast<decltype(wl_display_roundtrip)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_display_roundtrip"));
+            function_table_.compositor_interface = reinterpret_cast<decltype(wl_compositor_interface)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_compositor_interface"));
+            function_table_.shell_interface = reinterpret_cast<decltype(wl_shell_interface)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_shell_interface"));
+            function_table_.seat_interface = reinterpret_cast<decltype(wl_seat_interface)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_seat_interface"));
+
+            // Proxy functions
+            function_table_.proxy_add_listener = reinterpret_cast<decltype(wl_proxy_add_listener)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_proxy_add_listener"));
+            function_table_.proxy_destroy = reinterpret_cast<decltype(wl_proxy_destroy)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_proxy_destroy"));
+            function_table_.proxy_marshal = reinterpret_cast<decltype(wl_proxy_marshal)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_proxy_marshal"));
+            function_table_.proxy_marshal_constructor = reinterpret_cast<decltype(wl_proxy_marshal_constructor)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_proxy_marshal_constructor"));
+            function_table_.proxy_marshal_constructor_versioned =
+                reinterpret_cast<decltype(wl_proxy_marshal_constructor_versioned)*>(
+                    util::platform::GetProcAddress(libwayland_, "wl_proxy_marshal_constructor_versioned"));
+
+            // Interfaces
+            function_table_.registry_interface = reinterpret_cast<decltype(wl_registry_interface)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_registry_interface"));
+            function_table_.keyboard_interface = reinterpret_cast<decltype(wl_keyboard_interface)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_keyboard_interface"));
+            function_table_.pointer_interface = reinterpret_cast<decltype(wl_pointer_interface)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_pointer_interface"));
+            function_table_.shell_surface_interface = reinterpret_cast<decltype(wl_shell_surface_interface)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_shell_surface_interface"));
+            function_table_.surface_interface = reinterpret_cast<decltype(wl_surface_interface)*>(
+                util::platform::GetProcAddress(libwayland_, "wl_surface_interface"));
+        }
+        else
+        {
+            GFXRECON_LOG_ERROR("Failed to load libwayland-client.so");
+            success = false;
+        }
+    }
+
+    return success;
+}
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/wayland_loader.h
+++ b/framework/util/wayland_loader.h
@@ -1,0 +1,234 @@
+/*
+** Copyright (c) 2020 Valve Corporation
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef GFXRECON_UTIL_WAYLAND_LOADER_H
+#define GFXRECON_UTIL_WAYLAND_LOADER_H
+
+#include "util/defines.h"
+#include "util/platform.h"
+
+#include <wayland-client.h>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+class WaylandLoader
+{
+  public:
+    class FunctionTable
+    {
+      public:
+        // client functions
+        decltype(wl_display_connect)*          display_connect;
+        decltype(wl_display_disconnect)*       display_disconnect;
+        decltype(wl_display_dispatch)*         display_dispatch;
+        decltype(wl_display_dispatch_pending)* display_dispatch_pending;
+        decltype(wl_display_flush)*            display_flush;
+        decltype(wl_display_roundtrip)*        display_roundtrip;
+        decltype(wl_compositor_interface)*     compositor_interface;
+        decltype(wl_shell_interface)*          shell_interface;
+        decltype(wl_seat_interface)*           seat_interface;
+
+        // proxy functions
+        decltype(wl_proxy_add_listener)*                  proxy_add_listener;
+        decltype(wl_proxy_destroy)*                       proxy_destroy;
+        decltype(wl_proxy_marshal)*                       proxy_marshal;
+        decltype(wl_proxy_marshal_constructor)*           proxy_marshal_constructor;
+        decltype(wl_proxy_marshal_constructor_versioned)* proxy_marshal_constructor_versioned;
+
+        // interfaces
+        decltype(wl_registry_interface)*      registry_interface;
+        decltype(wl_keyboard_interface)*      keyboard_interface;
+        decltype(wl_pointer_interface)*       pointer_interface;
+        decltype(wl_shell_surface_interface)* shell_surface_interface;
+        decltype(wl_surface_interface)*       surface_interface;
+
+        // inline functions, adapted from wayland-client-protocol.h
+        struct wl_surface* compositor_create_surface(struct wl_compositor* wl_compositor) const
+        {
+            struct wl_proxy* id;
+
+            id = this->proxy_marshal_constructor(
+                (struct wl_proxy*)wl_compositor, WL_COMPOSITOR_CREATE_SURFACE, this->surface_interface, NULL);
+
+            return (struct wl_surface*)id;
+        }
+
+        void compositor_destroy(struct wl_compositor* wl_compositor) const
+        {
+            this->proxy_destroy((struct wl_proxy*)wl_compositor);
+        }
+
+        struct wl_registry* display_get_registry(struct wl_display* wl_display) const
+        {
+            struct wl_proxy* registry;
+
+            registry = this->proxy_marshal_constructor(
+                (struct wl_proxy*)wl_display, WL_DISPLAY_GET_REGISTRY, this->registry_interface, NULL);
+
+            return (struct wl_registry*)registry;
+        }
+
+        int keyboard_add_listener(struct wl_keyboard*                wl_keyboard,
+                                  const struct wl_keyboard_listener* listener,
+                                  void*                              data) const
+        {
+            return this->proxy_add_listener((struct wl_proxy*)wl_keyboard, (void (**)(void))listener, data);
+        }
+
+        void keyboard_destroy(struct wl_keyboard* wl_keyboard) const
+        {
+            this->proxy_destroy((struct wl_proxy*)wl_keyboard);
+        }
+
+        int pointer_add_listener(struct wl_pointer*                wl_pointer,
+                                 const struct wl_pointer_listener* listener,
+                                 void*                             data) const
+        {
+            return this->proxy_add_listener((struct wl_proxy*)wl_pointer, (void (**)(void))listener, data);
+        }
+
+        void pointer_destroy(struct wl_pointer* wl_pointer) const { this->proxy_destroy((struct wl_proxy*)wl_pointer); }
+
+        int registry_add_listener(struct wl_registry*                wl_registry,
+                                  const struct wl_registry_listener* listener,
+                                  void*                              data) const
+        {
+            return this->proxy_add_listener((struct wl_proxy*)wl_registry, (void (**)(void))listener, data);
+        }
+
+        void* registry_bind(struct wl_registry*        wl_registry,
+                            uint32_t                   name,
+                            const struct wl_interface* interface,
+                            uint32_t                   version) const
+        {
+            struct wl_proxy* id;
+
+            id = this->proxy_marshal_constructor_versioned((struct wl_proxy*)wl_registry,
+                                                           WL_REGISTRY_BIND,
+                                                           interface,
+                                                           version,
+                                                           name,
+                                                           interface->name,
+                                                           version,
+                                                           NULL);
+
+            return (void*)id;
+        }
+
+        void registry_destroy(struct wl_registry* wl_registry) const
+        {
+            this->proxy_destroy((struct wl_proxy*)wl_registry);
+        }
+
+        int seat_add_listener(struct wl_seat* wl_seat, const struct wl_seat_listener* listener, void* data) const
+        {
+            return proxy_add_listener((struct wl_proxy*)wl_seat, (void (**)(void))listener, data);
+        }
+
+        void seat_destroy(struct wl_seat* wl_seat) const { this->proxy_destroy((struct wl_proxy*)wl_seat); }
+
+        struct wl_keyboard* seat_get_keyboard(struct wl_seat* wl_seat) const
+        {
+            struct wl_proxy* id;
+
+            id = this->proxy_marshal_constructor(
+                (struct wl_proxy*)wl_seat, WL_SEAT_GET_KEYBOARD, this->keyboard_interface, NULL);
+
+            return (struct wl_keyboard*)id;
+        }
+
+        struct wl_pointer* seat_get_pointer(struct wl_seat* wl_seat) const
+        {
+            struct wl_proxy* id;
+
+            id = this->proxy_marshal_constructor(
+                (struct wl_proxy*)wl_seat, WL_SEAT_GET_POINTER, this->pointer_interface, NULL);
+
+            return (struct wl_pointer*)id;
+        }
+
+        void shell_destroy(struct wl_shell* wl_shell) const { this->proxy_destroy((struct wl_proxy*)wl_shell); }
+
+        struct wl_shell_surface* shell_get_shell_surface(struct wl_shell* wl_shell, struct wl_surface* surface) const
+        {
+            struct wl_proxy* id;
+
+            id = this->proxy_marshal_constructor(
+                (struct wl_proxy*)wl_shell, WL_SHELL_GET_SHELL_SURFACE, this->shell_surface_interface, NULL, surface);
+
+            return (struct wl_shell_surface*)id;
+        }
+
+        int shell_surface_add_listener(struct wl_shell_surface*                wl_shell_surface,
+                                       const struct wl_shell_surface_listener* listener,
+                                       void*                                   data) const
+        {
+            return this->proxy_add_listener((struct wl_proxy*)wl_shell_surface, (void (**)(void))listener, data);
+        }
+
+        void shell_surface_destroy(struct wl_shell_surface* wl_shell_surface) const
+        {
+            this->proxy_destroy((struct wl_proxy*)wl_shell_surface);
+        }
+
+        void shell_surface_move(struct wl_shell_surface* wl_shell_surface, struct wl_seat* seat, uint32_t serial) const
+        {
+            this->proxy_marshal((struct wl_proxy*)wl_shell_surface, WL_SHELL_SURFACE_MOVE, seat, serial);
+        }
+
+        void shell_surface_pong(struct wl_shell_surface* wl_shell_surface, uint32_t serial) const
+        {
+            this->proxy_marshal((struct wl_proxy*)wl_shell_surface, WL_SHELL_SURFACE_PONG, serial);
+        }
+
+        void shell_surface_set_title(struct wl_shell_surface* wl_shell_surface, const char* title) const
+        {
+            this->proxy_marshal((struct wl_proxy*)wl_shell_surface, WL_SHELL_SURFACE_SET_TITLE, title);
+        }
+
+        void shell_surface_set_toplevel(struct wl_shell_surface* wl_shell_surface) const
+        {
+            this->proxy_marshal((struct wl_proxy*)wl_shell_surface, WL_SHELL_SURFACE_SET_TOPLEVEL);
+        }
+
+        void surface_destroy(struct wl_surface* wl_surface) const
+        {
+            this->proxy_marshal((struct wl_proxy*)wl_surface, WL_SURFACE_DESTROY);
+
+            this->proxy_destroy((struct wl_proxy*)wl_surface);
+        }
+    };
+
+  public:
+    WaylandLoader();
+
+    ~WaylandLoader();
+
+    bool Initialize();
+
+    const FunctionTable& GetFunctionTable() const { return function_table_; }
+
+  private:
+    util::platform::LibraryHandle libwayland_;
+    FunctionTable                 function_table_;
+};
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_UTIL_WAYLAND_LOADER_H

--- a/framework/util/xcb_loader.cpp
+++ b/framework/util/xcb_loader.cpp
@@ -1,0 +1,102 @@
+/*
+** Copyright (c) 2020 Valve Corporation
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include "util/xcb_loader.h"
+
+#include "util/logging.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+XcbLoader::XcbLoader() : libxcb_(nullptr), function_table_{} {}
+
+XcbLoader::~XcbLoader()
+{
+    if (libxcb_)
+    {
+        util::platform::CloseLibrary(libxcb_);
+        libxcb_ = nullptr;
+    }
+}
+
+bool XcbLoader::Initialize()
+{
+    bool success = true;
+
+    // Guard against double initializaiton
+    if (!libxcb_)
+    {
+        libxcb_ = util::platform::OpenLibrary("libxcb.so");
+        if (libxcb_)
+        {
+            function_table_.change_property = reinterpret_cast<decltype(xcb_change_property)*>(
+                util::platform::GetProcAddress(libxcb_, "xcb_change_property"));
+            function_table_.configure_window = reinterpret_cast<decltype(xcb_configure_window)*>(
+                util::platform::GetProcAddress(libxcb_, "xcb_configure_window"));
+            function_table_.connect =
+                reinterpret_cast<decltype(xcb_connect)*>(util::platform::GetProcAddress(libxcb_, "xcb_connect"));
+            function_table_.connection_has_error = reinterpret_cast<decltype(xcb_connection_has_error)*>(
+                util::platform::GetProcAddress(libxcb_, "xcb_connection_has_error"));
+            function_table_.create_window_checked = reinterpret_cast<decltype(xcb_create_window_checked)*>(
+                util::platform::GetProcAddress(libxcb_, "xcb_create_window_checked"));
+            function_table_.destroy_window = reinterpret_cast<decltype(xcb_destroy_window)*>(
+                util::platform::GetProcAddress(libxcb_, "xcb_destroy_window"));
+            function_table_.disconnect =
+                reinterpret_cast<decltype(xcb_disconnect)*>(util::platform::GetProcAddress(libxcb_, "xcb_disconnect"));
+            function_table_.flush =
+                reinterpret_cast<decltype(xcb_flush)*>(util::platform::GetProcAddress(libxcb_, "xcb_flush"));
+            function_table_.generate_id =
+                reinterpret_cast<decltype(xcb_generate_id)*>(util::platform::GetProcAddress(libxcb_, "xcb_generate_id"));
+            function_table_.get_geometry =
+                reinterpret_cast<decltype(xcb_get_geometry)*>(util::platform::GetProcAddress(libxcb_, "xcb_get_geometry"));
+            function_table_.get_geometry_reply = reinterpret_cast<decltype(xcb_get_geometry_reply)*>(
+                util::platform::GetProcAddress(libxcb_, "xcb_get_geometry_reply"));
+            function_table_.get_setup =
+                reinterpret_cast<decltype(xcb_get_setup)*>(util::platform::GetProcAddress(libxcb_, "xcb_get_setup"));
+            function_table_.intern_atom =
+                reinterpret_cast<decltype(xcb_intern_atom)*>(util::platform::GetProcAddress(libxcb_, "xcb_intern_atom"));
+            function_table_.intern_atom_reply = reinterpret_cast<decltype(xcb_intern_atom_reply)*>(
+                util::platform::GetProcAddress(libxcb_, "xcb_intern_atom_reply"));
+            function_table_.map_window =
+                reinterpret_cast<decltype(xcb_map_window)*>(util::platform::GetProcAddress(libxcb_, "xcb_map_window"));
+            function_table_.poll_for_event = reinterpret_cast<decltype(xcb_poll_for_event)*>(
+                util::platform::GetProcAddress(libxcb_, "xcb_poll_for_event"));
+            function_table_.request_check = reinterpret_cast<decltype(xcb_request_check)*>(
+                util::platform::GetProcAddress(libxcb_, "xcb_request_check"));
+            function_table_.screen_next =
+                reinterpret_cast<decltype(xcb_screen_next)*>(util::platform::GetProcAddress(libxcb_, "xcb_screen_next"));
+            function_table_.send_event =
+                reinterpret_cast<decltype(xcb_send_event)*>(util::platform::GetProcAddress(libxcb_, "xcb_send_event"));
+            function_table_.setup_roots_iterator = reinterpret_cast<decltype(xcb_setup_roots_iterator)*>(
+                util::platform::GetProcAddress(libxcb_, "xcb_setup_roots_iterator"));
+            function_table_.unmap_window =
+                reinterpret_cast<decltype(xcb_unmap_window)*>(util::platform::GetProcAddress(libxcb_, "xcb_unmap_window"));
+            function_table_.wait_for_event = reinterpret_cast<decltype(xcb_wait_for_event)*>(
+                util::platform::GetProcAddress(libxcb_, "xcb_wait_for_event"));
+        }
+        else
+        {
+            GFXRECON_LOG_ERROR("Failed to load libxcb.so");
+            success = false;
+        }
+    }
+
+    return success;
+}
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/xcb_loader.cpp
+++ b/framework/util/xcb_loader.cpp
@@ -90,7 +90,7 @@ bool XcbLoader::Initialize()
         }
         else
         {
-            GFXRECON_LOG_ERROR("Failed to load libxcb.so");
+            GFXRECON_LOG_DEBUG("Failed to load libxcb.so");
             success = false;
         }
     }

--- a/framework/util/xcb_loader.h
+++ b/framework/util/xcb_loader.h
@@ -1,0 +1,75 @@
+/*
+** Copyright (c) 2020 Valve Corporation
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef GFXRECON_UTIL_XCB_LOADER_H
+#define GFXRECON_UTIL_XCB_LOADER_H
+
+#include "util/defines.h"
+#include "util/platform.h"
+
+#include <xcb/xcb.h>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+class XcbLoader
+{
+  public:
+    struct FunctionTable
+    {
+        decltype(xcb_change_property)*       change_property;
+        decltype(xcb_configure_window)*      configure_window;
+        decltype(xcb_connect)*               connect;
+        decltype(xcb_connection_has_error)*  connection_has_error;
+        decltype(xcb_create_window_checked)* create_window_checked;
+        decltype(xcb_destroy_window)*        destroy_window;
+        decltype(xcb_disconnect)*            disconnect;
+        decltype(xcb_flush)*                 flush;
+        decltype(xcb_generate_id)*           generate_id;
+        decltype(xcb_get_geometry)*          get_geometry;
+        decltype(xcb_get_geometry_reply)*    get_geometry_reply;
+        decltype(xcb_get_setup)*             get_setup;
+        decltype(xcb_intern_atom)*           intern_atom;
+        decltype(xcb_intern_atom_reply)*     intern_atom_reply;
+        decltype(xcb_map_window)*            map_window;
+        decltype(xcb_poll_for_event)*        poll_for_event;
+        decltype(xcb_request_check)*         request_check;
+        decltype(xcb_screen_next)*           screen_next;
+        decltype(xcb_send_event)*            send_event;
+        decltype(xcb_setup_roots_iterator)*  setup_roots_iterator;
+        decltype(xcb_unmap_window)*          unmap_window;
+        decltype(xcb_wait_for_event)*        wait_for_event;
+    };
+
+  public:
+    XcbLoader();
+
+    ~XcbLoader();
+
+    bool Initialize();
+
+    const FunctionTable& GetFunctionTable() const { return function_table_; }
+
+  private:
+    util::platform::LibraryHandle libxcb_;
+    FunctionTable                 function_table_;
+};
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_UTIL_XCB_LOADER_H

--- a/tools/replay/README.md
+++ b/tools/replay/README.md
@@ -10,7 +10,8 @@ The `gfxrecon-replay` tool for Desktop accepts the following command line argume
 ```
 gfxrecon-replay         [--version] [--gpu <index>] [--pause-frame <N>]
                         [--paused] [--sfa | --skip-failed-allocations]
-                        [--opcd | --omit-pipeline-cache-data]
+                        [--replace-shaders <dir>]
+                        [--opcd | --omit-pipeline-cache-data] [--wsi <platform>]
                         [-m <mode> | --memory-translation <mode>] <file>
 
 Required arguments:
@@ -29,8 +30,13 @@ Optional arguments:
   --sfa                 Skip vkAllocateMemory, vkAllocateCommandBuffers, and
                         vkAllocateDescriptorSets calls that failed during
                         capture (same as --skip-failed-allocations).
+  --replace-shaders <dir> Replace the shader code in each CreateShaderModule
+                        with the contents of the file <dir>/sh<hash> if found, where
+                        <hash> is the xor sum of the original shader code.
   --opcd                Omit pipeline cache data from calls to
                         vkCreatePipelineCache (same as --omit-pipeline-cache-data).
+  --wsi <platform>      Force replay to use the specified wsi platform.
+                        Available platforms are: auto,win32,xcb,wayland
   -m <mode>             Enable memory translation for replay on GPUs with memory
                         types that are not compatible with the capture GPU's
                         memory types.  Available modes are:

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -90,26 +90,41 @@ int main(int argc, const char** argv)
             // Setup platform specific application and window factory.
 #if defined(WIN32)
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-            gfxrecon::application::Win32Application* win32_application =
-                new gfxrecon::application::Win32Application(kApplicationName);
-            application    = std::unique_ptr<gfxrecon::application::Application>(win32_application);
-            window_factory = std::make_unique<gfxrecon::application::Win32WindowFactory>(win32_application);
+            auto win32_application = std::make_unique<gfxrecon::application::Win32Application>(kApplicationName);
+            if (win32_application->Initialize(&file_processor))
+            {
+                window_factory = std::make_unique<gfxrecon::application::Win32WindowFactory>(win32_application.get());
+                application    = std::move(win32_application);
+            }
 #endif
 #else
+#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+            if (!application)
+            {
+                auto wayland_application =
+                    std::make_unique<gfxrecon::application::WaylandApplication>(kApplicationName);
+                if (wayland_application->Initialize(&file_processor))
+                {
+                    window_factory =
+                        std::make_unique<gfxrecon::application::WaylandWindowFactory>(wayland_application.get());
+                    application = std::move(wayland_application);
+                }
+            }
+#endif
 #if defined(VK_USE_PLATFORM_XCB_KHR)
-            gfxrecon::application::XcbApplication* xcb_application =
-                new gfxrecon::application::XcbApplication(kApplicationName);
-            application    = std::unique_ptr<gfxrecon::application::Application>(xcb_application);
-            window_factory = std::make_unique<gfxrecon::application::XcbWindowFactory>(xcb_application);
-#elif defined(VK_USE_PLATFORM_WAYLAND_KHR)
-            gfxrecon::application::WaylandApplication* wayland_application =
-                new gfxrecon::application::WaylandApplication(kApplicationName);
-            application    = std::unique_ptr<gfxrecon::application::Application>(wayland_application);
-            window_factory = std::make_unique<gfxrecon::application::WaylandWindowFactory>(wayland_application);
+            if (!application)
+            {
+                auto xcb_application = std::make_unique<gfxrecon::application::XcbApplication>(kApplicationName);
+                if (xcb_application->Initialize(&file_processor))
+                {
+                    window_factory = std::make_unique<gfxrecon::application::XcbWindowFactory>(xcb_application.get());
+                    application    = std::move(xcb_application);
+                }
+            }
 #endif
 #endif
 
-            if (!window_factory || !application || !application->Initialize(&file_processor))
+            if (!window_factory || !application)
             {
                 GFXRECON_WRITE_CONSOLE(
                     "Failed to initialize platform specific window system management.\nEnsure that the appropriate "


### PR DESCRIPTION
Modify gfxrecon-replay so the Linux windowing system selection is not hard-coded at build:
- dlopen XCB and Wayland instead of linking directly
- Add fallback logic to automatically select a compatible WSI platform at run-time
- Add switch --wsi to override the automatic WSI platform selection