### PR TITLE
Use handle id in filename for shader extract and replace.

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3074,7 +3074,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShaderModule(
     GFXRECON_UNREFERENCED_PARAMETER(original_result);
 
     const VkShaderModuleCreateInfo* original_info = pCreateInfo.GetPointer();
-    if (options_.replace_dir.empty())
+    if (original_result < 0 || options_.replace_dir.empty())
     {
         return func(
             device_info->handle, original_info, GetAllocationCallbacks(pAllocator), pShaderModule->GetHandlePointer());
@@ -3086,8 +3086,8 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShaderModule(
     std::unique_ptr<char[]> file_code;
     const uint32_t*         orig_code = pCreateInfo.GetPointer()->pCode;
     size_t                  orig_size = pCreateInfo.GetPointer()->codeSize;
-    uint32_t                check_sum = util::hash::CheckSum(orig_code, orig_size);
-    std::string             file_name = "sh" + std::to_string(check_sum);
+    uint64_t                handle_id = *pShaderModule->GetPointer();
+    std::string             file_name = "sh" + std::to_string(handle_id);
     std::string             file_path = util::filepath::Join(options_.replace_dir, file_name);
 
     FILE*   fp     = nullptr;

--- a/tools/extract/main.cpp
+++ b/tools/extract/main.cpp
@@ -54,18 +54,18 @@ class VulkanExtractConsumer : public gfxrecon::decode::VulkanConsumer
     VulkanExtractConsumer(std::string& extract_dir) : extract_dir_(extract_dir) {}
 
     virtual void Process_vkCreateShaderModule(
-        VkResult returnValue,
-        gfxrecon::format::HandleId,
+        VkResult                                                                                          returnValue,
+        gfxrecon::format::HandleId                                                                        shaderModule,
         const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkShaderModuleCreateInfo>& pCreateInfo,
         const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>&,
-        gfxrecon::decode::HandlePointerDecoder<VkShaderModule>*)
+        gfxrecon::decode::HandlePointerDecoder<VkShaderModule>* pShaderModule)
     {
         if (returnValue >= 0)
         {
             const uint32_t* orig_code = pCreateInfo.GetPointer()->pCode;
             size_t          orig_size = pCreateInfo.GetPointer()->codeSize;
-            uint32_t        check_sum = gfxrecon::util::hash::CheckSum(orig_code, orig_size);
-            std::string     file_name = "sh" + std::to_string(check_sum);
+            uint64_t        handle_id = *pShaderModule->GetPointer();
+            std::string     file_name = "sh" + std::to_string(handle_id);
             std::string     file_path = gfxrecon::util::filepath::Join(extract_dir_, file_name);
 
             FILE*   fp     = nullptr;


### PR DESCRIPTION
This replaces a hash of the shader contents. It causes some replication
in the extracted shaders but associating shaders with their handle ids has
debugging benefits.

Change-Id: I3e9f43292684451b781c543a7f4fc1a49ce1d11c