### PR TITLE
Fix usage for gfxrecon-extract and gfxrecon --replace shaders.

### DIFF
--- a/tools/extract/main.cpp
+++ b/tools/extract/main.cpp
@@ -42,8 +42,10 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("  %s [--dir <dir>] <file>\n", app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Optional arguments:");
     GFXRECON_WRITE_CONSOLE("  --dir <dir>\tPlace extracted shaders into directory <dir>. Otherwise");
-    GFXRECON_WRITE_CONSOLE("             \tuse <file>.shaders in working directory. Create directory")
-    GFXRECON_WRITE_CONSOLE("             \tif necessary.")
+    GFXRECON_WRITE_CONSOLE("             \tuse <file>.shaders in working directory. Create directory");
+    GFXRECON_WRITE_CONSOLE("             \tif necessary. Each shader is placed in individual file");
+    GFXRECON_WRITE_CONSOLE("             \tnamed sh<handle_id> where handle_id is handle id of the");
+    GFXRECON_WRITE_CONSOLE("             \tCreateShaderModule call. See gfxrecon-replay --replace-shaders.");
     GFXRECON_WRITE_CONSOLE("Required arguments:");
     GFXRECON_WRITE_CONSOLE("  <file>\tThe GFXReconstruct capture file to be processed.");
 }

--- a/tools/replay/README.md
+++ b/tools/replay/README.md
@@ -31,8 +31,9 @@ Optional arguments:
                         vkAllocateDescriptorSets calls that failed during
                         capture (same as --skip-failed-allocations).
   --replace-shaders <dir> Replace the shader code in each CreateShaderModule
-                        with the contents of the file <dir>/sh<hash> if found, where
-                        <hash> is the xor sum of the original shader code.
+                        with the contents of the file <dir>/sh<handle_id> if
+                        found, where <handle_id> is the handle id of the
+                        vkCreateShaderModule call. Also see gfxrecon-extract.
   --opcd                Omit pipeline cache data from calls to
                         vkCreatePipelineCache (same as --omit-pipeline-cache-data).
   --wsi <platform>      Force replay to use the specified wsi platform.

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -284,8 +284,9 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("       \t\t\tvkAllocateDescriptorSets calls that failed during");
     GFXRECON_WRITE_CONSOLE("       \t\t\tcapture (same as --skip-failed-allocations).");
     GFXRECON_WRITE_CONSOLE("  --replace-shaders <dir> Replace the shader code in each CreateShaderModule");
-    GFXRECON_WRITE_CONSOLE("       \t\t\twith the contents of the file <dir>/sh<hash> if found, where");
-    GFXRECON_WRITE_CONSOLE("       \t\t\t<hash> is the xor sum of the original shader code.");
+    GFXRECON_WRITE_CONSOLE("       \t\t\twith the contents of the file <dir>/sh<handle_id> if found, where");
+    GFXRECON_WRITE_CONSOLE("       \t\t\t<handle_id> is the handle id of the CreateShaderModule call.");
+    GFXRECON_WRITE_CONSOLE("       \t\t\tSee gfxrecon-extract.");
     GFXRECON_WRITE_CONSOLE("  --opcd\t\tOmit pipeline cache data from calls to");
     GFXRECON_WRITE_CONSOLE("        \t\tvkCreatePipelineCache (same as --omit-pipeline-cache-data).");
     GFXRECON_WRITE_CONSOLE("  --wsi <platform>\tForce replay to use the specified wsi platform.");


### PR DESCRIPTION
Now that handle_id is used for shader file names.

Change-Id: I63eb712f73cc1067f63879b6e507bcab7b057500