### PR TITLE
dlopen capture trigger on linux

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -174,7 +174,7 @@ The following optional packages are also recommended:
 On Ubuntu, the required packages can be installed with the following
 command:
 ```
-sudo apt-get install git cmake build-essential libx11-xcb-dev libxcb-keysyms1-dev libxkbcommon-dev \
+sudo apt-get install git cmake build-essential libx11-xcb-dev libxcb-keysyms1-dev \
         libwayland-dev libxrandr-dev liblz4-dev libzstd-dev clang-format clang-tidy
 ```
 
@@ -182,7 +182,7 @@ sudo apt-get install git cmake build-essential libx11-xcb-dev libxcb-keysyms1-de
 On Fedora Core, the required packages can be installed with the following
 command:
 ```
-sudo dnf install git cmake libxcb-devel xcb-util-keysyms-devel libxkbcommon-devel \
+sudo dnf install git cmake libxcb-devel libX11-devel xcb-util-keysyms-devel \
         libXrandr-devel wayland-devel lz4-devel libzstd-devel clang clang-tools-extra
 ```
 

--- a/android/framework/util/CMakeLists.txt
+++ b/android/framework/util/CMakeLists.txt
@@ -13,6 +13,8 @@ target_sources(gfxrecon_util
                    ${GFXRECON_SOURCE_DIR}/framework/util/file_path.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/util/hash.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/hash.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/util/keyboard.h
+                   ${GFXRECON_SOURCE_DIR}/framework/util/keyboard.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/util/logging.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/logging.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/util/lz4_compressor.h

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -46,12 +46,6 @@ target_include_directories(gfxrecon_encode
                            PUBLIC
                                ${CMAKE_SOURCE_DIR}/framework)
 
-# include xcb libs for keypress trigegr in Linux
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    find_package(XCB)
-    target_link_libraries(gfxrecon_encode $<$<BOOL:${XCB_FOUND}>:${XCB_LIBRARIES}>)
-endif()
-
 target_link_libraries(gfxrecon_encode gfxrecon_format gfxrecon_util vulkan_registry platform_specific)
 
 common_build_directives(gfxrecon_encode)

--- a/framework/encode/custom_encoder_commands.h
+++ b/framework/encode/custom_encoder_commands.h
@@ -150,6 +150,17 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfa
     }
 };
 
+// Dispatch custom command to set xcb keyboard connection during create xlib surface
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateXlibSurfaceKHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PreProcess_vkCreateXlibSurfaceKHR(args...);
+    }
+};
+
 // Dispatch custom command to set xcb keyboard connection during create xcb surface
 template <>
 struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateXcbSurfaceKHR>

--- a/framework/encode/custom_encoder_commands.h
+++ b/framework/encode/custom_encoder_commands.h
@@ -172,6 +172,17 @@ struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateXcbSurfaceKHR>
     }
 };
 
+// Dispatch custom command to give implementation warning during create wayland surface
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateWaylandSurfaceKHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PreProcess_vkCreateWaylandSurfaceKHR(args...);
+    }
+};
+
 // Dispatch custom command for window resize command generation.
 template <>
 struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateSwapchainKHR>

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -1492,12 +1492,19 @@ void TraceManager::PreProcess_vkCreateXlibSurfaceKHR(VkInstance                 
 
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
     assert(pCreateInfo != nullptr);
-    if (pCreateInfo)
+    if (pCreateInfo && !trim_key_.empty())
     {
-        keyboard_.Initialize(pCreateInfo->dpy);
+        if (!keyboard_.Initialize(pCreateInfo->dpy))
+        {
+            GFXRECON_LOG_ERROR("Failed to initialize Xlib keyboard capture trigger");
+        }
     }
 #else
     GFXRECON_UNREFERENCED_PARAMETER(pCreateInfo);
+    if (!trim_key_.empty())
+    {
+        GFXRECON_LOG_WARNING("Xlib keyboard capture trigger is not enabled on this system");
+    }
 #endif
 }
 
@@ -1512,13 +1519,35 @@ void TraceManager::PreProcess_vkCreateXcbSurfaceKHR(VkInstance                  
 
 #if defined(VK_USE_PLATFORM_XCB_KHR)
     assert(pCreateInfo != nullptr);
-    if (pCreateInfo)
+    if (pCreateInfo && !trim_key_.empty())
     {
-        keyboard_.Initialize(pCreateInfo->connection);
+        if (!keyboard_.Initialize(pCreateInfo->connection))
+        {
+            GFXRECON_LOG_ERROR("Failed to initialize XCB keyboard capture trigger");
+        }
     }
 #else
     GFXRECON_UNREFERENCED_PARAMETER(pCreateInfo);
+    if (!trim_key_.empty())
+    {
+        GFXRECON_LOG_WARNING("Xcb keyboard capture trigger is not enabled on this system");
+    }
 #endif
+}
+
+void TraceManager::PreProcess_vkCreateWaylandSurfaceKHR(VkInstance                           instance,
+                                                        const VkWaylandSurfaceCreateInfoKHR* pCreateInfo,
+                                                        const VkAllocationCallbacks*         pAllocator,
+                                                        VkSurfaceKHR*                        pSurface)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(instance);
+    GFXRECON_UNREFERENCED_PARAMETER(pCreateInfo);
+    GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
+    GFXRECON_UNREFERENCED_PARAMETER(pSurface);
+    if (!trim_key_.empty())
+    {
+        GFXRECON_LOG_WARNING("Wayland keyboard capture trigger is not implemented");
+    }
 }
 
 void TraceManager::PreProcess_vkCreateSwapchain(VkDevice                        device,

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -1481,6 +1481,26 @@ void TraceManager::PostProcess_vkEnumeratePhysicalDevices(VkResult          resu
     }
 }
 
+void TraceManager::PreProcess_vkCreateXlibSurfaceKHR(VkInstance                        instance,
+                                                     const VkXlibSurfaceCreateInfoKHR* pCreateInfo,
+                                                     const VkAllocationCallbacks*      pAllocator,
+                                                     VkSurfaceKHR*                     pSurface)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(instance);
+    GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
+    GFXRECON_UNREFERENCED_PARAMETER(pSurface);
+
+#if defined(VK_USE_PLATFORM_XLIB_KHR)
+    assert(pCreateInfo != nullptr);
+    if (pCreateInfo)
+    {
+        keyboard_.Initialize(pCreateInfo->dpy);
+    }
+#else
+    GFXRECON_UNREFERENCED_PARAMETER(pCreateInfo);
+#endif
+}
+
 void TraceManager::PreProcess_vkCreateXcbSurfaceKHR(VkInstance                       instance,
                                                     const VkXcbSurfaceCreateInfoKHR* pCreateInfo,
                                                     const VkAllocationCallbacks*     pAllocator,

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -410,6 +410,11 @@ class TraceManager
                                           const VkAllocationCallbacks*     pAllocator,
                                           VkSurfaceKHR*                    pSurface);
 
+    void PreProcess_vkCreateWaylandSurfaceKHR(VkInstance                           instance,
+                                              const VkWaylandSurfaceCreateInfoKHR* pCreateInfo,
+                                              const VkAllocationCallbacks*         pAllocator,
+                                              VkSurfaceKHR*                        pSurface);
+
     void PreProcess_vkCreateSwapchain(VkDevice                        device,
                                       const VkSwapchainCreateInfoKHR* pCreateInfo,
                                       const VkAllocationCallbacks*    pAllocator,

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -33,6 +33,7 @@
 #include "util/compressor.h"
 #include "util/defines.h"
 #include "util/file_output_stream.h"
+#include "util/keyboard.h"
 #include "util/memory_output_stream.h"
 
 #include "vulkan/vulkan.h"
@@ -965,7 +966,6 @@ class TraceManager
     static thread_local std::unique_ptr<ThreadData> thread_data_;
     static LayerTable                               layer_table_;
     static std::atomic<format::HandleId>            unique_id_counter_;
-    static bool                                     previous_hotkey_trigger_;
     format::EnabledOptions                          file_options_;
     std::unique_ptr<util::FileOutputStream>         file_stream_;
     std::string                                     base_filename_;
@@ -988,6 +988,8 @@ class TraceManager
     std::unique_ptr<VulkanStateTracker>             state_tracker_;
     CaptureMode                                     capture_mode_;
     HardwareBufferMap                               hardware_buffers_;
+    util::Keyboard                                  keyboard_;
+    bool                                            previous_hotkey_state_;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -400,6 +400,11 @@ class TraceManager
         }
     }
 
+    void PreProcess_vkCreateXlibSurfaceKHR(VkInstance                        instance,
+                                           const VkXlibSurfaceCreateInfoKHR* pCreateInfo,
+                                           const VkAllocationCallbacks*      pAllocator,
+                                           VkSurfaceKHR*                     pSurface);
+
     void PreProcess_vkCreateXcbSurfaceKHR(VkInstance                       instance,
                                           const VkXcbSurfaceCreateInfoKHR* pCreateInfo,
                                           const VkAllocationCallbacks*     pAllocator,

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -13,6 +13,8 @@ target_sources(gfxrecon_util
                    file_path.cpp
                    hash.h
                    hash.cpp
+                   keyboard.h
+                   keyboard.cpp
                    logging.h
                    logging.cpp
                    lz4_compressor.h
@@ -40,7 +42,7 @@ target_include_directories(gfxrecon_util
                            PUBLIC
                                ${CMAKE_SOURCE_DIR}/framework)
 
-target_link_libraries(gfxrecon_util platform_specific ${CMAKE_DL_LIBS})
+target_link_libraries(gfxrecon_util platform_specific ${CMAKE_DL_LIBS} $<$<BOOL:${XCB_FOUND}>:${XCB_LIBRARIES}>)
 
 if (UNIX AND NOT APPLE)
     # Check for clock_gettime in libc

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -34,6 +34,8 @@ target_sources(gfxrecon_util
                    settings_loader.cpp
                    $<$<BOOL:${XCB_FOUND}>:xcb_loader.h>
                    $<$<BOOL:${XCB_FOUND}>:xcb_loader.cpp>
+                   $<$<BOOL:${XCB_FOUND}>:xcb_keysyms_loader.h>
+                   $<$<BOOL:${XCB_FOUND}>:xcb_keysyms_loader.cpp>
                    $<$<BOOL:${WAYLAND_FOUND}>:wayland_loader.h>
                    $<$<BOOL:${WAYLAND_FOUND}>:wayland_loader.cpp>
               )
@@ -42,7 +44,7 @@ target_include_directories(gfxrecon_util
                            PUBLIC
                                ${CMAKE_SOURCE_DIR}/framework)
 
-target_link_libraries(gfxrecon_util platform_specific ${CMAKE_DL_LIBS} $<$<BOOL:${XCB_FOUND}>:${XCB_LIBRARIES}>)
+target_link_libraries(gfxrecon_util platform_specific ${CMAKE_DL_LIBS})
 
 if (UNIX AND NOT APPLE)
     # Check for clock_gettime in libc

--- a/framework/util/keyboard.cpp
+++ b/framework/util/keyboard.cpp
@@ -21,6 +21,9 @@
 
 #if defined(VK_USE_PLATFORM_XCB_KHR)
 #include <X11/keysym.h>
+#if defined(VK_USE_PLATFORM_XLIB_KHR)
+#include <X11/Xlib-xcb.h>
+#endif
 #endif
 
 #include <unordered_map>
@@ -35,6 +38,25 @@ void Keyboard::Initialize(xcb_connection_t* connection)
     {
         xcb_connection_ = connection;
     }
+}
+#endif
+
+#if defined(VK_USE_PLATFORM_XLIB_KHR)
+void Keyboard::Initialize(Display* display)
+{
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+    // TODO: Native Xlib support
+    auto xlib_xcb = util::platform::OpenLibrary("libX11-xcb.so");
+    if (xlib_xcb)
+    {
+        auto x_get_xcb_connection = reinterpret_cast<decltype(XGetXCBConnection)*>(
+            util::platform::GetProcAddress(xlib_xcb, "XGetXCBConnection"));
+        Initialize(x_get_xcb_connection(display));
+        util::platform::CloseLibrary(xlib_xcb);
+    }
+#else
+    GFXRECON_UNREFERENCED_PARAMETER(display);
+#endif
 }
 #endif
 

--- a/framework/util/keyboard.cpp
+++ b/framework/util/keyboard.cpp
@@ -1,0 +1,113 @@
+
+/*
+** Copyright (c) 2020 Valve Corporation
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include "util/keyboard.h"
+#include "util/platform.h"
+
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+#include <X11/keysym.h>
+#endif
+
+#include <unordered_map>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+void Keyboard::Initialize(xcb_connection_t* connection)
+{
+    xcb_connection_ = connection;
+}
+#endif
+
+bool Keyboard::GetKeyState(const std::string& key)
+{
+    bool result = false;
+
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+    static const std::unordered_map<std::string, int> win32_key_code_map = { { "F1", VK_F1 },
+                                                                             { "F2", VK_F2 },
+                                                                             { "F3", VK_F3 },
+                                                                             { "F4", VK_F4 },
+                                                                             { "F5", VK_F5 },
+                                                                             { "F6", VK_F6 },
+                                                                             { "F7", VK_F7 },
+                                                                             { "F8", VK_F8 },
+                                                                             { "F9", VK_F9 },
+                                                                             { "F10", VK_F10 },
+                                                                             { "F11", VK_F11 },
+                                                                             { "F12", VK_F12 },
+                                                                             { "TAB", VK_TAB },
+                                                                             { "ControlLeft", VK_LCONTROL },
+                                                                             { "ControlRight", VK_RCONTROL } };
+
+    auto iterator_key_code = win32_key_code_map.find(key);
+    if (iterator_key_code != win32_key_code_map.end())
+    {
+        result |= (GetAsyncKeyState(iterator_key_code->second) != 0);
+    }
+#endif
+
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+    static const std::unordered_map<std::string, int> xcb_key_code_map = { { "F1", XK_F1 },
+                                                                           { "F2", XK_F2 },
+                                                                           { "F3", XK_F3 },
+                                                                           { "F4", XK_F4 },
+                                                                           { "F5", XK_F5 },
+                                                                           { "F6", XK_F6 },
+                                                                           { "F7", XK_F7 },
+                                                                           { "F8", XK_F8 },
+                                                                           { "F9", XK_F9 },
+                                                                           { "F10", XK_F10 },
+                                                                           { "F11", XK_F11 },
+                                                                           { "F12", XK_F12 },
+                                                                           { "Tab", XK_Tab },
+                                                                           { "ControlLeft", XK_Control_L },
+                                                                           { "ControlRight", XK_Control_R } };
+    if (xcb_connection_)
+    {
+        auto iterator_key_code = xcb_key_code_map.find(key);
+        if (iterator_key_code != xcb_key_code_map.end())
+        {
+            int                key_state      = 0;
+            xcb_key_symbols_t* hot_key_symbol = xcb_key_symbols_alloc(xcb_connection_);
+            if (hot_key_symbol != nullptr)
+            {
+                xcb_keycode_t* xcb_key_code = xcb_key_symbols_get_keycode(hot_key_symbol, iterator_key_code->second);
+                if (xcb_key_code != nullptr)
+                {
+                    xcb_query_keymap_cookie_t cookie       = xcb_query_keymap(xcb_connection_);
+                    xcb_query_keymap_reply_t* keys_bit_map = xcb_query_keymap_reply(xcb_connection_, cookie, NULL);
+                    if ((keys_bit_map->keys[(*xcb_key_code / 8)] & (1 << (*xcb_key_code % 8))) != 0)
+                    {
+                        result = true;
+                    }
+                    free(keys_bit_map);
+                    free(xcb_key_code);
+                }
+                xcb_key_symbols_free(hot_key_symbol);
+            }
+        }
+    }
+#endif
+
+    return result;
+}
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/keyboard.h
+++ b/framework/util/keyboard.h
@@ -24,6 +24,9 @@
 #if defined(VK_USE_PLATFORM_XCB_KHR)
 #include "util/xcb_keysyms_loader.h"
 #endif
+#if defined(VK_USE_PLATFORM_XLIB_KHR)
+#include "X11/Xlib.h"
+#endif
 
 #include <string>
 
@@ -35,6 +38,9 @@ class Keyboard
   public:
 #if defined(VK_USE_PLATFORM_XCB_KHR)
     void Initialize(xcb_connection_t* connection);
+#endif
+#if defined(VK_USE_PLATFORM_XLIB_KHR)
+    void Initialize(Display* display);
 #endif
     bool GetKeyState(const std::string& key);
 

--- a/framework/util/keyboard.h
+++ b/framework/util/keyboard.h
@@ -37,10 +37,10 @@ class Keyboard
 {
   public:
 #if defined(VK_USE_PLATFORM_XCB_KHR)
-    void Initialize(xcb_connection_t* connection);
+    bool Initialize(xcb_connection_t* connection);
 #endif
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
-    void Initialize(Display* display);
+    bool Initialize(Display* display);
 #endif
     bool GetKeyState(const std::string& key);
 

--- a/framework/util/keyboard.h
+++ b/framework/util/keyboard.h
@@ -21,11 +21,11 @@
 
 #include "util/defines.h"
 
-#include <string>
-
 #if defined(VK_USE_PLATFORM_XCB_KHR)
-#include <xcb/xcb_keysyms.h>
+#include "util/xcb_keysyms_loader.h"
 #endif
+
+#include <string>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)
@@ -48,6 +48,7 @@ class Keyboard
   private:
 #if defined(VK_USE_PLATFORM_XCB_KHR)
     xcb_connection_t* xcb_connection_;
+    XcbKeysymsLoader  xcb_keysyms_loader_;
 #endif
 };
 

--- a/framework/util/keyboard.h
+++ b/framework/util/keyboard.h
@@ -1,0 +1,57 @@
+
+/*
+** Copyright (c) 2020 Valve Corporation
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef GFXRECON_UTIL_KEYBOARD_H
+#define GFXRECON_UTIL_KEYBOARD_H
+
+#include "util/defines.h"
+
+#include <string>
+
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+#include <xcb/xcb_keysyms.h>
+#endif
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+class Keyboard
+{
+  public:
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+    void Initialize(xcb_connection_t* connection);
+#endif
+    bool GetKeyState(const std::string& key);
+
+    Keyboard()
+    {
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+        xcb_connection_ = nullptr;
+#endif
+    }
+
+  private:
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+    xcb_connection_t* xcb_connection_;
+#endif
+};
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_UTIL_KEYBOARD_H

--- a/framework/util/xcb_keysyms_loader.cpp
+++ b/framework/util/xcb_keysyms_loader.cpp
@@ -1,0 +1,68 @@
+/*
+** Copyright (c) 2020 Valve Corporation
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include "util/xcb_keysyms_loader.h"
+
+#include "util/logging.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+XcbKeysymsLoader::XcbKeysymsLoader() : libxcbkeysyms_(nullptr), function_table_{} {}
+
+XcbKeysymsLoader::~XcbKeysymsLoader()
+{
+    if (libxcbkeysyms_)
+    {
+        util::platform::CloseLibrary(libxcbkeysyms_);
+        libxcbkeysyms_ = nullptr;
+    }
+}
+
+bool XcbKeysymsLoader::Initialize()
+{
+    bool success = true;
+
+    // Guard against double initializaiton
+    if (!libxcbkeysyms_)
+    {
+        libxcbkeysyms_ = util::platform::OpenLibrary("libxcb-keysyms.so");
+        if (libxcbkeysyms_)
+        {
+            function_table_.key_symbols_alloc = reinterpret_cast<decltype(xcb_key_symbols_alloc)*>(
+                util::platform::GetProcAddress(libxcbkeysyms_, "xcb_key_symbols_alloc"));
+            function_table_.key_symbols_get_keycode = reinterpret_cast<decltype(xcb_key_symbols_get_keycode)*>(
+                util::platform::GetProcAddress(libxcbkeysyms_, "xcb_key_symbols_get_keycode"));
+            function_table_.query_keymap = reinterpret_cast<decltype(xcb_query_keymap)*>(
+                util::platform::GetProcAddress(libxcbkeysyms_, "xcb_query_keymap"));
+            function_table_.query_keymap_reply = reinterpret_cast<decltype(xcb_query_keymap_reply)*>(
+                util::platform::GetProcAddress(libxcbkeysyms_, "xcb_query_keymap_reply"));
+            function_table_.key_symbols_free = reinterpret_cast<decltype(xcb_key_symbols_free)*>(
+                util::platform::GetProcAddress(libxcbkeysyms_, "xcb_key_symbols_free"));
+        }
+        else
+        {
+            GFXRECON_LOG_DEBUG("Failed to load libxcb-keysyms.so");
+            success = false;
+        }
+    }
+
+    return success;
+}
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/xcb_keysyms_loader.h
+++ b/framework/util/xcb_keysyms_loader.h
@@ -1,0 +1,58 @@
+/*
+** Copyright (c) 2020 Valve Corporation
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef GFXRECON_UTIL_XCB_KEYSYMS_LOADER_H
+#define GFXRECON_UTIL_XCB_KEYSYMS_LOADER_H
+
+#include "util/defines.h"
+#include "util/platform.h"
+
+#include <xcb/xcb_keysyms.h>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+class XcbKeysymsLoader
+{
+  public:
+    struct FunctionTable
+    {
+        decltype(xcb_key_symbols_alloc)*       key_symbols_alloc;
+        decltype(xcb_key_symbols_get_keycode)* key_symbols_get_keycode;
+        decltype(xcb_query_keymap)*            query_keymap;
+        decltype(xcb_query_keymap_reply)*      query_keymap_reply;
+        decltype(xcb_key_symbols_free)*        key_symbols_free;
+    };
+
+  public:
+    XcbKeysymsLoader();
+
+    ~XcbKeysymsLoader();
+
+    bool Initialize();
+
+    const FunctionTable& GetFunctionTable() const { return function_table_; }
+
+  private:
+    util::platform::LibraryHandle libxcbkeysyms_;
+    FunctionTable                 function_table_;
+};
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_UTIL_XCB_KEYSYMS_LOADER_H


### PR DESCRIPTION
- Move platform-specific keyboard code out of TraceManager and into separate utility
- dlopen libxcb-keysyms.so instead of linking so capture does not fail on systems without that library
- Add hotkey capture support for Xlib surfaces using XGetXCBConnection and existing XCB implementation
- Better error reporting if a user tries to use hotkey capture and it either isn't supported or encounters an error