### PR TITLE
Adjust Variable Length Array Sizes on Replay

### DIFF
--- a/framework/decode/descriptor_update_template_decoder.h
+++ b/framework/decode/descriptor_update_template_decoder.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -42,13 +42,24 @@ class DescriptorUpdateTemplateDecoder : public PointerDecoderBase
     size_t GetBufferInfoCount() const { return buffer_info_count_; }
     size_t GetTexelBufferViewCount() const { return texel_buffer_view_count_; }
 
-    Decoded_VkDescriptorImageInfo*  GetImageInfoMetaStructPointer() const { return decoded_image_info_.get(); }
-    Decoded_VkDescriptorBufferInfo* GetBufferInfoMetaStructPointer() const { return decoded_buffer_info_.get(); }
-    format::HandleId* GetTexelBufferViewHandleIdsPointer() const { return decoded_texel_buffer_view_handle_ids_.get(); }
+    Decoded_VkDescriptorImageInfo*  GetImageInfoMetaStructPointer() { return decoded_image_info_.get(); }
+    Decoded_VkDescriptorBufferInfo* GetBufferInfoMetaStructPointer() { return decoded_buffer_info_.get(); }
+    format::HandleId* GetTexelBufferViewHandleIdsPointer() { return decoded_texel_buffer_view_handle_ids_.get(); }
 
-    VkDescriptorImageInfo*  GetImageInfoPointer() const { return image_info_; }
-    VkDescriptorBufferInfo* GetBufferInfoPointer() const { return buffer_info_; }
-    VkBufferView*           GetTexelBufferViewPointer() const { return texel_buffer_views_; }
+    const Decoded_VkDescriptorImageInfo*  GetImageInfoMetaStructPointer() const { return decoded_image_info_.get(); }
+    const Decoded_VkDescriptorBufferInfo* GetBufferInfoMetaStructPointer() const { return decoded_buffer_info_.get(); }
+    const format::HandleId*               GetTexelBufferViewHandleIdsPointer() const
+    {
+        return decoded_texel_buffer_view_handle_ids_.get();
+    }
+
+    VkDescriptorImageInfo*  GetImageInfoPointer() { return image_info_; }
+    VkDescriptorBufferInfo* GetBufferInfoPointer() { return buffer_info_; }
+    VkBufferView*           GetTexelBufferViewPointer() { return texel_buffer_views_; }
+
+    const VkDescriptorImageInfo*  GetImageInfoPointer() const { return image_info_; }
+    const VkDescriptorBufferInfo* GetBufferInfoPointer() const { return buffer_info_; }
+    const VkBufferView*           GetTexelBufferViewPointer() const { return texel_buffer_views_; }
 
     size_t Decode(const uint8_t* buffer, size_t buffer_size);
 

--- a/framework/decode/handle_pointer_decoder.h
+++ b/framework/decode/handle_pointer_decoder.h
@@ -32,13 +32,7 @@ class HandlePointerDecoder
   public:
     HandlePointerDecoder() : handle_data_(nullptr), capacity_(0), is_memory_external_(false) {}
 
-    ~HandlePointerDecoder()
-    {
-        if ((handle_data_ != nullptr) && !is_memory_external_)
-        {
-            delete[] handle_data_;
-        }
-    }
+    ~HandlePointerDecoder() {}
 
     bool IsNull() const { return decoder_.IsNull(); }
 
@@ -83,7 +77,7 @@ class HandlePointerDecoder
             assert(handle_data_ == nullptr);
 
             size_t len   = GetLength();
-            handle_data_ = new T[len];
+            handle_data_ = decoder_.AllocateOutputData(len);
         }
 
         return result;
@@ -119,11 +113,11 @@ class HandlePointerDecoder
     }
 
   private:
-    PointerDecoder<format::HandleId> decoder_;
-    T*                               handle_data_;
-    size_t                           capacity_;
-    bool                             is_memory_external_;
-    std::unique_ptr<void* []>        consumer_data_;
+    PointerDecoder<format::HandleId, T> decoder_;
+    T*                                  handle_data_;
+    size_t                              capacity_;
+    bool                                is_memory_external_;
+    std::unique_ptr<void* []>           consumer_data_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/handle_pointer_decoder.h
+++ b/framework/decode/handle_pointer_decoder.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2019 Valve Corporation
-** Copyright (c) 2019 LunarG, Inc.
+** Copyright (c) 2019-2020 Valve Corporation
+** Copyright (c) 2019-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -52,8 +52,6 @@ class HandlePointerDecoder
 
     size_t GetLength() const { return decoder_.GetLength(); }
 
-    format::HandleId* GetPointer() { return decoder_.GetPointer(); }
-
     const format::HandleId* GetPointer() const { return decoder_.GetPointer(); }
 
     void SetExternalMemory(T* data, size_t capacity)
@@ -72,7 +70,9 @@ class HandlePointerDecoder
         }
     }
 
-    T* GetHandlePointer() const { return handle_data_; }
+    T* GetHandlePointer() { return handle_data_; }
+
+    const T* GetHandlePointer() const { return handle_data_; }
 
     size_t Decode(const uint8_t* buffer, size_t buffer_size)
     {

--- a/framework/decode/pnext_node.h
+++ b/framework/decode/pnext_node.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -39,9 +39,11 @@ class PNextNode
 
     virtual void* GetPointer() = 0;
 
-    const virtual void* GetPointer() const = 0;
+    virtual const void* GetPointer() const = 0;
 
-    virtual void* GetMetaStructPointer() const = 0;
+    virtual void* GetMetaStructPointer() = 0;
+
+    virtual const void* GetMetaStructPointer() const = 0;
 
     virtual size_t Decode(const uint8_t* buffer, size_t buffer_size) = 0;
 };

--- a/framework/decode/pnext_typed_node.h
+++ b/framework/decode/pnext_typed_node.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -42,9 +42,11 @@ class PNextTypedNode : public PNextNode
 
     virtual void* GetPointer() override { return struct_pointer_.GetPointer(); }
 
-    const virtual void* GetPointer() const override { return struct_pointer_.GetPointer(); }
+    virtual const void* GetPointer() const override { return struct_pointer_.GetPointer(); }
 
-    virtual void* GetMetaStructPointer() const override { return struct_pointer_.GetMetaStructPointer(); }
+    virtual void* GetMetaStructPointer() override { return struct_pointer_.GetMetaStructPointer(); }
+
+    virtual const void* GetMetaStructPointer() const override { return struct_pointer_.GetMetaStructPointer(); }
 
     virtual size_t Decode(const uint8_t* buffer, size_t buffer_size) override
     {

--- a/framework/decode/string_array_decoder.h
+++ b/framework/decode/string_array_decoder.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -38,13 +38,13 @@ class BasicStringArrayDecoder : public PointerDecoderBase
 
     ~BasicStringArrayDecoder() { DestroyStrings(); }
 
-    uint32_t* GetStringAttributes() const { return string_attributes_.get(); }
+    const uint32_t* GetStringAttributes() const { return string_attributes_.get(); }
 
-    uint64_t* GetStringAddresses() const { return string_addresses_.get(); }
+    const uint64_t* GetStringAddresses() const { return string_addresses_.get(); }
 
-    size_t* GetStringLengths() const { return string_lengths_.get(); }
+    const size_t* GetStringLengths() const { return string_lengths_.get(); }
 
-    CharT** GetPointer() const { return strings_.get(); }
+    const CharT* const* GetPointer() const { return strings_.get(); }
 
     size_t Decode(const uint8_t* buffer, size_t buffer_size)
     {

--- a/framework/decode/string_decoder.h
+++ b/framework/decode/string_decoder.h
@@ -43,7 +43,7 @@ class BasicStringDecoder : public PointerDecoderBase
         }
     }
 
-    CharT* GetPointer() const { return data_; }
+    const CharT* GetPointer() const { return data_; }
 
     void SetExternalMemory(CharT* data, size_t capacity)
     {

--- a/framework/decode/struct_pointer_decoder.h
+++ b/framework/decode/struct_pointer_decoder.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018-2019 Valve Corporation
-** Copyright (c) 2018-2019 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -52,7 +52,9 @@ class StructPointerDecoder : public PointerDecoderBase
         }
     }
 
-    T* GetMetaStructPointer() const { return decoded_structs_; }
+    T* GetMetaStructPointer() { return decoded_structs_; }
+
+    const T* GetMetaStructPointer() const { return decoded_structs_; }
 
     typename T::struct_type* GetPointer() { return struct_memory_; }
 

--- a/framework/decode/struct_pointer_decoder_nvx.h
+++ b/framework/decode/struct_pointer_decoder_nvx.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -66,13 +66,17 @@ class StructPointerDecoder<Decoded_VkObjectTableEntryNVX> : public PointerDecode
         }
     }
 
-    uint32_t* GetAttributes() const { return struct_attributes_.get(); }
+    const uint32_t* GetAttributes() const { return struct_attributes_.get(); }
 
-    uint64_t* GetAddresses() const { return struct_addresses_.get(); }
+    const uint64_t* GetAddresses() const { return struct_addresses_.get(); }
 
-    Decoded_VkObjectTableEntryNVX** GetMetaStructPointer() const { return decoded_structs_.get(); }
+    Decoded_VkObjectTableEntryNVX** GetMetaStructPointer() { return decoded_structs_.get(); }
 
-    VkObjectTableEntryNVX** GetPointer() const { return struct_memory_.get(); }
+    const Decoded_VkObjectTableEntryNVX* const* GetMetaStructPointer() const { return decoded_structs_.get(); }
+
+    VkObjectTableEntryNVX** GetPointer() { return struct_memory_.get(); }
+
+    const VkObjectTableEntryNVX* const* GetPointer() const { return struct_memory_.get(); }
 
     size_t Decode(const uint8_t* buffer, size_t buffer_size)
     {

--- a/framework/decode/vulkan_ascii_consumer_base.cpp
+++ b/framework/decode/vulkan_ascii_consumer_base.cpp
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ void VulkanAsciiConsumerBase::Destroy()
 void VulkanAsciiConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(format::HandleId device,
                                                                         format::HandleId descriptorSet,
                                                                         format::HandleId descriptorUpdateTemplate,
-                                                                        const DescriptorUpdateTemplateDecoder& pData)
+                                                                        DescriptorUpdateTemplateDecoder* pData)
 {
     GFXRECON_UNREFERENCED_PARAMETER(device);
     GFXRECON_UNREFERENCED_PARAMETER(descriptorSet);
@@ -66,12 +66,11 @@ void VulkanAsciiConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(format::
     fprintf(m_file, "%s\n", "vkUpdateDescriptorSetWithTemplate");
 }
 
-void VulkanAsciiConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(
-    format::HandleId                       commandBuffer,
-    format::HandleId                       descriptorUpdateTemplate,
-    format::HandleId                       layout,
-    uint32_t                               set,
-    const DescriptorUpdateTemplateDecoder& pData)
+void VulkanAsciiConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(format::HandleId commandBuffer,
+                                                                            format::HandleId descriptorUpdateTemplate,
+                                                                            format::HandleId layout,
+                                                                            uint32_t         set,
+                                                                            DescriptorUpdateTemplateDecoder* pData)
 {
     GFXRECON_UNREFERENCED_PARAMETER(commandBuffer);
     GFXRECON_UNREFERENCED_PARAMETER(descriptorUpdateTemplate);
@@ -84,7 +83,7 @@ void VulkanAsciiConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(
 void VulkanAsciiConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(format::HandleId device,
                                                                            format::HandleId descriptorSet,
                                                                            format::HandleId descriptorUpdateTemplate,
-                                                                           const DescriptorUpdateTemplateDecoder& pData)
+                                                                           DescriptorUpdateTemplateDecoder* pData)
 {
     GFXRECON_UNREFERENCED_PARAMETER(device);
     GFXRECON_UNREFERENCED_PARAMETER(descriptorSet);
@@ -94,12 +93,12 @@ void VulkanAsciiConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(forma
 }
 
 void VulkanAsciiConsumerBase::Process_vkRegisterObjectsNVX(
-    VkResult                                                   returnValue,
-    format::HandleId                                           device,
-    format::HandleId                                           objectTable,
-    uint32_t                                                   objectCount,
-    const StructPointerDecoder<Decoded_VkObjectTableEntryNVX>& ppObjectTableEntries,
-    const PointerDecoder<uint32_t>&                            pObjectIndices)
+    VkResult                                             returnValue,
+    format::HandleId                                     device,
+    format::HandleId                                     objectTable,
+    uint32_t                                             objectCount,
+    StructPointerDecoder<Decoded_VkObjectTableEntryNVX>* ppObjectTableEntries,
+    PointerDecoder<uint32_t>*                            pObjectIndices)
 {
     GFXRECON_UNREFERENCED_PARAMETER(returnValue);
     GFXRECON_UNREFERENCED_PARAMETER(device);

--- a/framework/decode/vulkan_ascii_consumer_base.h
+++ b/framework/decode/vulkan_ascii_consumer_base.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -45,29 +45,28 @@ class VulkanAsciiConsumerBase : public VulkanConsumer
 
     const std::string& GetFilename() const { return m_filename; }
 
-    virtual void Process_vkUpdateDescriptorSetWithTemplate(format::HandleId device,
-                                                           format::HandleId descriptorSet,
-                                                           format::HandleId descriptorUpdateTemplate,
-                                                           const DescriptorUpdateTemplateDecoder& pData) override;
+    virtual void Process_vkUpdateDescriptorSetWithTemplate(format::HandleId                 device,
+                                                           format::HandleId                 descriptorSet,
+                                                           format::HandleId                 descriptorUpdateTemplate,
+                                                           DescriptorUpdateTemplateDecoder* pData) override;
 
     virtual void Process_vkCmdPushDescriptorSetWithTemplateKHR(format::HandleId commandBuffer,
                                                                format::HandleId descriptorUpdateTemplate,
                                                                format::HandleId layout,
                                                                uint32_t         set,
-                                                               const DescriptorUpdateTemplateDecoder& pData) override;
+                                                               DescriptorUpdateTemplateDecoder* pData) override;
 
-    virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(format::HandleId device,
-                                                              format::HandleId descriptorSet,
-                                                              format::HandleId descriptorUpdateTemplate,
-                                                              const DescriptorUpdateTemplateDecoder& pData) override;
+    virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(format::HandleId                 device,
+                                                              format::HandleId                 descriptorSet,
+                                                              format::HandleId                 descriptorUpdateTemplate,
+                                                              DescriptorUpdateTemplateDecoder* pData) override;
 
-    virtual void
-    Process_vkRegisterObjectsNVX(VkResult                                                   returnValue,
-                                 format::HandleId                                           device,
-                                 format::HandleId                                           objectTable,
-                                 uint32_t                                                   objectCount,
-                                 const StructPointerDecoder<Decoded_VkObjectTableEntryNVX>& ppObjectTableEntries,
-                                 const PointerDecoder<uint32_t>&                            pObjectIndices) override;
+    virtual void Process_vkRegisterObjectsNVX(VkResult                                             returnValue,
+                                              format::HandleId                                     device,
+                                              format::HandleId                                     objectTable,
+                                              uint32_t                                             objectCount,
+                                              StructPointerDecoder<Decoded_VkObjectTableEntryNVX>* ppObjectTableEntries,
+                                              PointerDecoder<uint32_t>* pObjectIndices) override;
 
   protected:
     FILE* GetFile() const { return m_file; }

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -95,32 +95,31 @@ class VulkanConsumerBase
                                          const uint8_t*               data)
     {}
 
-    virtual void Process_vkUpdateDescriptorSetWithTemplate(format::HandleId device,
-                                                           format::HandleId descriptorSet,
-                                                           format::HandleId descriptorUpdateTemplate,
-                                                           const DescriptorUpdateTemplateDecoder& pData)
+    virtual void Process_vkUpdateDescriptorSetWithTemplate(format::HandleId                 device,
+                                                           format::HandleId                 descriptorSet,
+                                                           format::HandleId                 descriptorUpdateTemplate,
+                                                           DescriptorUpdateTemplateDecoder* pData)
     {}
 
     virtual void Process_vkCmdPushDescriptorSetWithTemplateKHR(format::HandleId commandBuffer,
                                                                format::HandleId descriptorUpdateTemplate,
                                                                format::HandleId layout,
                                                                uint32_t         set,
-                                                               const DescriptorUpdateTemplateDecoder& pData)
+                                                               DescriptorUpdateTemplateDecoder* pData)
     {}
 
-    virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(format::HandleId device,
-                                                              format::HandleId descriptorSet,
-                                                              format::HandleId descriptorUpdateTemplate,
-                                                              const DescriptorUpdateTemplateDecoder& pData)
+    virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(format::HandleId                 device,
+                                                              format::HandleId                 descriptorSet,
+                                                              format::HandleId                 descriptorUpdateTemplate,
+                                                              DescriptorUpdateTemplateDecoder* pData)
     {}
 
-    virtual void
-    Process_vkRegisterObjectsNVX(VkResult                                                   returnValue,
-                                 format::HandleId                                           device,
-                                 format::HandleId                                           objectTable,
-                                 uint32_t                                                   objectCount,
-                                 const StructPointerDecoder<Decoded_VkObjectTableEntryNVX>& ppObjectTableEntries,
-                                 const PointerDecoder<uint32_t>&                            pObjectIndices)
+    virtual void Process_vkRegisterObjectsNVX(VkResult                                             returnValue,
+                                              format::HandleId                                     device,
+                                              format::HandleId                                     objectTable,
+                                              uint32_t                                             objectCount,
+                                              StructPointerDecoder<Decoded_VkObjectTableEntryNVX>* ppObjectTableEntries,
+                                              PointerDecoder<uint32_t>*                            pObjectIndices)
     {}
 };
 

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -210,7 +210,7 @@ size_t VulkanDecoderBase::Decode_vkUpdateDescriptorSetWithTemplate(const uint8_t
 
     for (auto consumer : consumers_)
     {
-        consumer->Process_vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, pData);
+        consumer->Process_vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, &pData);
     }
 
     return bytes_read;
@@ -239,7 +239,7 @@ size_t VulkanDecoderBase::Decode_vkCmdPushDescriptorSetWithTemplateKHR(const uin
     for (auto consumer : consumers_)
     {
         consumer->Process_vkCmdPushDescriptorSetWithTemplateKHR(
-            commandBuffer, descriptorUpdateTemplate, layout, set, pData);
+            commandBuffer, descriptorUpdateTemplate, layout, set, &pData);
     }
 
     return bytes_read;
@@ -265,7 +265,7 @@ size_t VulkanDecoderBase::Decode_vkUpdateDescriptorSetWithTemplateKHR(const uint
 
     for (auto consumer : consumers_)
     {
-        consumer->Process_vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, pData);
+        consumer->Process_vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, &pData);
     }
 
     return bytes_read;
@@ -296,7 +296,7 @@ size_t VulkanDecoderBase::Decode_vkRegisterObjectsNVX(const uint8_t* parameter_b
     for (auto consumer : consumers_)
     {
         consumer->Process_vkRegisterObjectsNVX(
-            return_value, device, objectTable, objectCount, ppObjectTableEntries, pObjectIndices);
+            return_value, device, objectTable, objectCount, &ppObjectTableEntries, &pObjectIndices);
     }
 
     return bytes_read;

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -26,9 +26,9 @@
 
 #include "vulkan/vulkan.h"
 
-#include <array>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
@@ -38,8 +38,6 @@ enum InstanceArrayIndices : uint32_t
 {
     kInstanceArrayEnumeratePhysicalDevices      = 0,
     kInstanceArrayEnumeratePhysicalDeviceGroups = 1,
-    // Value to use for array sizes.
-    kInstanceArrayIndexCount,
     // Aliases for extensions functions that were promoted to core.
     kInstanceArrayEnumeratePhysicalDeviceGroupsKHR = kInstanceArrayEnumeratePhysicalDeviceGroups
 };
@@ -60,8 +58,6 @@ enum PhysicalDeviceArrayIndices : uint32_t
     kPhysicalDeviceArrayGetPhysicalDeviceCooperativeMatrixPropertiesNV                  = 11,
     kPhysicalDeviceArrayGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV = 12,
     kPhysicalDeviceArrayGetPhysicalDeviceSurfacePresentModes2EXT                        = 13,
-    // Value to use for array sizes.
-    kPhysicalDeviceArrayIndexCount,
     // Aliases for extensions functions that were promoted to core.
     kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2KHR =
         kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2,
@@ -75,70 +71,52 @@ enum DeviceArrayIndices : uint32_t
     kDeviceArrayGetPipelineExecutablePropertiesKHR              = 1,
     kDeviceArrayGetPipelineExecutableStatisticsKHR              = 2,
     kDeviceArrayGetPipelineExecutableInternalRepresentationsKHR = 3,
-    // Value to use for array sizes.
-    kDeviceArrayIndexCount,
     // Aliases for extensions functions that were promoted to core.
     kDeviceArrayGetImageSparseMemoryRequirements2KHR = kDeviceArrayGetImageSparseMemoryRequirements2
 };
 
 enum QueueArrayIndices : uint32_t
 {
-    kQueueArrayGetQueueCheckpointDataNV = 0,
-    // Value to use for array sizes.
-    kQueueArrayIndexCount
+    kQueueArrayGetQueueCheckpointDataNV = 0
 };
 
 enum ImageArrayIndices : uint32_t
 {
-    kImageArrayGetImageSparseMemoryRequirements = 0,
-    // Value to use for array sizes.
-    kImageArrayIndexCount
+    kImageArrayGetImageSparseMemoryRequirements = 0
 };
 
 enum PipelineCacheArrayIndices : uint32_t
 {
-    kPipelineCacheArrayGetPipelineCacheData = 0,
-    // Value to use for array sizes.
-    kPipelineCacheArrayIndexCount
+    kPipelineCacheArrayGetPipelineCacheData = 0
 };
 
 enum PipelineArrayIndices : uint32_t
 {
-    kPipelineArrayGetShaderInfoAMD = 0,
-    // Value to use for array sizes.
-    kPipelineArrayIndexCount
+    kPipelineArrayGetShaderInfoAMD = 0
 };
 
 enum DisplayKHRArrayIndices : uint32_t
 {
     kDisplayKHRArrayGetDisplayModePropertiesKHR  = 0,
-    kDisplayKHRArrayGetDisplayModeProperties2KHR = 1,
-    // Value to use for array sizes.
-    kDisplayKHRArrayIndexCount
+    kDisplayKHRArrayGetDisplayModeProperties2KHR = 1
 };
 
 enum SurfaceKHRArrayIndices : uint32_t
 {
     kSurfaceKHRArrayGetPhysicalDeviceSurfaceFormatsKHR      = 0,
     kSurfaceKHRArrayGetPhysicalDeviceSurfacePresentModesKHR = 1,
-    kSurfaceKHRArrayGetPhysicalDevicePresentRectanglesKHR   = 2,
-    // Value to use for array sizes.
-    kSurfaceKHRArrayIndexCount
+    kSurfaceKHRArrayGetPhysicalDevicePresentRectanglesKHR   = 2
 };
 
 enum SwapchainKHRArrayIndices : uint32_t
 {
     kSwapchainKHRArrayGetSwapchainImagesKHR           = 0,
-    kSwapchainKHRArrayGetPastPresentationTimingGOOGLE = 1,
-    // Value to use for array sizes.
-    kSwapchainKHRArrayIndexCount
+    kSwapchainKHRArrayGetPastPresentationTimingGOOGLE = 1
 };
 
 enum ValidationCacheEXTArrayIndices : uint32_t
 {
-    kValidationCacheEXTArrayGetValidationCacheDataEXT = 0,
-    // Value to use for array sizes.
-    kValidationCacheEXTArrayIndexCount
+    kValidationCacheEXTArrayGetValidationCacheDataEXT = 0
 };
 
 template <typename T>
@@ -186,26 +164,26 @@ typedef VulkanObjectInfo<VkPerformanceConfigurationINTEL> PerformanceConfigurati
 
 struct InstanceInfo : public VulkanObjectInfo<VkInstance>
 {
-    uint32_t                                     api_version{ 0 };
-    std::array<size_t, kInstanceArrayIndexCount> array_counts;
+    uint32_t                             api_version{ 0 };
+    std::unordered_map<uint32_t, size_t> array_counts;
 };
 
 struct PhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
 {
-    VkInstance                                         parent{ VK_NULL_HANDLE };
-    uint32_t                                           parent_api_version{ 0 };
-    VkPhysicalDeviceMemoryProperties                   capture_memory_properties{};
-    VkPhysicalDeviceMemoryProperties                   replay_memory_properties{};
-    std::array<size_t, kPhysicalDeviceArrayIndexCount> array_counts;
+    VkInstance                           parent{ VK_NULL_HANDLE };
+    uint32_t                             parent_api_version{ 0 };
+    VkPhysicalDeviceMemoryProperties     capture_memory_properties{};
+    VkPhysicalDeviceMemoryProperties     replay_memory_properties{};
+    std::unordered_map<uint32_t, size_t> array_counts;
 };
 
 struct DeviceInfo : public VulkanObjectInfo<VkDevice>
 {
-    VkPhysicalDevice                           parent{ VK_NULL_HANDLE };
-    std::unique_ptr<VulkanResourceAllocator>   allocator;
-    const VkPhysicalDeviceMemoryProperties*    capture_memory_properties{ nullptr };
-    const VkPhysicalDeviceMemoryProperties*    replay_memory_properties{ nullptr };
-    std::array<size_t, kDeviceArrayIndexCount> array_counts;
+    VkPhysicalDevice                         parent{ VK_NULL_HANDLE };
+    std::unique_ptr<VulkanResourceAllocator> allocator;
+    const VkPhysicalDeviceMemoryProperties*  capture_memory_properties{ nullptr };
+    const VkPhysicalDeviceMemoryProperties*  replay_memory_properties{ nullptr };
+    std::unordered_map<uint32_t, size_t>     array_counts;
 
     // The following values are only used when loading the initial state for trimmed files.
     std::vector<std::string>                   extensions;
@@ -214,7 +192,7 @@ struct DeviceInfo : public VulkanObjectInfo<VkDevice>
 
 struct QueueInfo : public VulkanObjectInfo<VkQueue>
 {
-    std::array<size_t, kQueueArrayIndexCount> array_counts;
+    std::unordered_map<uint32_t, size_t> array_counts;
 };
 
 struct DeviceMemoryInfo : public VulkanObjectInfo<VkDeviceMemory>
@@ -239,7 +217,7 @@ struct BufferInfo : public VulkanObjectInfo<VkBuffer>
 
 struct ImageInfo : public VulkanObjectInfo<VkImage>
 {
-    std::array<size_t, kImageArrayIndexCount> array_counts;
+    std::unordered_map<uint32_t, size_t> array_counts;
 
     // The following values are only used for memory portability.
     VulkanResourceAllocator::ResourceData allocator_data{ 0 };
@@ -263,12 +241,12 @@ struct ImageInfo : public VulkanObjectInfo<VkImage>
 
 struct PipelineCacheInfo : public VulkanObjectInfo<VkPipelineCache>
 {
-    std::array<size_t, kPipelineCacheArrayIndexCount> array_counts;
+    std::unordered_map<uint32_t, size_t> array_counts;
 };
 
 struct PipelineInfo : public VulkanObjectInfo<VkPipeline>
 {
-    std::array<size_t, kPipelineArrayIndexCount> array_counts;
+    std::unordered_map<uint32_t, size_t> array_counts;
 };
 
 struct DescriptorUpdateTemplateInfo : public VulkanObjectInfo<VkDescriptorUpdateTemplate>
@@ -278,19 +256,19 @@ struct DescriptorUpdateTemplateInfo : public VulkanObjectInfo<VkDescriptorUpdate
 
 struct DisplayKHRInfo : public VulkanObjectInfo<VkDisplayKHR>
 {
-    std::array<size_t, kDisplayKHRArrayIndexCount> array_counts;
+    std::unordered_map<uint32_t, size_t> array_counts;
 };
 
 struct SurfaceKHRInfo : public VulkanObjectInfo<VkSurfaceKHR>
 {
-    Window*                                        window{ nullptr };
-    std::array<size_t, kSurfaceKHRArrayIndexCount> array_counts;
+    Window*                              window{ nullptr };
+    std::unordered_map<uint32_t, size_t> array_counts;
 };
 
 struct SwapchainKHRInfo : public VulkanObjectInfo<VkSwapchainKHR>
 {
-    VkSurfaceKHR                                     surface{ VK_NULL_HANDLE };
-    std::array<size_t, kSwapchainKHRArrayIndexCount> array_counts;
+    VkSurfaceKHR                         surface{ VK_NULL_HANDLE };
+    std::unordered_map<uint32_t, size_t> array_counts;
 
     // The following values are only used when loading the initial state for trimmed files.
     uint32_t queue_family_index{ 0 };
@@ -298,7 +276,7 @@ struct SwapchainKHRInfo : public VulkanObjectInfo<VkSwapchainKHR>
 
 struct ValidationCacheEXTInfo : public VulkanObjectInfo<VkValidationCacheEXT>
 {
-    std::array<size_t, kValidationCacheEXTArrayIndexCount> array_counts;
+    std::unordered_map<uint32_t, size_t> array_counts;
 };
 
 //

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -24,7 +24,6 @@
 #include "generated/generated_vulkan_struct_handle_mappers.h"
 #include "util/file_path.h"
 #include "util/hash.h"
-#include "util/logging.h"
 #include "util/platform.h"
 
 #include <cstdint>

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2094,14 +2094,15 @@ VulkanReplayConsumerBase::OverrideEnumeratePhysicalDevices(PFN_vkEnumeratePhysic
            (pPhysicalDeviceCount->GetPointer() != nullptr) && (pPhysicalDevices != nullptr));
 
     VkInstance        instance            = instance_info->handle;
-    uint32_t          replay_device_count = (*pPhysicalDeviceCount->GetPointer());
+    uint32_t*         replay_device_count = pPhysicalDeviceCount->GetOutputPointer();
     VkPhysicalDevice* replay_devices      = pPhysicalDevices->GetHandlePointer();
 
-    VkResult result = func(instance, &replay_device_count, replay_devices);
+    VkResult result = func(instance, replay_device_count, replay_devices);
 
-    if ((result >= 0) && (replay_devices != nullptr) && (instance_devices_.find(instance) == instance_devices_.end()))
+    if ((result >= 0) && (replay_device_count != nullptr) && (replay_devices != nullptr) &&
+        (instance_devices_.find(instance) == instance_devices_.end()))
     {
-        for (uint32_t i = 0; i < replay_device_count; ++i)
+        for (uint32_t i = 0; i < *replay_device_count; ++i)
         {
             // TODO: This will require GH #189 to work correctly when the capture and replay systems have a different
             // number of physcial devices.
@@ -2121,7 +2122,7 @@ VulkanReplayConsumerBase::OverrideEnumeratePhysicalDevices(PFN_vkEnumeratePhysic
             devices.capture_devices.push_back(capture_devices[i]);
         }
 
-        for (uint32_t i = 0; i < replay_device_count; ++i)
+        for (uint32_t i = 0; i < *replay_device_count; ++i)
         {
             devices.replay_devices.push_back(replay_devices[i]);
         }

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3616,11 +3616,22 @@ void VulkanReplayConsumerBase::MapDescriptorUpdateTemplateHandles(
 
     if (texel_buffer_view_count > 0)
     {
-        MapHandles<BufferViewInfo>(decoder->GetTexelBufferViewHandleIdsPointer(),
-                                   texel_buffer_view_count,
-                                   decoder->GetTexelBufferViewPointer(),
-                                   texel_buffer_view_count,
-                                   &VulkanObjectInfoTable::GetBufferViewInfo);
+        auto texel_buffer_view_ids     = decoder->GetTexelBufferViewHandleIdsPointer();
+        auto texel_buffer_view_handles = decoder->GetTexelBufferViewPointer();
+
+        for (size_t i = 0; i < texel_buffer_view_count; ++i)
+        {
+            auto texel_buffer_view_info = object_info_table_.GetBufferViewInfo(texel_buffer_view_ids[i]);
+
+            if (texel_buffer_view_info != nullptr)
+            {
+                texel_buffer_view_handles[i] = texel_buffer_view_info->handle;
+            }
+            else
+            {
+                texel_buffer_view_handles[i] = VK_NULL_HANDLE;
+            }
+        }
     }
 }
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -285,6 +285,19 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         }
     }
 
+    template <typename HandleInfoT>
+    void SetOutputArrayCount(format::HandleId handle_id,
+                             uint32_t         index,
+                             size_t           count,
+                             HandleInfoT* (VulkanObjectInfoTable::*HandleInfoFunc)(format::HandleId))
+    {
+        HandleInfoT* info = (object_info_table_.*HandleInfoFunc)(handle_id);
+        if (info != nullptr)
+        {
+            info->array_counts[index] = count;
+        }
+    }
+
     //
     // Replay function overrides provided to the replay consumer code generator with replay_overrides.json
     //

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -117,29 +117,28 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                          const std::vector<uint64_t>& level_sizes,
                                          const uint8_t*               data) override;
 
-    virtual void Process_vkUpdateDescriptorSetWithTemplate(format::HandleId device,
-                                                           format::HandleId descriptorSet,
-                                                           format::HandleId descriptorUpdateTemplate,
-                                                           const DescriptorUpdateTemplateDecoder& pData) override;
+    virtual void Process_vkUpdateDescriptorSetWithTemplate(format::HandleId                 device,
+                                                           format::HandleId                 descriptorSet,
+                                                           format::HandleId                 descriptorUpdateTemplate,
+                                                           DescriptorUpdateTemplateDecoder* pData) override;
 
     virtual void Process_vkCmdPushDescriptorSetWithTemplateKHR(format::HandleId commandBuffer,
                                                                format::HandleId descriptorUpdateTemplate,
                                                                format::HandleId layout,
                                                                uint32_t         set,
-                                                               const DescriptorUpdateTemplateDecoder& pData) override;
+                                                               DescriptorUpdateTemplateDecoder* pData) override;
 
-    virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(format::HandleId device,
-                                                              format::HandleId descriptorSet,
-                                                              format::HandleId descriptorUpdateTemplate,
-                                                              const DescriptorUpdateTemplateDecoder& pData) override;
+    virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(format::HandleId                 device,
+                                                              format::HandleId                 descriptorSet,
+                                                              format::HandleId                 descriptorUpdateTemplate,
+                                                              DescriptorUpdateTemplateDecoder* pData) override;
 
-    virtual void
-    Process_vkRegisterObjectsNVX(VkResult                                                   returnValue,
-                                 format::HandleId                                           device,
-                                 format::HandleId                                           objectTable,
-                                 uint32_t                                                   objectCount,
-                                 const StructPointerDecoder<Decoded_VkObjectTableEntryNVX>& ppObjectTableEntries,
-                                 const PointerDecoder<uint32_t>&                            pObjectIndices) override;
+    virtual void Process_vkRegisterObjectsNVX(VkResult                                             returnValue,
+                                              format::HandleId                                     device,
+                                              format::HandleId                                     objectTable,
+                                              uint32_t                                             objectCount,
+                                              StructPointerDecoder<Decoded_VkObjectTableEntryNVX>* ppObjectTableEntries,
+                                              PointerDecoder<uint32_t>* pObjectIndices) override;
 
   protected:
     const VulkanObjectInfoTable& GetObjectInfoTable() const { return object_info_table_; }
@@ -156,7 +155,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         VkResult replay_reslt, uint64_t object_id, void* object, format::ApiCallId call_id, const char* call_name);
 
     const VkAllocationCallbacks*
-    GetAllocationCallbacks(const StructPointerDecoder<Decoded_VkAllocationCallbacks>& original_callbacks);
+    GetAllocationCallbacks(const StructPointerDecoder<Decoded_VkAllocationCallbacks>* original_callbacks);
 
     void CheckResult(const char* func_name, VkResult original, VkResult replay);
 
@@ -279,14 +278,14 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     //
 
     VkResult OverrideCreateInstance(VkResult                                                   original_result,
-                                    const StructPointerDecoder<Decoded_VkInstanceCreateInfo>&  pCreateInfo,
-                                    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+                                    const StructPointerDecoder<Decoded_VkInstanceCreateInfo>*  pCreateInfo,
+                                    const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                     HandlePointerDecoder<VkInstance>*                          pInstance);
 
     VkResult OverrideCreateDevice(VkResult                                                   original_result,
                                   PhysicalDeviceInfo*                                        physical_device_info,
-                                  const StructPointerDecoder<Decoded_VkDeviceCreateInfo>&    pCreateInfo,
-                                  const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+                                  const StructPointerDecoder<Decoded_VkDeviceCreateInfo>*    pCreateInfo,
+                                  const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                   HandlePointerDecoder<VkDevice>*                            pDevice);
 
     VkResult OverrideEnumeratePhysicalDevices(PFN_vkEnumeratePhysicalDevices          func,
@@ -317,7 +316,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                    VkResult                             original_result,
                                    const DeviceInfo*                    device_info,
                                    uint32_t                             fenceCount,
-                                   const HandlePointerDecoder<VkFence>& pFences,
+                                   const HandlePointerDecoder<VkFence>* pFences,
                                    VkBool32                             waitAll,
                                    uint64_t                             timeout);
 
@@ -346,21 +345,21 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     OverrideAllocateCommandBuffers(PFN_vkAllocateCommandBuffers                                     func,
                                    VkResult                                                         original_result,
                                    const DeviceInfo*                                                device_info,
-                                   const StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>& pAllocateInfo,
+                                   const StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
                                    HandlePointerDecoder<VkCommandBuffer>*                           pCommandBuffers);
 
     VkResult
     OverrideAllocateDescriptorSets(PFN_vkAllocateDescriptorSets                                     func,
                                    VkResult                                                         original_result,
                                    const DeviceInfo*                                                device_info,
-                                   const StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>& pAllocateInfo,
+                                   const StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
                                    HandlePointerDecoder<VkDescriptorSet>*                           pDescriptorSets);
 
     VkResult OverrideAllocateMemory(PFN_vkAllocateMemory                                       func,
                                     VkResult                                                   original_result,
                                     const DeviceInfo*                                          device_info,
-                                    const StructPointerDecoder<Decoded_VkMemoryAllocateInfo>&  pAllocateInfo,
-                                    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+                                    const StructPointerDecoder<Decoded_VkMemoryAllocateInfo>*  pAllocateInfo,
+                                    const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                     HandlePointerDecoder<VkDeviceMemory>*                      pMemory);
 
     VkResult OverrideMapMemory(PFN_vkMapMemory   func,
@@ -378,19 +377,19 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                              VkResult                                                 original_result,
                                              const DeviceInfo*                                        device_info,
                                              uint32_t                                                 memoryRangeCount,
-                                             const StructPointerDecoder<Decoded_VkMappedMemoryRange>& pMemoryRanges);
+                                             const StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges);
 
     VkResult
     OverrideInvalidateMappedMemoryRanges(PFN_vkInvalidateMappedMemoryRanges                       func,
                                          VkResult                                                 original_result,
                                          const DeviceInfo*                                        device_info,
                                          uint32_t                                                 memoryRangeCount,
-                                         const StructPointerDecoder<Decoded_VkMappedMemoryRange>& pMemoryRanges);
+                                         const StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges);
 
     void OverrideFreeMemory(PFN_vkFreeMemory                                           func,
                             const DeviceInfo*                                          device_info,
                             DeviceMemoryInfo*                                          memory_info,
-                            const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator);
+                            const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     VkResult OverrideBindBufferMemory(PFN_vkBindBufferMemory func,
                                       VkResult               original_result,
@@ -403,7 +402,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                        VkResult                                                    original_result,
                                        const DeviceInfo*                                           device_info,
                                        uint32_t                                                    bindInfoCount,
-                                       const StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>& pBindInfos);
+                                       const StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos);
 
     VkResult OverrideBindImageMemory(PFN_vkBindImageMemory func,
                                      VkResult              original_result,
@@ -416,86 +415,86 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                       VkResult                                                   original_result,
                                       const DeviceInfo*                                          device_info,
                                       uint32_t                                                   bindInfoCount,
-                                      const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>& pBindInfos);
+                                      const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos);
 
     VkResult OverrideCreateBuffer(PFN_vkCreateBuffer                                         func,
                                   VkResult                                                   original_result,
                                   const DeviceInfo*                                          device_info,
-                                  const StructPointerDecoder<Decoded_VkBufferCreateInfo>&    pCreateInfo,
-                                  const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+                                  const StructPointerDecoder<Decoded_VkBufferCreateInfo>*    pCreateInfo,
+                                  const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                   HandlePointerDecoder<VkBuffer>*                            pBuffer);
 
     void OverrideDestroyBuffer(PFN_vkDestroyBuffer                                        func,
                                const DeviceInfo*                                          device_info,
                                BufferInfo*                                                buffer_info,
-                               const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator);
+                               const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     VkResult OverrideCreateImage(PFN_vkCreateImage                                          func,
                                  VkResult                                                   original_result,
                                  const DeviceInfo*                                          device_info,
-                                 const StructPointerDecoder<Decoded_VkImageCreateInfo>&     pCreateInfo,
-                                 const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+                                 const StructPointerDecoder<Decoded_VkImageCreateInfo>*     pCreateInfo,
+                                 const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                  HandlePointerDecoder<VkImage>*                             pImage);
 
     void OverrideDestroyImage(PFN_vkDestroyImage                                         func,
                               const DeviceInfo*                                          device_info,
                               ImageInfo*                                                 image_info,
-                              const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator);
+                              const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     void OverrideGetImageSubresourceLayout(PFN_vkGetImageSubresourceLayout                         func,
                                            const DeviceInfo*                                       device_info,
                                            const ImageInfo*                                        image_info,
-                                           const StructPointerDecoder<Decoded_VkImageSubresource>& pSubresource,
+                                           const StructPointerDecoder<Decoded_VkImageSubresource>* pSubresource,
                                            StructPointerDecoder<Decoded_VkSubresourceLayout>*      pLayout);
 
     VkResult OverrideCreateDescriptorUpdateTemplate(
         PFN_vkCreateDescriptorUpdateTemplate                                      func,
         VkResult                                                                  original_result,
         const DeviceInfo*                                                         device_info,
-        const StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>&                pAllocator,
+        const StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>*                pAllocator,
         HandlePointerDecoder<VkDescriptorUpdateTemplate>*                         pDescriptorUpdateTemplate);
 
     void OverrideDestroyDescriptorUpdateTemplate(PFN_vkDestroyDescriptorUpdateTemplate func,
                                                  const DeviceInfo*                     device_info,
                                                  const DescriptorUpdateTemplateInfo*   descriptor_update_template_info,
-                                                 const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator);
+                                                 const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
     VkResult OverrideCreateShaderModule(PFN_vkCreateShaderModule                                      func,
                                         VkResult                                                      original_result,
                                         const DeviceInfo*                                             device_info,
-                                        const StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>& pCreateInfo,
-                                        const StructPointerDecoder<Decoded_VkAllocationCallbacks>&    pAllocator,
+                                        const StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>* pCreateInfo,
+                                        const StructPointerDecoder<Decoded_VkAllocationCallbacks>*    pAllocator,
                                         HandlePointerDecoder<VkShaderModule>*                         pShaderModule);
 
     VkResult OverrideCreatePipelineCache(PFN_vkCreatePipelineCache                                      func,
                                          VkResult                                                       original_result,
                                          const DeviceInfo*                                              device_info,
-                                         const StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>& pCreateInfo,
-                                         const StructPointerDecoder<Decoded_VkAllocationCallbacks>&     pAllocator,
+                                         const StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>* pCreateInfo,
+                                         const StructPointerDecoder<Decoded_VkAllocationCallbacks>*     pAllocator,
                                          HandlePointerDecoder<VkPipelineCache>*                         pPipelineCache);
 
     VkResult OverrideCreateDebugReportCallbackEXT(
         PFN_vkCreateDebugReportCallbackEXT                                      func,
         VkResult                                                                original_result,
         const InstanceInfo*                                                     instance_info,
-        const StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>&              pAllocator,
+        const StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>* pCreateInfo,
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>*              pAllocator,
         HandlePointerDecoder<VkDebugReportCallbackEXT>*                         pCallback);
 
     VkResult OverrideCreateDebugUtilsMessengerEXT(
         PFN_vkCreateDebugUtilsMessengerEXT                                      func,
         VkResult                                                                original_result,
         const InstanceInfo*                                                     instance_info,
-        const StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>&              pAllocator,
+        const StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>* pCreateInfo,
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>*              pAllocator,
         HandlePointerDecoder<VkDebugUtilsMessengerEXT>*                         pMessenger);
 
     VkResult OverrideCreateSwapchainKHR(PFN_vkCreateSwapchainKHR                                      func,
                                         VkResult                                                      original_result,
                                         const DeviceInfo*                                             device_info,
-                                        const StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>& pCreateInfo,
-                                        const StructPointerDecoder<Decoded_VkAllocationCallbacks>&    pAllocator,
+                                        const StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfo,
+                                        const StructPointerDecoder<Decoded_VkAllocationCallbacks>*    pAllocator,
                                         HandlePointerDecoder<VkSwapchainKHR>*                         pSwapchain);
 
     VkResult OverrideAcquireNextImageKHR(PFN_vkAcquireNextImageKHR func,
@@ -510,7 +509,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     VkResult OverrideAcquireNextImage2KHR(PFN_vkAcquireNextImage2KHR func,
                                           VkResult                   original_result,
                                           const DeviceInfo*          device_info,
-                                          const StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>& pAcquireInfo,
+                                          const StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>* pAcquireInfo,
                                           PointerDecoder<uint32_t>*                                      pImageIndex);
 
     // Window/Surface related overrides, which can transform the window/surface type from the platform
@@ -519,15 +518,15 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     OverrideCreateAndroidSurfaceKHR(PFN_vkCreateAndroidSurfaceKHR                                      func,
                                     VkResult                                                           original_result,
                                     const InstanceInfo*                                                instance_info,
-                                    const StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>& pCreateInfo,
-                                    const StructPointerDecoder<Decoded_VkAllocationCallbacks>&         pAllocator,
+                                    const StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>* pCreateInfo,
+                                    const StructPointerDecoder<Decoded_VkAllocationCallbacks>*         pAllocator,
                                     HandlePointerDecoder<VkSurfaceKHR>*                                pSurface);
 
     VkResult OverrideCreateWin32SurfaceKHR(PFN_vkCreateWin32SurfaceKHR func,
                                            VkResult                    original_result,
                                            const InstanceInfo*         instance_info,
-                                           const StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>& pCreateInfo,
-                                           const StructPointerDecoder<Decoded_VkAllocationCallbacks>&       pAllocator,
+                                           const StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>* pCreateInfo,
+                                           const StructPointerDecoder<Decoded_VkAllocationCallbacks>*       pAllocator,
                                            HandlePointerDecoder<VkSurfaceKHR>*                              pSurface);
 
     VkBool32
@@ -538,8 +537,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     VkResult OverrideCreateXcbSurfaceKHR(PFN_vkCreateXcbSurfaceKHR                                      func,
                                          VkResult                                                       original_result,
                                          const InstanceInfo*                                            instance_info,
-                                         const StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>& pCreateInfo,
-                                         const StructPointerDecoder<Decoded_VkAllocationCallbacks>&     pAllocator,
+                                         const StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>* pCreateInfo,
+                                         const StructPointerDecoder<Decoded_VkAllocationCallbacks>*     pAllocator,
                                          HandlePointerDecoder<VkSurfaceKHR>*                            pSurface);
 
     VkBool32 OverrideGetPhysicalDeviceXcbPresentationSupportKHR(PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR func,
@@ -551,8 +550,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     VkResult OverrideCreateXlibSurfaceKHR(PFN_vkCreateXlibSurfaceKHR func,
                                           VkResult                   original_result,
                                           const InstanceInfo*        instance_info,
-                                          const StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>& pCreateInfo,
-                                          const StructPointerDecoder<Decoded_VkAllocationCallbacks>&      pAllocator,
+                                          const StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>* pCreateInfo,
+                                          const StructPointerDecoder<Decoded_VkAllocationCallbacks>*      pAllocator,
                                           HandlePointerDecoder<VkSurfaceKHR>*                             pSurface);
 
     VkBool32 OverrideGetPhysicalDeviceXlibPresentationSupportKHR(PFN_vkGetPhysicalDeviceXlibPresentationSupportKHR func,
@@ -565,8 +564,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     OverrideCreateWaylandSurfaceKHR(PFN_vkCreateWaylandSurfaceKHR                                      func,
                                     VkResult                                                           original_result,
                                     const InstanceInfo*                                                instance_info,
-                                    const StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>& pCreateInfo,
-                                    const StructPointerDecoder<Decoded_VkAllocationCallbacks>&         pAllocator,
+                                    const StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>* pCreateInfo,
+                                    const StructPointerDecoder<Decoded_VkAllocationCallbacks>*         pAllocator,
                                     HandlePointerDecoder<VkSurfaceKHR>*                                pSurface);
 
     VkBool32
@@ -578,7 +577,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     void OverrideDestroySurfaceKHR(PFN_vkDestroySurfaceKHR                                    func,
                                    const InstanceInfo*                                        instance_info,
                                    const SurfaceKHRInfo*                                      surface_info,
-                                   const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator);
+                                   const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
   private:
     void RaiseFatalError(const char* message) const;
@@ -608,8 +607,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     VkResult CreateSurface(VkInstance instance, VkFlags flags, HandlePointerDecoder<VkSurfaceKHR>* surface);
 
-    void MapDescriptorUpdateTemplateHandles(const DescriptorUpdateTemplateInfo*    update_template_info,
-                                            const DescriptorUpdateTemplateDecoder& decoder);
+    void MapDescriptorUpdateTemplateHandles(const DescriptorUpdateTemplateInfo* update_template_info,
+                                            DescriptorUpdateTemplateDecoder*    decoder);
 
     // When processing swapchain image state for the trimming state setup, acquire all swapchain images to transition to
     // the expected layout and keep them acquired until first use.
@@ -627,9 +626,9 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                                   uint32_t       last_presented_image,
                                                   const std::vector<format::SwapchainImageStateInfo>& image_info);
 
-    void ProcessSwapchainFullScreenExclusiveInfo(Decoded_VkSwapchainCreateInfoKHR* swapchain_info);
+    void ProcessSwapchainFullScreenExclusiveInfo(const Decoded_VkSwapchainCreateInfoKHR* swapchain_info);
 
-    void ProcessImportAndroidHardwareBufferInfo(Decoded_VkMemoryAllocateInfo* allocate_info);
+    void ProcessImportAndroidHardwareBufferInfo(const Decoded_VkMemoryAllocateInfo* allocate_info);
 
   private:
     struct InstanceDevices

--- a/framework/generated/generated_vulkan_ascii_consumer.cpp
+++ b/framework/generated/generated_vulkan_ascii_consumer.cpp
@@ -31,8 +31,8 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 void VulkanAsciiConsumer::Process_vkCreateInstance(
     VkResult                                    returnValue,
-    const StructPointerDecoder<Decoded_VkInstanceCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkInstanceCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkInstance>*           pInstance)
 {
     fprintf(GetFile(), "%s\n", "vkCreateInstance");
@@ -40,7 +40,7 @@ void VulkanAsciiConsumer::Process_vkCreateInstance(
 
 void VulkanAsciiConsumer::Process_vkDestroyInstance(
     format::HandleId                            instance,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyInstance");
 }
@@ -107,8 +107,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties(
 void VulkanAsciiConsumer::Process_vkCreateDevice(
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
-    const StructPointerDecoder<Decoded_VkDeviceCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkDeviceCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkDevice>*             pDevice)
 {
     fprintf(GetFile(), "%s\n", "vkCreateDevice");
@@ -116,7 +116,7 @@ void VulkanAsciiConsumer::Process_vkCreateDevice(
 
 void VulkanAsciiConsumer::Process_vkDestroyDevice(
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyDevice");
 }
@@ -134,7 +134,7 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit(
     VkResult                                    returnValue,
     format::HandleId                            queue,
     uint32_t                                    submitCount,
-    const StructPointerDecoder<Decoded_VkSubmitInfo>& pSubmits,
+    StructPointerDecoder<Decoded_VkSubmitInfo>* pSubmits,
     format::HandleId                            fence)
 {
     fprintf(GetFile(), "%s\n", "vkQueueSubmit");
@@ -157,8 +157,8 @@ void VulkanAsciiConsumer::Process_vkDeviceWaitIdle(
 void VulkanAsciiConsumer::Process_vkAllocateMemory(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkMemoryAllocateInfo>& pAllocateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkMemoryAllocateInfo>* pAllocateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkDeviceMemory>*       pMemory)
 {
     fprintf(GetFile(), "%s\n", "vkAllocateMemory");
@@ -167,7 +167,7 @@ void VulkanAsciiConsumer::Process_vkAllocateMemory(
 void VulkanAsciiConsumer::Process_vkFreeMemory(
     format::HandleId                            device,
     format::HandleId                            memory,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkFreeMemory");
 }
@@ -195,7 +195,7 @@ void VulkanAsciiConsumer::Process_vkFlushMappedMemoryRanges(
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    memoryRangeCount,
-    const StructPointerDecoder<Decoded_VkMappedMemoryRange>& pMemoryRanges)
+    StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges)
 {
     fprintf(GetFile(), "%s\n", "vkFlushMappedMemoryRanges");
 }
@@ -204,7 +204,7 @@ void VulkanAsciiConsumer::Process_vkInvalidateMappedMemoryRanges(
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    memoryRangeCount,
-    const StructPointerDecoder<Decoded_VkMappedMemoryRange>& pMemoryRanges)
+    StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges)
 {
     fprintf(GetFile(), "%s\n", "vkInvalidateMappedMemoryRanges");
 }
@@ -279,7 +279,7 @@ void VulkanAsciiConsumer::Process_vkQueueBindSparse(
     VkResult                                    returnValue,
     format::HandleId                            queue,
     uint32_t                                    bindInfoCount,
-    const StructPointerDecoder<Decoded_VkBindSparseInfo>& pBindInfo,
+    StructPointerDecoder<Decoded_VkBindSparseInfo>* pBindInfo,
     format::HandleId                            fence)
 {
     fprintf(GetFile(), "%s\n", "vkQueueBindSparse");
@@ -288,8 +288,8 @@ void VulkanAsciiConsumer::Process_vkQueueBindSparse(
 void VulkanAsciiConsumer::Process_vkCreateFence(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkFenceCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkFenceCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkFence>*              pFence)
 {
     fprintf(GetFile(), "%s\n", "vkCreateFence");
@@ -298,7 +298,7 @@ void VulkanAsciiConsumer::Process_vkCreateFence(
 void VulkanAsciiConsumer::Process_vkDestroyFence(
     format::HandleId                            device,
     format::HandleId                            fence,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyFence");
 }
@@ -307,7 +307,7 @@ void VulkanAsciiConsumer::Process_vkResetFences(
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    fenceCount,
-    const HandlePointerDecoder<VkFence>&        pFences)
+    HandlePointerDecoder<VkFence>*              pFences)
 {
     fprintf(GetFile(), "%s\n", "vkResetFences");
 }
@@ -324,7 +324,7 @@ void VulkanAsciiConsumer::Process_vkWaitForFences(
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    fenceCount,
-    const HandlePointerDecoder<VkFence>&        pFences,
+    HandlePointerDecoder<VkFence>*              pFences,
     VkBool32                                    waitAll,
     uint64_t                                    timeout)
 {
@@ -334,8 +334,8 @@ void VulkanAsciiConsumer::Process_vkWaitForFences(
 void VulkanAsciiConsumer::Process_vkCreateSemaphore(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkSemaphoreCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkSemaphoreCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSemaphore>*          pSemaphore)
 {
     fprintf(GetFile(), "%s\n", "vkCreateSemaphore");
@@ -344,7 +344,7 @@ void VulkanAsciiConsumer::Process_vkCreateSemaphore(
 void VulkanAsciiConsumer::Process_vkDestroySemaphore(
     format::HandleId                            device,
     format::HandleId                            semaphore,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroySemaphore");
 }
@@ -352,8 +352,8 @@ void VulkanAsciiConsumer::Process_vkDestroySemaphore(
 void VulkanAsciiConsumer::Process_vkCreateEvent(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkEventCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkEventCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkEvent>*              pEvent)
 {
     fprintf(GetFile(), "%s\n", "vkCreateEvent");
@@ -362,7 +362,7 @@ void VulkanAsciiConsumer::Process_vkCreateEvent(
 void VulkanAsciiConsumer::Process_vkDestroyEvent(
     format::HandleId                            device,
     format::HandleId                            event,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyEvent");
 }
@@ -394,8 +394,8 @@ void VulkanAsciiConsumer::Process_vkResetEvent(
 void VulkanAsciiConsumer::Process_vkCreateQueryPool(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkQueryPoolCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkQueryPoolCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkQueryPool>*          pQueryPool)
 {
     fprintf(GetFile(), "%s\n", "vkCreateQueryPool");
@@ -404,7 +404,7 @@ void VulkanAsciiConsumer::Process_vkCreateQueryPool(
 void VulkanAsciiConsumer::Process_vkDestroyQueryPool(
     format::HandleId                            device,
     format::HandleId                            queryPool,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyQueryPool");
 }
@@ -426,8 +426,8 @@ void VulkanAsciiConsumer::Process_vkGetQueryPoolResults(
 void VulkanAsciiConsumer::Process_vkCreateBuffer(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkBufferCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkBufferCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkBuffer>*             pBuffer)
 {
     fprintf(GetFile(), "%s\n", "vkCreateBuffer");
@@ -436,7 +436,7 @@ void VulkanAsciiConsumer::Process_vkCreateBuffer(
 void VulkanAsciiConsumer::Process_vkDestroyBuffer(
     format::HandleId                            device,
     format::HandleId                            buffer,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyBuffer");
 }
@@ -444,8 +444,8 @@ void VulkanAsciiConsumer::Process_vkDestroyBuffer(
 void VulkanAsciiConsumer::Process_vkCreateBufferView(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkBufferViewCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkBufferViewCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkBufferView>*         pView)
 {
     fprintf(GetFile(), "%s\n", "vkCreateBufferView");
@@ -454,7 +454,7 @@ void VulkanAsciiConsumer::Process_vkCreateBufferView(
 void VulkanAsciiConsumer::Process_vkDestroyBufferView(
     format::HandleId                            device,
     format::HandleId                            bufferView,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyBufferView");
 }
@@ -462,8 +462,8 @@ void VulkanAsciiConsumer::Process_vkDestroyBufferView(
 void VulkanAsciiConsumer::Process_vkCreateImage(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkImageCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkImageCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkImage>*              pImage)
 {
     fprintf(GetFile(), "%s\n", "vkCreateImage");
@@ -472,7 +472,7 @@ void VulkanAsciiConsumer::Process_vkCreateImage(
 void VulkanAsciiConsumer::Process_vkDestroyImage(
     format::HandleId                            device,
     format::HandleId                            image,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyImage");
 }
@@ -480,7 +480,7 @@ void VulkanAsciiConsumer::Process_vkDestroyImage(
 void VulkanAsciiConsumer::Process_vkGetImageSubresourceLayout(
     format::HandleId                            device,
     format::HandleId                            image,
-    const StructPointerDecoder<Decoded_VkImageSubresource>& pSubresource,
+    StructPointerDecoder<Decoded_VkImageSubresource>* pSubresource,
     StructPointerDecoder<Decoded_VkSubresourceLayout>* pLayout)
 {
     fprintf(GetFile(), "%s\n", "vkGetImageSubresourceLayout");
@@ -489,8 +489,8 @@ void VulkanAsciiConsumer::Process_vkGetImageSubresourceLayout(
 void VulkanAsciiConsumer::Process_vkCreateImageView(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkImageViewCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkImageViewCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkImageView>*          pView)
 {
     fprintf(GetFile(), "%s\n", "vkCreateImageView");
@@ -499,7 +499,7 @@ void VulkanAsciiConsumer::Process_vkCreateImageView(
 void VulkanAsciiConsumer::Process_vkDestroyImageView(
     format::HandleId                            device,
     format::HandleId                            imageView,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyImageView");
 }
@@ -507,8 +507,8 @@ void VulkanAsciiConsumer::Process_vkDestroyImageView(
 void VulkanAsciiConsumer::Process_vkCreateShaderModule(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkShaderModule>*       pShaderModule)
 {
     fprintf(GetFile(), "%s\n", "vkCreateShaderModule");
@@ -517,7 +517,7 @@ void VulkanAsciiConsumer::Process_vkCreateShaderModule(
 void VulkanAsciiConsumer::Process_vkDestroyShaderModule(
     format::HandleId                            device,
     format::HandleId                            shaderModule,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyShaderModule");
 }
@@ -525,8 +525,8 @@ void VulkanAsciiConsumer::Process_vkDestroyShaderModule(
 void VulkanAsciiConsumer::Process_vkCreatePipelineCache(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkPipelineCache>*      pPipelineCache)
 {
     fprintf(GetFile(), "%s\n", "vkCreatePipelineCache");
@@ -535,7 +535,7 @@ void VulkanAsciiConsumer::Process_vkCreatePipelineCache(
 void VulkanAsciiConsumer::Process_vkDestroyPipelineCache(
     format::HandleId                            device,
     format::HandleId                            pipelineCache,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyPipelineCache");
 }
@@ -555,7 +555,7 @@ void VulkanAsciiConsumer::Process_vkMergePipelineCaches(
     format::HandleId                            device,
     format::HandleId                            dstCache,
     uint32_t                                    srcCacheCount,
-    const HandlePointerDecoder<VkPipelineCache>& pSrcCaches)
+    HandlePointerDecoder<VkPipelineCache>*      pSrcCaches)
 {
     fprintf(GetFile(), "%s\n", "vkMergePipelineCaches");
 }
@@ -565,8 +565,8 @@ void VulkanAsciiConsumer::Process_vkCreateGraphicsPipelines(
     format::HandleId                            device,
     format::HandleId                            pipelineCache,
     uint32_t                                    createInfoCount,
-    const StructPointerDecoder<Decoded_VkGraphicsPipelineCreateInfo>& pCreateInfos,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkGraphicsPipelineCreateInfo>* pCreateInfos,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkPipeline>*           pPipelines)
 {
     fprintf(GetFile(), "%s\n", "vkCreateGraphicsPipelines");
@@ -577,8 +577,8 @@ void VulkanAsciiConsumer::Process_vkCreateComputePipelines(
     format::HandleId                            device,
     format::HandleId                            pipelineCache,
     uint32_t                                    createInfoCount,
-    const StructPointerDecoder<Decoded_VkComputePipelineCreateInfo>& pCreateInfos,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkComputePipelineCreateInfo>* pCreateInfos,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkPipeline>*           pPipelines)
 {
     fprintf(GetFile(), "%s\n", "vkCreateComputePipelines");
@@ -587,7 +587,7 @@ void VulkanAsciiConsumer::Process_vkCreateComputePipelines(
 void VulkanAsciiConsumer::Process_vkDestroyPipeline(
     format::HandleId                            device,
     format::HandleId                            pipeline,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyPipeline");
 }
@@ -595,8 +595,8 @@ void VulkanAsciiConsumer::Process_vkDestroyPipeline(
 void VulkanAsciiConsumer::Process_vkCreatePipelineLayout(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkPipelineLayoutCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkPipelineLayoutCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkPipelineLayout>*     pPipelineLayout)
 {
     fprintf(GetFile(), "%s\n", "vkCreatePipelineLayout");
@@ -605,7 +605,7 @@ void VulkanAsciiConsumer::Process_vkCreatePipelineLayout(
 void VulkanAsciiConsumer::Process_vkDestroyPipelineLayout(
     format::HandleId                            device,
     format::HandleId                            pipelineLayout,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyPipelineLayout");
 }
@@ -613,8 +613,8 @@ void VulkanAsciiConsumer::Process_vkDestroyPipelineLayout(
 void VulkanAsciiConsumer::Process_vkCreateSampler(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkSamplerCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkSamplerCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSampler>*            pSampler)
 {
     fprintf(GetFile(), "%s\n", "vkCreateSampler");
@@ -623,7 +623,7 @@ void VulkanAsciiConsumer::Process_vkCreateSampler(
 void VulkanAsciiConsumer::Process_vkDestroySampler(
     format::HandleId                            device,
     format::HandleId                            sampler,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroySampler");
 }
@@ -631,8 +631,8 @@ void VulkanAsciiConsumer::Process_vkDestroySampler(
 void VulkanAsciiConsumer::Process_vkCreateDescriptorSetLayout(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkDescriptorSetLayout>* pSetLayout)
 {
     fprintf(GetFile(), "%s\n", "vkCreateDescriptorSetLayout");
@@ -641,7 +641,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorSetLayout(
 void VulkanAsciiConsumer::Process_vkDestroyDescriptorSetLayout(
     format::HandleId                            device,
     format::HandleId                            descriptorSetLayout,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyDescriptorSetLayout");
 }
@@ -649,8 +649,8 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorSetLayout(
 void VulkanAsciiConsumer::Process_vkCreateDescriptorPool(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkDescriptorPool>*     pDescriptorPool)
 {
     fprintf(GetFile(), "%s\n", "vkCreateDescriptorPool");
@@ -659,7 +659,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorPool(
 void VulkanAsciiConsumer::Process_vkDestroyDescriptorPool(
     format::HandleId                            device,
     format::HandleId                            descriptorPool,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyDescriptorPool");
 }
@@ -676,7 +676,7 @@ void VulkanAsciiConsumer::Process_vkResetDescriptorPool(
 void VulkanAsciiConsumer::Process_vkAllocateDescriptorSets(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>& pAllocateInfo,
+    StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
     HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets)
 {
     fprintf(GetFile(), "%s\n", "vkAllocateDescriptorSets");
@@ -687,7 +687,7 @@ void VulkanAsciiConsumer::Process_vkFreeDescriptorSets(
     format::HandleId                            device,
     format::HandleId                            descriptorPool,
     uint32_t                                    descriptorSetCount,
-    const HandlePointerDecoder<VkDescriptorSet>& pDescriptorSets)
+    HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets)
 {
     fprintf(GetFile(), "%s\n", "vkFreeDescriptorSets");
 }
@@ -695,9 +695,9 @@ void VulkanAsciiConsumer::Process_vkFreeDescriptorSets(
 void VulkanAsciiConsumer::Process_vkUpdateDescriptorSets(
     format::HandleId                            device,
     uint32_t                                    descriptorWriteCount,
-    const StructPointerDecoder<Decoded_VkWriteDescriptorSet>& pDescriptorWrites,
+    StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites,
     uint32_t                                    descriptorCopyCount,
-    const StructPointerDecoder<Decoded_VkCopyDescriptorSet>& pDescriptorCopies)
+    StructPointerDecoder<Decoded_VkCopyDescriptorSet>* pDescriptorCopies)
 {
     fprintf(GetFile(), "%s\n", "vkUpdateDescriptorSets");
 }
@@ -705,8 +705,8 @@ void VulkanAsciiConsumer::Process_vkUpdateDescriptorSets(
 void VulkanAsciiConsumer::Process_vkCreateFramebuffer(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkFramebufferCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkFramebuffer>*        pFramebuffer)
 {
     fprintf(GetFile(), "%s\n", "vkCreateFramebuffer");
@@ -715,7 +715,7 @@ void VulkanAsciiConsumer::Process_vkCreateFramebuffer(
 void VulkanAsciiConsumer::Process_vkDestroyFramebuffer(
     format::HandleId                            device,
     format::HandleId                            framebuffer,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyFramebuffer");
 }
@@ -723,8 +723,8 @@ void VulkanAsciiConsumer::Process_vkDestroyFramebuffer(
 void VulkanAsciiConsumer::Process_vkCreateRenderPass(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkRenderPassCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkRenderPassCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkRenderPass>*         pRenderPass)
 {
     fprintf(GetFile(), "%s\n", "vkCreateRenderPass");
@@ -733,7 +733,7 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass(
 void VulkanAsciiConsumer::Process_vkDestroyRenderPass(
     format::HandleId                            device,
     format::HandleId                            renderPass,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyRenderPass");
 }
@@ -749,8 +749,8 @@ void VulkanAsciiConsumer::Process_vkGetRenderAreaGranularity(
 void VulkanAsciiConsumer::Process_vkCreateCommandPool(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkCommandPool>*        pCommandPool)
 {
     fprintf(GetFile(), "%s\n", "vkCreateCommandPool");
@@ -759,7 +759,7 @@ void VulkanAsciiConsumer::Process_vkCreateCommandPool(
 void VulkanAsciiConsumer::Process_vkDestroyCommandPool(
     format::HandleId                            device,
     format::HandleId                            commandPool,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyCommandPool");
 }
@@ -776,7 +776,7 @@ void VulkanAsciiConsumer::Process_vkResetCommandPool(
 void VulkanAsciiConsumer::Process_vkAllocateCommandBuffers(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>& pAllocateInfo,
+    StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
     HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers)
 {
     fprintf(GetFile(), "%s\n", "vkAllocateCommandBuffers");
@@ -786,7 +786,7 @@ void VulkanAsciiConsumer::Process_vkFreeCommandBuffers(
     format::HandleId                            device,
     format::HandleId                            commandPool,
     uint32_t                                    commandBufferCount,
-    const HandlePointerDecoder<VkCommandBuffer>& pCommandBuffers)
+    HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers)
 {
     fprintf(GetFile(), "%s\n", "vkFreeCommandBuffers");
 }
@@ -794,7 +794,7 @@ void VulkanAsciiConsumer::Process_vkFreeCommandBuffers(
 void VulkanAsciiConsumer::Process_vkBeginCommandBuffer(
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>& pBeginInfo)
+    StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo)
 {
     fprintf(GetFile(), "%s\n", "vkBeginCommandBuffer");
 }
@@ -826,7 +826,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewport(
     format::HandleId                            commandBuffer,
     uint32_t                                    firstViewport,
     uint32_t                                    viewportCount,
-    const StructPointerDecoder<Decoded_VkViewport>& pViewports)
+    StructPointerDecoder<Decoded_VkViewport>*   pViewports)
 {
     fprintf(GetFile(), "%s\n", "vkCmdSetViewport");
 }
@@ -835,7 +835,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetScissor(
     format::HandleId                            commandBuffer,
     uint32_t                                    firstScissor,
     uint32_t                                    scissorCount,
-    const StructPointerDecoder<Decoded_VkRect2D>& pScissors)
+    StructPointerDecoder<Decoded_VkRect2D>*     pScissors)
 {
     fprintf(GetFile(), "%s\n", "vkCmdSetScissor");
 }
@@ -858,7 +858,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBias(
 
 void VulkanAsciiConsumer::Process_vkCmdSetBlendConstants(
     format::HandleId                            commandBuffer,
-    const PointerDecoder<float>&                blendConstants)
+    PointerDecoder<float>*                      blendConstants)
 {
     fprintf(GetFile(), "%s\n", "vkCmdSetBlendConstants");
 }
@@ -901,9 +901,9 @@ void VulkanAsciiConsumer::Process_vkCmdBindDescriptorSets(
     format::HandleId                            layout,
     uint32_t                                    firstSet,
     uint32_t                                    descriptorSetCount,
-    const HandlePointerDecoder<VkDescriptorSet>& pDescriptorSets,
+    HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets,
     uint32_t                                    dynamicOffsetCount,
-    const PointerDecoder<uint32_t>&             pDynamicOffsets)
+    PointerDecoder<uint32_t>*                   pDynamicOffsets)
 {
     fprintf(GetFile(), "%s\n", "vkCmdBindDescriptorSets");
 }
@@ -921,8 +921,8 @@ void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers(
     format::HandleId                            commandBuffer,
     uint32_t                                    firstBinding,
     uint32_t                                    bindingCount,
-    const HandlePointerDecoder<VkBuffer>&       pBuffers,
-    const PointerDecoder<VkDeviceSize>&         pOffsets)
+    HandlePointerDecoder<VkBuffer>*             pBuffers,
+    PointerDecoder<VkDeviceSize>*               pOffsets)
 {
     fprintf(GetFile(), "%s\n", "vkCmdBindVertexBuffers");
 }
@@ -990,7 +990,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBuffer(
     format::HandleId                            srcBuffer,
     format::HandleId                            dstBuffer,
     uint32_t                                    regionCount,
-    const StructPointerDecoder<Decoded_VkBufferCopy>& pRegions)
+    StructPointerDecoder<Decoded_VkBufferCopy>* pRegions)
 {
     fprintf(GetFile(), "%s\n", "vkCmdCopyBuffer");
 }
@@ -1002,7 +1002,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImage(
     format::HandleId                            dstImage,
     VkImageLayout                               dstImageLayout,
     uint32_t                                    regionCount,
-    const StructPointerDecoder<Decoded_VkImageCopy>& pRegions)
+    StructPointerDecoder<Decoded_VkImageCopy>*  pRegions)
 {
     fprintf(GetFile(), "%s\n", "vkCmdCopyImage");
 }
@@ -1014,7 +1014,7 @@ void VulkanAsciiConsumer::Process_vkCmdBlitImage(
     format::HandleId                            dstImage,
     VkImageLayout                               dstImageLayout,
     uint32_t                                    regionCount,
-    const StructPointerDecoder<Decoded_VkImageBlit>& pRegions,
+    StructPointerDecoder<Decoded_VkImageBlit>*  pRegions,
     VkFilter                                    filter)
 {
     fprintf(GetFile(), "%s\n", "vkCmdBlitImage");
@@ -1026,7 +1026,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBufferToImage(
     format::HandleId                            dstImage,
     VkImageLayout                               dstImageLayout,
     uint32_t                                    regionCount,
-    const StructPointerDecoder<Decoded_VkBufferImageCopy>& pRegions)
+    StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions)
 {
     fprintf(GetFile(), "%s\n", "vkCmdCopyBufferToImage");
 }
@@ -1037,7 +1037,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImageToBuffer(
     VkImageLayout                               srcImageLayout,
     format::HandleId                            dstBuffer,
     uint32_t                                    regionCount,
-    const StructPointerDecoder<Decoded_VkBufferImageCopy>& pRegions)
+    StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions)
 {
     fprintf(GetFile(), "%s\n", "vkCmdCopyImageToBuffer");
 }
@@ -1047,7 +1047,7 @@ void VulkanAsciiConsumer::Process_vkCmdUpdateBuffer(
     format::HandleId                            dstBuffer,
     VkDeviceSize                                dstOffset,
     VkDeviceSize                                dataSize,
-    const PointerDecoder<uint8_t>&              pData)
+    PointerDecoder<uint8_t>*                    pData)
 {
     fprintf(GetFile(), "%s\n", "vkCmdUpdateBuffer");
 }
@@ -1066,9 +1066,9 @@ void VulkanAsciiConsumer::Process_vkCmdClearColorImage(
     format::HandleId                            commandBuffer,
     format::HandleId                            image,
     VkImageLayout                               imageLayout,
-    const StructPointerDecoder<Decoded_VkClearColorValue>& pColor,
+    StructPointerDecoder<Decoded_VkClearColorValue>* pColor,
     uint32_t                                    rangeCount,
-    const StructPointerDecoder<Decoded_VkImageSubresourceRange>& pRanges)
+    StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges)
 {
     fprintf(GetFile(), "%s\n", "vkCmdClearColorImage");
 }
@@ -1077,9 +1077,9 @@ void VulkanAsciiConsumer::Process_vkCmdClearDepthStencilImage(
     format::HandleId                            commandBuffer,
     format::HandleId                            image,
     VkImageLayout                               imageLayout,
-    const StructPointerDecoder<Decoded_VkClearDepthStencilValue>& pDepthStencil,
+    StructPointerDecoder<Decoded_VkClearDepthStencilValue>* pDepthStencil,
     uint32_t                                    rangeCount,
-    const StructPointerDecoder<Decoded_VkImageSubresourceRange>& pRanges)
+    StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges)
 {
     fprintf(GetFile(), "%s\n", "vkCmdClearDepthStencilImage");
 }
@@ -1087,9 +1087,9 @@ void VulkanAsciiConsumer::Process_vkCmdClearDepthStencilImage(
 void VulkanAsciiConsumer::Process_vkCmdClearAttachments(
     format::HandleId                            commandBuffer,
     uint32_t                                    attachmentCount,
-    const StructPointerDecoder<Decoded_VkClearAttachment>& pAttachments,
+    StructPointerDecoder<Decoded_VkClearAttachment>* pAttachments,
     uint32_t                                    rectCount,
-    const StructPointerDecoder<Decoded_VkClearRect>& pRects)
+    StructPointerDecoder<Decoded_VkClearRect>*  pRects)
 {
     fprintf(GetFile(), "%s\n", "vkCmdClearAttachments");
 }
@@ -1101,7 +1101,7 @@ void VulkanAsciiConsumer::Process_vkCmdResolveImage(
     format::HandleId                            dstImage,
     VkImageLayout                               dstImageLayout,
     uint32_t                                    regionCount,
-    const StructPointerDecoder<Decoded_VkImageResolve>& pRegions)
+    StructPointerDecoder<Decoded_VkImageResolve>* pRegions)
 {
     fprintf(GetFile(), "%s\n", "vkCmdResolveImage");
 }
@@ -1125,15 +1125,15 @@ void VulkanAsciiConsumer::Process_vkCmdResetEvent(
 void VulkanAsciiConsumer::Process_vkCmdWaitEvents(
     format::HandleId                            commandBuffer,
     uint32_t                                    eventCount,
-    const HandlePointerDecoder<VkEvent>&        pEvents,
+    HandlePointerDecoder<VkEvent>*              pEvents,
     VkPipelineStageFlags                        srcStageMask,
     VkPipelineStageFlags                        dstStageMask,
     uint32_t                                    memoryBarrierCount,
-    const StructPointerDecoder<Decoded_VkMemoryBarrier>& pMemoryBarriers,
+    StructPointerDecoder<Decoded_VkMemoryBarrier>* pMemoryBarriers,
     uint32_t                                    bufferMemoryBarrierCount,
-    const StructPointerDecoder<Decoded_VkBufferMemoryBarrier>& pBufferMemoryBarriers,
+    StructPointerDecoder<Decoded_VkBufferMemoryBarrier>* pBufferMemoryBarriers,
     uint32_t                                    imageMemoryBarrierCount,
-    const StructPointerDecoder<Decoded_VkImageMemoryBarrier>& pImageMemoryBarriers)
+    StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers)
 {
     fprintf(GetFile(), "%s\n", "vkCmdWaitEvents");
 }
@@ -1144,11 +1144,11 @@ void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier(
     VkPipelineStageFlags                        dstStageMask,
     VkDependencyFlags                           dependencyFlags,
     uint32_t                                    memoryBarrierCount,
-    const StructPointerDecoder<Decoded_VkMemoryBarrier>& pMemoryBarriers,
+    StructPointerDecoder<Decoded_VkMemoryBarrier>* pMemoryBarriers,
     uint32_t                                    bufferMemoryBarrierCount,
-    const StructPointerDecoder<Decoded_VkBufferMemoryBarrier>& pBufferMemoryBarriers,
+    StructPointerDecoder<Decoded_VkBufferMemoryBarrier>* pBufferMemoryBarriers,
     uint32_t                                    imageMemoryBarrierCount,
-    const StructPointerDecoder<Decoded_VkImageMemoryBarrier>& pImageMemoryBarriers)
+    StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers)
 {
     fprintf(GetFile(), "%s\n", "vkCmdPipelineBarrier");
 }
@@ -1207,14 +1207,14 @@ void VulkanAsciiConsumer::Process_vkCmdPushConstants(
     VkShaderStageFlags                          stageFlags,
     uint32_t                                    offset,
     uint32_t                                    size,
-    const PointerDecoder<uint8_t>&              pValues)
+    PointerDecoder<uint8_t>*                    pValues)
 {
     fprintf(GetFile(), "%s\n", "vkCmdPushConstants");
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass(
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkRenderPassBeginInfo>& pRenderPassBegin,
+    StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
     VkSubpassContents                           contents)
 {
     fprintf(GetFile(), "%s\n", "vkCmdBeginRenderPass");
@@ -1236,7 +1236,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndRenderPass(
 void VulkanAsciiConsumer::Process_vkCmdExecuteCommands(
     format::HandleId                            commandBuffer,
     uint32_t                                    commandBufferCount,
-    const HandlePointerDecoder<VkCommandBuffer>& pCommandBuffers)
+    HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers)
 {
     fprintf(GetFile(), "%s\n", "vkCmdExecuteCommands");
 }
@@ -1245,7 +1245,7 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory2(
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    bindInfoCount,
-    const StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>& pBindInfos)
+    StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos)
 {
     fprintf(GetFile(), "%s\n", "vkBindBufferMemory2");
 }
@@ -1254,7 +1254,7 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory2(
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    bindInfoCount,
-    const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>& pBindInfos)
+    StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos)
 {
     fprintf(GetFile(), "%s\n", "vkBindImageMemory2");
 }
@@ -1299,7 +1299,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroups(
 
 void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements2(
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>& pInfo,
+    StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
 {
     fprintf(GetFile(), "%s\n", "vkGetImageMemoryRequirements2");
@@ -1307,7 +1307,7 @@ void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements2(
 
 void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements2(
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>& pInfo,
+    StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
 {
     fprintf(GetFile(), "%s\n", "vkGetBufferMemoryRequirements2");
@@ -1315,7 +1315,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements2(
 
 void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements2(
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>& pInfo,
+    StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
     StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements)
 {
@@ -1347,7 +1347,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties2(
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2(
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
-    const StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>& pImageFormatInfo,
+    StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
     StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties)
 {
     fprintf(GetFile(), "%s\n", "vkGetPhysicalDeviceImageFormatProperties2");
@@ -1370,7 +1370,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties2(
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties2(
     format::HandleId                            physicalDevice,
-    const StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>& pFormatInfo,
+    StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
     PointerDecoder<uint32_t>*                   pPropertyCount,
     StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties)
 {
@@ -1387,7 +1387,7 @@ void VulkanAsciiConsumer::Process_vkTrimCommandPool(
 
 void VulkanAsciiConsumer::Process_vkGetDeviceQueue2(
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkDeviceQueueInfo2>& pQueueInfo,
+    StructPointerDecoder<Decoded_VkDeviceQueueInfo2>* pQueueInfo,
     HandlePointerDecoder<VkQueue>*              pQueue)
 {
     fprintf(GetFile(), "%s\n", "vkGetDeviceQueue2");
@@ -1396,8 +1396,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceQueue2(
 void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversion(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion)
 {
     fprintf(GetFile(), "%s\n", "vkCreateSamplerYcbcrConversion");
@@ -1406,7 +1406,7 @@ void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversion(
 void VulkanAsciiConsumer::Process_vkDestroySamplerYcbcrConversion(
     format::HandleId                            device,
     format::HandleId                            ycbcrConversion,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroySamplerYcbcrConversion");
 }
@@ -1414,8 +1414,8 @@ void VulkanAsciiConsumer::Process_vkDestroySamplerYcbcrConversion(
 void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplate(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate)
 {
     fprintf(GetFile(), "%s\n", "vkCreateDescriptorUpdateTemplate");
@@ -1424,14 +1424,14 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplate(
 void VulkanAsciiConsumer::Process_vkDestroyDescriptorUpdateTemplate(
     format::HandleId                            device,
     format::HandleId                            descriptorUpdateTemplate,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyDescriptorUpdateTemplate");
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalBufferProperties(
     format::HandleId                            physicalDevice,
-    const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>& pExternalBufferInfo,
+    StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
     StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties)
 {
     fprintf(GetFile(), "%s\n", "vkGetPhysicalDeviceExternalBufferProperties");
@@ -1439,7 +1439,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalBufferProperties(
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalFenceProperties(
     format::HandleId                            physicalDevice,
-    const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>& pExternalFenceInfo,
+    StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
     StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties)
 {
     fprintf(GetFile(), "%s\n", "vkGetPhysicalDeviceExternalFenceProperties");
@@ -1447,7 +1447,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalFenceProperties(
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalSemaphoreProperties(
     format::HandleId                            physicalDevice,
-    const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>& pExternalSemaphoreInfo,
+    StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
     StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties)
 {
     fprintf(GetFile(), "%s\n", "vkGetPhysicalDeviceExternalSemaphoreProperties");
@@ -1455,7 +1455,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalSemaphoreProperties
 
 void VulkanAsciiConsumer::Process_vkGetDescriptorSetLayoutSupport(
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>& pCreateInfo,
+    StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport)
 {
     fprintf(GetFile(), "%s\n", "vkGetDescriptorSetLayoutSupport");
@@ -1464,7 +1464,7 @@ void VulkanAsciiConsumer::Process_vkGetDescriptorSetLayoutSupport(
 void VulkanAsciiConsumer::Process_vkDestroySurfaceKHR(
     format::HandleId                            instance,
     format::HandleId                            surface,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroySurfaceKHR");
 }
@@ -1511,8 +1511,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
 void VulkanAsciiConsumer::Process_vkCreateSwapchainKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSwapchainKHR>*       pSwapchain)
 {
     fprintf(GetFile(), "%s\n", "vkCreateSwapchainKHR");
@@ -1521,7 +1521,7 @@ void VulkanAsciiConsumer::Process_vkCreateSwapchainKHR(
 void VulkanAsciiConsumer::Process_vkDestroySwapchainKHR(
     format::HandleId                            device,
     format::HandleId                            swapchain,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroySwapchainKHR");
 }
@@ -1551,7 +1551,7 @@ void VulkanAsciiConsumer::Process_vkAcquireNextImageKHR(
 void VulkanAsciiConsumer::Process_vkQueuePresentKHR(
     VkResult                                    returnValue,
     format::HandleId                            queue,
-    const StructPointerDecoder<Decoded_VkPresentInfoKHR>& pPresentInfo)
+    StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo)
 {
     fprintf(GetFile(), "%s\n", "vkQueuePresentKHR");
 }
@@ -1586,7 +1586,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
 void VulkanAsciiConsumer::Process_vkAcquireNextImage2KHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>& pAcquireInfo,
+    StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>* pAcquireInfo,
     PointerDecoder<uint32_t>*                   pImageIndex)
 {
     fprintf(GetFile(), "%s\n", "vkAcquireNextImage2KHR");
@@ -1634,8 +1634,8 @@ void VulkanAsciiConsumer::Process_vkCreateDisplayModeKHR(
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            display,
-    const StructPointerDecoder<Decoded_VkDisplayModeCreateInfoKHR>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkDisplayModeCreateInfoKHR>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkDisplayModeKHR>*     pMode)
 {
     fprintf(GetFile(), "%s\n", "vkCreateDisplayModeKHR");
@@ -1654,8 +1654,8 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilitiesKHR(
 void VulkanAsciiConsumer::Process_vkCreateDisplayPlaneSurfaceKHR(
     VkResult                                    returnValue,
     format::HandleId                            instance,
-    const StructPointerDecoder<Decoded_VkDisplaySurfaceCreateInfoKHR>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkDisplaySurfaceCreateInfoKHR>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
     fprintf(GetFile(), "%s\n", "vkCreateDisplayPlaneSurfaceKHR");
@@ -1665,8 +1665,8 @@ void VulkanAsciiConsumer::Process_vkCreateSharedSwapchainsKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    swapchainCount,
-    const StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>& pCreateInfos,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfos,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains)
 {
     fprintf(GetFile(), "%s\n", "vkCreateSharedSwapchainsKHR");
@@ -1675,8 +1675,8 @@ void VulkanAsciiConsumer::Process_vkCreateSharedSwapchainsKHR(
 void VulkanAsciiConsumer::Process_vkCreateXlibSurfaceKHR(
     VkResult                                    returnValue,
     format::HandleId                            instance,
-    const StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
     fprintf(GetFile(), "%s\n", "vkCreateXlibSurfaceKHR");
@@ -1695,8 +1695,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
 void VulkanAsciiConsumer::Process_vkCreateXcbSurfaceKHR(
     VkResult                                    returnValue,
     format::HandleId                            instance,
-    const StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
     fprintf(GetFile(), "%s\n", "vkCreateXcbSurfaceKHR");
@@ -1715,8 +1715,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
 void VulkanAsciiConsumer::Process_vkCreateWaylandSurfaceKHR(
     VkResult                                    returnValue,
     format::HandleId                            instance,
-    const StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
     fprintf(GetFile(), "%s\n", "vkCreateWaylandSurfaceKHR");
@@ -1734,8 +1734,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWaylandPresentationSupportK
 void VulkanAsciiConsumer::Process_vkCreateAndroidSurfaceKHR(
     VkResult                                    returnValue,
     format::HandleId                            instance,
-    const StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
     fprintf(GetFile(), "%s\n", "vkCreateAndroidSurfaceKHR");
@@ -1744,8 +1744,8 @@ void VulkanAsciiConsumer::Process_vkCreateAndroidSurfaceKHR(
 void VulkanAsciiConsumer::Process_vkCreateWin32SurfaceKHR(
     VkResult                                    returnValue,
     format::HandleId                            instance,
-    const StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
     fprintf(GetFile(), "%s\n", "vkCreateWin32SurfaceKHR");
@@ -1784,7 +1784,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties2KHR(
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
-    const StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>& pImageFormatInfo,
+    StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
     StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties)
 {
     fprintf(GetFile(), "%s\n", "vkGetPhysicalDeviceImageFormatProperties2KHR");
@@ -1807,7 +1807,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties2KHR(
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(
     format::HandleId                            physicalDevice,
-    const StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>& pFormatInfo,
+    StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
     PointerDecoder<uint32_t>*                   pPropertyCount,
     StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties)
 {
@@ -1862,7 +1862,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR(
     format::HandleId                            physicalDevice,
-    const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>& pExternalBufferInfo,
+    StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
     StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties)
 {
     fprintf(GetFile(), "%s\n", "vkGetPhysicalDeviceExternalBufferPropertiesKHR");
@@ -1871,7 +1871,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR
 void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkMemoryGetWin32HandleInfoKHR>& pGetWin32HandleInfo,
+    StructPointerDecoder<Decoded_VkMemoryGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
     PointerDecoder<uint64_t, void*>*            pHandle)
 {
     fprintf(GetFile(), "%s\n", "vkGetMemoryWin32HandleKHR");
@@ -1890,7 +1890,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandlePropertiesKHR(
 void VulkanAsciiConsumer::Process_vkGetMemoryFdKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkMemoryGetFdInfoKHR>& pGetFdInfo,
+    StructPointerDecoder<Decoded_VkMemoryGetFdInfoKHR>* pGetFdInfo,
     PointerDecoder<int>*                        pFd)
 {
     fprintf(GetFile(), "%s\n", "vkGetMemoryFdKHR");
@@ -1908,7 +1908,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryFdPropertiesKHR(
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(
     format::HandleId                            physicalDevice,
-    const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>& pExternalSemaphoreInfo,
+    StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
     StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties)
 {
     fprintf(GetFile(), "%s\n", "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR");
@@ -1917,7 +1917,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalSemaphoreProperties
 void VulkanAsciiConsumer::Process_vkImportSemaphoreWin32HandleKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>& pImportSemaphoreWin32HandleInfo)
+    StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>* pImportSemaphoreWin32HandleInfo)
 {
     fprintf(GetFile(), "%s\n", "vkImportSemaphoreWin32HandleKHR");
 }
@@ -1925,7 +1925,7 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreWin32HandleKHR(
 void VulkanAsciiConsumer::Process_vkGetSemaphoreWin32HandleKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>& pGetWin32HandleInfo,
+    StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
     PointerDecoder<uint64_t, void*>*            pHandle)
 {
     fprintf(GetFile(), "%s\n", "vkGetSemaphoreWin32HandleKHR");
@@ -1934,7 +1934,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreWin32HandleKHR(
 void VulkanAsciiConsumer::Process_vkImportSemaphoreFdKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>& pImportSemaphoreFdInfo)
+    StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>* pImportSemaphoreFdInfo)
 {
     fprintf(GetFile(), "%s\n", "vkImportSemaphoreFdKHR");
 }
@@ -1942,7 +1942,7 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreFdKHR(
 void VulkanAsciiConsumer::Process_vkGetSemaphoreFdKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkSemaphoreGetFdInfoKHR>& pGetFdInfo,
+    StructPointerDecoder<Decoded_VkSemaphoreGetFdInfoKHR>* pGetFdInfo,
     PointerDecoder<int>*                        pFd)
 {
     fprintf(GetFile(), "%s\n", "vkGetSemaphoreFdKHR");
@@ -1954,7 +1954,7 @@ void VulkanAsciiConsumer::Process_vkCmdPushDescriptorSetKHR(
     format::HandleId                            layout,
     uint32_t                                    set,
     uint32_t                                    descriptorWriteCount,
-    const StructPointerDecoder<Decoded_VkWriteDescriptorSet>& pDescriptorWrites)
+    StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites)
 {
     fprintf(GetFile(), "%s\n", "vkCmdPushDescriptorSetKHR");
 }
@@ -1962,8 +1962,8 @@ void VulkanAsciiConsumer::Process_vkCmdPushDescriptorSetKHR(
 void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplateKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate)
 {
     fprintf(GetFile(), "%s\n", "vkCreateDescriptorUpdateTemplateKHR");
@@ -1972,7 +1972,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplateKHR(
 void VulkanAsciiConsumer::Process_vkDestroyDescriptorUpdateTemplateKHR(
     format::HandleId                            device,
     format::HandleId                            descriptorUpdateTemplate,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyDescriptorUpdateTemplateKHR");
 }
@@ -1980,8 +1980,8 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorUpdateTemplateKHR(
 void VulkanAsciiConsumer::Process_vkCreateRenderPass2KHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkRenderPassCreateInfo2KHR>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkRenderPassCreateInfo2KHR>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkRenderPass>*         pRenderPass)
 {
     fprintf(GetFile(), "%s\n", "vkCreateRenderPass2KHR");
@@ -1989,23 +1989,23 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass2KHR(
 
 void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass2KHR(
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkRenderPassBeginInfo>& pRenderPassBegin,
-    const StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>& pSubpassBeginInfo)
+    StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
+    StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>* pSubpassBeginInfo)
 {
     fprintf(GetFile(), "%s\n", "vkCmdBeginRenderPass2KHR");
 }
 
 void VulkanAsciiConsumer::Process_vkCmdNextSubpass2KHR(
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>& pSubpassBeginInfo,
-    const StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>& pSubpassEndInfo)
+    StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>* pSubpassBeginInfo,
+    StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>* pSubpassEndInfo)
 {
     fprintf(GetFile(), "%s\n", "vkCmdNextSubpass2KHR");
 }
 
 void VulkanAsciiConsumer::Process_vkCmdEndRenderPass2KHR(
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>& pSubpassEndInfo)
+    StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>* pSubpassEndInfo)
 {
     fprintf(GetFile(), "%s\n", "vkCmdEndRenderPass2KHR");
 }
@@ -2020,7 +2020,7 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainStatusKHR(
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(
     format::HandleId                            physicalDevice,
-    const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>& pExternalFenceInfo,
+    StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
     StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties)
 {
     fprintf(GetFile(), "%s\n", "vkGetPhysicalDeviceExternalFencePropertiesKHR");
@@ -2029,7 +2029,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(
 void VulkanAsciiConsumer::Process_vkImportFenceWin32HandleKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkImportFenceWin32HandleInfoKHR>& pImportFenceWin32HandleInfo)
+    StructPointerDecoder<Decoded_VkImportFenceWin32HandleInfoKHR>* pImportFenceWin32HandleInfo)
 {
     fprintf(GetFile(), "%s\n", "vkImportFenceWin32HandleKHR");
 }
@@ -2037,7 +2037,7 @@ void VulkanAsciiConsumer::Process_vkImportFenceWin32HandleKHR(
 void VulkanAsciiConsumer::Process_vkGetFenceWin32HandleKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkFenceGetWin32HandleInfoKHR>& pGetWin32HandleInfo,
+    StructPointerDecoder<Decoded_VkFenceGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
     PointerDecoder<uint64_t, void*>*            pHandle)
 {
     fprintf(GetFile(), "%s\n", "vkGetFenceWin32HandleKHR");
@@ -2046,7 +2046,7 @@ void VulkanAsciiConsumer::Process_vkGetFenceWin32HandleKHR(
 void VulkanAsciiConsumer::Process_vkImportFenceFdKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkImportFenceFdInfoKHR>& pImportFenceFdInfo)
+    StructPointerDecoder<Decoded_VkImportFenceFdInfoKHR>* pImportFenceFdInfo)
 {
     fprintf(GetFile(), "%s\n", "vkImportFenceFdKHR");
 }
@@ -2054,7 +2054,7 @@ void VulkanAsciiConsumer::Process_vkImportFenceFdKHR(
 void VulkanAsciiConsumer::Process_vkGetFenceFdKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkFenceGetFdInfoKHR>& pGetFdInfo,
+    StructPointerDecoder<Decoded_VkFenceGetFdInfoKHR>* pGetFdInfo,
     PointerDecoder<int>*                        pFd)
 {
     fprintf(GetFile(), "%s\n", "vkGetFenceFdKHR");
@@ -2063,7 +2063,7 @@ void VulkanAsciiConsumer::Process_vkGetFenceFdKHR(
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
-    const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
+    StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
     StructPointerDecoder<Decoded_VkSurfaceCapabilities2KHR>* pSurfaceCapabilities)
 {
     fprintf(GetFile(), "%s\n", "vkGetPhysicalDeviceSurfaceCapabilities2KHR");
@@ -2072,7 +2072,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
-    const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
+    StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
     PointerDecoder<uint32_t>*                   pSurfaceFormatCount,
     StructPointerDecoder<Decoded_VkSurfaceFormat2KHR>* pSurfaceFormats)
 {
@@ -2110,7 +2110,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayModeProperties2KHR(
 void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
-    const StructPointerDecoder<Decoded_VkDisplayPlaneInfo2KHR>& pDisplayPlaneInfo,
+    StructPointerDecoder<Decoded_VkDisplayPlaneInfo2KHR>* pDisplayPlaneInfo,
     StructPointerDecoder<Decoded_VkDisplayPlaneCapabilities2KHR>* pCapabilities)
 {
     fprintf(GetFile(), "%s\n", "vkGetDisplayPlaneCapabilities2KHR");
@@ -2118,7 +2118,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(
 
 void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements2KHR(
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>& pInfo,
+    StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
 {
     fprintf(GetFile(), "%s\n", "vkGetImageMemoryRequirements2KHR");
@@ -2126,7 +2126,7 @@ void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements2KHR(
 
 void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements2KHR(
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>& pInfo,
+    StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
 {
     fprintf(GetFile(), "%s\n", "vkGetBufferMemoryRequirements2KHR");
@@ -2134,7 +2134,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements2KHR(
 
 void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements2KHR(
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>& pInfo,
+    StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
     StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements)
 {
@@ -2144,8 +2144,8 @@ void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements2KHR(
 void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion)
 {
     fprintf(GetFile(), "%s\n", "vkCreateSamplerYcbcrConversionKHR");
@@ -2154,7 +2154,7 @@ void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
 void VulkanAsciiConsumer::Process_vkDestroySamplerYcbcrConversionKHR(
     format::HandleId                            device,
     format::HandleId                            ycbcrConversion,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroySamplerYcbcrConversionKHR");
 }
@@ -2163,7 +2163,7 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory2KHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    bindInfoCount,
-    const StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>& pBindInfos)
+    StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos)
 {
     fprintf(GetFile(), "%s\n", "vkBindBufferMemory2KHR");
 }
@@ -2172,14 +2172,14 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory2KHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    bindInfoCount,
-    const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>& pBindInfos)
+    StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos)
 {
     fprintf(GetFile(), "%s\n", "vkBindImageMemory2KHR");
 }
 
 void VulkanAsciiConsumer::Process_vkGetDescriptorSetLayoutSupportKHR(
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>& pCreateInfo,
+    StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport)
 {
     fprintf(GetFile(), "%s\n", "vkGetDescriptorSetLayoutSupportKHR");
@@ -2221,7 +2221,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValueKHR(
 void VulkanAsciiConsumer::Process_vkWaitSemaphoresKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkSemaphoreWaitInfoKHR>& pWaitInfo,
+    StructPointerDecoder<Decoded_VkSemaphoreWaitInfoKHR>* pWaitInfo,
     uint64_t                                    timeout)
 {
     fprintf(GetFile(), "%s\n", "vkWaitSemaphoresKHR");
@@ -2230,7 +2230,7 @@ void VulkanAsciiConsumer::Process_vkWaitSemaphoresKHR(
 void VulkanAsciiConsumer::Process_vkSignalSemaphoreKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkSemaphoreSignalInfoKHR>& pSignalInfo)
+    StructPointerDecoder<Decoded_VkSemaphoreSignalInfoKHR>* pSignalInfo)
 {
     fprintf(GetFile(), "%s\n", "vkSignalSemaphoreKHR");
 }
@@ -2238,7 +2238,7 @@ void VulkanAsciiConsumer::Process_vkSignalSemaphoreKHR(
 void VulkanAsciiConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkPipelineInfoKHR>& pPipelineInfo,
+    StructPointerDecoder<Decoded_VkPipelineInfoKHR>* pPipelineInfo,
     PointerDecoder<uint32_t>*                   pExecutableCount,
     StructPointerDecoder<Decoded_VkPipelineExecutablePropertiesKHR>* pProperties)
 {
@@ -2248,7 +2248,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
 void VulkanAsciiConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>& pExecutableInfo,
+    StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
     PointerDecoder<uint32_t>*                   pStatisticCount,
     StructPointerDecoder<Decoded_VkPipelineExecutableStatisticKHR>* pStatistics)
 {
@@ -2258,7 +2258,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
 void VulkanAsciiConsumer::Process_vkGetPipelineExecutableInternalRepresentationsKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>& pExecutableInfo,
+    StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
     PointerDecoder<uint32_t>*                   pInternalRepresentationCount,
     StructPointerDecoder<Decoded_VkPipelineExecutableInternalRepresentationKHR>* pInternalRepresentations)
 {
@@ -2268,8 +2268,8 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutableInternalRepresentations
 void VulkanAsciiConsumer::Process_vkCreateDebugReportCallbackEXT(
     VkResult                                    returnValue,
     format::HandleId                            instance,
-    const StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkDebugReportCallbackEXT>* pCallback)
 {
     fprintf(GetFile(), "%s\n", "vkCreateDebugReportCallbackEXT");
@@ -2278,7 +2278,7 @@ void VulkanAsciiConsumer::Process_vkCreateDebugReportCallbackEXT(
 void VulkanAsciiConsumer::Process_vkDestroyDebugReportCallbackEXT(
     format::HandleId                            instance,
     format::HandleId                            callback,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyDebugReportCallbackEXT");
 }
@@ -2290,8 +2290,8 @@ void VulkanAsciiConsumer::Process_vkDebugReportMessageEXT(
     uint64_t                                    object,
     size_t                                      location,
     int32_t                                     messageCode,
-    const StringDecoder&                        pLayerPrefix,
-    const StringDecoder&                        pMessage)
+    StringDecoder*                              pLayerPrefix,
+    StringDecoder*                              pMessage)
 {
     fprintf(GetFile(), "%s\n", "vkDebugReportMessageEXT");
 }
@@ -2299,7 +2299,7 @@ void VulkanAsciiConsumer::Process_vkDebugReportMessageEXT(
 void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectTagEXT(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkDebugMarkerObjectTagInfoEXT>& pTagInfo)
+    StructPointerDecoder<Decoded_VkDebugMarkerObjectTagInfoEXT>* pTagInfo)
 {
     fprintf(GetFile(), "%s\n", "vkDebugMarkerSetObjectTagEXT");
 }
@@ -2307,14 +2307,14 @@ void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectTagEXT(
 void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectNameEXT(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkDebugMarkerObjectNameInfoEXT>& pNameInfo)
+    StructPointerDecoder<Decoded_VkDebugMarkerObjectNameInfoEXT>* pNameInfo)
 {
     fprintf(GetFile(), "%s\n", "vkDebugMarkerSetObjectNameEXT");
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDebugMarkerBeginEXT(
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>& pMarkerInfo)
+    StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo)
 {
     fprintf(GetFile(), "%s\n", "vkCmdDebugMarkerBeginEXT");
 }
@@ -2327,7 +2327,7 @@ void VulkanAsciiConsumer::Process_vkCmdDebugMarkerEndEXT(
 
 void VulkanAsciiConsumer::Process_vkCmdDebugMarkerInsertEXT(
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>& pMarkerInfo)
+    StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo)
 {
     fprintf(GetFile(), "%s\n", "vkCmdDebugMarkerInsertEXT");
 }
@@ -2336,9 +2336,9 @@ void VulkanAsciiConsumer::Process_vkCmdBindTransformFeedbackBuffersEXT(
     format::HandleId                            commandBuffer,
     uint32_t                                    firstBinding,
     uint32_t                                    bindingCount,
-    const HandlePointerDecoder<VkBuffer>&       pBuffers,
-    const PointerDecoder<VkDeviceSize>&         pOffsets,
-    const PointerDecoder<VkDeviceSize>&         pSizes)
+    HandlePointerDecoder<VkBuffer>*             pBuffers,
+    PointerDecoder<VkDeviceSize>*               pOffsets,
+    PointerDecoder<VkDeviceSize>*               pSizes)
 {
     fprintf(GetFile(), "%s\n", "vkCmdBindTransformFeedbackBuffersEXT");
 }
@@ -2347,8 +2347,8 @@ void VulkanAsciiConsumer::Process_vkCmdBeginTransformFeedbackEXT(
     format::HandleId                            commandBuffer,
     uint32_t                                    firstCounterBuffer,
     uint32_t                                    counterBufferCount,
-    const HandlePointerDecoder<VkBuffer>&       pCounterBuffers,
-    const PointerDecoder<VkDeviceSize>&         pCounterBufferOffsets)
+    HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
+    PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets)
 {
     fprintf(GetFile(), "%s\n", "vkCmdBeginTransformFeedbackEXT");
 }
@@ -2357,8 +2357,8 @@ void VulkanAsciiConsumer::Process_vkCmdEndTransformFeedbackEXT(
     format::HandleId                            commandBuffer,
     uint32_t                                    firstCounterBuffer,
     uint32_t                                    counterBufferCount,
-    const HandlePointerDecoder<VkBuffer>&       pCounterBuffers,
-    const PointerDecoder<VkDeviceSize>&         pCounterBufferOffsets)
+    HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
+    PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets)
 {
     fprintf(GetFile(), "%s\n", "vkCmdEndTransformFeedbackEXT");
 }
@@ -2397,7 +2397,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectByteCountEXT(
 void VulkanAsciiConsumer::Process_vkGetImageViewHandleNVX(
     uint32_t                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>& pInfo)
+    StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>* pInfo)
 {
     fprintf(GetFile(), "%s\n", "vkGetImageViewHandleNVX");
 }
@@ -2441,8 +2441,8 @@ void VulkanAsciiConsumer::Process_vkGetShaderInfoAMD(
 void VulkanAsciiConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
     VkResult                                    returnValue,
     format::HandleId                            instance,
-    const StructPointerDecoder<Decoded_VkStreamDescriptorSurfaceCreateInfoGGP>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkStreamDescriptorSurfaceCreateInfoGGP>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
     fprintf(GetFile(), "%s\n", "vkCreateStreamDescriptorSurfaceGGP");
@@ -2475,8 +2475,8 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleNV(
 void VulkanAsciiConsumer::Process_vkCreateViSurfaceNN(
     VkResult                                    returnValue,
     format::HandleId                            instance,
-    const StructPointerDecoder<Decoded_VkViSurfaceCreateInfoNN>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkViSurfaceCreateInfoNN>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
     fprintf(GetFile(), "%s\n", "vkCreateViSurfaceNN");
@@ -2484,7 +2484,7 @@ void VulkanAsciiConsumer::Process_vkCreateViSurfaceNN(
 
 void VulkanAsciiConsumer::Process_vkCmdBeginConditionalRenderingEXT(
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>& pConditionalRenderingBegin)
+    StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>* pConditionalRenderingBegin)
 {
     fprintf(GetFile(), "%s\n", "vkCmdBeginConditionalRenderingEXT");
 }
@@ -2497,14 +2497,14 @@ void VulkanAsciiConsumer::Process_vkCmdEndConditionalRenderingEXT(
 
 void VulkanAsciiConsumer::Process_vkCmdProcessCommandsNVX(
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkCmdProcessCommandsInfoNVX>& pProcessCommandsInfo)
+    StructPointerDecoder<Decoded_VkCmdProcessCommandsInfoNVX>* pProcessCommandsInfo)
 {
     fprintf(GetFile(), "%s\n", "vkCmdProcessCommandsNVX");
 }
 
 void VulkanAsciiConsumer::Process_vkCmdReserveSpaceForCommandsNVX(
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkCmdReserveSpaceForCommandsInfoNVX>& pReserveSpaceInfo)
+    StructPointerDecoder<Decoded_VkCmdReserveSpaceForCommandsInfoNVX>* pReserveSpaceInfo)
 {
     fprintf(GetFile(), "%s\n", "vkCmdReserveSpaceForCommandsNVX");
 }
@@ -2512,8 +2512,8 @@ void VulkanAsciiConsumer::Process_vkCmdReserveSpaceForCommandsNVX(
 void VulkanAsciiConsumer::Process_vkCreateIndirectCommandsLayoutNVX(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkIndirectCommandsLayoutCreateInfoNVX>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkIndirectCommandsLayoutCreateInfoNVX>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkIndirectCommandsLayoutNVX>* pIndirectCommandsLayout)
 {
     fprintf(GetFile(), "%s\n", "vkCreateIndirectCommandsLayoutNVX");
@@ -2522,7 +2522,7 @@ void VulkanAsciiConsumer::Process_vkCreateIndirectCommandsLayoutNVX(
 void VulkanAsciiConsumer::Process_vkDestroyIndirectCommandsLayoutNVX(
     format::HandleId                            device,
     format::HandleId                            indirectCommandsLayout,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyIndirectCommandsLayoutNVX");
 }
@@ -2530,8 +2530,8 @@ void VulkanAsciiConsumer::Process_vkDestroyIndirectCommandsLayoutNVX(
 void VulkanAsciiConsumer::Process_vkCreateObjectTableNVX(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkObjectTableCreateInfoNVX>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkObjectTableCreateInfoNVX>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkObjectTableNVX>*     pObjectTable)
 {
     fprintf(GetFile(), "%s\n", "vkCreateObjectTableNVX");
@@ -2540,7 +2540,7 @@ void VulkanAsciiConsumer::Process_vkCreateObjectTableNVX(
 void VulkanAsciiConsumer::Process_vkDestroyObjectTableNVX(
     format::HandleId                            device,
     format::HandleId                            objectTable,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyObjectTableNVX");
 }
@@ -2550,8 +2550,8 @@ void VulkanAsciiConsumer::Process_vkUnregisterObjectsNVX(
     format::HandleId                            device,
     format::HandleId                            objectTable,
     uint32_t                                    objectCount,
-    const PointerDecoder<VkObjectEntryTypeNVX>& pObjectEntryTypes,
-    const PointerDecoder<uint32_t>&             pObjectIndices)
+    PointerDecoder<VkObjectEntryTypeNVX>*       pObjectEntryTypes,
+    PointerDecoder<uint32_t>*                   pObjectIndices)
 {
     fprintf(GetFile(), "%s\n", "vkUnregisterObjectsNVX");
 }
@@ -2568,7 +2568,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportWScalingNV(
     format::HandleId                            commandBuffer,
     uint32_t                                    firstViewport,
     uint32_t                                    viewportCount,
-    const StructPointerDecoder<Decoded_VkViewportWScalingNV>& pViewportWScalings)
+    StructPointerDecoder<Decoded_VkViewportWScalingNV>* pViewportWScalings)
 {
     fprintf(GetFile(), "%s\n", "vkCmdSetViewportWScalingNV");
 }
@@ -2613,7 +2613,7 @@ void VulkanAsciiConsumer::Process_vkDisplayPowerControlEXT(
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            display,
-    const StructPointerDecoder<Decoded_VkDisplayPowerInfoEXT>& pDisplayPowerInfo)
+    StructPointerDecoder<Decoded_VkDisplayPowerInfoEXT>* pDisplayPowerInfo)
 {
     fprintf(GetFile(), "%s\n", "vkDisplayPowerControlEXT");
 }
@@ -2621,8 +2621,8 @@ void VulkanAsciiConsumer::Process_vkDisplayPowerControlEXT(
 void VulkanAsciiConsumer::Process_vkRegisterDeviceEventEXT(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkDeviceEventInfoEXT>& pDeviceEventInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkDeviceEventInfoEXT>* pDeviceEventInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkFence>*              pFence)
 {
     fprintf(GetFile(), "%s\n", "vkRegisterDeviceEventEXT");
@@ -2632,8 +2632,8 @@ void VulkanAsciiConsumer::Process_vkRegisterDisplayEventEXT(
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            display,
-    const StructPointerDecoder<Decoded_VkDisplayEventInfoEXT>& pDisplayEventInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkDisplayEventInfoEXT>* pDisplayEventInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkFence>*              pFence)
 {
     fprintf(GetFile(), "%s\n", "vkRegisterDisplayEventEXT");
@@ -2672,7 +2672,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDiscardRectangleEXT(
     format::HandleId                            commandBuffer,
     uint32_t                                    firstDiscardRectangle,
     uint32_t                                    discardRectangleCount,
-    const StructPointerDecoder<Decoded_VkRect2D>& pDiscardRectangles)
+    StructPointerDecoder<Decoded_VkRect2D>*     pDiscardRectangles)
 {
     fprintf(GetFile(), "%s\n", "vkCmdSetDiscardRectangleEXT");
 }
@@ -2680,8 +2680,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetDiscardRectangleEXT(
 void VulkanAsciiConsumer::Process_vkSetHdrMetadataEXT(
     format::HandleId                            device,
     uint32_t                                    swapchainCount,
-    const HandlePointerDecoder<VkSwapchainKHR>& pSwapchains,
-    const StructPointerDecoder<Decoded_VkHdrMetadataEXT>& pMetadata)
+    HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains,
+    StructPointerDecoder<Decoded_VkHdrMetadataEXT>* pMetadata)
 {
     fprintf(GetFile(), "%s\n", "vkSetHdrMetadataEXT");
 }
@@ -2689,8 +2689,8 @@ void VulkanAsciiConsumer::Process_vkSetHdrMetadataEXT(
 void VulkanAsciiConsumer::Process_vkCreateIOSSurfaceMVK(
     VkResult                                    returnValue,
     format::HandleId                            instance,
-    const StructPointerDecoder<Decoded_VkIOSSurfaceCreateInfoMVK>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkIOSSurfaceCreateInfoMVK>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
     fprintf(GetFile(), "%s\n", "vkCreateIOSSurfaceMVK");
@@ -2699,8 +2699,8 @@ void VulkanAsciiConsumer::Process_vkCreateIOSSurfaceMVK(
 void VulkanAsciiConsumer::Process_vkCreateMacOSSurfaceMVK(
     VkResult                                    returnValue,
     format::HandleId                            instance,
-    const StructPointerDecoder<Decoded_VkMacOSSurfaceCreateInfoMVK>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkMacOSSurfaceCreateInfoMVK>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
     fprintf(GetFile(), "%s\n", "vkCreateMacOSSurfaceMVK");
@@ -2709,7 +2709,7 @@ void VulkanAsciiConsumer::Process_vkCreateMacOSSurfaceMVK(
 void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectNameEXT(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>& pNameInfo)
+    StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* pNameInfo)
 {
     fprintf(GetFile(), "%s\n", "vkSetDebugUtilsObjectNameEXT");
 }
@@ -2717,14 +2717,14 @@ void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectNameEXT(
 void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectTagEXT(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>& pTagInfo)
+    StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>* pTagInfo)
 {
     fprintf(GetFile(), "%s\n", "vkSetDebugUtilsObjectTagEXT");
 }
 
 void VulkanAsciiConsumer::Process_vkQueueBeginDebugUtilsLabelEXT(
     format::HandleId                            queue,
-    const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo)
+    StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo)
 {
     fprintf(GetFile(), "%s\n", "vkQueueBeginDebugUtilsLabelEXT");
 }
@@ -2737,14 +2737,14 @@ void VulkanAsciiConsumer::Process_vkQueueEndDebugUtilsLabelEXT(
 
 void VulkanAsciiConsumer::Process_vkQueueInsertDebugUtilsLabelEXT(
     format::HandleId                            queue,
-    const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo)
+    StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo)
 {
     fprintf(GetFile(), "%s\n", "vkQueueInsertDebugUtilsLabelEXT");
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBeginDebugUtilsLabelEXT(
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo)
+    StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo)
 {
     fprintf(GetFile(), "%s\n", "vkCmdBeginDebugUtilsLabelEXT");
 }
@@ -2757,7 +2757,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndDebugUtilsLabelEXT(
 
 void VulkanAsciiConsumer::Process_vkCmdInsertDebugUtilsLabelEXT(
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo)
+    StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo)
 {
     fprintf(GetFile(), "%s\n", "vkCmdInsertDebugUtilsLabelEXT");
 }
@@ -2765,8 +2765,8 @@ void VulkanAsciiConsumer::Process_vkCmdInsertDebugUtilsLabelEXT(
 void VulkanAsciiConsumer::Process_vkCreateDebugUtilsMessengerEXT(
     VkResult                                    returnValue,
     format::HandleId                            instance,
-    const StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkDebugUtilsMessengerEXT>* pMessenger)
 {
     fprintf(GetFile(), "%s\n", "vkCreateDebugUtilsMessengerEXT");
@@ -2775,7 +2775,7 @@ void VulkanAsciiConsumer::Process_vkCreateDebugUtilsMessengerEXT(
 void VulkanAsciiConsumer::Process_vkDestroyDebugUtilsMessengerEXT(
     format::HandleId                            instance,
     format::HandleId                            messenger,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyDebugUtilsMessengerEXT");
 }
@@ -2784,7 +2784,7 @@ void VulkanAsciiConsumer::Process_vkSubmitDebugUtilsMessageEXT(
     format::HandleId                            instance,
     VkDebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,
     VkDebugUtilsMessageTypeFlagsEXT             messageTypes,
-    const StructPointerDecoder<Decoded_VkDebugUtilsMessengerCallbackDataEXT>& pCallbackData)
+    StructPointerDecoder<Decoded_VkDebugUtilsMessengerCallbackDataEXT>* pCallbackData)
 {
     fprintf(GetFile(), "%s\n", "vkSubmitDebugUtilsMessageEXT");
 }
@@ -2801,7 +2801,7 @@ void VulkanAsciiConsumer::Process_vkGetAndroidHardwareBufferPropertiesANDROID(
 void VulkanAsciiConsumer::Process_vkGetMemoryAndroidHardwareBufferANDROID(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID>& pInfo,
+    StructPointerDecoder<Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID>* pInfo,
     PointerDecoder<uint64_t, void*>*            pBuffer)
 {
     fprintf(GetFile(), "%s\n", "vkGetMemoryAndroidHardwareBufferANDROID");
@@ -2809,7 +2809,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryAndroidHardwareBufferANDROID(
 
 void VulkanAsciiConsumer::Process_vkCmdSetSampleLocationsEXT(
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkSampleLocationsInfoEXT>& pSampleLocationsInfo)
+    StructPointerDecoder<Decoded_VkSampleLocationsInfoEXT>* pSampleLocationsInfo)
 {
     fprintf(GetFile(), "%s\n", "vkCmdSetSampleLocationsEXT");
 }
@@ -2834,8 +2834,8 @@ void VulkanAsciiConsumer::Process_vkGetImageDrmFormatModifierPropertiesEXT(
 void VulkanAsciiConsumer::Process_vkCreateValidationCacheEXT(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkValidationCacheCreateInfoEXT>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkValidationCacheCreateInfoEXT>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkValidationCacheEXT>* pValidationCache)
 {
     fprintf(GetFile(), "%s\n", "vkCreateValidationCacheEXT");
@@ -2844,7 +2844,7 @@ void VulkanAsciiConsumer::Process_vkCreateValidationCacheEXT(
 void VulkanAsciiConsumer::Process_vkDestroyValidationCacheEXT(
     format::HandleId                            device,
     format::HandleId                            validationCache,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyValidationCacheEXT");
 }
@@ -2854,7 +2854,7 @@ void VulkanAsciiConsumer::Process_vkMergeValidationCachesEXT(
     format::HandleId                            device,
     format::HandleId                            dstCache,
     uint32_t                                    srcCacheCount,
-    const HandlePointerDecoder<VkValidationCacheEXT>& pSrcCaches)
+    HandlePointerDecoder<VkValidationCacheEXT>* pSrcCaches)
 {
     fprintf(GetFile(), "%s\n", "vkMergeValidationCachesEXT");
 }
@@ -2881,7 +2881,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportShadingRatePaletteNV(
     format::HandleId                            commandBuffer,
     uint32_t                                    firstViewport,
     uint32_t                                    viewportCount,
-    const StructPointerDecoder<Decoded_VkShadingRatePaletteNV>& pShadingRatePalettes)
+    StructPointerDecoder<Decoded_VkShadingRatePaletteNV>* pShadingRatePalettes)
 {
     fprintf(GetFile(), "%s\n", "vkCmdSetViewportShadingRatePaletteNV");
 }
@@ -2890,7 +2890,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetCoarseSampleOrderNV(
     format::HandleId                            commandBuffer,
     VkCoarseSampleOrderTypeNV                   sampleOrderType,
     uint32_t                                    customSampleOrderCount,
-    const StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>& pCustomSampleOrders)
+    StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>* pCustomSampleOrders)
 {
     fprintf(GetFile(), "%s\n", "vkCmdSetCoarseSampleOrderNV");
 }
@@ -2898,8 +2898,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetCoarseSampleOrderNV(
 void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureNV(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoNV>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoNV>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructure)
 {
     fprintf(GetFile(), "%s\n", "vkCreateAccelerationStructureNV");
@@ -2908,14 +2908,14 @@ void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureNV(
 void VulkanAsciiConsumer::Process_vkDestroyAccelerationStructureNV(
     format::HandleId                            device,
     format::HandleId                            accelerationStructure,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator)
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     fprintf(GetFile(), "%s\n", "vkDestroyAccelerationStructureNV");
 }
 
 void VulkanAsciiConsumer::Process_vkGetAccelerationStructureMemoryRequirementsNV(
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkAccelerationStructureMemoryRequirementsInfoNV>& pInfo,
+    StructPointerDecoder<Decoded_VkAccelerationStructureMemoryRequirementsInfoNV>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2KHR>* pMemoryRequirements)
 {
     fprintf(GetFile(), "%s\n", "vkGetAccelerationStructureMemoryRequirementsNV");
@@ -2925,14 +2925,14 @@ void VulkanAsciiConsumer::Process_vkBindAccelerationStructureMemoryNV(
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    bindInfoCount,
-    const StructPointerDecoder<Decoded_VkBindAccelerationStructureMemoryInfoNV>& pBindInfos)
+    StructPointerDecoder<Decoded_VkBindAccelerationStructureMemoryInfoNV>* pBindInfos)
 {
     fprintf(GetFile(), "%s\n", "vkBindAccelerationStructureMemoryNV");
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBuildAccelerationStructureNV(
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>& pInfo,
+    StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>* pInfo,
     format::HandleId                            instanceData,
     VkDeviceSize                                instanceOffset,
     VkBool32                                    update,
@@ -2978,8 +2978,8 @@ void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesNV(
     format::HandleId                            device,
     format::HandleId                            pipelineCache,
     uint32_t                                    createInfoCount,
-    const StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoNV>& pCreateInfos,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoNV>* pCreateInfos,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkPipeline>*           pPipelines)
 {
     fprintf(GetFile(), "%s\n", "vkCreateRayTracingPipelinesNV");
@@ -3010,7 +3010,7 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureHandleNV(
 void VulkanAsciiConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesNV(
     format::HandleId                            commandBuffer,
     uint32_t                                    accelerationStructureCount,
-    const HandlePointerDecoder<VkAccelerationStructureNV>& pAccelerationStructures,
+    HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructures,
     VkQueryType                                 queryType,
     format::HandleId                            queryPool,
     uint32_t                                    firstQuery)
@@ -3060,7 +3060,7 @@ void VulkanAsciiConsumer::Process_vkGetCalibratedTimestampsEXT(
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    timestampCount,
-    const StructPointerDecoder<Decoded_VkCalibratedTimestampInfoEXT>& pTimestampInfos,
+    StructPointerDecoder<Decoded_VkCalibratedTimestampInfoEXT>* pTimestampInfos,
     PointerDecoder<uint64_t>*                   pTimestamps,
     PointerDecoder<uint64_t>*                   pMaxDeviation)
 {
@@ -3101,7 +3101,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetExclusiveScissorNV(
     format::HandleId                            commandBuffer,
     uint32_t                                    firstExclusiveScissor,
     uint32_t                                    exclusiveScissorCount,
-    const StructPointerDecoder<Decoded_VkRect2D>& pExclusiveScissors)
+    StructPointerDecoder<Decoded_VkRect2D>*     pExclusiveScissors)
 {
     fprintf(GetFile(), "%s\n", "vkCmdSetExclusiveScissorNV");
 }
@@ -3124,7 +3124,7 @@ void VulkanAsciiConsumer::Process_vkGetQueueCheckpointDataNV(
 void VulkanAsciiConsumer::Process_vkInitializePerformanceApiINTEL(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkInitializePerformanceApiInfoINTEL>& pInitializeInfo)
+    StructPointerDecoder<Decoded_VkInitializePerformanceApiInfoINTEL>* pInitializeInfo)
 {
     fprintf(GetFile(), "%s\n", "vkInitializePerformanceApiINTEL");
 }
@@ -3138,7 +3138,7 @@ void VulkanAsciiConsumer::Process_vkUninitializePerformanceApiINTEL(
 void VulkanAsciiConsumer::Process_vkCmdSetPerformanceMarkerINTEL(
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkPerformanceMarkerInfoINTEL>& pMarkerInfo)
+    StructPointerDecoder<Decoded_VkPerformanceMarkerInfoINTEL>* pMarkerInfo)
 {
     fprintf(GetFile(), "%s\n", "vkCmdSetPerformanceMarkerINTEL");
 }
@@ -3146,7 +3146,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceMarkerINTEL(
 void VulkanAsciiConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkPerformanceStreamMarkerInfoINTEL>& pMarkerInfo)
+    StructPointerDecoder<Decoded_VkPerformanceStreamMarkerInfoINTEL>* pMarkerInfo)
 {
     fprintf(GetFile(), "%s\n", "vkCmdSetPerformanceStreamMarkerINTEL");
 }
@@ -3154,7 +3154,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
 void VulkanAsciiConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer,
-    const StructPointerDecoder<Decoded_VkPerformanceOverrideInfoINTEL>& pOverrideInfo)
+    StructPointerDecoder<Decoded_VkPerformanceOverrideInfoINTEL>* pOverrideInfo)
 {
     fprintf(GetFile(), "%s\n", "vkCmdSetPerformanceOverrideINTEL");
 }
@@ -3162,7 +3162,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
 void VulkanAsciiConsumer::Process_vkAcquirePerformanceConfigurationINTEL(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkPerformanceConfigurationAcquireInfoINTEL>& pAcquireInfo,
+    StructPointerDecoder<Decoded_VkPerformanceConfigurationAcquireInfoINTEL>* pAcquireInfo,
     HandlePointerDecoder<VkPerformanceConfigurationINTEL>* pConfiguration)
 {
     fprintf(GetFile(), "%s\n", "vkAcquirePerformanceConfigurationINTEL");
@@ -3204,8 +3204,8 @@ void VulkanAsciiConsumer::Process_vkSetLocalDimmingAMD(
 void VulkanAsciiConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
     VkResult                                    returnValue,
     format::HandleId                            instance,
-    const StructPointerDecoder<Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
     fprintf(GetFile(), "%s\n", "vkCreateImagePipeSurfaceFUCHSIA");
@@ -3214,8 +3214,8 @@ void VulkanAsciiConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
 void VulkanAsciiConsumer::Process_vkCreateMetalSurfaceEXT(
     VkResult                                    returnValue,
     format::HandleId                            instance,
-    const StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
     fprintf(GetFile(), "%s\n", "vkCreateMetalSurfaceEXT");
@@ -3224,7 +3224,7 @@ void VulkanAsciiConsumer::Process_vkCreateMetalSurfaceEXT(
 void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressEXT(
     VkDeviceAddress                             returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkBufferDeviceAddressInfoEXT>& pInfo)
+    StructPointerDecoder<Decoded_VkBufferDeviceAddressInfoEXT>* pInfo)
 {
     fprintf(GetFile(), "%s\n", "vkGetBufferDeviceAddressEXT");
 }
@@ -3250,7 +3250,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedSa
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
-    const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
+    StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
     PointerDecoder<uint32_t>*                   pPresentModeCount,
     PointerDecoder<VkPresentModeKHR>*           pPresentModes)
 {
@@ -3276,7 +3276,7 @@ void VulkanAsciiConsumer::Process_vkReleaseFullScreenExclusiveModeEXT(
 void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModes2EXT(
     VkResult                                    returnValue,
     format::HandleId                            device,
-    const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
+    StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
     PointerDecoder<VkDeviceGroupPresentModeFlagsKHR>* pModes)
 {
     fprintf(GetFile(), "%s\n", "vkGetDeviceGroupSurfacePresentModes2EXT");
@@ -3285,8 +3285,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModes2EXT(
 void VulkanAsciiConsumer::Process_vkCreateHeadlessSurfaceEXT(
     VkResult                                    returnValue,
     format::HandleId                            instance,
-    const StructPointerDecoder<Decoded_VkHeadlessSurfaceCreateInfoEXT>& pCreateInfo,
-    const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+    StructPointerDecoder<Decoded_VkHeadlessSurfaceCreateInfoEXT>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkSurfaceKHR>*         pSurface)
 {
     fprintf(GetFile(), "%s\n", "vkCreateHeadlessSurfaceEXT");

--- a/framework/generated/generated_vulkan_ascii_consumer.h
+++ b/framework/generated/generated_vulkan_ascii_consumer.h
@@ -40,13 +40,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
 
     virtual void Process_vkCreateInstance(
         VkResult                                    returnValue,
-        const StructPointerDecoder<Decoded_VkInstanceCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkInstanceCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkInstance>*           pInstance) override;
 
     virtual void Process_vkDestroyInstance(
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkEnumeratePhysicalDevices(
         VkResult                                    returnValue,
@@ -89,13 +89,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCreateDevice(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkDeviceCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDeviceCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDevice>*             pDevice) override;
 
     virtual void Process_vkDestroyDevice(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetDeviceQueue(
         format::HandleId                            device,
@@ -107,7 +107,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    submitCount,
-        const StructPointerDecoder<Decoded_VkSubmitInfo>& pSubmits,
+        StructPointerDecoder<Decoded_VkSubmitInfo>* pSubmits,
         format::HandleId                            fence) override;
 
     virtual void Process_vkQueueWaitIdle(
@@ -121,14 +121,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkAllocateMemory(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkMemoryAllocateInfo>& pAllocateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkMemoryAllocateInfo>* pAllocateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDeviceMemory>*       pMemory) override;
 
     virtual void Process_vkFreeMemory(
         format::HandleId                            device,
         format::HandleId                            memory,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkMapMemory(
         VkResult                                    returnValue,
@@ -147,13 +147,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    memoryRangeCount,
-        const StructPointerDecoder<Decoded_VkMappedMemoryRange>& pMemoryRanges) override;
+        StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges) override;
 
     virtual void Process_vkInvalidateMappedMemoryRanges(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    memoryRangeCount,
-        const StructPointerDecoder<Decoded_VkMappedMemoryRange>& pMemoryRanges) override;
+        StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges) override;
 
     virtual void Process_vkGetDeviceMemoryCommitment(
         format::HandleId                            device,
@@ -204,26 +204,26 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindSparseInfo>& pBindInfo,
+        StructPointerDecoder<Decoded_VkBindSparseInfo>* pBindInfo,
         format::HandleId                            fence) override;
 
     virtual void Process_vkCreateFence(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkFenceCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkFenceCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkFence>*              pFence) override;
 
     virtual void Process_vkDestroyFence(
         format::HandleId                            device,
         format::HandleId                            fence,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkResetFences(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    fenceCount,
-        const HandlePointerDecoder<VkFence>&        pFences) override;
+        HandlePointerDecoder<VkFence>*              pFences) override;
 
     virtual void Process_vkGetFenceStatus(
         VkResult                                    returnValue,
@@ -234,33 +234,33 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    fenceCount,
-        const HandlePointerDecoder<VkFence>&        pFences,
+        HandlePointerDecoder<VkFence>*              pFences,
         VkBool32                                    waitAll,
         uint64_t                                    timeout) override;
 
     virtual void Process_vkCreateSemaphore(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSemaphoreCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSemaphoreCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSemaphore>*          pSemaphore) override;
 
     virtual void Process_vkDestroySemaphore(
         format::HandleId                            device,
         format::HandleId                            semaphore,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateEvent(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkEventCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkEventCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkEvent>*              pEvent) override;
 
     virtual void Process_vkDestroyEvent(
         format::HandleId                            device,
         format::HandleId                            event,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetEventStatus(
         VkResult                                    returnValue,
@@ -280,14 +280,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCreateQueryPool(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkQueryPoolCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkQueryPoolCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkQueryPool>*          pQueryPool) override;
 
     virtual void Process_vkDestroyQueryPool(
         format::HandleId                            device,
         format::HandleId                            queryPool,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetQueryPoolResults(
         VkResult                                    returnValue,
@@ -303,80 +303,80 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCreateBuffer(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkBufferCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkBufferCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkBuffer>*             pBuffer) override;
 
     virtual void Process_vkDestroyBuffer(
         format::HandleId                            device,
         format::HandleId                            buffer,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateBufferView(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkBufferViewCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkBufferViewCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkBufferView>*         pView) override;
 
     virtual void Process_vkDestroyBufferView(
         format::HandleId                            device,
         format::HandleId                            bufferView,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateImage(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkImageCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkImage>*              pImage) override;
 
     virtual void Process_vkDestroyImage(
         format::HandleId                            device,
         format::HandleId                            image,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetImageSubresourceLayout(
         format::HandleId                            device,
         format::HandleId                            image,
-        const StructPointerDecoder<Decoded_VkImageSubresource>& pSubresource,
+        StructPointerDecoder<Decoded_VkImageSubresource>* pSubresource,
         StructPointerDecoder<Decoded_VkSubresourceLayout>* pLayout) override;
 
     virtual void Process_vkCreateImageView(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageViewCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkImageViewCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkImageView>*          pView) override;
 
     virtual void Process_vkDestroyImageView(
         format::HandleId                            device,
         format::HandleId                            imageView,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateShaderModule(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkShaderModule>*       pShaderModule) override;
 
     virtual void Process_vkDestroyShaderModule(
         format::HandleId                            device,
         format::HandleId                            shaderModule,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreatePipelineCache(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkPipelineCache>*      pPipelineCache) override;
 
     virtual void Process_vkDestroyPipelineCache(
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetPipelineCacheData(
         VkResult                                    returnValue,
@@ -390,15 +390,15 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            device,
         format::HandleId                            dstCache,
         uint32_t                                    srcCacheCount,
-        const HandlePointerDecoder<VkPipelineCache>& pSrcCaches) override;
+        HandlePointerDecoder<VkPipelineCache>*      pSrcCaches) override;
 
     virtual void Process_vkCreateGraphicsPipelines(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
         uint32_t                                    createInfoCount,
-        const StructPointerDecoder<Decoded_VkGraphicsPipelineCreateInfo>& pCreateInfos,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkGraphicsPipelineCreateInfo>* pCreateInfos,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkPipeline>*           pPipelines) override;
 
     virtual void Process_vkCreateComputePipelines(
@@ -406,62 +406,62 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
         uint32_t                                    createInfoCount,
-        const StructPointerDecoder<Decoded_VkComputePipelineCreateInfo>& pCreateInfos,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkComputePipelineCreateInfo>* pCreateInfos,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkPipeline>*           pPipelines) override;
 
     virtual void Process_vkDestroyPipeline(
         format::HandleId                            device,
         format::HandleId                            pipeline,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreatePipelineLayout(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPipelineLayoutCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkPipelineLayoutCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkPipelineLayout>*     pPipelineLayout) override;
 
     virtual void Process_vkDestroyPipelineLayout(
         format::HandleId                            device,
         format::HandleId                            pipelineLayout,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateSampler(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSamplerCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSamplerCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSampler>*            pSampler) override;
 
     virtual void Process_vkDestroySampler(
         format::HandleId                            device,
         format::HandleId                            sampler,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateDescriptorSetLayout(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDescriptorSetLayout>* pSetLayout) override;
 
     virtual void Process_vkDestroyDescriptorSetLayout(
         format::HandleId                            device,
         format::HandleId                            descriptorSetLayout,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateDescriptorPool(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDescriptorPool>*     pDescriptorPool) override;
 
     virtual void Process_vkDestroyDescriptorPool(
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkResetDescriptorPool(
         VkResult                                    returnValue,
@@ -472,7 +472,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkAllocateDescriptorSets(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>& pAllocateInfo,
+        StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
         HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) override;
 
     virtual void Process_vkFreeDescriptorSets(
@@ -480,38 +480,38 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
         uint32_t                                    descriptorSetCount,
-        const HandlePointerDecoder<VkDescriptorSet>& pDescriptorSets) override;
+        HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) override;
 
     virtual void Process_vkUpdateDescriptorSets(
         format::HandleId                            device,
         uint32_t                                    descriptorWriteCount,
-        const StructPointerDecoder<Decoded_VkWriteDescriptorSet>& pDescriptorWrites,
+        StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites,
         uint32_t                                    descriptorCopyCount,
-        const StructPointerDecoder<Decoded_VkCopyDescriptorSet>& pDescriptorCopies) override;
+        StructPointerDecoder<Decoded_VkCopyDescriptorSet>* pDescriptorCopies) override;
 
     virtual void Process_vkCreateFramebuffer(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkFramebufferCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkFramebuffer>*        pFramebuffer) override;
 
     virtual void Process_vkDestroyFramebuffer(
         format::HandleId                            device,
         format::HandleId                            framebuffer,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateRenderPass(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkRenderPassCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkRenderPassCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkRenderPass>*         pRenderPass) override;
 
     virtual void Process_vkDestroyRenderPass(
         format::HandleId                            device,
         format::HandleId                            renderPass,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetRenderAreaGranularity(
         format::HandleId                            device,
@@ -521,14 +521,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCreateCommandPool(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkCommandPool>*        pCommandPool) override;
 
     virtual void Process_vkDestroyCommandPool(
         format::HandleId                            device,
         format::HandleId                            commandPool,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkResetCommandPool(
         VkResult                                    returnValue,
@@ -539,19 +539,19 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkAllocateCommandBuffers(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>& pAllocateInfo,
+        StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
         HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) override;
 
     virtual void Process_vkFreeCommandBuffers(
         format::HandleId                            device,
         format::HandleId                            commandPool,
         uint32_t                                    commandBufferCount,
-        const HandlePointerDecoder<VkCommandBuffer>& pCommandBuffers) override;
+        HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) override;
 
     virtual void Process_vkBeginCommandBuffer(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>& pBeginInfo) override;
+        StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo) override;
 
     virtual void Process_vkEndCommandBuffer(
         VkResult                                    returnValue,
@@ -571,13 +571,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
-        const StructPointerDecoder<Decoded_VkViewport>& pViewports) override;
+        StructPointerDecoder<Decoded_VkViewport>*   pViewports) override;
 
     virtual void Process_vkCmdSetScissor(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstScissor,
         uint32_t                                    scissorCount,
-        const StructPointerDecoder<Decoded_VkRect2D>& pScissors) override;
+        StructPointerDecoder<Decoded_VkRect2D>*     pScissors) override;
 
     virtual void Process_vkCmdSetLineWidth(
         format::HandleId                            commandBuffer,
@@ -591,7 +591,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
 
     virtual void Process_vkCmdSetBlendConstants(
         format::HandleId                            commandBuffer,
-        const PointerDecoder<float>&                blendConstants) override;
+        PointerDecoder<float>*                      blendConstants) override;
 
     virtual void Process_vkCmdSetDepthBounds(
         format::HandleId                            commandBuffer,
@@ -619,9 +619,9 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            layout,
         uint32_t                                    firstSet,
         uint32_t                                    descriptorSetCount,
-        const HandlePointerDecoder<VkDescriptorSet>& pDescriptorSets,
+        HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets,
         uint32_t                                    dynamicOffsetCount,
-        const PointerDecoder<uint32_t>&             pDynamicOffsets) override;
+        PointerDecoder<uint32_t>*                   pDynamicOffsets) override;
 
     virtual void Process_vkCmdBindIndexBuffer(
         format::HandleId                            commandBuffer,
@@ -633,8 +633,8 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
-        const HandlePointerDecoder<VkBuffer>&       pBuffers,
-        const PointerDecoder<VkDeviceSize>&         pOffsets) override;
+        HandlePointerDecoder<VkBuffer>*             pBuffers,
+        PointerDecoder<VkDeviceSize>*               pOffsets) override;
 
     virtual void Process_vkCmdDraw(
         format::HandleId                            commandBuffer,
@@ -681,7 +681,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            srcBuffer,
         format::HandleId                            dstBuffer,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkBufferCopy>& pRegions) override;
+        StructPointerDecoder<Decoded_VkBufferCopy>* pRegions) override;
 
     virtual void Process_vkCmdCopyImage(
         format::HandleId                            commandBuffer,
@@ -690,7 +690,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            dstImage,
         VkImageLayout                               dstImageLayout,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkImageCopy>& pRegions) override;
+        StructPointerDecoder<Decoded_VkImageCopy>*  pRegions) override;
 
     virtual void Process_vkCmdBlitImage(
         format::HandleId                            commandBuffer,
@@ -699,7 +699,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            dstImage,
         VkImageLayout                               dstImageLayout,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkImageBlit>& pRegions,
+        StructPointerDecoder<Decoded_VkImageBlit>*  pRegions,
         VkFilter                                    filter) override;
 
     virtual void Process_vkCmdCopyBufferToImage(
@@ -708,7 +708,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            dstImage,
         VkImageLayout                               dstImageLayout,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkBufferImageCopy>& pRegions) override;
+        StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions) override;
 
     virtual void Process_vkCmdCopyImageToBuffer(
         format::HandleId                            commandBuffer,
@@ -716,14 +716,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkImageLayout                               srcImageLayout,
         format::HandleId                            dstBuffer,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkBufferImageCopy>& pRegions) override;
+        StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions) override;
 
     virtual void Process_vkCmdUpdateBuffer(
         format::HandleId                            commandBuffer,
         format::HandleId                            dstBuffer,
         VkDeviceSize                                dstOffset,
         VkDeviceSize                                dataSize,
-        const PointerDecoder<uint8_t>&              pData) override;
+        PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkCmdFillBuffer(
         format::HandleId                            commandBuffer,
@@ -736,24 +736,24 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            commandBuffer,
         format::HandleId                            image,
         VkImageLayout                               imageLayout,
-        const StructPointerDecoder<Decoded_VkClearColorValue>& pColor,
+        StructPointerDecoder<Decoded_VkClearColorValue>* pColor,
         uint32_t                                    rangeCount,
-        const StructPointerDecoder<Decoded_VkImageSubresourceRange>& pRanges) override;
+        StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges) override;
 
     virtual void Process_vkCmdClearDepthStencilImage(
         format::HandleId                            commandBuffer,
         format::HandleId                            image,
         VkImageLayout                               imageLayout,
-        const StructPointerDecoder<Decoded_VkClearDepthStencilValue>& pDepthStencil,
+        StructPointerDecoder<Decoded_VkClearDepthStencilValue>* pDepthStencil,
         uint32_t                                    rangeCount,
-        const StructPointerDecoder<Decoded_VkImageSubresourceRange>& pRanges) override;
+        StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges) override;
 
     virtual void Process_vkCmdClearAttachments(
         format::HandleId                            commandBuffer,
         uint32_t                                    attachmentCount,
-        const StructPointerDecoder<Decoded_VkClearAttachment>& pAttachments,
+        StructPointerDecoder<Decoded_VkClearAttachment>* pAttachments,
         uint32_t                                    rectCount,
-        const StructPointerDecoder<Decoded_VkClearRect>& pRects) override;
+        StructPointerDecoder<Decoded_VkClearRect>*  pRects) override;
 
     virtual void Process_vkCmdResolveImage(
         format::HandleId                            commandBuffer,
@@ -762,7 +762,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            dstImage,
         VkImageLayout                               dstImageLayout,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkImageResolve>& pRegions) override;
+        StructPointerDecoder<Decoded_VkImageResolve>* pRegions) override;
 
     virtual void Process_vkCmdSetEvent(
         format::HandleId                            commandBuffer,
@@ -777,15 +777,15 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCmdWaitEvents(
         format::HandleId                            commandBuffer,
         uint32_t                                    eventCount,
-        const HandlePointerDecoder<VkEvent>&        pEvents,
+        HandlePointerDecoder<VkEvent>*              pEvents,
         VkPipelineStageFlags                        srcStageMask,
         VkPipelineStageFlags                        dstStageMask,
         uint32_t                                    memoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkMemoryBarrier>& pMemoryBarriers,
+        StructPointerDecoder<Decoded_VkMemoryBarrier>* pMemoryBarriers,
         uint32_t                                    bufferMemoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkBufferMemoryBarrier>& pBufferMemoryBarriers,
+        StructPointerDecoder<Decoded_VkBufferMemoryBarrier>* pBufferMemoryBarriers,
         uint32_t                                    imageMemoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkImageMemoryBarrier>& pImageMemoryBarriers) override;
+        StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers) override;
 
     virtual void Process_vkCmdPipelineBarrier(
         format::HandleId                            commandBuffer,
@@ -793,11 +793,11 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkPipelineStageFlags                        dstStageMask,
         VkDependencyFlags                           dependencyFlags,
         uint32_t                                    memoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkMemoryBarrier>& pMemoryBarriers,
+        StructPointerDecoder<Decoded_VkMemoryBarrier>* pMemoryBarriers,
         uint32_t                                    bufferMemoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkBufferMemoryBarrier>& pBufferMemoryBarriers,
+        StructPointerDecoder<Decoded_VkBufferMemoryBarrier>* pBufferMemoryBarriers,
         uint32_t                                    imageMemoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkImageMemoryBarrier>& pImageMemoryBarriers) override;
+        StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers) override;
 
     virtual void Process_vkCmdBeginQuery(
         format::HandleId                            commandBuffer,
@@ -838,11 +838,11 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkShaderStageFlags                          stageFlags,
         uint32_t                                    offset,
         uint32_t                                    size,
-        const PointerDecoder<uint8_t>&              pValues) override;
+        PointerDecoder<uint8_t>*                    pValues) override;
 
     virtual void Process_vkCmdBeginRenderPass(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkRenderPassBeginInfo>& pRenderPassBegin,
+        StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
         VkSubpassContents                           contents) override;
 
     virtual void Process_vkCmdNextSubpass(
@@ -855,19 +855,19 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCmdExecuteCommands(
         format::HandleId                            commandBuffer,
         uint32_t                                    commandBufferCount,
-        const HandlePointerDecoder<VkCommandBuffer>& pCommandBuffers) override;
+        HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) override;
 
     virtual void Process_vkBindBufferMemory2(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>& pBindInfos) override;
+        StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos) override;
 
     virtual void Process_vkBindImageMemory2(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>& pBindInfos) override;
+        StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos) override;
 
     virtual void Process_vkGetDeviceGroupPeerMemoryFeatures(
         format::HandleId                            device,
@@ -897,17 +897,17 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
 
     virtual void Process_vkGetImageMemoryRequirements2(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetBufferMemoryRequirements2(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetImageSparseMemoryRequirements2(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) override;
 
@@ -927,7 +927,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties2(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>& pImageFormatInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
         StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties2(
@@ -941,7 +941,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties2(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>& pFormatInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties) override;
 
@@ -952,57 +952,57 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
 
     virtual void Process_vkGetDeviceQueue2(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDeviceQueueInfo2>& pQueueInfo,
+        StructPointerDecoder<Decoded_VkDeviceQueueInfo2>* pQueueInfo,
         HandlePointerDecoder<VkQueue>*              pQueue) override;
 
     virtual void Process_vkCreateSamplerYcbcrConversion(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion) override;
 
     virtual void Process_vkDestroySamplerYcbcrConversion(
         format::HandleId                            device,
         format::HandleId                            ycbcrConversion,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateDescriptorUpdateTemplate(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate) override;
 
     virtual void Process_vkDestroyDescriptorUpdateTemplate(
         format::HandleId                            device,
         format::HandleId                            descriptorUpdateTemplate,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalBufferProperties(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>& pExternalBufferInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
         StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalFenceProperties(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>& pExternalFenceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
         StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalSemaphoreProperties(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>& pExternalSemaphoreInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
         StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties) override;
 
     virtual void Process_vkGetDescriptorSetLayoutSupport(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>& pCreateInfo,
+        StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport) override;
 
     virtual void Process_vkDestroySurfaceKHR(
         format::HandleId                            instance,
         format::HandleId                            surface,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceSupportKHR(
         VkResult                                    returnValue,
@@ -1034,14 +1034,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCreateSwapchainKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSwapchainKHR>*       pSwapchain) override;
 
     virtual void Process_vkDestroySwapchainKHR(
         format::HandleId                            device,
         format::HandleId                            swapchain,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetSwapchainImagesKHR(
         VkResult                                    returnValue,
@@ -1062,7 +1062,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkQueuePresentKHR(
         VkResult                                    returnValue,
         format::HandleId                            queue,
-        const StructPointerDecoder<Decoded_VkPresentInfoKHR>& pPresentInfo) override;
+        StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo) override;
 
     virtual void Process_vkGetDeviceGroupPresentCapabilitiesKHR(
         VkResult                                    returnValue,
@@ -1085,7 +1085,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkAcquireNextImage2KHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>& pAcquireInfo,
+        StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>* pAcquireInfo,
         PointerDecoder<uint32_t>*                   pImageIndex) override;
 
     virtual void Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
@@ -1118,8 +1118,8 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display,
-        const StructPointerDecoder<Decoded_VkDisplayModeCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDisplayModeCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDisplayModeKHR>*     pMode) override;
 
     virtual void Process_vkGetDisplayPlaneCapabilitiesKHR(
@@ -1132,23 +1132,23 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCreateDisplayPlaneSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkDisplaySurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDisplaySurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCreateSharedSwapchainsKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    swapchainCount,
-        const StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>& pCreateInfos,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfos,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains) override;
 
     virtual void Process_vkCreateXlibSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
@@ -1161,8 +1161,8 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCreateXcbSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
@@ -1175,8 +1175,8 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCreateWaylandSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceWaylandPresentationSupportKHR(
@@ -1188,15 +1188,15 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCreateAndroidSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCreateWin32SurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceWin32PresentationSupportKHR(
@@ -1220,7 +1220,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>& pImageFormatInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
         StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
@@ -1234,7 +1234,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>& pFormatInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties) override;
 
@@ -1271,13 +1271,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
 
     virtual void Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>& pExternalBufferInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
         StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties) override;
 
     virtual void Process_vkGetMemoryWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkMemoryGetWin32HandleInfoKHR>& pGetWin32HandleInfo,
+        StructPointerDecoder<Decoded_VkMemoryGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) override;
 
     virtual void Process_vkGetMemoryWin32HandlePropertiesKHR(
@@ -1290,7 +1290,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkGetMemoryFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkMemoryGetFdInfoKHR>& pGetFdInfo,
+        StructPointerDecoder<Decoded_VkMemoryGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) override;
 
     virtual void Process_vkGetMemoryFdPropertiesKHR(
@@ -1302,29 +1302,29 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
 
     virtual void Process_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>& pExternalSemaphoreInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
         StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties) override;
 
     virtual void Process_vkImportSemaphoreWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>& pImportSemaphoreWin32HandleInfo) override;
+        StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>* pImportSemaphoreWin32HandleInfo) override;
 
     virtual void Process_vkGetSemaphoreWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>& pGetWin32HandleInfo,
+        StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) override;
 
     virtual void Process_vkImportSemaphoreFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>& pImportSemaphoreFdInfo) override;
+        StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>* pImportSemaphoreFdInfo) override;
 
     virtual void Process_vkGetSemaphoreFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSemaphoreGetFdInfoKHR>& pGetFdInfo,
+        StructPointerDecoder<Decoded_VkSemaphoreGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) override;
 
     virtual void Process_vkCmdPushDescriptorSetKHR(
@@ -1333,40 +1333,40 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            layout,
         uint32_t                                    set,
         uint32_t                                    descriptorWriteCount,
-        const StructPointerDecoder<Decoded_VkWriteDescriptorSet>& pDescriptorWrites) override;
+        StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites) override;
 
     virtual void Process_vkCreateDescriptorUpdateTemplateKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate) override;
 
     virtual void Process_vkDestroyDescriptorUpdateTemplateKHR(
         format::HandleId                            device,
         format::HandleId                            descriptorUpdateTemplate,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateRenderPass2KHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkRenderPassCreateInfo2KHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkRenderPassCreateInfo2KHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkRenderPass>*         pRenderPass) override;
 
     virtual void Process_vkCmdBeginRenderPass2KHR(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkRenderPassBeginInfo>& pRenderPassBegin,
-        const StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>& pSubpassBeginInfo) override;
+        StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
+        StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>* pSubpassBeginInfo) override;
 
     virtual void Process_vkCmdNextSubpass2KHR(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>& pSubpassBeginInfo,
-        const StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>& pSubpassEndInfo) override;
+        StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>* pSubpassBeginInfo,
+        StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>* pSubpassEndInfo) override;
 
     virtual void Process_vkCmdEndRenderPass2KHR(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>& pSubpassEndInfo) override;
+        StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>* pSubpassEndInfo) override;
 
     virtual void Process_vkGetSwapchainStatusKHR(
         VkResult                                    returnValue,
@@ -1375,41 +1375,41 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
 
     virtual void Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>& pExternalFenceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
         StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties) override;
 
     virtual void Process_vkImportFenceWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImportFenceWin32HandleInfoKHR>& pImportFenceWin32HandleInfo) override;
+        StructPointerDecoder<Decoded_VkImportFenceWin32HandleInfoKHR>* pImportFenceWin32HandleInfo) override;
 
     virtual void Process_vkGetFenceWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkFenceGetWin32HandleInfoKHR>& pGetWin32HandleInfo,
+        StructPointerDecoder<Decoded_VkFenceGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) override;
 
     virtual void Process_vkImportFenceFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImportFenceFdInfoKHR>& pImportFenceFdInfo) override;
+        StructPointerDecoder<Decoded_VkImportFenceFdInfoKHR>* pImportFenceFdInfo) override;
 
     virtual void Process_vkGetFenceFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkFenceGetFdInfoKHR>& pGetFdInfo,
+        StructPointerDecoder<Decoded_VkFenceGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         StructPointerDecoder<Decoded_VkSurfaceCapabilities2KHR>* pSurfaceCapabilities) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         PointerDecoder<uint32_t>*                   pSurfaceFormatCount,
         StructPointerDecoder<Decoded_VkSurfaceFormat2KHR>* pSurfaceFormats) override;
 
@@ -1435,52 +1435,52 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkGetDisplayPlaneCapabilities2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkDisplayPlaneInfo2KHR>& pDisplayPlaneInfo,
+        StructPointerDecoder<Decoded_VkDisplayPlaneInfo2KHR>* pDisplayPlaneInfo,
         StructPointerDecoder<Decoded_VkDisplayPlaneCapabilities2KHR>* pCapabilities) override;
 
     virtual void Process_vkGetImageMemoryRequirements2KHR(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetBufferMemoryRequirements2KHR(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetImageSparseMemoryRequirements2KHR(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) override;
 
     virtual void Process_vkCreateSamplerYcbcrConversionKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion) override;
 
     virtual void Process_vkDestroySamplerYcbcrConversionKHR(
         format::HandleId                            device,
         format::HandleId                            ycbcrConversion,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkBindBufferMemory2KHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>& pBindInfos) override;
+        StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos) override;
 
     virtual void Process_vkBindImageMemory2KHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>& pBindInfos) override;
+        StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos) override;
 
     virtual void Process_vkGetDescriptorSetLayoutSupportKHR(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>& pCreateInfo,
+        StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport) override;
 
     virtual void Process_vkCmdDrawIndirectCountKHR(
@@ -1510,46 +1510,46 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkWaitSemaphoresKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSemaphoreWaitInfoKHR>& pWaitInfo,
+        StructPointerDecoder<Decoded_VkSemaphoreWaitInfoKHR>* pWaitInfo,
         uint64_t                                    timeout) override;
 
     virtual void Process_vkSignalSemaphoreKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSemaphoreSignalInfoKHR>& pSignalInfo) override;
+        StructPointerDecoder<Decoded_VkSemaphoreSignalInfoKHR>* pSignalInfo) override;
 
     virtual void Process_vkGetPipelineExecutablePropertiesKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPipelineInfoKHR>& pPipelineInfo,
+        StructPointerDecoder<Decoded_VkPipelineInfoKHR>* pPipelineInfo,
         PointerDecoder<uint32_t>*                   pExecutableCount,
         StructPointerDecoder<Decoded_VkPipelineExecutablePropertiesKHR>* pProperties) override;
 
     virtual void Process_vkGetPipelineExecutableStatisticsKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>& pExecutableInfo,
+        StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
         PointerDecoder<uint32_t>*                   pStatisticCount,
         StructPointerDecoder<Decoded_VkPipelineExecutableStatisticKHR>* pStatistics) override;
 
     virtual void Process_vkGetPipelineExecutableInternalRepresentationsKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>& pExecutableInfo,
+        StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
         PointerDecoder<uint32_t>*                   pInternalRepresentationCount,
         StructPointerDecoder<Decoded_VkPipelineExecutableInternalRepresentationKHR>* pInternalRepresentations) override;
 
     virtual void Process_vkCreateDebugReportCallbackEXT(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDebugReportCallbackEXT>* pCallback) override;
 
     virtual void Process_vkDestroyDebugReportCallbackEXT(
         format::HandleId                            instance,
         format::HandleId                            callback,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkDebugReportMessageEXT(
         format::HandleId                            instance,
@@ -1558,51 +1558,51 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint64_t                                    object,
         size_t                                      location,
         int32_t                                     messageCode,
-        const StringDecoder&                        pLayerPrefix,
-        const StringDecoder&                        pMessage) override;
+        StringDecoder*                              pLayerPrefix,
+        StringDecoder*                              pMessage) override;
 
     virtual void Process_vkDebugMarkerSetObjectTagEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDebugMarkerObjectTagInfoEXT>& pTagInfo) override;
+        StructPointerDecoder<Decoded_VkDebugMarkerObjectTagInfoEXT>* pTagInfo) override;
 
     virtual void Process_vkDebugMarkerSetObjectNameEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDebugMarkerObjectNameInfoEXT>& pNameInfo) override;
+        StructPointerDecoder<Decoded_VkDebugMarkerObjectNameInfoEXT>* pNameInfo) override;
 
     virtual void Process_vkCmdDebugMarkerBeginEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>& pMarkerInfo) override;
+        StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo) override;
 
     virtual void Process_vkCmdDebugMarkerEndEXT(
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkCmdDebugMarkerInsertEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>& pMarkerInfo) override;
+        StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo) override;
 
     virtual void Process_vkCmdBindTransformFeedbackBuffersEXT(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
-        const HandlePointerDecoder<VkBuffer>&       pBuffers,
-        const PointerDecoder<VkDeviceSize>&         pOffsets,
-        const PointerDecoder<VkDeviceSize>&         pSizes) override;
+        HandlePointerDecoder<VkBuffer>*             pBuffers,
+        PointerDecoder<VkDeviceSize>*               pOffsets,
+        PointerDecoder<VkDeviceSize>*               pSizes) override;
 
     virtual void Process_vkCmdBeginTransformFeedbackEXT(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstCounterBuffer,
         uint32_t                                    counterBufferCount,
-        const HandlePointerDecoder<VkBuffer>&       pCounterBuffers,
-        const PointerDecoder<VkDeviceSize>&         pCounterBufferOffsets) override;
+        HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
+        PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets) override;
 
     virtual void Process_vkCmdEndTransformFeedbackEXT(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstCounterBuffer,
         uint32_t                                    counterBufferCount,
-        const HandlePointerDecoder<VkBuffer>&       pCounterBuffers,
-        const PointerDecoder<VkDeviceSize>&         pCounterBufferOffsets) override;
+        HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
+        PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets) override;
 
     virtual void Process_vkCmdBeginQueryIndexedEXT(
         format::HandleId                            commandBuffer,
@@ -1629,7 +1629,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkGetImageViewHandleNVX(
         uint32_t                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>& pInfo) override;
+        StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>* pInfo) override;
 
     virtual void Process_vkCmdDrawIndirectCountAMD(
         format::HandleId                            commandBuffer,
@@ -1661,8 +1661,8 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCreateStreamDescriptorSurfaceGGP(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkStreamDescriptorSurfaceCreateInfoGGP>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkStreamDescriptorSurfaceCreateInfoGGP>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(
@@ -1686,56 +1686,56 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCreateViSurfaceNN(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkViSurfaceCreateInfoNN>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkViSurfaceCreateInfoNN>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCmdBeginConditionalRenderingEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>& pConditionalRenderingBegin) override;
+        StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>* pConditionalRenderingBegin) override;
 
     virtual void Process_vkCmdEndConditionalRenderingEXT(
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkCmdProcessCommandsNVX(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkCmdProcessCommandsInfoNVX>& pProcessCommandsInfo) override;
+        StructPointerDecoder<Decoded_VkCmdProcessCommandsInfoNVX>* pProcessCommandsInfo) override;
 
     virtual void Process_vkCmdReserveSpaceForCommandsNVX(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkCmdReserveSpaceForCommandsInfoNVX>& pReserveSpaceInfo) override;
+        StructPointerDecoder<Decoded_VkCmdReserveSpaceForCommandsInfoNVX>* pReserveSpaceInfo) override;
 
     virtual void Process_vkCreateIndirectCommandsLayoutNVX(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkIndirectCommandsLayoutCreateInfoNVX>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkIndirectCommandsLayoutCreateInfoNVX>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkIndirectCommandsLayoutNVX>* pIndirectCommandsLayout) override;
 
     virtual void Process_vkDestroyIndirectCommandsLayoutNVX(
         format::HandleId                            device,
         format::HandleId                            indirectCommandsLayout,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateObjectTableNVX(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkObjectTableCreateInfoNVX>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkObjectTableCreateInfoNVX>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkObjectTableNVX>*     pObjectTable) override;
 
     virtual void Process_vkDestroyObjectTableNVX(
         format::HandleId                            device,
         format::HandleId                            objectTable,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkUnregisterObjectsNVX(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            objectTable,
         uint32_t                                    objectCount,
-        const PointerDecoder<VkObjectEntryTypeNVX>& pObjectEntryTypes,
-        const PointerDecoder<uint32_t>&             pObjectIndices) override;
+        PointerDecoder<VkObjectEntryTypeNVX>*       pObjectEntryTypes,
+        PointerDecoder<uint32_t>*                   pObjectIndices) override;
 
     virtual void Process_vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX(
         format::HandleId                            physicalDevice,
@@ -1746,7 +1746,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
-        const StructPointerDecoder<Decoded_VkViewportWScalingNV>& pViewportWScalings) override;
+        StructPointerDecoder<Decoded_VkViewportWScalingNV>* pViewportWScalings) override;
 
     virtual void Process_vkReleaseDisplayEXT(
         VkResult                                    returnValue,
@@ -1776,21 +1776,21 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            display,
-        const StructPointerDecoder<Decoded_VkDisplayPowerInfoEXT>& pDisplayPowerInfo) override;
+        StructPointerDecoder<Decoded_VkDisplayPowerInfoEXT>* pDisplayPowerInfo) override;
 
     virtual void Process_vkRegisterDeviceEventEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDeviceEventInfoEXT>& pDeviceEventInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDeviceEventInfoEXT>* pDeviceEventInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkFence>*              pFence) override;
 
     virtual void Process_vkRegisterDisplayEventEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            display,
-        const StructPointerDecoder<Decoded_VkDisplayEventInfoEXT>& pDisplayEventInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDisplayEventInfoEXT>* pDisplayEventInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkFence>*              pFence) override;
 
     virtual void Process_vkGetSwapchainCounterEXT(
@@ -1817,77 +1817,77 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstDiscardRectangle,
         uint32_t                                    discardRectangleCount,
-        const StructPointerDecoder<Decoded_VkRect2D>& pDiscardRectangles) override;
+        StructPointerDecoder<Decoded_VkRect2D>*     pDiscardRectangles) override;
 
     virtual void Process_vkSetHdrMetadataEXT(
         format::HandleId                            device,
         uint32_t                                    swapchainCount,
-        const HandlePointerDecoder<VkSwapchainKHR>& pSwapchains,
-        const StructPointerDecoder<Decoded_VkHdrMetadataEXT>& pMetadata) override;
+        HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains,
+        StructPointerDecoder<Decoded_VkHdrMetadataEXT>* pMetadata) override;
 
     virtual void Process_vkCreateIOSSurfaceMVK(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkIOSSurfaceCreateInfoMVK>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkIOSSurfaceCreateInfoMVK>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCreateMacOSSurfaceMVK(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkMacOSSurfaceCreateInfoMVK>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkMacOSSurfaceCreateInfoMVK>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkSetDebugUtilsObjectNameEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>& pNameInfo) override;
+        StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* pNameInfo) override;
 
     virtual void Process_vkSetDebugUtilsObjectTagEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>& pTagInfo) override;
+        StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>* pTagInfo) override;
 
     virtual void Process_vkQueueBeginDebugUtilsLabelEXT(
         format::HandleId                            queue,
-        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) override;
+        StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) override;
 
     virtual void Process_vkQueueEndDebugUtilsLabelEXT(
         format::HandleId                            queue) override;
 
     virtual void Process_vkQueueInsertDebugUtilsLabelEXT(
         format::HandleId                            queue,
-        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) override;
+        StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) override;
 
     virtual void Process_vkCmdBeginDebugUtilsLabelEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) override;
+        StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) override;
 
     virtual void Process_vkCmdEndDebugUtilsLabelEXT(
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkCmdInsertDebugUtilsLabelEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) override;
+        StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) override;
 
     virtual void Process_vkCreateDebugUtilsMessengerEXT(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDebugUtilsMessengerEXT>* pMessenger) override;
 
     virtual void Process_vkDestroyDebugUtilsMessengerEXT(
         format::HandleId                            instance,
         format::HandleId                            messenger,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkSubmitDebugUtilsMessageEXT(
         format::HandleId                            instance,
         VkDebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,
         VkDebugUtilsMessageTypeFlagsEXT             messageTypes,
-        const StructPointerDecoder<Decoded_VkDebugUtilsMessengerCallbackDataEXT>& pCallbackData) override;
+        StructPointerDecoder<Decoded_VkDebugUtilsMessengerCallbackDataEXT>* pCallbackData) override;
 
     virtual void Process_vkGetAndroidHardwareBufferPropertiesANDROID(
         VkResult                                    returnValue,
@@ -1898,12 +1898,12 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkGetMemoryAndroidHardwareBufferANDROID(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID>& pInfo,
+        StructPointerDecoder<Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID>* pInfo,
         PointerDecoder<uint64_t, void*>*            pBuffer) override;
 
     virtual void Process_vkCmdSetSampleLocationsEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkSampleLocationsInfoEXT>& pSampleLocationsInfo) override;
+        StructPointerDecoder<Decoded_VkSampleLocationsInfoEXT>* pSampleLocationsInfo) override;
 
     virtual void Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(
         format::HandleId                            physicalDevice,
@@ -1919,21 +1919,21 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCreateValidationCacheEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkValidationCacheCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkValidationCacheCreateInfoEXT>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkValidationCacheEXT>* pValidationCache) override;
 
     virtual void Process_vkDestroyValidationCacheEXT(
         format::HandleId                            device,
         format::HandleId                            validationCache,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkMergeValidationCachesEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            dstCache,
         uint32_t                                    srcCacheCount,
-        const HandlePointerDecoder<VkValidationCacheEXT>& pSrcCaches) override;
+        HandlePointerDecoder<VkValidationCacheEXT>* pSrcCaches) override;
 
     virtual void Process_vkGetValidationCacheDataEXT(
         VkResult                                    returnValue,
@@ -1951,40 +1951,40 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
-        const StructPointerDecoder<Decoded_VkShadingRatePaletteNV>& pShadingRatePalettes) override;
+        StructPointerDecoder<Decoded_VkShadingRatePaletteNV>* pShadingRatePalettes) override;
 
     virtual void Process_vkCmdSetCoarseSampleOrderNV(
         format::HandleId                            commandBuffer,
         VkCoarseSampleOrderTypeNV                   sampleOrderType,
         uint32_t                                    customSampleOrderCount,
-        const StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>& pCustomSampleOrders) override;
+        StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>* pCustomSampleOrders) override;
 
     virtual void Process_vkCreateAccelerationStructureNV(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoNV>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoNV>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructure) override;
 
     virtual void Process_vkDestroyAccelerationStructureNV(
         format::HandleId                            device,
         format::HandleId                            accelerationStructure,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetAccelerationStructureMemoryRequirementsNV(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkAccelerationStructureMemoryRequirementsInfoNV>& pInfo,
+        StructPointerDecoder<Decoded_VkAccelerationStructureMemoryRequirementsInfoNV>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2KHR>* pMemoryRequirements) override;
 
     virtual void Process_vkBindAccelerationStructureMemoryNV(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindAccelerationStructureMemoryInfoNV>& pBindInfos) override;
+        StructPointerDecoder<Decoded_VkBindAccelerationStructureMemoryInfoNV>* pBindInfos) override;
 
     virtual void Process_vkCmdBuildAccelerationStructureNV(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>& pInfo,
+        StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>* pInfo,
         format::HandleId                            instanceData,
         VkDeviceSize                                instanceOffset,
         VkBool32                                    update,
@@ -2021,8 +2021,8 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
         uint32_t                                    createInfoCount,
-        const StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoNV>& pCreateInfos,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoNV>* pCreateInfos,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkPipeline>*           pPipelines) override;
 
     virtual void Process_vkGetRayTracingShaderGroupHandlesNV(
@@ -2044,7 +2044,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCmdWriteAccelerationStructuresPropertiesNV(
         format::HandleId                            commandBuffer,
         uint32_t                                    accelerationStructureCount,
-        const HandlePointerDecoder<VkAccelerationStructureNV>& pAccelerationStructures,
+        HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructures,
         VkQueryType                                 queryType,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery) override;
@@ -2079,7 +2079,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    timestampCount,
-        const StructPointerDecoder<Decoded_VkCalibratedTimestampInfoEXT>& pTimestampInfos,
+        StructPointerDecoder<Decoded_VkCalibratedTimestampInfoEXT>* pTimestampInfos,
         PointerDecoder<uint64_t>*                   pTimestamps,
         PointerDecoder<uint64_t>*                   pMaxDeviation) override;
 
@@ -2108,7 +2108,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstExclusiveScissor,
         uint32_t                                    exclusiveScissorCount,
-        const StructPointerDecoder<Decoded_VkRect2D>& pExclusiveScissors) override;
+        StructPointerDecoder<Decoded_VkRect2D>*     pExclusiveScissors) override;
 
     virtual void Process_vkCmdSetCheckpointNV(
         format::HandleId                            commandBuffer,
@@ -2122,7 +2122,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkInitializePerformanceApiINTEL(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkInitializePerformanceApiInfoINTEL>& pInitializeInfo) override;
+        StructPointerDecoder<Decoded_VkInitializePerformanceApiInfoINTEL>* pInitializeInfo) override;
 
     virtual void Process_vkUninitializePerformanceApiINTEL(
         format::HandleId                            device) override;
@@ -2130,22 +2130,22 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCmdSetPerformanceMarkerINTEL(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkPerformanceMarkerInfoINTEL>& pMarkerInfo) override;
+        StructPointerDecoder<Decoded_VkPerformanceMarkerInfoINTEL>* pMarkerInfo) override;
 
     virtual void Process_vkCmdSetPerformanceStreamMarkerINTEL(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkPerformanceStreamMarkerInfoINTEL>& pMarkerInfo) override;
+        StructPointerDecoder<Decoded_VkPerformanceStreamMarkerInfoINTEL>* pMarkerInfo) override;
 
     virtual void Process_vkCmdSetPerformanceOverrideINTEL(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkPerformanceOverrideInfoINTEL>& pOverrideInfo) override;
+        StructPointerDecoder<Decoded_VkPerformanceOverrideInfoINTEL>* pOverrideInfo) override;
 
     virtual void Process_vkAcquirePerformanceConfigurationINTEL(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPerformanceConfigurationAcquireInfoINTEL>& pAcquireInfo,
+        StructPointerDecoder<Decoded_VkPerformanceConfigurationAcquireInfoINTEL>* pAcquireInfo,
         HandlePointerDecoder<VkPerformanceConfigurationINTEL>* pConfiguration) override;
 
     virtual void Process_vkReleasePerformanceConfigurationINTEL(
@@ -2172,21 +2172,21 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkCreateImagePipeSurfaceFUCHSIA(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCreateMetalSurfaceEXT(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetBufferDeviceAddressEXT(
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkBufferDeviceAddressInfoEXT>& pInfo) override;
+        StructPointerDecoder<Decoded_VkBufferDeviceAddressInfoEXT>* pInfo) override;
 
     virtual void Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(
         VkResult                                    returnValue,
@@ -2203,7 +2203,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         PointerDecoder<uint32_t>*                   pPresentModeCount,
         PointerDecoder<VkPresentModeKHR>*           pPresentModes) override;
 
@@ -2220,14 +2220,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual void Process_vkGetDeviceGroupSurfacePresentModes2EXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         PointerDecoder<VkDeviceGroupPresentModeFlagsKHR>* pModes) override;
 
     virtual void Process_vkCreateHeadlessSurfaceEXT(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkHeadlessSurfaceCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkHeadlessSurfaceCreateInfoEXT>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCmdSetLineStippleEXT(

--- a/framework/generated/generated_vulkan_consumer.h
+++ b/framework/generated/generated_vulkan_consumer.h
@@ -40,13 +40,13 @@ class VulkanConsumer : public VulkanConsumerBase
 
     virtual void Process_vkCreateInstance(
         VkResult                                    returnValue,
-        const StructPointerDecoder<Decoded_VkInstanceCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkInstanceCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkInstance>*           pInstance) {}
 
     virtual void Process_vkDestroyInstance(
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkEnumeratePhysicalDevices(
         VkResult                                    returnValue,
@@ -89,13 +89,13 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCreateDevice(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkDeviceCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDeviceCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDevice>*             pDevice) {}
 
     virtual void Process_vkDestroyDevice(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetDeviceQueue(
         format::HandleId                            device,
@@ -107,7 +107,7 @@ class VulkanConsumer : public VulkanConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    submitCount,
-        const StructPointerDecoder<Decoded_VkSubmitInfo>& pSubmits,
+        StructPointerDecoder<Decoded_VkSubmitInfo>* pSubmits,
         format::HandleId                            fence) {}
 
     virtual void Process_vkQueueWaitIdle(
@@ -121,14 +121,14 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkAllocateMemory(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkMemoryAllocateInfo>& pAllocateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkMemoryAllocateInfo>* pAllocateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDeviceMemory>*       pMemory) {}
 
     virtual void Process_vkFreeMemory(
         format::HandleId                            device,
         format::HandleId                            memory,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkMapMemory(
         VkResult                                    returnValue,
@@ -147,13 +147,13 @@ class VulkanConsumer : public VulkanConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    memoryRangeCount,
-        const StructPointerDecoder<Decoded_VkMappedMemoryRange>& pMemoryRanges) {}
+        StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges) {}
 
     virtual void Process_vkInvalidateMappedMemoryRanges(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    memoryRangeCount,
-        const StructPointerDecoder<Decoded_VkMappedMemoryRange>& pMemoryRanges) {}
+        StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges) {}
 
     virtual void Process_vkGetDeviceMemoryCommitment(
         format::HandleId                            device,
@@ -204,26 +204,26 @@ class VulkanConsumer : public VulkanConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindSparseInfo>& pBindInfo,
+        StructPointerDecoder<Decoded_VkBindSparseInfo>* pBindInfo,
         format::HandleId                            fence) {}
 
     virtual void Process_vkCreateFence(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkFenceCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkFenceCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkFence>*              pFence) {}
 
     virtual void Process_vkDestroyFence(
         format::HandleId                            device,
         format::HandleId                            fence,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkResetFences(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    fenceCount,
-        const HandlePointerDecoder<VkFence>&        pFences) {}
+        HandlePointerDecoder<VkFence>*              pFences) {}
 
     virtual void Process_vkGetFenceStatus(
         VkResult                                    returnValue,
@@ -234,33 +234,33 @@ class VulkanConsumer : public VulkanConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    fenceCount,
-        const HandlePointerDecoder<VkFence>&        pFences,
+        HandlePointerDecoder<VkFence>*              pFences,
         VkBool32                                    waitAll,
         uint64_t                                    timeout) {}
 
     virtual void Process_vkCreateSemaphore(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSemaphoreCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSemaphoreCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSemaphore>*          pSemaphore) {}
 
     virtual void Process_vkDestroySemaphore(
         format::HandleId                            device,
         format::HandleId                            semaphore,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateEvent(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkEventCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkEventCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkEvent>*              pEvent) {}
 
     virtual void Process_vkDestroyEvent(
         format::HandleId                            device,
         format::HandleId                            event,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetEventStatus(
         VkResult                                    returnValue,
@@ -280,14 +280,14 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCreateQueryPool(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkQueryPoolCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkQueryPoolCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkQueryPool>*          pQueryPool) {}
 
     virtual void Process_vkDestroyQueryPool(
         format::HandleId                            device,
         format::HandleId                            queryPool,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetQueryPoolResults(
         VkResult                                    returnValue,
@@ -303,80 +303,80 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCreateBuffer(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkBufferCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkBufferCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkBuffer>*             pBuffer) {}
 
     virtual void Process_vkDestroyBuffer(
         format::HandleId                            device,
         format::HandleId                            buffer,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateBufferView(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkBufferViewCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkBufferViewCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkBufferView>*         pView) {}
 
     virtual void Process_vkDestroyBufferView(
         format::HandleId                            device,
         format::HandleId                            bufferView,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateImage(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkImageCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkImage>*              pImage) {}
 
     virtual void Process_vkDestroyImage(
         format::HandleId                            device,
         format::HandleId                            image,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetImageSubresourceLayout(
         format::HandleId                            device,
         format::HandleId                            image,
-        const StructPointerDecoder<Decoded_VkImageSubresource>& pSubresource,
+        StructPointerDecoder<Decoded_VkImageSubresource>* pSubresource,
         StructPointerDecoder<Decoded_VkSubresourceLayout>* pLayout) {}
 
     virtual void Process_vkCreateImageView(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageViewCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkImageViewCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkImageView>*          pView) {}
 
     virtual void Process_vkDestroyImageView(
         format::HandleId                            device,
         format::HandleId                            imageView,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateShaderModule(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkShaderModule>*       pShaderModule) {}
 
     virtual void Process_vkDestroyShaderModule(
         format::HandleId                            device,
         format::HandleId                            shaderModule,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreatePipelineCache(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkPipelineCache>*      pPipelineCache) {}
 
     virtual void Process_vkDestroyPipelineCache(
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetPipelineCacheData(
         VkResult                                    returnValue,
@@ -390,15 +390,15 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            device,
         format::HandleId                            dstCache,
         uint32_t                                    srcCacheCount,
-        const HandlePointerDecoder<VkPipelineCache>& pSrcCaches) {}
+        HandlePointerDecoder<VkPipelineCache>*      pSrcCaches) {}
 
     virtual void Process_vkCreateGraphicsPipelines(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
         uint32_t                                    createInfoCount,
-        const StructPointerDecoder<Decoded_VkGraphicsPipelineCreateInfo>& pCreateInfos,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkGraphicsPipelineCreateInfo>* pCreateInfos,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkPipeline>*           pPipelines) {}
 
     virtual void Process_vkCreateComputePipelines(
@@ -406,62 +406,62 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
         uint32_t                                    createInfoCount,
-        const StructPointerDecoder<Decoded_VkComputePipelineCreateInfo>& pCreateInfos,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkComputePipelineCreateInfo>* pCreateInfos,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkPipeline>*           pPipelines) {}
 
     virtual void Process_vkDestroyPipeline(
         format::HandleId                            device,
         format::HandleId                            pipeline,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreatePipelineLayout(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPipelineLayoutCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkPipelineLayoutCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkPipelineLayout>*     pPipelineLayout) {}
 
     virtual void Process_vkDestroyPipelineLayout(
         format::HandleId                            device,
         format::HandleId                            pipelineLayout,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateSampler(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSamplerCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSamplerCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSampler>*            pSampler) {}
 
     virtual void Process_vkDestroySampler(
         format::HandleId                            device,
         format::HandleId                            sampler,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateDescriptorSetLayout(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDescriptorSetLayout>* pSetLayout) {}
 
     virtual void Process_vkDestroyDescriptorSetLayout(
         format::HandleId                            device,
         format::HandleId                            descriptorSetLayout,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateDescriptorPool(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDescriptorPool>*     pDescriptorPool) {}
 
     virtual void Process_vkDestroyDescriptorPool(
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkResetDescriptorPool(
         VkResult                                    returnValue,
@@ -472,7 +472,7 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkAllocateDescriptorSets(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>& pAllocateInfo,
+        StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
         HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) {}
 
     virtual void Process_vkFreeDescriptorSets(
@@ -480,38 +480,38 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
         uint32_t                                    descriptorSetCount,
-        const HandlePointerDecoder<VkDescriptorSet>& pDescriptorSets) {}
+        HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) {}
 
     virtual void Process_vkUpdateDescriptorSets(
         format::HandleId                            device,
         uint32_t                                    descriptorWriteCount,
-        const StructPointerDecoder<Decoded_VkWriteDescriptorSet>& pDescriptorWrites,
+        StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites,
         uint32_t                                    descriptorCopyCount,
-        const StructPointerDecoder<Decoded_VkCopyDescriptorSet>& pDescriptorCopies) {}
+        StructPointerDecoder<Decoded_VkCopyDescriptorSet>* pDescriptorCopies) {}
 
     virtual void Process_vkCreateFramebuffer(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkFramebufferCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkFramebuffer>*        pFramebuffer) {}
 
     virtual void Process_vkDestroyFramebuffer(
         format::HandleId                            device,
         format::HandleId                            framebuffer,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateRenderPass(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkRenderPassCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkRenderPassCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkRenderPass>*         pRenderPass) {}
 
     virtual void Process_vkDestroyRenderPass(
         format::HandleId                            device,
         format::HandleId                            renderPass,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetRenderAreaGranularity(
         format::HandleId                            device,
@@ -521,14 +521,14 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCreateCommandPool(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkCommandPool>*        pCommandPool) {}
 
     virtual void Process_vkDestroyCommandPool(
         format::HandleId                            device,
         format::HandleId                            commandPool,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkResetCommandPool(
         VkResult                                    returnValue,
@@ -539,19 +539,19 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkAllocateCommandBuffers(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>& pAllocateInfo,
+        StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
         HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) {}
 
     virtual void Process_vkFreeCommandBuffers(
         format::HandleId                            device,
         format::HandleId                            commandPool,
         uint32_t                                    commandBufferCount,
-        const HandlePointerDecoder<VkCommandBuffer>& pCommandBuffers) {}
+        HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) {}
 
     virtual void Process_vkBeginCommandBuffer(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>& pBeginInfo) {}
+        StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo) {}
 
     virtual void Process_vkEndCommandBuffer(
         VkResult                                    returnValue,
@@ -571,13 +571,13 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
-        const StructPointerDecoder<Decoded_VkViewport>& pViewports) {}
+        StructPointerDecoder<Decoded_VkViewport>*   pViewports) {}
 
     virtual void Process_vkCmdSetScissor(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstScissor,
         uint32_t                                    scissorCount,
-        const StructPointerDecoder<Decoded_VkRect2D>& pScissors) {}
+        StructPointerDecoder<Decoded_VkRect2D>*     pScissors) {}
 
     virtual void Process_vkCmdSetLineWidth(
         format::HandleId                            commandBuffer,
@@ -591,7 +591,7 @@ class VulkanConsumer : public VulkanConsumerBase
 
     virtual void Process_vkCmdSetBlendConstants(
         format::HandleId                            commandBuffer,
-        const PointerDecoder<float>&                blendConstants) {}
+        PointerDecoder<float>*                      blendConstants) {}
 
     virtual void Process_vkCmdSetDepthBounds(
         format::HandleId                            commandBuffer,
@@ -619,9 +619,9 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            layout,
         uint32_t                                    firstSet,
         uint32_t                                    descriptorSetCount,
-        const HandlePointerDecoder<VkDescriptorSet>& pDescriptorSets,
+        HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets,
         uint32_t                                    dynamicOffsetCount,
-        const PointerDecoder<uint32_t>&             pDynamicOffsets) {}
+        PointerDecoder<uint32_t>*                   pDynamicOffsets) {}
 
     virtual void Process_vkCmdBindIndexBuffer(
         format::HandleId                            commandBuffer,
@@ -633,8 +633,8 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
-        const HandlePointerDecoder<VkBuffer>&       pBuffers,
-        const PointerDecoder<VkDeviceSize>&         pOffsets) {}
+        HandlePointerDecoder<VkBuffer>*             pBuffers,
+        PointerDecoder<VkDeviceSize>*               pOffsets) {}
 
     virtual void Process_vkCmdDraw(
         format::HandleId                            commandBuffer,
@@ -681,7 +681,7 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            srcBuffer,
         format::HandleId                            dstBuffer,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkBufferCopy>& pRegions) {}
+        StructPointerDecoder<Decoded_VkBufferCopy>* pRegions) {}
 
     virtual void Process_vkCmdCopyImage(
         format::HandleId                            commandBuffer,
@@ -690,7 +690,7 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            dstImage,
         VkImageLayout                               dstImageLayout,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkImageCopy>& pRegions) {}
+        StructPointerDecoder<Decoded_VkImageCopy>*  pRegions) {}
 
     virtual void Process_vkCmdBlitImage(
         format::HandleId                            commandBuffer,
@@ -699,7 +699,7 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            dstImage,
         VkImageLayout                               dstImageLayout,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkImageBlit>& pRegions,
+        StructPointerDecoder<Decoded_VkImageBlit>*  pRegions,
         VkFilter                                    filter) {}
 
     virtual void Process_vkCmdCopyBufferToImage(
@@ -708,7 +708,7 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            dstImage,
         VkImageLayout                               dstImageLayout,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkBufferImageCopy>& pRegions) {}
+        StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions) {}
 
     virtual void Process_vkCmdCopyImageToBuffer(
         format::HandleId                            commandBuffer,
@@ -716,14 +716,14 @@ class VulkanConsumer : public VulkanConsumerBase
         VkImageLayout                               srcImageLayout,
         format::HandleId                            dstBuffer,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkBufferImageCopy>& pRegions) {}
+        StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions) {}
 
     virtual void Process_vkCmdUpdateBuffer(
         format::HandleId                            commandBuffer,
         format::HandleId                            dstBuffer,
         VkDeviceSize                                dstOffset,
         VkDeviceSize                                dataSize,
-        const PointerDecoder<uint8_t>&              pData) {}
+        PointerDecoder<uint8_t>*                    pData) {}
 
     virtual void Process_vkCmdFillBuffer(
         format::HandleId                            commandBuffer,
@@ -736,24 +736,24 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            commandBuffer,
         format::HandleId                            image,
         VkImageLayout                               imageLayout,
-        const StructPointerDecoder<Decoded_VkClearColorValue>& pColor,
+        StructPointerDecoder<Decoded_VkClearColorValue>* pColor,
         uint32_t                                    rangeCount,
-        const StructPointerDecoder<Decoded_VkImageSubresourceRange>& pRanges) {}
+        StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges) {}
 
     virtual void Process_vkCmdClearDepthStencilImage(
         format::HandleId                            commandBuffer,
         format::HandleId                            image,
         VkImageLayout                               imageLayout,
-        const StructPointerDecoder<Decoded_VkClearDepthStencilValue>& pDepthStencil,
+        StructPointerDecoder<Decoded_VkClearDepthStencilValue>* pDepthStencil,
         uint32_t                                    rangeCount,
-        const StructPointerDecoder<Decoded_VkImageSubresourceRange>& pRanges) {}
+        StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges) {}
 
     virtual void Process_vkCmdClearAttachments(
         format::HandleId                            commandBuffer,
         uint32_t                                    attachmentCount,
-        const StructPointerDecoder<Decoded_VkClearAttachment>& pAttachments,
+        StructPointerDecoder<Decoded_VkClearAttachment>* pAttachments,
         uint32_t                                    rectCount,
-        const StructPointerDecoder<Decoded_VkClearRect>& pRects) {}
+        StructPointerDecoder<Decoded_VkClearRect>*  pRects) {}
 
     virtual void Process_vkCmdResolveImage(
         format::HandleId                            commandBuffer,
@@ -762,7 +762,7 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            dstImage,
         VkImageLayout                               dstImageLayout,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkImageResolve>& pRegions) {}
+        StructPointerDecoder<Decoded_VkImageResolve>* pRegions) {}
 
     virtual void Process_vkCmdSetEvent(
         format::HandleId                            commandBuffer,
@@ -777,15 +777,15 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCmdWaitEvents(
         format::HandleId                            commandBuffer,
         uint32_t                                    eventCount,
-        const HandlePointerDecoder<VkEvent>&        pEvents,
+        HandlePointerDecoder<VkEvent>*              pEvents,
         VkPipelineStageFlags                        srcStageMask,
         VkPipelineStageFlags                        dstStageMask,
         uint32_t                                    memoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkMemoryBarrier>& pMemoryBarriers,
+        StructPointerDecoder<Decoded_VkMemoryBarrier>* pMemoryBarriers,
         uint32_t                                    bufferMemoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkBufferMemoryBarrier>& pBufferMemoryBarriers,
+        StructPointerDecoder<Decoded_VkBufferMemoryBarrier>* pBufferMemoryBarriers,
         uint32_t                                    imageMemoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkImageMemoryBarrier>& pImageMemoryBarriers) {}
+        StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers) {}
 
     virtual void Process_vkCmdPipelineBarrier(
         format::HandleId                            commandBuffer,
@@ -793,11 +793,11 @@ class VulkanConsumer : public VulkanConsumerBase
         VkPipelineStageFlags                        dstStageMask,
         VkDependencyFlags                           dependencyFlags,
         uint32_t                                    memoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkMemoryBarrier>& pMemoryBarriers,
+        StructPointerDecoder<Decoded_VkMemoryBarrier>* pMemoryBarriers,
         uint32_t                                    bufferMemoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkBufferMemoryBarrier>& pBufferMemoryBarriers,
+        StructPointerDecoder<Decoded_VkBufferMemoryBarrier>* pBufferMemoryBarriers,
         uint32_t                                    imageMemoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkImageMemoryBarrier>& pImageMemoryBarriers) {}
+        StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers) {}
 
     virtual void Process_vkCmdBeginQuery(
         format::HandleId                            commandBuffer,
@@ -838,11 +838,11 @@ class VulkanConsumer : public VulkanConsumerBase
         VkShaderStageFlags                          stageFlags,
         uint32_t                                    offset,
         uint32_t                                    size,
-        const PointerDecoder<uint8_t>&              pValues) {}
+        PointerDecoder<uint8_t>*                    pValues) {}
 
     virtual void Process_vkCmdBeginRenderPass(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkRenderPassBeginInfo>& pRenderPassBegin,
+        StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
         VkSubpassContents                           contents) {}
 
     virtual void Process_vkCmdNextSubpass(
@@ -855,19 +855,19 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCmdExecuteCommands(
         format::HandleId                            commandBuffer,
         uint32_t                                    commandBufferCount,
-        const HandlePointerDecoder<VkCommandBuffer>& pCommandBuffers) {}
+        HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) {}
 
     virtual void Process_vkBindBufferMemory2(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>& pBindInfos) {}
+        StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos) {}
 
     virtual void Process_vkBindImageMemory2(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>& pBindInfos) {}
+        StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos) {}
 
     virtual void Process_vkGetDeviceGroupPeerMemoryFeatures(
         format::HandleId                            device,
@@ -897,17 +897,17 @@ class VulkanConsumer : public VulkanConsumerBase
 
     virtual void Process_vkGetImageMemoryRequirements2(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkGetBufferMemoryRequirements2(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkGetImageSparseMemoryRequirements2(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) {}
 
@@ -927,7 +927,7 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties2(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>& pImageFormatInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
         StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties2(
@@ -941,7 +941,7 @@ class VulkanConsumer : public VulkanConsumerBase
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties2(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>& pFormatInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties) {}
 
@@ -952,57 +952,57 @@ class VulkanConsumer : public VulkanConsumerBase
 
     virtual void Process_vkGetDeviceQueue2(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDeviceQueueInfo2>& pQueueInfo,
+        StructPointerDecoder<Decoded_VkDeviceQueueInfo2>* pQueueInfo,
         HandlePointerDecoder<VkQueue>*              pQueue) {}
 
     virtual void Process_vkCreateSamplerYcbcrConversion(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion) {}
 
     virtual void Process_vkDestroySamplerYcbcrConversion(
         format::HandleId                            device,
         format::HandleId                            ycbcrConversion,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateDescriptorUpdateTemplate(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate) {}
 
     virtual void Process_vkDestroyDescriptorUpdateTemplate(
         format::HandleId                            device,
         format::HandleId                            descriptorUpdateTemplate,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalBufferProperties(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>& pExternalBufferInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
         StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalFenceProperties(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>& pExternalFenceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
         StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalSemaphoreProperties(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>& pExternalSemaphoreInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
         StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties) {}
 
     virtual void Process_vkGetDescriptorSetLayoutSupport(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>& pCreateInfo,
+        StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport) {}
 
     virtual void Process_vkDestroySurfaceKHR(
         format::HandleId                            instance,
         format::HandleId                            surface,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfaceSupportKHR(
         VkResult                                    returnValue,
@@ -1034,14 +1034,14 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCreateSwapchainKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSwapchainKHR>*       pSwapchain) {}
 
     virtual void Process_vkDestroySwapchainKHR(
         format::HandleId                            device,
         format::HandleId                            swapchain,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetSwapchainImagesKHR(
         VkResult                                    returnValue,
@@ -1062,7 +1062,7 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkQueuePresentKHR(
         VkResult                                    returnValue,
         format::HandleId                            queue,
-        const StructPointerDecoder<Decoded_VkPresentInfoKHR>& pPresentInfo) {}
+        StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo) {}
 
     virtual void Process_vkGetDeviceGroupPresentCapabilitiesKHR(
         VkResult                                    returnValue,
@@ -1085,7 +1085,7 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkAcquireNextImage2KHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>& pAcquireInfo,
+        StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>* pAcquireInfo,
         PointerDecoder<uint32_t>*                   pImageIndex) {}
 
     virtual void Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
@@ -1118,8 +1118,8 @@ class VulkanConsumer : public VulkanConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display,
-        const StructPointerDecoder<Decoded_VkDisplayModeCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDisplayModeCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDisplayModeKHR>*     pMode) {}
 
     virtual void Process_vkGetDisplayPlaneCapabilitiesKHR(
@@ -1132,23 +1132,23 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCreateDisplayPlaneSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkDisplaySurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDisplaySurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCreateSharedSwapchainsKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    swapchainCount,
-        const StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>& pCreateInfos,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfos,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains) {}
 
     virtual void Process_vkCreateXlibSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
@@ -1161,8 +1161,8 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCreateXcbSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
@@ -1175,8 +1175,8 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCreateWaylandSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceWaylandPresentationSupportKHR(
@@ -1188,15 +1188,15 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCreateAndroidSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCreateWin32SurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceWin32PresentationSupportKHR(
@@ -1220,7 +1220,7 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>& pImageFormatInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
         StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
@@ -1234,7 +1234,7 @@ class VulkanConsumer : public VulkanConsumerBase
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>& pFormatInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties) {}
 
@@ -1271,13 +1271,13 @@ class VulkanConsumer : public VulkanConsumerBase
 
     virtual void Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>& pExternalBufferInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
         StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties) {}
 
     virtual void Process_vkGetMemoryWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkMemoryGetWin32HandleInfoKHR>& pGetWin32HandleInfo,
+        StructPointerDecoder<Decoded_VkMemoryGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) {}
 
     virtual void Process_vkGetMemoryWin32HandlePropertiesKHR(
@@ -1290,7 +1290,7 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkGetMemoryFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkMemoryGetFdInfoKHR>& pGetFdInfo,
+        StructPointerDecoder<Decoded_VkMemoryGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) {}
 
     virtual void Process_vkGetMemoryFdPropertiesKHR(
@@ -1302,29 +1302,29 @@ class VulkanConsumer : public VulkanConsumerBase
 
     virtual void Process_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>& pExternalSemaphoreInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
         StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties) {}
 
     virtual void Process_vkImportSemaphoreWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>& pImportSemaphoreWin32HandleInfo) {}
+        StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>* pImportSemaphoreWin32HandleInfo) {}
 
     virtual void Process_vkGetSemaphoreWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>& pGetWin32HandleInfo,
+        StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) {}
 
     virtual void Process_vkImportSemaphoreFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>& pImportSemaphoreFdInfo) {}
+        StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>* pImportSemaphoreFdInfo) {}
 
     virtual void Process_vkGetSemaphoreFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSemaphoreGetFdInfoKHR>& pGetFdInfo,
+        StructPointerDecoder<Decoded_VkSemaphoreGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) {}
 
     virtual void Process_vkCmdPushDescriptorSetKHR(
@@ -1333,40 +1333,40 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            layout,
         uint32_t                                    set,
         uint32_t                                    descriptorWriteCount,
-        const StructPointerDecoder<Decoded_VkWriteDescriptorSet>& pDescriptorWrites) {}
+        StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites) {}
 
     virtual void Process_vkCreateDescriptorUpdateTemplateKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate) {}
 
     virtual void Process_vkDestroyDescriptorUpdateTemplateKHR(
         format::HandleId                            device,
         format::HandleId                            descriptorUpdateTemplate,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateRenderPass2KHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkRenderPassCreateInfo2KHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkRenderPassCreateInfo2KHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkRenderPass>*         pRenderPass) {}
 
     virtual void Process_vkCmdBeginRenderPass2KHR(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkRenderPassBeginInfo>& pRenderPassBegin,
-        const StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>& pSubpassBeginInfo) {}
+        StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
+        StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>* pSubpassBeginInfo) {}
 
     virtual void Process_vkCmdNextSubpass2KHR(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>& pSubpassBeginInfo,
-        const StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>& pSubpassEndInfo) {}
+        StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>* pSubpassBeginInfo,
+        StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>* pSubpassEndInfo) {}
 
     virtual void Process_vkCmdEndRenderPass2KHR(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>& pSubpassEndInfo) {}
+        StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>* pSubpassEndInfo) {}
 
     virtual void Process_vkGetSwapchainStatusKHR(
         VkResult                                    returnValue,
@@ -1375,41 +1375,41 @@ class VulkanConsumer : public VulkanConsumerBase
 
     virtual void Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>& pExternalFenceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
         StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties) {}
 
     virtual void Process_vkImportFenceWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImportFenceWin32HandleInfoKHR>& pImportFenceWin32HandleInfo) {}
+        StructPointerDecoder<Decoded_VkImportFenceWin32HandleInfoKHR>* pImportFenceWin32HandleInfo) {}
 
     virtual void Process_vkGetFenceWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkFenceGetWin32HandleInfoKHR>& pGetWin32HandleInfo,
+        StructPointerDecoder<Decoded_VkFenceGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) {}
 
     virtual void Process_vkImportFenceFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImportFenceFdInfoKHR>& pImportFenceFdInfo) {}
+        StructPointerDecoder<Decoded_VkImportFenceFdInfoKHR>* pImportFenceFdInfo) {}
 
     virtual void Process_vkGetFenceFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkFenceGetFdInfoKHR>& pGetFdInfo,
+        StructPointerDecoder<Decoded_VkFenceGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         StructPointerDecoder<Decoded_VkSurfaceCapabilities2KHR>* pSurfaceCapabilities) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         PointerDecoder<uint32_t>*                   pSurfaceFormatCount,
         StructPointerDecoder<Decoded_VkSurfaceFormat2KHR>* pSurfaceFormats) {}
 
@@ -1435,52 +1435,52 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkGetDisplayPlaneCapabilities2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkDisplayPlaneInfo2KHR>& pDisplayPlaneInfo,
+        StructPointerDecoder<Decoded_VkDisplayPlaneInfo2KHR>* pDisplayPlaneInfo,
         StructPointerDecoder<Decoded_VkDisplayPlaneCapabilities2KHR>* pCapabilities) {}
 
     virtual void Process_vkGetImageMemoryRequirements2KHR(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkGetBufferMemoryRequirements2KHR(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkGetImageSparseMemoryRequirements2KHR(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) {}
 
     virtual void Process_vkCreateSamplerYcbcrConversionKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion) {}
 
     virtual void Process_vkDestroySamplerYcbcrConversionKHR(
         format::HandleId                            device,
         format::HandleId                            ycbcrConversion,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkBindBufferMemory2KHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>& pBindInfos) {}
+        StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos) {}
 
     virtual void Process_vkBindImageMemory2KHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>& pBindInfos) {}
+        StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos) {}
 
     virtual void Process_vkGetDescriptorSetLayoutSupportKHR(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>& pCreateInfo,
+        StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport) {}
 
     virtual void Process_vkCmdDrawIndirectCountKHR(
@@ -1510,46 +1510,46 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkWaitSemaphoresKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSemaphoreWaitInfoKHR>& pWaitInfo,
+        StructPointerDecoder<Decoded_VkSemaphoreWaitInfoKHR>* pWaitInfo,
         uint64_t                                    timeout) {}
 
     virtual void Process_vkSignalSemaphoreKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSemaphoreSignalInfoKHR>& pSignalInfo) {}
+        StructPointerDecoder<Decoded_VkSemaphoreSignalInfoKHR>* pSignalInfo) {}
 
     virtual void Process_vkGetPipelineExecutablePropertiesKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPipelineInfoKHR>& pPipelineInfo,
+        StructPointerDecoder<Decoded_VkPipelineInfoKHR>* pPipelineInfo,
         PointerDecoder<uint32_t>*                   pExecutableCount,
         StructPointerDecoder<Decoded_VkPipelineExecutablePropertiesKHR>* pProperties) {}
 
     virtual void Process_vkGetPipelineExecutableStatisticsKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>& pExecutableInfo,
+        StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
         PointerDecoder<uint32_t>*                   pStatisticCount,
         StructPointerDecoder<Decoded_VkPipelineExecutableStatisticKHR>* pStatistics) {}
 
     virtual void Process_vkGetPipelineExecutableInternalRepresentationsKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>& pExecutableInfo,
+        StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
         PointerDecoder<uint32_t>*                   pInternalRepresentationCount,
         StructPointerDecoder<Decoded_VkPipelineExecutableInternalRepresentationKHR>* pInternalRepresentations) {}
 
     virtual void Process_vkCreateDebugReportCallbackEXT(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDebugReportCallbackEXT>* pCallback) {}
 
     virtual void Process_vkDestroyDebugReportCallbackEXT(
         format::HandleId                            instance,
         format::HandleId                            callback,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkDebugReportMessageEXT(
         format::HandleId                            instance,
@@ -1558,51 +1558,51 @@ class VulkanConsumer : public VulkanConsumerBase
         uint64_t                                    object,
         size_t                                      location,
         int32_t                                     messageCode,
-        const StringDecoder&                        pLayerPrefix,
-        const StringDecoder&                        pMessage) {}
+        StringDecoder*                              pLayerPrefix,
+        StringDecoder*                              pMessage) {}
 
     virtual void Process_vkDebugMarkerSetObjectTagEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDebugMarkerObjectTagInfoEXT>& pTagInfo) {}
+        StructPointerDecoder<Decoded_VkDebugMarkerObjectTagInfoEXT>* pTagInfo) {}
 
     virtual void Process_vkDebugMarkerSetObjectNameEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDebugMarkerObjectNameInfoEXT>& pNameInfo) {}
+        StructPointerDecoder<Decoded_VkDebugMarkerObjectNameInfoEXT>* pNameInfo) {}
 
     virtual void Process_vkCmdDebugMarkerBeginEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>& pMarkerInfo) {}
+        StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo) {}
 
     virtual void Process_vkCmdDebugMarkerEndEXT(
         format::HandleId                            commandBuffer) {}
 
     virtual void Process_vkCmdDebugMarkerInsertEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>& pMarkerInfo) {}
+        StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo) {}
 
     virtual void Process_vkCmdBindTransformFeedbackBuffersEXT(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
-        const HandlePointerDecoder<VkBuffer>&       pBuffers,
-        const PointerDecoder<VkDeviceSize>&         pOffsets,
-        const PointerDecoder<VkDeviceSize>&         pSizes) {}
+        HandlePointerDecoder<VkBuffer>*             pBuffers,
+        PointerDecoder<VkDeviceSize>*               pOffsets,
+        PointerDecoder<VkDeviceSize>*               pSizes) {}
 
     virtual void Process_vkCmdBeginTransformFeedbackEXT(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstCounterBuffer,
         uint32_t                                    counterBufferCount,
-        const HandlePointerDecoder<VkBuffer>&       pCounterBuffers,
-        const PointerDecoder<VkDeviceSize>&         pCounterBufferOffsets) {}
+        HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
+        PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets) {}
 
     virtual void Process_vkCmdEndTransformFeedbackEXT(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstCounterBuffer,
         uint32_t                                    counterBufferCount,
-        const HandlePointerDecoder<VkBuffer>&       pCounterBuffers,
-        const PointerDecoder<VkDeviceSize>&         pCounterBufferOffsets) {}
+        HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
+        PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets) {}
 
     virtual void Process_vkCmdBeginQueryIndexedEXT(
         format::HandleId                            commandBuffer,
@@ -1629,7 +1629,7 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkGetImageViewHandleNVX(
         uint32_t                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>& pInfo) {}
+        StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>* pInfo) {}
 
     virtual void Process_vkCmdDrawIndirectCountAMD(
         format::HandleId                            commandBuffer,
@@ -1661,8 +1661,8 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCreateStreamDescriptorSurfaceGGP(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkStreamDescriptorSurfaceCreateInfoGGP>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkStreamDescriptorSurfaceCreateInfoGGP>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(
@@ -1686,56 +1686,56 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCreateViSurfaceNN(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkViSurfaceCreateInfoNN>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkViSurfaceCreateInfoNN>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCmdBeginConditionalRenderingEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>& pConditionalRenderingBegin) {}
+        StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>* pConditionalRenderingBegin) {}
 
     virtual void Process_vkCmdEndConditionalRenderingEXT(
         format::HandleId                            commandBuffer) {}
 
     virtual void Process_vkCmdProcessCommandsNVX(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkCmdProcessCommandsInfoNVX>& pProcessCommandsInfo) {}
+        StructPointerDecoder<Decoded_VkCmdProcessCommandsInfoNVX>* pProcessCommandsInfo) {}
 
     virtual void Process_vkCmdReserveSpaceForCommandsNVX(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkCmdReserveSpaceForCommandsInfoNVX>& pReserveSpaceInfo) {}
+        StructPointerDecoder<Decoded_VkCmdReserveSpaceForCommandsInfoNVX>* pReserveSpaceInfo) {}
 
     virtual void Process_vkCreateIndirectCommandsLayoutNVX(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkIndirectCommandsLayoutCreateInfoNVX>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkIndirectCommandsLayoutCreateInfoNVX>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkIndirectCommandsLayoutNVX>* pIndirectCommandsLayout) {}
 
     virtual void Process_vkDestroyIndirectCommandsLayoutNVX(
         format::HandleId                            device,
         format::HandleId                            indirectCommandsLayout,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateObjectTableNVX(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkObjectTableCreateInfoNVX>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkObjectTableCreateInfoNVX>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkObjectTableNVX>*     pObjectTable) {}
 
     virtual void Process_vkDestroyObjectTableNVX(
         format::HandleId                            device,
         format::HandleId                            objectTable,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkUnregisterObjectsNVX(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            objectTable,
         uint32_t                                    objectCount,
-        const PointerDecoder<VkObjectEntryTypeNVX>& pObjectEntryTypes,
-        const PointerDecoder<uint32_t>&             pObjectIndices) {}
+        PointerDecoder<VkObjectEntryTypeNVX>*       pObjectEntryTypes,
+        PointerDecoder<uint32_t>*                   pObjectIndices) {}
 
     virtual void Process_vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX(
         format::HandleId                            physicalDevice,
@@ -1746,7 +1746,7 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
-        const StructPointerDecoder<Decoded_VkViewportWScalingNV>& pViewportWScalings) {}
+        StructPointerDecoder<Decoded_VkViewportWScalingNV>* pViewportWScalings) {}
 
     virtual void Process_vkReleaseDisplayEXT(
         VkResult                                    returnValue,
@@ -1776,21 +1776,21 @@ class VulkanConsumer : public VulkanConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            display,
-        const StructPointerDecoder<Decoded_VkDisplayPowerInfoEXT>& pDisplayPowerInfo) {}
+        StructPointerDecoder<Decoded_VkDisplayPowerInfoEXT>* pDisplayPowerInfo) {}
 
     virtual void Process_vkRegisterDeviceEventEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDeviceEventInfoEXT>& pDeviceEventInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDeviceEventInfoEXT>* pDeviceEventInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkFence>*              pFence) {}
 
     virtual void Process_vkRegisterDisplayEventEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            display,
-        const StructPointerDecoder<Decoded_VkDisplayEventInfoEXT>& pDisplayEventInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDisplayEventInfoEXT>* pDisplayEventInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkFence>*              pFence) {}
 
     virtual void Process_vkGetSwapchainCounterEXT(
@@ -1817,77 +1817,77 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstDiscardRectangle,
         uint32_t                                    discardRectangleCount,
-        const StructPointerDecoder<Decoded_VkRect2D>& pDiscardRectangles) {}
+        StructPointerDecoder<Decoded_VkRect2D>*     pDiscardRectangles) {}
 
     virtual void Process_vkSetHdrMetadataEXT(
         format::HandleId                            device,
         uint32_t                                    swapchainCount,
-        const HandlePointerDecoder<VkSwapchainKHR>& pSwapchains,
-        const StructPointerDecoder<Decoded_VkHdrMetadataEXT>& pMetadata) {}
+        HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains,
+        StructPointerDecoder<Decoded_VkHdrMetadataEXT>* pMetadata) {}
 
     virtual void Process_vkCreateIOSSurfaceMVK(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkIOSSurfaceCreateInfoMVK>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkIOSSurfaceCreateInfoMVK>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCreateMacOSSurfaceMVK(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkMacOSSurfaceCreateInfoMVK>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkMacOSSurfaceCreateInfoMVK>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkSetDebugUtilsObjectNameEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>& pNameInfo) {}
+        StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* pNameInfo) {}
 
     virtual void Process_vkSetDebugUtilsObjectTagEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>& pTagInfo) {}
+        StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>* pTagInfo) {}
 
     virtual void Process_vkQueueBeginDebugUtilsLabelEXT(
         format::HandleId                            queue,
-        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) {}
+        StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) {}
 
     virtual void Process_vkQueueEndDebugUtilsLabelEXT(
         format::HandleId                            queue) {}
 
     virtual void Process_vkQueueInsertDebugUtilsLabelEXT(
         format::HandleId                            queue,
-        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) {}
+        StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) {}
 
     virtual void Process_vkCmdBeginDebugUtilsLabelEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) {}
+        StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) {}
 
     virtual void Process_vkCmdEndDebugUtilsLabelEXT(
         format::HandleId                            commandBuffer) {}
 
     virtual void Process_vkCmdInsertDebugUtilsLabelEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) {}
+        StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) {}
 
     virtual void Process_vkCreateDebugUtilsMessengerEXT(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDebugUtilsMessengerEXT>* pMessenger) {}
 
     virtual void Process_vkDestroyDebugUtilsMessengerEXT(
         format::HandleId                            instance,
         format::HandleId                            messenger,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkSubmitDebugUtilsMessageEXT(
         format::HandleId                            instance,
         VkDebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,
         VkDebugUtilsMessageTypeFlagsEXT             messageTypes,
-        const StructPointerDecoder<Decoded_VkDebugUtilsMessengerCallbackDataEXT>& pCallbackData) {}
+        StructPointerDecoder<Decoded_VkDebugUtilsMessengerCallbackDataEXT>* pCallbackData) {}
 
     virtual void Process_vkGetAndroidHardwareBufferPropertiesANDROID(
         VkResult                                    returnValue,
@@ -1898,12 +1898,12 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkGetMemoryAndroidHardwareBufferANDROID(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID>& pInfo,
+        StructPointerDecoder<Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID>* pInfo,
         PointerDecoder<uint64_t, void*>*            pBuffer) {}
 
     virtual void Process_vkCmdSetSampleLocationsEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkSampleLocationsInfoEXT>& pSampleLocationsInfo) {}
+        StructPointerDecoder<Decoded_VkSampleLocationsInfoEXT>* pSampleLocationsInfo) {}
 
     virtual void Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(
         format::HandleId                            physicalDevice,
@@ -1919,21 +1919,21 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCreateValidationCacheEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkValidationCacheCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkValidationCacheCreateInfoEXT>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkValidationCacheEXT>* pValidationCache) {}
 
     virtual void Process_vkDestroyValidationCacheEXT(
         format::HandleId                            device,
         format::HandleId                            validationCache,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkMergeValidationCachesEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            dstCache,
         uint32_t                                    srcCacheCount,
-        const HandlePointerDecoder<VkValidationCacheEXT>& pSrcCaches) {}
+        HandlePointerDecoder<VkValidationCacheEXT>* pSrcCaches) {}
 
     virtual void Process_vkGetValidationCacheDataEXT(
         VkResult                                    returnValue,
@@ -1951,40 +1951,40 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
-        const StructPointerDecoder<Decoded_VkShadingRatePaletteNV>& pShadingRatePalettes) {}
+        StructPointerDecoder<Decoded_VkShadingRatePaletteNV>* pShadingRatePalettes) {}
 
     virtual void Process_vkCmdSetCoarseSampleOrderNV(
         format::HandleId                            commandBuffer,
         VkCoarseSampleOrderTypeNV                   sampleOrderType,
         uint32_t                                    customSampleOrderCount,
-        const StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>& pCustomSampleOrders) {}
+        StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>* pCustomSampleOrders) {}
 
     virtual void Process_vkCreateAccelerationStructureNV(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoNV>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoNV>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructure) {}
 
     virtual void Process_vkDestroyAccelerationStructureNV(
         format::HandleId                            device,
         format::HandleId                            accelerationStructure,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) {}
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetAccelerationStructureMemoryRequirementsNV(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkAccelerationStructureMemoryRequirementsInfoNV>& pInfo,
+        StructPointerDecoder<Decoded_VkAccelerationStructureMemoryRequirementsInfoNV>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2KHR>* pMemoryRequirements) {}
 
     virtual void Process_vkBindAccelerationStructureMemoryNV(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindAccelerationStructureMemoryInfoNV>& pBindInfos) {}
+        StructPointerDecoder<Decoded_VkBindAccelerationStructureMemoryInfoNV>* pBindInfos) {}
 
     virtual void Process_vkCmdBuildAccelerationStructureNV(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>& pInfo,
+        StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>* pInfo,
         format::HandleId                            instanceData,
         VkDeviceSize                                instanceOffset,
         VkBool32                                    update,
@@ -2021,8 +2021,8 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
         uint32_t                                    createInfoCount,
-        const StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoNV>& pCreateInfos,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoNV>* pCreateInfos,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkPipeline>*           pPipelines) {}
 
     virtual void Process_vkGetRayTracingShaderGroupHandlesNV(
@@ -2044,7 +2044,7 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCmdWriteAccelerationStructuresPropertiesNV(
         format::HandleId                            commandBuffer,
         uint32_t                                    accelerationStructureCount,
-        const HandlePointerDecoder<VkAccelerationStructureNV>& pAccelerationStructures,
+        HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructures,
         VkQueryType                                 queryType,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery) {}
@@ -2079,7 +2079,7 @@ class VulkanConsumer : public VulkanConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    timestampCount,
-        const StructPointerDecoder<Decoded_VkCalibratedTimestampInfoEXT>& pTimestampInfos,
+        StructPointerDecoder<Decoded_VkCalibratedTimestampInfoEXT>* pTimestampInfos,
         PointerDecoder<uint64_t>*                   pTimestamps,
         PointerDecoder<uint64_t>*                   pMaxDeviation) {}
 
@@ -2108,7 +2108,7 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstExclusiveScissor,
         uint32_t                                    exclusiveScissorCount,
-        const StructPointerDecoder<Decoded_VkRect2D>& pExclusiveScissors) {}
+        StructPointerDecoder<Decoded_VkRect2D>*     pExclusiveScissors) {}
 
     virtual void Process_vkCmdSetCheckpointNV(
         format::HandleId                            commandBuffer,
@@ -2122,7 +2122,7 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkInitializePerformanceApiINTEL(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkInitializePerformanceApiInfoINTEL>& pInitializeInfo) {}
+        StructPointerDecoder<Decoded_VkInitializePerformanceApiInfoINTEL>* pInitializeInfo) {}
 
     virtual void Process_vkUninitializePerformanceApiINTEL(
         format::HandleId                            device) {}
@@ -2130,22 +2130,22 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCmdSetPerformanceMarkerINTEL(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkPerformanceMarkerInfoINTEL>& pMarkerInfo) {}
+        StructPointerDecoder<Decoded_VkPerformanceMarkerInfoINTEL>* pMarkerInfo) {}
 
     virtual void Process_vkCmdSetPerformanceStreamMarkerINTEL(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkPerformanceStreamMarkerInfoINTEL>& pMarkerInfo) {}
+        StructPointerDecoder<Decoded_VkPerformanceStreamMarkerInfoINTEL>* pMarkerInfo) {}
 
     virtual void Process_vkCmdSetPerformanceOverrideINTEL(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkPerformanceOverrideInfoINTEL>& pOverrideInfo) {}
+        StructPointerDecoder<Decoded_VkPerformanceOverrideInfoINTEL>* pOverrideInfo) {}
 
     virtual void Process_vkAcquirePerformanceConfigurationINTEL(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPerformanceConfigurationAcquireInfoINTEL>& pAcquireInfo,
+        StructPointerDecoder<Decoded_VkPerformanceConfigurationAcquireInfoINTEL>* pAcquireInfo,
         HandlePointerDecoder<VkPerformanceConfigurationINTEL>* pConfiguration) {}
 
     virtual void Process_vkReleasePerformanceConfigurationINTEL(
@@ -2172,21 +2172,21 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkCreateImagePipeSurfaceFUCHSIA(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCreateMetalSurfaceEXT(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetBufferDeviceAddressEXT(
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkBufferDeviceAddressInfoEXT>& pInfo) {}
+        StructPointerDecoder<Decoded_VkBufferDeviceAddressInfoEXT>* pInfo) {}
 
     virtual void Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(
         VkResult                                    returnValue,
@@ -2203,7 +2203,7 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         PointerDecoder<uint32_t>*                   pPresentModeCount,
         PointerDecoder<VkPresentModeKHR>*           pPresentModes) {}
 
@@ -2220,14 +2220,14 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual void Process_vkGetDeviceGroupSurfacePresentModes2EXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         PointerDecoder<VkDeviceGroupPresentModeFlagsKHR>* pModes) {}
 
     virtual void Process_vkCreateHeadlessSurfaceEXT(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkHeadlessSurfaceCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkHeadlessSurfaceCreateInfoEXT>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCmdSetLineStippleEXT(

--- a/framework/generated/generated_vulkan_decoder.cpp
+++ b/framework/generated/generated_vulkan_decoder.cpp
@@ -54,7 +54,7 @@ size_t VulkanDecoder::Decode_vkCreateInstance(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateInstance(return_value, pCreateInfo, pAllocator, &pInstance);
+        consumer->Process_vkCreateInstance(return_value, &pCreateInfo, &pAllocator, &pInstance);
     }
 
     return bytes_read;
@@ -72,7 +72,7 @@ size_t VulkanDecoder::Decode_vkDestroyInstance(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyInstance(instance, pAllocator);
+        consumer->Process_vkDestroyInstance(instance, &pAllocator);
     }
 
     return bytes_read;
@@ -242,7 +242,7 @@ size_t VulkanDecoder::Decode_vkCreateDevice(const uint8_t* parameter_buffer, siz
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDevice(return_value, physicalDevice, pCreateInfo, pAllocator, &pDevice);
+        consumer->Process_vkCreateDevice(return_value, physicalDevice, &pCreateInfo, &pAllocator, &pDevice);
     }
 
     return bytes_read;
@@ -260,7 +260,7 @@ size_t VulkanDecoder::Decode_vkDestroyDevice(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyDevice(device, pAllocator);
+        consumer->Process_vkDestroyDevice(device, &pAllocator);
     }
 
     return bytes_read;
@@ -306,7 +306,7 @@ size_t VulkanDecoder::Decode_vkQueueSubmit(const uint8_t* parameter_buffer, size
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkQueueSubmit(return_value, queue, submitCount, pSubmits, fence);
+        consumer->Process_vkQueueSubmit(return_value, queue, submitCount, &pSubmits, fence);
     }
 
     return bytes_read;
@@ -366,7 +366,7 @@ size_t VulkanDecoder::Decode_vkAllocateMemory(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkAllocateMemory(return_value, device, pAllocateInfo, pAllocator, &pMemory);
+        consumer->Process_vkAllocateMemory(return_value, device, &pAllocateInfo, &pAllocator, &pMemory);
     }
 
     return bytes_read;
@@ -386,7 +386,7 @@ size_t VulkanDecoder::Decode_vkFreeMemory(const uint8_t* parameter_buffer, size_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkFreeMemory(device, memory, pAllocator);
+        consumer->Process_vkFreeMemory(device, memory, &pAllocator);
     }
 
     return bytes_read;
@@ -454,7 +454,7 @@ size_t VulkanDecoder::Decode_vkFlushMappedMemoryRanges(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkFlushMappedMemoryRanges(return_value, device, memoryRangeCount, pMemoryRanges);
+        consumer->Process_vkFlushMappedMemoryRanges(return_value, device, memoryRangeCount, &pMemoryRanges);
     }
 
     return bytes_read;
@@ -476,7 +476,7 @@ size_t VulkanDecoder::Decode_vkInvalidateMappedMemoryRanges(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkInvalidateMappedMemoryRanges(return_value, device, memoryRangeCount, pMemoryRanges);
+        consumer->Process_vkInvalidateMappedMemoryRanges(return_value, device, memoryRangeCount, &pMemoryRanges);
     }
 
     return bytes_read;
@@ -660,7 +660,7 @@ size_t VulkanDecoder::Decode_vkQueueBindSparse(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkQueueBindSparse(return_value, queue, bindInfoCount, pBindInfo, fence);
+        consumer->Process_vkQueueBindSparse(return_value, queue, bindInfoCount, &pBindInfo, fence);
     }
 
     return bytes_read;
@@ -684,7 +684,7 @@ size_t VulkanDecoder::Decode_vkCreateFence(const uint8_t* parameter_buffer, size
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateFence(return_value, device, pCreateInfo, pAllocator, &pFence);
+        consumer->Process_vkCreateFence(return_value, device, &pCreateInfo, &pAllocator, &pFence);
     }
 
     return bytes_read;
@@ -704,7 +704,7 @@ size_t VulkanDecoder::Decode_vkDestroyFence(const uint8_t* parameter_buffer, siz
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyFence(device, fence, pAllocator);
+        consumer->Process_vkDestroyFence(device, fence, &pAllocator);
     }
 
     return bytes_read;
@@ -726,7 +726,7 @@ size_t VulkanDecoder::Decode_vkResetFences(const uint8_t* parameter_buffer, size
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkResetFences(return_value, device, fenceCount, pFences);
+        consumer->Process_vkResetFences(return_value, device, fenceCount, &pFences);
     }
 
     return bytes_read;
@@ -772,7 +772,7 @@ size_t VulkanDecoder::Decode_vkWaitForFences(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkWaitForFences(return_value, device, fenceCount, pFences, waitAll, timeout);
+        consumer->Process_vkWaitForFences(return_value, device, fenceCount, &pFences, waitAll, timeout);
     }
 
     return bytes_read;
@@ -796,7 +796,7 @@ size_t VulkanDecoder::Decode_vkCreateSemaphore(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateSemaphore(return_value, device, pCreateInfo, pAllocator, &pSemaphore);
+        consumer->Process_vkCreateSemaphore(return_value, device, &pCreateInfo, &pAllocator, &pSemaphore);
     }
 
     return bytes_read;
@@ -816,7 +816,7 @@ size_t VulkanDecoder::Decode_vkDestroySemaphore(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroySemaphore(device, semaphore, pAllocator);
+        consumer->Process_vkDestroySemaphore(device, semaphore, &pAllocator);
     }
 
     return bytes_read;
@@ -840,7 +840,7 @@ size_t VulkanDecoder::Decode_vkCreateEvent(const uint8_t* parameter_buffer, size
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateEvent(return_value, device, pCreateInfo, pAllocator, &pEvent);
+        consumer->Process_vkCreateEvent(return_value, device, &pCreateInfo, &pAllocator, &pEvent);
     }
 
     return bytes_read;
@@ -860,7 +860,7 @@ size_t VulkanDecoder::Decode_vkDestroyEvent(const uint8_t* parameter_buffer, siz
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyEvent(device, event, pAllocator);
+        consumer->Process_vkDestroyEvent(device, event, &pAllocator);
     }
 
     return bytes_read;
@@ -944,7 +944,7 @@ size_t VulkanDecoder::Decode_vkCreateQueryPool(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateQueryPool(return_value, device, pCreateInfo, pAllocator, &pQueryPool);
+        consumer->Process_vkCreateQueryPool(return_value, device, &pCreateInfo, &pAllocator, &pQueryPool);
     }
 
     return bytes_read;
@@ -964,7 +964,7 @@ size_t VulkanDecoder::Decode_vkDestroyQueryPool(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyQueryPool(device, queryPool, pAllocator);
+        consumer->Process_vkDestroyQueryPool(device, queryPool, &pAllocator);
     }
 
     return bytes_read;
@@ -1020,7 +1020,7 @@ size_t VulkanDecoder::Decode_vkCreateBuffer(const uint8_t* parameter_buffer, siz
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateBuffer(return_value, device, pCreateInfo, pAllocator, &pBuffer);
+        consumer->Process_vkCreateBuffer(return_value, device, &pCreateInfo, &pAllocator, &pBuffer);
     }
 
     return bytes_read;
@@ -1040,7 +1040,7 @@ size_t VulkanDecoder::Decode_vkDestroyBuffer(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyBuffer(device, buffer, pAllocator);
+        consumer->Process_vkDestroyBuffer(device, buffer, &pAllocator);
     }
 
     return bytes_read;
@@ -1064,7 +1064,7 @@ size_t VulkanDecoder::Decode_vkCreateBufferView(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateBufferView(return_value, device, pCreateInfo, pAllocator, &pView);
+        consumer->Process_vkCreateBufferView(return_value, device, &pCreateInfo, &pAllocator, &pView);
     }
 
     return bytes_read;
@@ -1084,7 +1084,7 @@ size_t VulkanDecoder::Decode_vkDestroyBufferView(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyBufferView(device, bufferView, pAllocator);
+        consumer->Process_vkDestroyBufferView(device, bufferView, &pAllocator);
     }
 
     return bytes_read;
@@ -1108,7 +1108,7 @@ size_t VulkanDecoder::Decode_vkCreateImage(const uint8_t* parameter_buffer, size
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateImage(return_value, device, pCreateInfo, pAllocator, &pImage);
+        consumer->Process_vkCreateImage(return_value, device, &pCreateInfo, &pAllocator, &pImage);
     }
 
     return bytes_read;
@@ -1128,7 +1128,7 @@ size_t VulkanDecoder::Decode_vkDestroyImage(const uint8_t* parameter_buffer, siz
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyImage(device, image, pAllocator);
+        consumer->Process_vkDestroyImage(device, image, &pAllocator);
     }
 
     return bytes_read;
@@ -1150,7 +1150,7 @@ size_t VulkanDecoder::Decode_vkGetImageSubresourceLayout(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetImageSubresourceLayout(device, image, pSubresource, &pLayout);
+        consumer->Process_vkGetImageSubresourceLayout(device, image, &pSubresource, &pLayout);
     }
 
     return bytes_read;
@@ -1174,7 +1174,7 @@ size_t VulkanDecoder::Decode_vkCreateImageView(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateImageView(return_value, device, pCreateInfo, pAllocator, &pView);
+        consumer->Process_vkCreateImageView(return_value, device, &pCreateInfo, &pAllocator, &pView);
     }
 
     return bytes_read;
@@ -1194,7 +1194,7 @@ size_t VulkanDecoder::Decode_vkDestroyImageView(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyImageView(device, imageView, pAllocator);
+        consumer->Process_vkDestroyImageView(device, imageView, &pAllocator);
     }
 
     return bytes_read;
@@ -1218,7 +1218,7 @@ size_t VulkanDecoder::Decode_vkCreateShaderModule(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateShaderModule(return_value, device, pCreateInfo, pAllocator, &pShaderModule);
+        consumer->Process_vkCreateShaderModule(return_value, device, &pCreateInfo, &pAllocator, &pShaderModule);
     }
 
     return bytes_read;
@@ -1238,7 +1238,7 @@ size_t VulkanDecoder::Decode_vkDestroyShaderModule(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyShaderModule(device, shaderModule, pAllocator);
+        consumer->Process_vkDestroyShaderModule(device, shaderModule, &pAllocator);
     }
 
     return bytes_read;
@@ -1262,7 +1262,7 @@ size_t VulkanDecoder::Decode_vkCreatePipelineCache(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreatePipelineCache(return_value, device, pCreateInfo, pAllocator, &pPipelineCache);
+        consumer->Process_vkCreatePipelineCache(return_value, device, &pCreateInfo, &pAllocator, &pPipelineCache);
     }
 
     return bytes_read;
@@ -1282,7 +1282,7 @@ size_t VulkanDecoder::Decode_vkDestroyPipelineCache(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyPipelineCache(device, pipelineCache, pAllocator);
+        consumer->Process_vkDestroyPipelineCache(device, pipelineCache, &pAllocator);
     }
 
     return bytes_read;
@@ -1330,7 +1330,7 @@ size_t VulkanDecoder::Decode_vkMergePipelineCaches(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkMergePipelineCaches(return_value, device, dstCache, srcCacheCount, pSrcCaches);
+        consumer->Process_vkMergePipelineCaches(return_value, device, dstCache, srcCacheCount, &pSrcCaches);
     }
 
     return bytes_read;
@@ -1358,7 +1358,7 @@ size_t VulkanDecoder::Decode_vkCreateGraphicsPipelines(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateGraphicsPipelines(return_value, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, &pPipelines);
+        consumer->Process_vkCreateGraphicsPipelines(return_value, device, pipelineCache, createInfoCount, &pCreateInfos, &pAllocator, &pPipelines);
     }
 
     return bytes_read;
@@ -1386,7 +1386,7 @@ size_t VulkanDecoder::Decode_vkCreateComputePipelines(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateComputePipelines(return_value, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, &pPipelines);
+        consumer->Process_vkCreateComputePipelines(return_value, device, pipelineCache, createInfoCount, &pCreateInfos, &pAllocator, &pPipelines);
     }
 
     return bytes_read;
@@ -1406,7 +1406,7 @@ size_t VulkanDecoder::Decode_vkDestroyPipeline(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyPipeline(device, pipeline, pAllocator);
+        consumer->Process_vkDestroyPipeline(device, pipeline, &pAllocator);
     }
 
     return bytes_read;
@@ -1430,7 +1430,7 @@ size_t VulkanDecoder::Decode_vkCreatePipelineLayout(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreatePipelineLayout(return_value, device, pCreateInfo, pAllocator, &pPipelineLayout);
+        consumer->Process_vkCreatePipelineLayout(return_value, device, &pCreateInfo, &pAllocator, &pPipelineLayout);
     }
 
     return bytes_read;
@@ -1450,7 +1450,7 @@ size_t VulkanDecoder::Decode_vkDestroyPipelineLayout(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyPipelineLayout(device, pipelineLayout, pAllocator);
+        consumer->Process_vkDestroyPipelineLayout(device, pipelineLayout, &pAllocator);
     }
 
     return bytes_read;
@@ -1474,7 +1474,7 @@ size_t VulkanDecoder::Decode_vkCreateSampler(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateSampler(return_value, device, pCreateInfo, pAllocator, &pSampler);
+        consumer->Process_vkCreateSampler(return_value, device, &pCreateInfo, &pAllocator, &pSampler);
     }
 
     return bytes_read;
@@ -1494,7 +1494,7 @@ size_t VulkanDecoder::Decode_vkDestroySampler(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroySampler(device, sampler, pAllocator);
+        consumer->Process_vkDestroySampler(device, sampler, &pAllocator);
     }
 
     return bytes_read;
@@ -1518,7 +1518,7 @@ size_t VulkanDecoder::Decode_vkCreateDescriptorSetLayout(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDescriptorSetLayout(return_value, device, pCreateInfo, pAllocator, &pSetLayout);
+        consumer->Process_vkCreateDescriptorSetLayout(return_value, device, &pCreateInfo, &pAllocator, &pSetLayout);
     }
 
     return bytes_read;
@@ -1538,7 +1538,7 @@ size_t VulkanDecoder::Decode_vkDestroyDescriptorSetLayout(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyDescriptorSetLayout(device, descriptorSetLayout, pAllocator);
+        consumer->Process_vkDestroyDescriptorSetLayout(device, descriptorSetLayout, &pAllocator);
     }
 
     return bytes_read;
@@ -1562,7 +1562,7 @@ size_t VulkanDecoder::Decode_vkCreateDescriptorPool(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDescriptorPool(return_value, device, pCreateInfo, pAllocator, &pDescriptorPool);
+        consumer->Process_vkCreateDescriptorPool(return_value, device, &pCreateInfo, &pAllocator, &pDescriptorPool);
     }
 
     return bytes_read;
@@ -1582,7 +1582,7 @@ size_t VulkanDecoder::Decode_vkDestroyDescriptorPool(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyDescriptorPool(device, descriptorPool, pAllocator);
+        consumer->Process_vkDestroyDescriptorPool(device, descriptorPool, &pAllocator);
     }
 
     return bytes_read;
@@ -1626,7 +1626,7 @@ size_t VulkanDecoder::Decode_vkAllocateDescriptorSets(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkAllocateDescriptorSets(return_value, device, pAllocateInfo, &pDescriptorSets);
+        consumer->Process_vkAllocateDescriptorSets(return_value, device, &pAllocateInfo, &pDescriptorSets);
     }
 
     return bytes_read;
@@ -1650,7 +1650,7 @@ size_t VulkanDecoder::Decode_vkFreeDescriptorSets(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkFreeDescriptorSets(return_value, device, descriptorPool, descriptorSetCount, pDescriptorSets);
+        consumer->Process_vkFreeDescriptorSets(return_value, device, descriptorPool, descriptorSetCount, &pDescriptorSets);
     }
 
     return bytes_read;
@@ -1674,7 +1674,7 @@ size_t VulkanDecoder::Decode_vkUpdateDescriptorSets(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkUpdateDescriptorSets(device, descriptorWriteCount, pDescriptorWrites, descriptorCopyCount, pDescriptorCopies);
+        consumer->Process_vkUpdateDescriptorSets(device, descriptorWriteCount, &pDescriptorWrites, descriptorCopyCount, &pDescriptorCopies);
     }
 
     return bytes_read;
@@ -1698,7 +1698,7 @@ size_t VulkanDecoder::Decode_vkCreateFramebuffer(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateFramebuffer(return_value, device, pCreateInfo, pAllocator, &pFramebuffer);
+        consumer->Process_vkCreateFramebuffer(return_value, device, &pCreateInfo, &pAllocator, &pFramebuffer);
     }
 
     return bytes_read;
@@ -1718,7 +1718,7 @@ size_t VulkanDecoder::Decode_vkDestroyFramebuffer(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyFramebuffer(device, framebuffer, pAllocator);
+        consumer->Process_vkDestroyFramebuffer(device, framebuffer, &pAllocator);
     }
 
     return bytes_read;
@@ -1742,7 +1742,7 @@ size_t VulkanDecoder::Decode_vkCreateRenderPass(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateRenderPass(return_value, device, pCreateInfo, pAllocator, &pRenderPass);
+        consumer->Process_vkCreateRenderPass(return_value, device, &pCreateInfo, &pAllocator, &pRenderPass);
     }
 
     return bytes_read;
@@ -1762,7 +1762,7 @@ size_t VulkanDecoder::Decode_vkDestroyRenderPass(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyRenderPass(device, renderPass, pAllocator);
+        consumer->Process_vkDestroyRenderPass(device, renderPass, &pAllocator);
     }
 
     return bytes_read;
@@ -1806,7 +1806,7 @@ size_t VulkanDecoder::Decode_vkCreateCommandPool(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateCommandPool(return_value, device, pCreateInfo, pAllocator, &pCommandPool);
+        consumer->Process_vkCreateCommandPool(return_value, device, &pCreateInfo, &pAllocator, &pCommandPool);
     }
 
     return bytes_read;
@@ -1826,7 +1826,7 @@ size_t VulkanDecoder::Decode_vkDestroyCommandPool(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyCommandPool(device, commandPool, pAllocator);
+        consumer->Process_vkDestroyCommandPool(device, commandPool, &pAllocator);
     }
 
     return bytes_read;
@@ -1870,7 +1870,7 @@ size_t VulkanDecoder::Decode_vkAllocateCommandBuffers(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkAllocateCommandBuffers(return_value, device, pAllocateInfo, &pCommandBuffers);
+        consumer->Process_vkAllocateCommandBuffers(return_value, device, &pAllocateInfo, &pCommandBuffers);
     }
 
     return bytes_read;
@@ -1892,7 +1892,7 @@ size_t VulkanDecoder::Decode_vkFreeCommandBuffers(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkFreeCommandBuffers(device, commandPool, commandBufferCount, pCommandBuffers);
+        consumer->Process_vkFreeCommandBuffers(device, commandPool, commandBufferCount, &pCommandBuffers);
     }
 
     return bytes_read;
@@ -1912,7 +1912,7 @@ size_t VulkanDecoder::Decode_vkBeginCommandBuffer(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkBeginCommandBuffer(return_value, commandBuffer, pBeginInfo);
+        consumer->Process_vkBeginCommandBuffer(return_value, commandBuffer, &pBeginInfo);
     }
 
     return bytes_read;
@@ -1992,7 +1992,7 @@ size_t VulkanDecoder::Decode_vkCmdSetViewport(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, pViewports);
+        consumer->Process_vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, &pViewports);
     }
 
     return bytes_read;
@@ -2014,7 +2014,7 @@ size_t VulkanDecoder::Decode_vkCmdSetScissor(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, pScissors);
+        consumer->Process_vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, &pScissors);
     }
 
     return bytes_read;
@@ -2072,7 +2072,7 @@ size_t VulkanDecoder::Decode_vkCmdSetBlendConstants(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetBlendConstants(commandBuffer, blendConstants);
+        consumer->Process_vkCmdSetBlendConstants(commandBuffer, &blendConstants);
     }
 
     return bytes_read;
@@ -2182,7 +2182,7 @@ size_t VulkanDecoder::Decode_vkCmdBindDescriptorSets(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, pDescriptorSets, dynamicOffsetCount, pDynamicOffsets);
+        consumer->Process_vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, &pDescriptorSets, dynamicOffsetCount, &pDynamicOffsets);
     }
 
     return bytes_read;
@@ -2228,7 +2228,7 @@ size_t VulkanDecoder::Decode_vkCmdBindVertexBuffers(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets);
+        consumer->Process_vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, &pBuffers, &pOffsets);
     }
 
     return bytes_read;
@@ -2392,7 +2392,7 @@ size_t VulkanDecoder::Decode_vkCmdCopyBuffer(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions);
+        consumer->Process_vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, &pRegions);
     }
 
     return bytes_read;
@@ -2420,7 +2420,7 @@ size_t VulkanDecoder::Decode_vkCmdCopyImage(const uint8_t* parameter_buffer, siz
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
+        consumer->Process_vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, &pRegions);
     }
 
     return bytes_read;
@@ -2450,7 +2450,7 @@ size_t VulkanDecoder::Decode_vkCmdBlitImage(const uint8_t* parameter_buffer, siz
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter);
+        consumer->Process_vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, &pRegions, filter);
     }
 
     return bytes_read;
@@ -2476,7 +2476,7 @@ size_t VulkanDecoder::Decode_vkCmdCopyBufferToImage(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions);
+        consumer->Process_vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, &pRegions);
     }
 
     return bytes_read;
@@ -2502,7 +2502,7 @@ size_t VulkanDecoder::Decode_vkCmdCopyImageToBuffer(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions);
+        consumer->Process_vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, &pRegions);
     }
 
     return bytes_read;
@@ -2526,7 +2526,7 @@ size_t VulkanDecoder::Decode_vkCmdUpdateBuffer(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData);
+        consumer->Process_vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, &pData);
     }
 
     return bytes_read;
@@ -2576,7 +2576,7 @@ size_t VulkanDecoder::Decode_vkCmdClearColorImage(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
+        consumer->Process_vkCmdClearColorImage(commandBuffer, image, imageLayout, &pColor, rangeCount, &pRanges);
     }
 
     return bytes_read;
@@ -2602,7 +2602,7 @@ size_t VulkanDecoder::Decode_vkCmdClearDepthStencilImage(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges);
+        consumer->Process_vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, &pDepthStencil, rangeCount, &pRanges);
     }
 
     return bytes_read;
@@ -2626,7 +2626,7 @@ size_t VulkanDecoder::Decode_vkCmdClearAttachments(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects);
+        consumer->Process_vkCmdClearAttachments(commandBuffer, attachmentCount, &pAttachments, rectCount, &pRects);
     }
 
     return bytes_read;
@@ -2654,7 +2654,7 @@ size_t VulkanDecoder::Decode_vkCmdResolveImage(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
+        consumer->Process_vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, &pRegions);
     }
 
     return bytes_read;
@@ -2730,7 +2730,7 @@ size_t VulkanDecoder::Decode_vkCmdWaitEvents(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
+        consumer->Process_vkCmdWaitEvents(commandBuffer, eventCount, &pEvents, srcStageMask, dstStageMask, memoryBarrierCount, &pMemoryBarriers, bufferMemoryBarrierCount, &pBufferMemoryBarriers, imageMemoryBarrierCount, &pImageMemoryBarriers);
     }
 
     return bytes_read;
@@ -2764,7 +2764,7 @@ size_t VulkanDecoder::Decode_vkCmdPipelineBarrier(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers);
+        consumer->Process_vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, &pMemoryBarriers, bufferMemoryBarrierCount, &pBufferMemoryBarriers, imageMemoryBarrierCount, &pImageMemoryBarriers);
     }
 
     return bytes_read;
@@ -2906,7 +2906,7 @@ size_t VulkanDecoder::Decode_vkCmdPushConstants(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues);
+        consumer->Process_vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, &pValues);
     }
 
     return bytes_read;
@@ -2926,7 +2926,7 @@ size_t VulkanDecoder::Decode_vkCmdBeginRenderPass(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents);
+        consumer->Process_vkCmdBeginRenderPass(commandBuffer, &pRenderPassBegin, contents);
     }
 
     return bytes_read;
@@ -2980,7 +2980,7 @@ size_t VulkanDecoder::Decode_vkCmdExecuteCommands(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers);
+        consumer->Process_vkCmdExecuteCommands(commandBuffer, commandBufferCount, &pCommandBuffers);
     }
 
     return bytes_read;
@@ -3002,7 +3002,7 @@ size_t VulkanDecoder::Decode_vkBindBufferMemory2(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkBindBufferMemory2(return_value, device, bindInfoCount, pBindInfos);
+        consumer->Process_vkBindBufferMemory2(return_value, device, bindInfoCount, &pBindInfos);
     }
 
     return bytes_read;
@@ -3024,7 +3024,7 @@ size_t VulkanDecoder::Decode_vkBindImageMemory2(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkBindImageMemory2(return_value, device, bindInfoCount, pBindInfos);
+        consumer->Process_vkBindImageMemory2(return_value, device, bindInfoCount, &pBindInfos);
     }
 
     return bytes_read;
@@ -3136,7 +3136,7 @@ size_t VulkanDecoder::Decode_vkGetImageMemoryRequirements2(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetImageMemoryRequirements2(device, pInfo, &pMemoryRequirements);
+        consumer->Process_vkGetImageMemoryRequirements2(device, &pInfo, &pMemoryRequirements);
     }
 
     return bytes_read;
@@ -3156,7 +3156,7 @@ size_t VulkanDecoder::Decode_vkGetBufferMemoryRequirements2(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetBufferMemoryRequirements2(device, pInfo, &pMemoryRequirements);
+        consumer->Process_vkGetBufferMemoryRequirements2(device, &pInfo, &pMemoryRequirements);
     }
 
     return bytes_read;
@@ -3178,7 +3178,7 @@ size_t VulkanDecoder::Decode_vkGetImageSparseMemoryRequirements2(const uint8_t* 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetImageSparseMemoryRequirements2(device, pInfo, &pSparseMemoryRequirementCount, &pSparseMemoryRequirements);
+        consumer->Process_vkGetImageSparseMemoryRequirements2(device, &pInfo, &pSparseMemoryRequirementCount, &pSparseMemoryRequirements);
     }
 
     return bytes_read;
@@ -3256,7 +3256,7 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceImageFormatProperties2(const uin
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceImageFormatProperties2(return_value, physicalDevice, pImageFormatInfo, &pImageFormatProperties);
+        consumer->Process_vkGetPhysicalDeviceImageFormatProperties2(return_value, physicalDevice, &pImageFormatInfo, &pImageFormatProperties);
     }
 
     return bytes_read;
@@ -3316,7 +3316,7 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSparseImageFormatProperties2(con
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, &pPropertyCount, &pProperties);
+        consumer->Process_vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, &pFormatInfo, &pPropertyCount, &pProperties);
     }
 
     return bytes_read;
@@ -3356,7 +3356,7 @@ size_t VulkanDecoder::Decode_vkGetDeviceQueue2(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceQueue2(device, pQueueInfo, &pQueue);
+        consumer->Process_vkGetDeviceQueue2(device, &pQueueInfo, &pQueue);
     }
 
     return bytes_read;
@@ -3380,7 +3380,7 @@ size_t VulkanDecoder::Decode_vkCreateSamplerYcbcrConversion(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateSamplerYcbcrConversion(return_value, device, pCreateInfo, pAllocator, &pYcbcrConversion);
+        consumer->Process_vkCreateSamplerYcbcrConversion(return_value, device, &pCreateInfo, &pAllocator, &pYcbcrConversion);
     }
 
     return bytes_read;
@@ -3400,7 +3400,7 @@ size_t VulkanDecoder::Decode_vkDestroySamplerYcbcrConversion(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroySamplerYcbcrConversion(device, ycbcrConversion, pAllocator);
+        consumer->Process_vkDestroySamplerYcbcrConversion(device, ycbcrConversion, &pAllocator);
     }
 
     return bytes_read;
@@ -3424,7 +3424,7 @@ size_t VulkanDecoder::Decode_vkCreateDescriptorUpdateTemplate(const uint8_t* par
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDescriptorUpdateTemplate(return_value, device, pCreateInfo, pAllocator, &pDescriptorUpdateTemplate);
+        consumer->Process_vkCreateDescriptorUpdateTemplate(return_value, device, &pCreateInfo, &pAllocator, &pDescriptorUpdateTemplate);
     }
 
     return bytes_read;
@@ -3444,7 +3444,7 @@ size_t VulkanDecoder::Decode_vkDestroyDescriptorUpdateTemplate(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, pAllocator);
+        consumer->Process_vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, &pAllocator);
     }
 
     return bytes_read;
@@ -3464,7 +3464,7 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalBufferProperties(const u
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, pExternalBufferInfo, &pExternalBufferProperties);
+        consumer->Process_vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, &pExternalBufferInfo, &pExternalBufferProperties);
     }
 
     return bytes_read;
@@ -3484,7 +3484,7 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalFenceProperties(const ui
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, pExternalFenceInfo, &pExternalFenceProperties);
+        consumer->Process_vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, &pExternalFenceInfo, &pExternalFenceProperties);
     }
 
     return bytes_read;
@@ -3504,7 +3504,7 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalSemaphoreProperties(cons
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, pExternalSemaphoreInfo, &pExternalSemaphoreProperties);
+        consumer->Process_vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, &pExternalSemaphoreInfo, &pExternalSemaphoreProperties);
     }
 
     return bytes_read;
@@ -3524,7 +3524,7 @@ size_t VulkanDecoder::Decode_vkGetDescriptorSetLayoutSupport(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDescriptorSetLayoutSupport(device, pCreateInfo, &pSupport);
+        consumer->Process_vkGetDescriptorSetLayoutSupport(device, &pCreateInfo, &pSupport);
     }
 
     return bytes_read;
@@ -3544,7 +3544,7 @@ size_t VulkanDecoder::Decode_vkDestroySurfaceKHR(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroySurfaceKHR(instance, surface, pAllocator);
+        consumer->Process_vkDestroySurfaceKHR(instance, surface, &pAllocator);
     }
 
     return bytes_read;
@@ -3662,7 +3662,7 @@ size_t VulkanDecoder::Decode_vkCreateSwapchainKHR(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateSwapchainKHR(return_value, device, pCreateInfo, pAllocator, &pSwapchain);
+        consumer->Process_vkCreateSwapchainKHR(return_value, device, &pCreateInfo, &pAllocator, &pSwapchain);
     }
 
     return bytes_read;
@@ -3682,7 +3682,7 @@ size_t VulkanDecoder::Decode_vkDestroySwapchainKHR(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroySwapchainKHR(device, swapchain, pAllocator);
+        consumer->Process_vkDestroySwapchainKHR(device, swapchain, &pAllocator);
     }
 
     return bytes_read;
@@ -3754,7 +3754,7 @@ size_t VulkanDecoder::Decode_vkQueuePresentKHR(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkQueuePresentKHR(return_value, queue, pPresentInfo);
+        consumer->Process_vkQueuePresentKHR(return_value, queue, &pPresentInfo);
     }
 
     return bytes_read;
@@ -3842,7 +3842,7 @@ size_t VulkanDecoder::Decode_vkAcquireNextImage2KHR(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkAcquireNextImage2KHR(return_value, device, pAcquireInfo, &pImageIndex);
+        consumer->Process_vkAcquireNextImage2KHR(return_value, device, &pAcquireInfo, &pImageIndex);
     }
 
     return bytes_read;
@@ -3960,7 +3960,7 @@ size_t VulkanDecoder::Decode_vkCreateDisplayModeKHR(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDisplayModeKHR(return_value, physicalDevice, display, pCreateInfo, pAllocator, &pMode);
+        consumer->Process_vkCreateDisplayModeKHR(return_value, physicalDevice, display, &pCreateInfo, &pAllocator, &pMode);
     }
 
     return bytes_read;
@@ -4008,7 +4008,7 @@ size_t VulkanDecoder::Decode_vkCreateDisplayPlaneSurfaceKHR(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDisplayPlaneSurfaceKHR(return_value, instance, pCreateInfo, pAllocator, &pSurface);
+        consumer->Process_vkCreateDisplayPlaneSurfaceKHR(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
@@ -4034,7 +4034,7 @@ size_t VulkanDecoder::Decode_vkCreateSharedSwapchainsKHR(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateSharedSwapchainsKHR(return_value, device, swapchainCount, pCreateInfos, pAllocator, &pSwapchains);
+        consumer->Process_vkCreateSharedSwapchainsKHR(return_value, device, swapchainCount, &pCreateInfos, &pAllocator, &pSwapchains);
     }
 
     return bytes_read;
@@ -4058,7 +4058,7 @@ size_t VulkanDecoder::Decode_vkCreateXlibSurfaceKHR(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateXlibSurfaceKHR(return_value, instance, pCreateInfo, pAllocator, &pSurface);
+        consumer->Process_vkCreateXlibSurfaceKHR(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
@@ -4106,7 +4106,7 @@ size_t VulkanDecoder::Decode_vkCreateXcbSurfaceKHR(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateXcbSurfaceKHR(return_value, instance, pCreateInfo, pAllocator, &pSurface);
+        consumer->Process_vkCreateXcbSurfaceKHR(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
@@ -4154,7 +4154,7 @@ size_t VulkanDecoder::Decode_vkCreateWaylandSurfaceKHR(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateWaylandSurfaceKHR(return_value, instance, pCreateInfo, pAllocator, &pSurface);
+        consumer->Process_vkCreateWaylandSurfaceKHR(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
@@ -4200,7 +4200,7 @@ size_t VulkanDecoder::Decode_vkCreateAndroidSurfaceKHR(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateAndroidSurfaceKHR(return_value, instance, pCreateInfo, pAllocator, &pSurface);
+        consumer->Process_vkCreateAndroidSurfaceKHR(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
@@ -4224,7 +4224,7 @@ size_t VulkanDecoder::Decode_vkCreateWin32SurfaceKHR(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateWin32SurfaceKHR(return_value, instance, pCreateInfo, pAllocator, &pSurface);
+        consumer->Process_vkCreateWin32SurfaceKHR(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
@@ -4322,7 +4322,7 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceImageFormatProperties2KHR(const 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceImageFormatProperties2KHR(return_value, physicalDevice, pImageFormatInfo, &pImageFormatProperties);
+        consumer->Process_vkGetPhysicalDeviceImageFormatProperties2KHR(return_value, physicalDevice, &pImageFormatInfo, &pImageFormatProperties);
     }
 
     return bytes_read;
@@ -4382,7 +4382,7 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, &pPropertyCount, &pProperties);
+        consumer->Process_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, &pFormatInfo, &pPropertyCount, &pProperties);
     }
 
     return bytes_read;
@@ -4514,7 +4514,7 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalBufferPropertiesKHR(cons
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, pExternalBufferInfo, &pExternalBufferProperties);
+        consumer->Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, &pExternalBufferInfo, &pExternalBufferProperties);
     }
 
     return bytes_read;
@@ -4536,7 +4536,7 @@ size_t VulkanDecoder::Decode_vkGetMemoryWin32HandleKHR(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetMemoryWin32HandleKHR(return_value, device, pGetWin32HandleInfo, &pHandle);
+        consumer->Process_vkGetMemoryWin32HandleKHR(return_value, device, &pGetWin32HandleInfo, &pHandle);
     }
 
     return bytes_read;
@@ -4582,7 +4582,7 @@ size_t VulkanDecoder::Decode_vkGetMemoryFdKHR(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetMemoryFdKHR(return_value, device, pGetFdInfo, &pFd);
+        consumer->Process_vkGetMemoryFdKHR(return_value, device, &pGetFdInfo, &pFd);
     }
 
     return bytes_read;
@@ -4626,7 +4626,7 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(c
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, pExternalSemaphoreInfo, &pExternalSemaphoreProperties);
+        consumer->Process_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, &pExternalSemaphoreInfo, &pExternalSemaphoreProperties);
     }
 
     return bytes_read;
@@ -4646,7 +4646,7 @@ size_t VulkanDecoder::Decode_vkImportSemaphoreWin32HandleKHR(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkImportSemaphoreWin32HandleKHR(return_value, device, pImportSemaphoreWin32HandleInfo);
+        consumer->Process_vkImportSemaphoreWin32HandleKHR(return_value, device, &pImportSemaphoreWin32HandleInfo);
     }
 
     return bytes_read;
@@ -4668,7 +4668,7 @@ size_t VulkanDecoder::Decode_vkGetSemaphoreWin32HandleKHR(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetSemaphoreWin32HandleKHR(return_value, device, pGetWin32HandleInfo, &pHandle);
+        consumer->Process_vkGetSemaphoreWin32HandleKHR(return_value, device, &pGetWin32HandleInfo, &pHandle);
     }
 
     return bytes_read;
@@ -4688,7 +4688,7 @@ size_t VulkanDecoder::Decode_vkImportSemaphoreFdKHR(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkImportSemaphoreFdKHR(return_value, device, pImportSemaphoreFdInfo);
+        consumer->Process_vkImportSemaphoreFdKHR(return_value, device, &pImportSemaphoreFdInfo);
     }
 
     return bytes_read;
@@ -4710,7 +4710,7 @@ size_t VulkanDecoder::Decode_vkGetSemaphoreFdKHR(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetSemaphoreFdKHR(return_value, device, pGetFdInfo, &pFd);
+        consumer->Process_vkGetSemaphoreFdKHR(return_value, device, &pGetFdInfo, &pFd);
     }
 
     return bytes_read;
@@ -4736,7 +4736,7 @@ size_t VulkanDecoder::Decode_vkCmdPushDescriptorSetKHR(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, pDescriptorWrites);
+        consumer->Process_vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, &pDescriptorWrites);
     }
 
     return bytes_read;
@@ -4760,7 +4760,7 @@ size_t VulkanDecoder::Decode_vkCreateDescriptorUpdateTemplateKHR(const uint8_t* 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDescriptorUpdateTemplateKHR(return_value, device, pCreateInfo, pAllocator, &pDescriptorUpdateTemplate);
+        consumer->Process_vkCreateDescriptorUpdateTemplateKHR(return_value, device, &pCreateInfo, &pAllocator, &pDescriptorUpdateTemplate);
     }
 
     return bytes_read;
@@ -4780,7 +4780,7 @@ size_t VulkanDecoder::Decode_vkDestroyDescriptorUpdateTemplateKHR(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, pAllocator);
+        consumer->Process_vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, &pAllocator);
     }
 
     return bytes_read;
@@ -4804,7 +4804,7 @@ size_t VulkanDecoder::Decode_vkCreateRenderPass2KHR(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateRenderPass2KHR(return_value, device, pCreateInfo, pAllocator, &pRenderPass);
+        consumer->Process_vkCreateRenderPass2KHR(return_value, device, &pCreateInfo, &pAllocator, &pRenderPass);
     }
 
     return bytes_read;
@@ -4824,7 +4824,7 @@ size_t VulkanDecoder::Decode_vkCmdBeginRenderPass2KHR(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
+        consumer->Process_vkCmdBeginRenderPass2KHR(commandBuffer, &pRenderPassBegin, &pSubpassBeginInfo);
     }
 
     return bytes_read;
@@ -4844,7 +4844,7 @@ size_t VulkanDecoder::Decode_vkCmdNextSubpass2KHR(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdNextSubpass2KHR(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo);
+        consumer->Process_vkCmdNextSubpass2KHR(commandBuffer, &pSubpassBeginInfo, &pSubpassEndInfo);
     }
 
     return bytes_read;
@@ -4862,7 +4862,7 @@ size_t VulkanDecoder::Decode_vkCmdEndRenderPass2KHR(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo);
+        consumer->Process_vkCmdEndRenderPass2KHR(commandBuffer, &pSubpassEndInfo);
     }
 
     return bytes_read;
@@ -4902,7 +4902,7 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalFencePropertiesKHR(const
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, pExternalFenceInfo, &pExternalFenceProperties);
+        consumer->Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, &pExternalFenceInfo, &pExternalFenceProperties);
     }
 
     return bytes_read;
@@ -4922,7 +4922,7 @@ size_t VulkanDecoder::Decode_vkImportFenceWin32HandleKHR(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkImportFenceWin32HandleKHR(return_value, device, pImportFenceWin32HandleInfo);
+        consumer->Process_vkImportFenceWin32HandleKHR(return_value, device, &pImportFenceWin32HandleInfo);
     }
 
     return bytes_read;
@@ -4944,7 +4944,7 @@ size_t VulkanDecoder::Decode_vkGetFenceWin32HandleKHR(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetFenceWin32HandleKHR(return_value, device, pGetWin32HandleInfo, &pHandle);
+        consumer->Process_vkGetFenceWin32HandleKHR(return_value, device, &pGetWin32HandleInfo, &pHandle);
     }
 
     return bytes_read;
@@ -4964,7 +4964,7 @@ size_t VulkanDecoder::Decode_vkImportFenceFdKHR(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkImportFenceFdKHR(return_value, device, pImportFenceFdInfo);
+        consumer->Process_vkImportFenceFdKHR(return_value, device, &pImportFenceFdInfo);
     }
 
     return bytes_read;
@@ -4986,7 +4986,7 @@ size_t VulkanDecoder::Decode_vkGetFenceFdKHR(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetFenceFdKHR(return_value, device, pGetFdInfo, &pFd);
+        consumer->Process_vkGetFenceFdKHR(return_value, device, &pGetFdInfo, &pFd);
     }
 
     return bytes_read;
@@ -5008,7 +5008,7 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceCapabilities2KHR(const ui
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(return_value, physicalDevice, pSurfaceInfo, &pSurfaceCapabilities);
+        consumer->Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(return_value, physicalDevice, &pSurfaceInfo, &pSurfaceCapabilities);
     }
 
     return bytes_read;
@@ -5032,7 +5032,7 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceFormats2KHR(const uint8_t
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSurfaceFormats2KHR(return_value, physicalDevice, pSurfaceInfo, &pSurfaceFormatCount, &pSurfaceFormats);
+        consumer->Process_vkGetPhysicalDeviceSurfaceFormats2KHR(return_value, physicalDevice, &pSurfaceInfo, &pSurfaceFormatCount, &pSurfaceFormats);
     }
 
     return bytes_read;
@@ -5122,7 +5122,7 @@ size_t VulkanDecoder::Decode_vkGetDisplayPlaneCapabilities2KHR(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDisplayPlaneCapabilities2KHR(return_value, physicalDevice, pDisplayPlaneInfo, &pCapabilities);
+        consumer->Process_vkGetDisplayPlaneCapabilities2KHR(return_value, physicalDevice, &pDisplayPlaneInfo, &pCapabilities);
     }
 
     return bytes_read;
@@ -5142,7 +5142,7 @@ size_t VulkanDecoder::Decode_vkGetImageMemoryRequirements2KHR(const uint8_t* par
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetImageMemoryRequirements2KHR(device, pInfo, &pMemoryRequirements);
+        consumer->Process_vkGetImageMemoryRequirements2KHR(device, &pInfo, &pMemoryRequirements);
     }
 
     return bytes_read;
@@ -5162,7 +5162,7 @@ size_t VulkanDecoder::Decode_vkGetBufferMemoryRequirements2KHR(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetBufferMemoryRequirements2KHR(device, pInfo, &pMemoryRequirements);
+        consumer->Process_vkGetBufferMemoryRequirements2KHR(device, &pInfo, &pMemoryRequirements);
     }
 
     return bytes_read;
@@ -5184,7 +5184,7 @@ size_t VulkanDecoder::Decode_vkGetImageSparseMemoryRequirements2KHR(const uint8_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetImageSparseMemoryRequirements2KHR(device, pInfo, &pSparseMemoryRequirementCount, &pSparseMemoryRequirements);
+        consumer->Process_vkGetImageSparseMemoryRequirements2KHR(device, &pInfo, &pSparseMemoryRequirementCount, &pSparseMemoryRequirements);
     }
 
     return bytes_read;
@@ -5208,7 +5208,7 @@ size_t VulkanDecoder::Decode_vkCreateSamplerYcbcrConversionKHR(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateSamplerYcbcrConversionKHR(return_value, device, pCreateInfo, pAllocator, &pYcbcrConversion);
+        consumer->Process_vkCreateSamplerYcbcrConversionKHR(return_value, device, &pCreateInfo, &pAllocator, &pYcbcrConversion);
     }
 
     return bytes_read;
@@ -5228,7 +5228,7 @@ size_t VulkanDecoder::Decode_vkDestroySamplerYcbcrConversionKHR(const uint8_t* p
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator);
+        consumer->Process_vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, &pAllocator);
     }
 
     return bytes_read;
@@ -5250,7 +5250,7 @@ size_t VulkanDecoder::Decode_vkBindBufferMemory2KHR(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkBindBufferMemory2KHR(return_value, device, bindInfoCount, pBindInfos);
+        consumer->Process_vkBindBufferMemory2KHR(return_value, device, bindInfoCount, &pBindInfos);
     }
 
     return bytes_read;
@@ -5272,7 +5272,7 @@ size_t VulkanDecoder::Decode_vkBindImageMemory2KHR(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkBindImageMemory2KHR(return_value, device, bindInfoCount, pBindInfos);
+        consumer->Process_vkBindImageMemory2KHR(return_value, device, bindInfoCount, &pBindInfos);
     }
 
     return bytes_read;
@@ -5292,7 +5292,7 @@ size_t VulkanDecoder::Decode_vkGetDescriptorSetLayoutSupportKHR(const uint8_t* p
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDescriptorSetLayoutSupportKHR(device, pCreateInfo, &pSupport);
+        consumer->Process_vkGetDescriptorSetLayoutSupportKHR(device, &pCreateInfo, &pSupport);
     }
 
     return bytes_read;
@@ -5392,7 +5392,7 @@ size_t VulkanDecoder::Decode_vkWaitSemaphoresKHR(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkWaitSemaphoresKHR(return_value, device, pWaitInfo, timeout);
+        consumer->Process_vkWaitSemaphoresKHR(return_value, device, &pWaitInfo, timeout);
     }
 
     return bytes_read;
@@ -5412,7 +5412,7 @@ size_t VulkanDecoder::Decode_vkSignalSemaphoreKHR(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkSignalSemaphoreKHR(return_value, device, pSignalInfo);
+        consumer->Process_vkSignalSemaphoreKHR(return_value, device, &pSignalInfo);
     }
 
     return bytes_read;
@@ -5436,7 +5436,7 @@ size_t VulkanDecoder::Decode_vkGetPipelineExecutablePropertiesKHR(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPipelineExecutablePropertiesKHR(return_value, device, pPipelineInfo, &pExecutableCount, &pProperties);
+        consumer->Process_vkGetPipelineExecutablePropertiesKHR(return_value, device, &pPipelineInfo, &pExecutableCount, &pProperties);
     }
 
     return bytes_read;
@@ -5460,7 +5460,7 @@ size_t VulkanDecoder::Decode_vkGetPipelineExecutableStatisticsKHR(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPipelineExecutableStatisticsKHR(return_value, device, pExecutableInfo, &pStatisticCount, &pStatistics);
+        consumer->Process_vkGetPipelineExecutableStatisticsKHR(return_value, device, &pExecutableInfo, &pStatisticCount, &pStatistics);
     }
 
     return bytes_read;
@@ -5484,7 +5484,7 @@ size_t VulkanDecoder::Decode_vkGetPipelineExecutableInternalRepresentationsKHR(c
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPipelineExecutableInternalRepresentationsKHR(return_value, device, pExecutableInfo, &pInternalRepresentationCount, &pInternalRepresentations);
+        consumer->Process_vkGetPipelineExecutableInternalRepresentationsKHR(return_value, device, &pExecutableInfo, &pInternalRepresentationCount, &pInternalRepresentations);
     }
 
     return bytes_read;
@@ -5508,7 +5508,7 @@ size_t VulkanDecoder::Decode_vkCreateDebugReportCallbackEXT(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDebugReportCallbackEXT(return_value, instance, pCreateInfo, pAllocator, &pCallback);
+        consumer->Process_vkCreateDebugReportCallbackEXT(return_value, instance, &pCreateInfo, &pAllocator, &pCallback);
     }
 
     return bytes_read;
@@ -5528,7 +5528,7 @@ size_t VulkanDecoder::Decode_vkDestroyDebugReportCallbackEXT(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyDebugReportCallbackEXT(instance, callback, pAllocator);
+        consumer->Process_vkDestroyDebugReportCallbackEXT(instance, callback, &pAllocator);
     }
 
     return bytes_read;
@@ -5558,7 +5558,7 @@ size_t VulkanDecoder::Decode_vkDebugReportMessageEXT(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage);
+        consumer->Process_vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, &pLayerPrefix, &pMessage);
     }
 
     return bytes_read;
@@ -5578,7 +5578,7 @@ size_t VulkanDecoder::Decode_vkDebugMarkerSetObjectTagEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDebugMarkerSetObjectTagEXT(return_value, device, pTagInfo);
+        consumer->Process_vkDebugMarkerSetObjectTagEXT(return_value, device, &pTagInfo);
     }
 
     return bytes_read;
@@ -5598,7 +5598,7 @@ size_t VulkanDecoder::Decode_vkDebugMarkerSetObjectNameEXT(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDebugMarkerSetObjectNameEXT(return_value, device, pNameInfo);
+        consumer->Process_vkDebugMarkerSetObjectNameEXT(return_value, device, &pNameInfo);
     }
 
     return bytes_read;
@@ -5616,7 +5616,7 @@ size_t VulkanDecoder::Decode_vkCmdDebugMarkerBeginEXT(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDebugMarkerBeginEXT(commandBuffer, pMarkerInfo);
+        consumer->Process_vkCmdDebugMarkerBeginEXT(commandBuffer, &pMarkerInfo);
     }
 
     return bytes_read;
@@ -5650,7 +5650,7 @@ size_t VulkanDecoder::Decode_vkCmdDebugMarkerInsertEXT(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDebugMarkerInsertEXT(commandBuffer, pMarkerInfo);
+        consumer->Process_vkCmdDebugMarkerInsertEXT(commandBuffer, &pMarkerInfo);
     }
 
     return bytes_read;
@@ -5676,7 +5676,7 @@ size_t VulkanDecoder::Decode_vkCmdBindTransformFeedbackBuffersEXT(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, pBuffers, pOffsets, pSizes);
+        consumer->Process_vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, &pBuffers, &pOffsets, &pSizes);
     }
 
     return bytes_read;
@@ -5700,7 +5700,7 @@ size_t VulkanDecoder::Decode_vkCmdBeginTransformFeedbackEXT(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets);
+        consumer->Process_vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, &pCounterBuffers, &pCounterBufferOffsets);
     }
 
     return bytes_read;
@@ -5724,7 +5724,7 @@ size_t VulkanDecoder::Decode_vkCmdEndTransformFeedbackEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, pCounterBuffers, pCounterBufferOffsets);
+        consumer->Process_vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, &pCounterBuffers, &pCounterBufferOffsets);
     }
 
     return bytes_read;
@@ -5818,7 +5818,7 @@ size_t VulkanDecoder::Decode_vkGetImageViewHandleNVX(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetImageViewHandleNVX(return_value, device, pInfo);
+        consumer->Process_vkGetImageViewHandleNVX(return_value, device, &pInfo);
     }
 
     return bytes_read;
@@ -5926,7 +5926,7 @@ size_t VulkanDecoder::Decode_vkCreateStreamDescriptorSurfaceGGP(const uint8_t* p
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateStreamDescriptorSurfaceGGP(return_value, instance, pCreateInfo, pAllocator, &pSurface);
+        consumer->Process_vkCreateStreamDescriptorSurfaceGGP(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
@@ -6006,7 +6006,7 @@ size_t VulkanDecoder::Decode_vkCreateViSurfaceNN(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateViSurfaceNN(return_value, instance, pCreateInfo, pAllocator, &pSurface);
+        consumer->Process_vkCreateViSurfaceNN(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
@@ -6024,7 +6024,7 @@ size_t VulkanDecoder::Decode_vkCmdBeginConditionalRenderingEXT(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBeginConditionalRenderingEXT(commandBuffer, pConditionalRenderingBegin);
+        consumer->Process_vkCmdBeginConditionalRenderingEXT(commandBuffer, &pConditionalRenderingBegin);
     }
 
     return bytes_read;
@@ -6058,7 +6058,7 @@ size_t VulkanDecoder::Decode_vkCmdProcessCommandsNVX(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdProcessCommandsNVX(commandBuffer, pProcessCommandsInfo);
+        consumer->Process_vkCmdProcessCommandsNVX(commandBuffer, &pProcessCommandsInfo);
     }
 
     return bytes_read;
@@ -6076,7 +6076,7 @@ size_t VulkanDecoder::Decode_vkCmdReserveSpaceForCommandsNVX(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdReserveSpaceForCommandsNVX(commandBuffer, pReserveSpaceInfo);
+        consumer->Process_vkCmdReserveSpaceForCommandsNVX(commandBuffer, &pReserveSpaceInfo);
     }
 
     return bytes_read;
@@ -6100,7 +6100,7 @@ size_t VulkanDecoder::Decode_vkCreateIndirectCommandsLayoutNVX(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateIndirectCommandsLayoutNVX(return_value, device, pCreateInfo, pAllocator, &pIndirectCommandsLayout);
+        consumer->Process_vkCreateIndirectCommandsLayoutNVX(return_value, device, &pCreateInfo, &pAllocator, &pIndirectCommandsLayout);
     }
 
     return bytes_read;
@@ -6120,7 +6120,7 @@ size_t VulkanDecoder::Decode_vkDestroyIndirectCommandsLayoutNVX(const uint8_t* p
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyIndirectCommandsLayoutNVX(device, indirectCommandsLayout, pAllocator);
+        consumer->Process_vkDestroyIndirectCommandsLayoutNVX(device, indirectCommandsLayout, &pAllocator);
     }
 
     return bytes_read;
@@ -6144,7 +6144,7 @@ size_t VulkanDecoder::Decode_vkCreateObjectTableNVX(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateObjectTableNVX(return_value, device, pCreateInfo, pAllocator, &pObjectTable);
+        consumer->Process_vkCreateObjectTableNVX(return_value, device, &pCreateInfo, &pAllocator, &pObjectTable);
     }
 
     return bytes_read;
@@ -6164,7 +6164,7 @@ size_t VulkanDecoder::Decode_vkDestroyObjectTableNVX(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyObjectTableNVX(device, objectTable, pAllocator);
+        consumer->Process_vkDestroyObjectTableNVX(device, objectTable, &pAllocator);
     }
 
     return bytes_read;
@@ -6190,7 +6190,7 @@ size_t VulkanDecoder::Decode_vkUnregisterObjectsNVX(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkUnregisterObjectsNVX(return_value, device, objectTable, objectCount, pObjectEntryTypes, pObjectIndices);
+        consumer->Process_vkUnregisterObjectsNVX(return_value, device, objectTable, objectCount, &pObjectEntryTypes, &pObjectIndices);
     }
 
     return bytes_read;
@@ -6232,7 +6232,7 @@ size_t VulkanDecoder::Decode_vkCmdSetViewportWScalingNV(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, pViewportWScalings);
+        consumer->Process_vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, &pViewportWScalings);
     }
 
     return bytes_read;
@@ -6342,7 +6342,7 @@ size_t VulkanDecoder::Decode_vkDisplayPowerControlEXT(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDisplayPowerControlEXT(return_value, device, display, pDisplayPowerInfo);
+        consumer->Process_vkDisplayPowerControlEXT(return_value, device, display, &pDisplayPowerInfo);
     }
 
     return bytes_read;
@@ -6366,7 +6366,7 @@ size_t VulkanDecoder::Decode_vkRegisterDeviceEventEXT(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkRegisterDeviceEventEXT(return_value, device, pDeviceEventInfo, pAllocator, &pFence);
+        consumer->Process_vkRegisterDeviceEventEXT(return_value, device, &pDeviceEventInfo, &pAllocator, &pFence);
     }
 
     return bytes_read;
@@ -6392,7 +6392,7 @@ size_t VulkanDecoder::Decode_vkRegisterDisplayEventEXT(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkRegisterDisplayEventEXT(return_value, device, display, pDisplayEventInfo, pAllocator, &pFence);
+        consumer->Process_vkRegisterDisplayEventEXT(return_value, device, display, &pDisplayEventInfo, &pAllocator, &pFence);
     }
 
     return bytes_read;
@@ -6484,7 +6484,7 @@ size_t VulkanDecoder::Decode_vkCmdSetDiscardRectangleEXT(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles);
+        consumer->Process_vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, &pDiscardRectangles);
     }
 
     return bytes_read;
@@ -6506,7 +6506,7 @@ size_t VulkanDecoder::Decode_vkSetHdrMetadataEXT(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkSetHdrMetadataEXT(device, swapchainCount, pSwapchains, pMetadata);
+        consumer->Process_vkSetHdrMetadataEXT(device, swapchainCount, &pSwapchains, &pMetadata);
     }
 
     return bytes_read;
@@ -6530,7 +6530,7 @@ size_t VulkanDecoder::Decode_vkCreateIOSSurfaceMVK(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateIOSSurfaceMVK(return_value, instance, pCreateInfo, pAllocator, &pSurface);
+        consumer->Process_vkCreateIOSSurfaceMVK(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
@@ -6554,7 +6554,7 @@ size_t VulkanDecoder::Decode_vkCreateMacOSSurfaceMVK(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateMacOSSurfaceMVK(return_value, instance, pCreateInfo, pAllocator, &pSurface);
+        consumer->Process_vkCreateMacOSSurfaceMVK(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
@@ -6574,7 +6574,7 @@ size_t VulkanDecoder::Decode_vkSetDebugUtilsObjectNameEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkSetDebugUtilsObjectNameEXT(return_value, device, pNameInfo);
+        consumer->Process_vkSetDebugUtilsObjectNameEXT(return_value, device, &pNameInfo);
     }
 
     return bytes_read;
@@ -6594,7 +6594,7 @@ size_t VulkanDecoder::Decode_vkSetDebugUtilsObjectTagEXT(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkSetDebugUtilsObjectTagEXT(return_value, device, pTagInfo);
+        consumer->Process_vkSetDebugUtilsObjectTagEXT(return_value, device, &pTagInfo);
     }
 
     return bytes_read;
@@ -6612,7 +6612,7 @@ size_t VulkanDecoder::Decode_vkQueueBeginDebugUtilsLabelEXT(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkQueueBeginDebugUtilsLabelEXT(queue, pLabelInfo);
+        consumer->Process_vkQueueBeginDebugUtilsLabelEXT(queue, &pLabelInfo);
     }
 
     return bytes_read;
@@ -6646,7 +6646,7 @@ size_t VulkanDecoder::Decode_vkQueueInsertDebugUtilsLabelEXT(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkQueueInsertDebugUtilsLabelEXT(queue, pLabelInfo);
+        consumer->Process_vkQueueInsertDebugUtilsLabelEXT(queue, &pLabelInfo);
     }
 
     return bytes_read;
@@ -6664,7 +6664,7 @@ size_t VulkanDecoder::Decode_vkCmdBeginDebugUtilsLabelEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
+        consumer->Process_vkCmdBeginDebugUtilsLabelEXT(commandBuffer, &pLabelInfo);
     }
 
     return bytes_read;
@@ -6698,7 +6698,7 @@ size_t VulkanDecoder::Decode_vkCmdInsertDebugUtilsLabelEXT(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdInsertDebugUtilsLabelEXT(commandBuffer, pLabelInfo);
+        consumer->Process_vkCmdInsertDebugUtilsLabelEXT(commandBuffer, &pLabelInfo);
     }
 
     return bytes_read;
@@ -6722,7 +6722,7 @@ size_t VulkanDecoder::Decode_vkCreateDebugUtilsMessengerEXT(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDebugUtilsMessengerEXT(return_value, instance, pCreateInfo, pAllocator, &pMessenger);
+        consumer->Process_vkCreateDebugUtilsMessengerEXT(return_value, instance, &pCreateInfo, &pAllocator, &pMessenger);
     }
 
     return bytes_read;
@@ -6742,7 +6742,7 @@ size_t VulkanDecoder::Decode_vkDestroyDebugUtilsMessengerEXT(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyDebugUtilsMessengerEXT(instance, messenger, pAllocator);
+        consumer->Process_vkDestroyDebugUtilsMessengerEXT(instance, messenger, &pAllocator);
     }
 
     return bytes_read;
@@ -6764,7 +6764,7 @@ size_t VulkanDecoder::Decode_vkSubmitDebugUtilsMessageEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData);
+        consumer->Process_vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, &pCallbackData);
     }
 
     return bytes_read;
@@ -6808,7 +6808,7 @@ size_t VulkanDecoder::Decode_vkGetMemoryAndroidHardwareBufferANDROID(const uint8
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetMemoryAndroidHardwareBufferANDROID(return_value, device, pInfo, &pBuffer);
+        consumer->Process_vkGetMemoryAndroidHardwareBufferANDROID(return_value, device, &pInfo, &pBuffer);
     }
 
     return bytes_read;
@@ -6826,7 +6826,7 @@ size_t VulkanDecoder::Decode_vkCmdSetSampleLocationsEXT(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetSampleLocationsEXT(commandBuffer, pSampleLocationsInfo);
+        consumer->Process_vkCmdSetSampleLocationsEXT(commandBuffer, &pSampleLocationsInfo);
     }
 
     return bytes_read;
@@ -6892,7 +6892,7 @@ size_t VulkanDecoder::Decode_vkCreateValidationCacheEXT(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateValidationCacheEXT(return_value, device, pCreateInfo, pAllocator, &pValidationCache);
+        consumer->Process_vkCreateValidationCacheEXT(return_value, device, &pCreateInfo, &pAllocator, &pValidationCache);
     }
 
     return bytes_read;
@@ -6912,7 +6912,7 @@ size_t VulkanDecoder::Decode_vkDestroyValidationCacheEXT(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyValidationCacheEXT(device, validationCache, pAllocator);
+        consumer->Process_vkDestroyValidationCacheEXT(device, validationCache, &pAllocator);
     }
 
     return bytes_read;
@@ -6936,7 +6936,7 @@ size_t VulkanDecoder::Decode_vkMergeValidationCachesEXT(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkMergeValidationCachesEXT(return_value, device, dstCache, srcCacheCount, pSrcCaches);
+        consumer->Process_vkMergeValidationCachesEXT(return_value, device, dstCache, srcCacheCount, &pSrcCaches);
     }
 
     return bytes_read;
@@ -7002,7 +7002,7 @@ size_t VulkanDecoder::Decode_vkCmdSetViewportShadingRatePaletteNV(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, pShadingRatePalettes);
+        consumer->Process_vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, &pShadingRatePalettes);
     }
 
     return bytes_read;
@@ -7024,7 +7024,7 @@ size_t VulkanDecoder::Decode_vkCmdSetCoarseSampleOrderNV(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, pCustomSampleOrders);
+        consumer->Process_vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, &pCustomSampleOrders);
     }
 
     return bytes_read;
@@ -7048,7 +7048,7 @@ size_t VulkanDecoder::Decode_vkCreateAccelerationStructureNV(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateAccelerationStructureNV(return_value, device, pCreateInfo, pAllocator, &pAccelerationStructure);
+        consumer->Process_vkCreateAccelerationStructureNV(return_value, device, &pCreateInfo, &pAllocator, &pAccelerationStructure);
     }
 
     return bytes_read;
@@ -7068,7 +7068,7 @@ size_t VulkanDecoder::Decode_vkDestroyAccelerationStructureNV(const uint8_t* par
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyAccelerationStructureNV(device, accelerationStructure, pAllocator);
+        consumer->Process_vkDestroyAccelerationStructureNV(device, accelerationStructure, &pAllocator);
     }
 
     return bytes_read;
@@ -7088,7 +7088,7 @@ size_t VulkanDecoder::Decode_vkGetAccelerationStructureMemoryRequirementsNV(cons
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetAccelerationStructureMemoryRequirementsNV(device, pInfo, &pMemoryRequirements);
+        consumer->Process_vkGetAccelerationStructureMemoryRequirementsNV(device, &pInfo, &pMemoryRequirements);
     }
 
     return bytes_read;
@@ -7110,7 +7110,7 @@ size_t VulkanDecoder::Decode_vkBindAccelerationStructureMemoryNV(const uint8_t* 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkBindAccelerationStructureMemoryNV(return_value, device, bindInfoCount, pBindInfos);
+        consumer->Process_vkBindAccelerationStructureMemoryNV(return_value, device, bindInfoCount, &pBindInfos);
     }
 
     return bytes_read;
@@ -7142,7 +7142,7 @@ size_t VulkanDecoder::Decode_vkCmdBuildAccelerationStructureNV(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBuildAccelerationStructureNV(commandBuffer, pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset);
+        consumer->Process_vkCmdBuildAccelerationStructureNV(commandBuffer, &pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset);
     }
 
     return bytes_read;
@@ -7236,7 +7236,7 @@ size_t VulkanDecoder::Decode_vkCreateRayTracingPipelinesNV(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateRayTracingPipelinesNV(return_value, device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, &pPipelines);
+        consumer->Process_vkCreateRayTracingPipelinesNV(return_value, device, pipelineCache, createInfoCount, &pCreateInfos, &pAllocator, &pPipelines);
     }
 
     return bytes_read;
@@ -7314,7 +7314,7 @@ size_t VulkanDecoder::Decode_vkCmdWriteAccelerationStructuresPropertiesNV(const 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, pAccelerationStructures, queryType, queryPool, firstQuery);
+        consumer->Process_vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, &pAccelerationStructures, queryType, queryPool, firstQuery);
     }
 
     return bytes_read;
@@ -7432,7 +7432,7 @@ size_t VulkanDecoder::Decode_vkGetCalibratedTimestampsEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetCalibratedTimestampsEXT(return_value, device, timestampCount, pTimestampInfos, &pTimestamps, &pMaxDeviation);
+        consumer->Process_vkGetCalibratedTimestampsEXT(return_value, device, timestampCount, &pTimestampInfos, &pTimestamps, &pMaxDeviation);
     }
 
     return bytes_read;
@@ -7526,7 +7526,7 @@ size_t VulkanDecoder::Decode_vkCmdSetExclusiveScissorNV(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, pExclusiveScissors);
+        consumer->Process_vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, &pExclusiveScissors);
     }
 
     return bytes_read;
@@ -7584,7 +7584,7 @@ size_t VulkanDecoder::Decode_vkInitializePerformanceApiINTEL(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkInitializePerformanceApiINTEL(return_value, device, pInitializeInfo);
+        consumer->Process_vkInitializePerformanceApiINTEL(return_value, device, &pInitializeInfo);
     }
 
     return bytes_read;
@@ -7620,7 +7620,7 @@ size_t VulkanDecoder::Decode_vkCmdSetPerformanceMarkerINTEL(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetPerformanceMarkerINTEL(return_value, commandBuffer, pMarkerInfo);
+        consumer->Process_vkCmdSetPerformanceMarkerINTEL(return_value, commandBuffer, &pMarkerInfo);
     }
 
     return bytes_read;
@@ -7640,7 +7640,7 @@ size_t VulkanDecoder::Decode_vkCmdSetPerformanceStreamMarkerINTEL(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetPerformanceStreamMarkerINTEL(return_value, commandBuffer, pMarkerInfo);
+        consumer->Process_vkCmdSetPerformanceStreamMarkerINTEL(return_value, commandBuffer, &pMarkerInfo);
     }
 
     return bytes_read;
@@ -7660,7 +7660,7 @@ size_t VulkanDecoder::Decode_vkCmdSetPerformanceOverrideINTEL(const uint8_t* par
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetPerformanceOverrideINTEL(return_value, commandBuffer, pOverrideInfo);
+        consumer->Process_vkCmdSetPerformanceOverrideINTEL(return_value, commandBuffer, &pOverrideInfo);
     }
 
     return bytes_read;
@@ -7682,7 +7682,7 @@ size_t VulkanDecoder::Decode_vkAcquirePerformanceConfigurationINTEL(const uint8_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkAcquirePerformanceConfigurationINTEL(return_value, device, pAcquireInfo, &pConfiguration);
+        consumer->Process_vkAcquirePerformanceConfigurationINTEL(return_value, device, &pAcquireInfo, &pConfiguration);
     }
 
     return bytes_read;
@@ -7788,7 +7788,7 @@ size_t VulkanDecoder::Decode_vkCreateImagePipeSurfaceFUCHSIA(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateImagePipeSurfaceFUCHSIA(return_value, instance, pCreateInfo, pAllocator, &pSurface);
+        consumer->Process_vkCreateImagePipeSurfaceFUCHSIA(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
@@ -7812,7 +7812,7 @@ size_t VulkanDecoder::Decode_vkCreateMetalSurfaceEXT(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateMetalSurfaceEXT(return_value, instance, pCreateInfo, pAllocator, &pSurface);
+        consumer->Process_vkCreateMetalSurfaceEXT(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
@@ -7832,7 +7832,7 @@ size_t VulkanDecoder::Decode_vkGetBufferDeviceAddressEXT(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetBufferDeviceAddressEXT(return_value, device, pInfo);
+        consumer->Process_vkGetBufferDeviceAddressEXT(return_value, device, &pInfo);
     }
 
     return bytes_read;
@@ -7900,7 +7900,7 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfacePresentModes2EXT(const ui
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(return_value, physicalDevice, pSurfaceInfo, &pPresentModeCount, &pPresentModes);
+        consumer->Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(return_value, physicalDevice, &pSurfaceInfo, &pPresentModeCount, &pPresentModes);
     }
 
     return bytes_read;
@@ -7962,7 +7962,7 @@ size_t VulkanDecoder::Decode_vkGetDeviceGroupSurfacePresentModes2EXT(const uint8
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceGroupSurfacePresentModes2EXT(return_value, device, pSurfaceInfo, &pModes);
+        consumer->Process_vkGetDeviceGroupSurfacePresentModes2EXT(return_value, device, &pSurfaceInfo, &pModes);
     }
 
     return bytes_read;
@@ -7986,7 +7986,7 @@ size_t VulkanDecoder::Decode_vkCreateHeadlessSurfaceEXT(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateHeadlessSurfaceEXT(return_value, instance, pCreateInfo, pAllocator, &pSurface);
+        consumer->Process_vkCreateHeadlessSurfaceEXT(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -63,7 +63,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDevices(
     HandlePointerDecoder<VkPhysicalDevice>*     pPhysicalDevices)
 {
     auto in_instance = GetObjectInfoTable().GetInstanceInfo(instance);
-    pPhysicalDeviceCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, InstanceInfo>("vkEnumeratePhysicalDevices", returnValue, instance, kInstanceArrayEnumeratePhysicalDevices, pPhysicalDeviceCount, pPhysicalDevices, &VulkanObjectInfoTable::GetInstanceInfo));
+    pPhysicalDeviceCount->IsNull() ? nullptr : pPhysicalDeviceCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, InstanceInfo>("vkEnumeratePhysicalDevices", returnValue, instance, kInstanceArrayEnumeratePhysicalDevices, pPhysicalDeviceCount, pPhysicalDevices, &VulkanObjectInfoTable::GetInstanceInfo));
     if (!pPhysicalDevices->IsNull()) { pPhysicalDevices->SetHandleLength(*pPhysicalDeviceCount->GetOutputPointer()); }
     std::vector<PhysicalDeviceInfo> handle_info(*pPhysicalDeviceCount->GetOutputPointer());
     for (size_t i = 0; i < *pPhysicalDeviceCount->GetOutputPointer(); ++i) { pPhysicalDevices->SetConsumerData(i, &handle_info[i]); }
@@ -80,7 +80,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFeatures(
     StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures>* pFeatures)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    VkPhysicalDeviceFeatures* out_pFeatures = pFeatures->AllocateOutputData(1);
+    VkPhysicalDeviceFeatures* out_pFeatures = pFeatures->IsNull() ? nullptr : pFeatures->AllocateOutputData(1);
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceFeatures(in_physicalDevice, out_pFeatures);
 }
@@ -91,7 +91,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFormatProperties(
     StructPointerDecoder<Decoded_VkFormatProperties>* pFormatProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    VkFormatProperties* out_pFormatProperties = pFormatProperties->AllocateOutputData(1);
+    VkFormatProperties* out_pFormatProperties = pFormatProperties->IsNull() ? nullptr : pFormatProperties->AllocateOutputData(1);
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceFormatProperties(in_physicalDevice, format, out_pFormatProperties);
 }
@@ -107,7 +107,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties(
     StructPointerDecoder<Decoded_VkImageFormatProperties>* pImageFormatProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    VkImageFormatProperties* out_pImageFormatProperties = pImageFormatProperties->AllocateOutputData(1);
+    VkImageFormatProperties* out_pImageFormatProperties = pImageFormatProperties->IsNull() ? nullptr : pImageFormatProperties->AllocateOutputData(1);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceImageFormatProperties(in_physicalDevice, format, type, tiling, usage, flags, out_pImageFormatProperties);
     CheckResult("vkGetPhysicalDeviceImageFormatProperties", returnValue, replay_result);
@@ -118,7 +118,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceProperties(
     StructPointerDecoder<Decoded_VkPhysicalDeviceProperties>* pProperties)
 {
     auto in_physicalDevice = GetObjectInfoTable().GetPhysicalDeviceInfo(physicalDevice);
-    pProperties->AllocateOutputData(1);
+    pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(1);
 
     OverrideGetPhysicalDeviceProperties(GetInstanceTable(in_physicalDevice->handle)->GetPhysicalDeviceProperties, in_physicalDevice, pProperties);
 }
@@ -129,7 +129,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties(
     StructPointerDecoder<Decoded_VkQueueFamilyProperties>* pQueueFamilyProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceQueueFamilyProperties", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties, pQueueFamilyPropertyCount, pQueueFamilyProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->IsNull() ? nullptr : pQueueFamilyPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceQueueFamilyProperties", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties, pQueueFamilyPropertyCount, pQueueFamilyProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkQueueFamilyProperties* out_pQueueFamilyProperties = pQueueFamilyProperties->IsNull() ? nullptr : pQueueFamilyProperties->AllocateOutputData(*out_pQueueFamilyPropertyCount);
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceQueueFamilyProperties(in_physicalDevice, out_pQueueFamilyPropertyCount, out_pQueueFamilyProperties);
@@ -142,7 +142,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMemoryProperties(
     StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties>* pMemoryProperties)
 {
     auto in_physicalDevice = GetObjectInfoTable().GetPhysicalDeviceInfo(physicalDevice);
-    pMemoryProperties->AllocateOutputData(1);
+    pMemoryProperties->IsNull() ? nullptr : pMemoryProperties->AllocateOutputData(1);
 
     OverrideGetPhysicalDeviceMemoryProperties(GetInstanceTable(in_physicalDevice->handle)->GetPhysicalDeviceMemoryProperties, in_physicalDevice, pMemoryProperties);
 }
@@ -270,7 +270,7 @@ void VulkanReplayConsumer::Process_vkMapMemory(
 {
     auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
     auto in_memory = GetObjectInfoTable().GetDeviceMemoryInfo(memory);
-    void** out_ppData = ppData->AllocateOutputData(1);
+    void** out_ppData = ppData->IsNull() ? nullptr : ppData->AllocateOutputData(1);
 
     VkResult replay_result = OverrideMapMemory(GetDeviceTable(in_device->handle)->MapMemory, returnValue, in_device, in_memory, offset, size, flags, out_ppData);
     CheckResult("vkMapMemory", returnValue, replay_result);
@@ -323,7 +323,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceMemoryCommitment(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkDeviceMemory in_memory = MapHandle<DeviceMemoryInfo>(memory, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
-    VkDeviceSize* out_pCommittedMemoryInBytes = pCommittedMemoryInBytes->AllocateOutputData(1, static_cast<VkDeviceSize>(0));
+    VkDeviceSize* out_pCommittedMemoryInBytes = pCommittedMemoryInBytes->IsNull() ? nullptr : pCommittedMemoryInBytes->AllocateOutputData(1, static_cast<VkDeviceSize>(0));
 
     GetDeviceTable(in_device)->GetDeviceMemoryCommitment(in_device, in_memory, out_pCommittedMemoryInBytes);
 }
@@ -365,7 +365,7 @@ void VulkanReplayConsumer::Process_vkGetBufferMemoryRequirements(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkBuffer in_buffer = MapHandle<BufferInfo>(buffer, &VulkanObjectInfoTable::GetBufferInfo);
-    VkMemoryRequirements* out_pMemoryRequirements = pMemoryRequirements->AllocateOutputData(1);
+    VkMemoryRequirements* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1);
 
     GetDeviceTable(in_device)->GetBufferMemoryRequirements(in_device, in_buffer, out_pMemoryRequirements);
 }
@@ -377,7 +377,7 @@ void VulkanReplayConsumer::Process_vkGetImageMemoryRequirements(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkImage in_image = MapHandle<ImageInfo>(image, &VulkanObjectInfoTable::GetImageInfo);
-    VkMemoryRequirements* out_pMemoryRequirements = pMemoryRequirements->AllocateOutputData(1);
+    VkMemoryRequirements* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1);
 
     GetDeviceTable(in_device)->GetImageMemoryRequirements(in_device, in_image, out_pMemoryRequirements);
 }
@@ -390,7 +390,7 @@ void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkImage in_image = MapHandle<ImageInfo>(image, &VulkanObjectInfoTable::GetImageInfo);
-    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, ImageInfo>("vkGetImageSparseMemoryRequirements", VK_SUCCESS, image, kImageArrayGetImageSparseMemoryRequirements, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &VulkanObjectInfoTable::GetImageInfo));
+    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->IsNull() ? nullptr : pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, ImageInfo>("vkGetImageSparseMemoryRequirements", VK_SUCCESS, image, kImageArrayGetImageSparseMemoryRequirements, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &VulkanObjectInfoTable::GetImageInfo));
     VkSparseImageMemoryRequirements* out_pSparseMemoryRequirements = pSparseMemoryRequirements->IsNull() ? nullptr : pSparseMemoryRequirements->AllocateOutputData(*out_pSparseMemoryRequirementCount);
 
     GetDeviceTable(in_device)->GetImageSparseMemoryRequirements(in_device, in_image, out_pSparseMemoryRequirementCount, out_pSparseMemoryRequirements);
@@ -409,7 +409,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
     StructPointerDecoder<Decoded_VkSparseImageFormatProperties>* pProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSparseImageFormatProperties", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSparseImageFormatProperties", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkSparseImageFormatProperties* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties(in_physicalDevice, format, type, samples, usage, tiling, out_pPropertyCount, out_pProperties);
@@ -752,7 +752,7 @@ void VulkanReplayConsumer::Process_vkGetImageSubresourceLayout(
 {
     auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
     auto in_image = GetObjectInfoTable().GetImageInfo(image);
-    pLayout->AllocateOutputData(1);
+    pLayout->IsNull() ? nullptr : pLayout->AllocateOutputData(1);
 
     OverrideGetImageSubresourceLayout(GetDeviceTable(in_device->handle)->GetImageSubresourceLayout, in_device, in_image, pSubresource, pLayout);
 }
@@ -860,7 +860,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineCacheData(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkPipelineCache in_pipelineCache = MapHandle<PipelineCacheInfo>(pipelineCache, &VulkanObjectInfoTable::GetPipelineCacheInfo);
-    size_t* out_pDataSize = pDataSize->AllocateOutputData(1, GetOutputArrayCount<size_t, PipelineCacheInfo>("vkGetPipelineCacheData", returnValue, pipelineCache, kPipelineCacheArrayGetPipelineCacheData, pDataSize, pData, &VulkanObjectInfoTable::GetPipelineCacheInfo));
+    size_t* out_pDataSize = pDataSize->IsNull() ? nullptr : pDataSize->AllocateOutputData(1, GetOutputArrayCount<size_t, PipelineCacheInfo>("vkGetPipelineCacheData", returnValue, pipelineCache, kPipelineCacheArrayGetPipelineCacheData, pDataSize, pData, &VulkanObjectInfoTable::GetPipelineCacheInfo));
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(*out_pDataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineCacheData(in_device, in_pipelineCache, out_pDataSize, out_pData);
@@ -1202,7 +1202,7 @@ void VulkanReplayConsumer::Process_vkGetRenderAreaGranularity(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkRenderPass in_renderPass = MapHandle<RenderPassInfo>(renderPass, &VulkanObjectInfoTable::GetRenderPassInfo);
-    VkExtent2D* out_pGranularity = pGranularity->AllocateOutputData(1);
+    VkExtent2D* out_pGranularity = pGranularity->IsNull() ? nullptr : pGranularity->AllocateOutputData(1);
 
     GetDeviceTable(in_device)->GetRenderAreaGranularity(in_device, in_renderPass, out_pGranularity);
 }
@@ -1934,7 +1934,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupPeerMemoryFeatures(
     PointerDecoder<VkPeerMemoryFeatureFlags>*   pPeerMemoryFeatures)
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkPeerMemoryFeatureFlags* out_pPeerMemoryFeatures = pPeerMemoryFeatures->AllocateOutputData(1, static_cast<VkPeerMemoryFeatureFlags>(0));
+    VkPeerMemoryFeatureFlags* out_pPeerMemoryFeatures = pPeerMemoryFeatures->IsNull() ? nullptr : pPeerMemoryFeatures->AllocateOutputData(1, static_cast<VkPeerMemoryFeatureFlags>(0));
 
     GetDeviceTable(in_device)->GetDeviceGroupPeerMemoryFeatures(in_device, heapIndex, localDeviceIndex, remoteDeviceIndex, out_pPeerMemoryFeatures);
 }
@@ -1969,7 +1969,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroups(
     StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties)
 {
     VkInstance in_instance = MapHandle<InstanceInfo>(instance, &VulkanObjectInfoTable::GetInstanceInfo);
-    uint32_t* out_pPhysicalDeviceGroupCount = pPhysicalDeviceGroupCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, InstanceInfo>("vkEnumeratePhysicalDeviceGroups", returnValue, instance, kInstanceArrayEnumeratePhysicalDeviceGroups, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, &VulkanObjectInfoTable::GetInstanceInfo));
+    uint32_t* out_pPhysicalDeviceGroupCount = pPhysicalDeviceGroupCount->IsNull() ? nullptr : pPhysicalDeviceGroupCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, InstanceInfo>("vkEnumeratePhysicalDeviceGroups", returnValue, instance, kInstanceArrayEnumeratePhysicalDeviceGroups, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, &VulkanObjectInfoTable::GetInstanceInfo));
     SetStructArrayHandleLengths<Decoded_VkPhysicalDeviceGroupProperties>(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength());
     VkPhysicalDeviceGroupProperties* out_pPhysicalDeviceGroupProperties = pPhysicalDeviceGroupProperties->IsNull() ? nullptr : pPhysicalDeviceGroupProperties->AllocateOutputData(*out_pPhysicalDeviceGroupCount, VkPhysicalDeviceGroupProperties{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES, nullptr });
 
@@ -1988,7 +1988,7 @@ void VulkanReplayConsumer::Process_vkGetImageMemoryRequirements2(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkImageMemoryRequirementsInfo2* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
+    VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
 
     GetDeviceTable(in_device)->GetImageMemoryRequirements2(in_device, in_pInfo, out_pMemoryRequirements);
 }
@@ -2001,7 +2001,7 @@ void VulkanReplayConsumer::Process_vkGetBufferMemoryRequirements2(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkBufferMemoryRequirementsInfo2* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
+    VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
 
     GetDeviceTable(in_device)->GetBufferMemoryRequirements2(in_device, in_pInfo, out_pMemoryRequirements);
 }
@@ -2015,7 +2015,7 @@ void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements2(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkImageSparseMemoryRequirementsInfo2* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DeviceInfo>("vkGetImageSparseMemoryRequirements2", VK_SUCCESS, device, kDeviceArrayGetImageSparseMemoryRequirements2, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &VulkanObjectInfoTable::GetDeviceInfo));
+    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->IsNull() ? nullptr : pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DeviceInfo>("vkGetImageSparseMemoryRequirements2", VK_SUCCESS, device, kDeviceArrayGetImageSparseMemoryRequirements2, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &VulkanObjectInfoTable::GetDeviceInfo));
     VkSparseImageMemoryRequirements2* out_pSparseMemoryRequirements = pSparseMemoryRequirements->IsNull() ? nullptr : pSparseMemoryRequirements->AllocateOutputData(*out_pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2, nullptr });
 
     GetDeviceTable(in_device)->GetImageSparseMemoryRequirements2(in_device, in_pInfo, out_pSparseMemoryRequirementCount, out_pSparseMemoryRequirements);
@@ -2028,7 +2028,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFeatures2(
     StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    VkPhysicalDeviceFeatures2* out_pFeatures = pFeatures->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, nullptr });
+    VkPhysicalDeviceFeatures2* out_pFeatures = pFeatures->IsNull() ? nullptr : pFeatures->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceFeatures2(in_physicalDevice, out_pFeatures);
 }
@@ -2038,7 +2038,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceProperties2(
     StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties)
 {
     auto in_physicalDevice = GetObjectInfoTable().GetPhysicalDeviceInfo(physicalDevice);
-    pProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, nullptr });
+    pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, nullptr });
 
     OverrideGetPhysicalDeviceProperties2(GetInstanceTable(in_physicalDevice->handle)->GetPhysicalDeviceProperties2, in_physicalDevice, pProperties);
 }
@@ -2049,7 +2049,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFormatProperties2(
     StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    VkFormatProperties2* out_pFormatProperties = pFormatProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2, nullptr });
+    VkFormatProperties2* out_pFormatProperties = pFormatProperties->IsNull() ? nullptr : pFormatProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceFormatProperties2(in_physicalDevice, format, out_pFormatProperties);
 }
@@ -2062,7 +2062,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceImageFormatInfo2* in_pImageFormatInfo = pImageFormatInfo->GetPointer();
-    VkImageFormatProperties2* out_pImageFormatProperties = pImageFormatProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2, nullptr });
+    VkImageFormatProperties2* out_pImageFormatProperties = pImageFormatProperties->IsNull() ? nullptr : pImageFormatProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceImageFormatProperties2(in_physicalDevice, in_pImageFormatInfo, out_pImageFormatProperties);
     CheckResult("vkGetPhysicalDeviceImageFormatProperties2", returnValue, replay_result);
@@ -2074,7 +2074,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2(
     StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceQueueFamilyProperties2", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2, pQueueFamilyPropertyCount, pQueueFamilyProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->IsNull() ? nullptr : pQueueFamilyPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceQueueFamilyProperties2", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2, pQueueFamilyPropertyCount, pQueueFamilyProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkQueueFamilyProperties2* out_pQueueFamilyProperties = pQueueFamilyProperties->IsNull() ? nullptr : pQueueFamilyProperties->AllocateOutputData(*out_pQueueFamilyPropertyCount, VkQueueFamilyProperties2{ VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceQueueFamilyProperties2(in_physicalDevice, out_pQueueFamilyPropertyCount, out_pQueueFamilyProperties);
@@ -2087,7 +2087,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMemoryProperties2(
     StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties)
 {
     auto in_physicalDevice = GetObjectInfoTable().GetPhysicalDeviceInfo(physicalDevice);
-    pMemoryProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2, nullptr });
+    pMemoryProperties->IsNull() ? nullptr : pMemoryProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2, nullptr });
 
     OverrideGetPhysicalDeviceMemoryProperties2(GetInstanceTable(in_physicalDevice->handle)->GetPhysicalDeviceMemoryProperties2, in_physicalDevice, pMemoryProperties);
 }
@@ -2100,7 +2100,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceSparseImageFormatInfo2* in_pFormatInfo = pFormatInfo->GetPointer();
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSparseImageFormatProperties2", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties2, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSparseImageFormatProperties2", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties2, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkSparseImageFormatProperties2* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkSparseImageFormatProperties2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties2(in_physicalDevice, in_pFormatInfo, out_pPropertyCount, out_pProperties);
@@ -2203,7 +2203,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalBufferProperties(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceExternalBufferInfo* in_pExternalBufferInfo = pExternalBufferInfo->GetPointer();
-    VkExternalBufferProperties* out_pExternalBufferProperties = pExternalBufferProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES, nullptr });
+    VkExternalBufferProperties* out_pExternalBufferProperties = pExternalBufferProperties->IsNull() ? nullptr : pExternalBufferProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceExternalBufferProperties(in_physicalDevice, in_pExternalBufferInfo, out_pExternalBufferProperties);
 }
@@ -2215,7 +2215,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalFenceProperties(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceExternalFenceInfo* in_pExternalFenceInfo = pExternalFenceInfo->GetPointer();
-    VkExternalFenceProperties* out_pExternalFenceProperties = pExternalFenceProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES, nullptr });
+    VkExternalFenceProperties* out_pExternalFenceProperties = pExternalFenceProperties->IsNull() ? nullptr : pExternalFenceProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceExternalFenceProperties(in_physicalDevice, in_pExternalFenceInfo, out_pExternalFenceProperties);
 }
@@ -2227,7 +2227,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalSemaphorePropertie
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceExternalSemaphoreInfo* in_pExternalSemaphoreInfo = pExternalSemaphoreInfo->GetPointer();
-    VkExternalSemaphoreProperties* out_pExternalSemaphoreProperties = pExternalSemaphoreProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES, nullptr });
+    VkExternalSemaphoreProperties* out_pExternalSemaphoreProperties = pExternalSemaphoreProperties->IsNull() ? nullptr : pExternalSemaphoreProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceExternalSemaphoreProperties(in_physicalDevice, in_pExternalSemaphoreInfo, out_pExternalSemaphoreProperties);
 }
@@ -2240,7 +2240,7 @@ void VulkanReplayConsumer::Process_vkGetDescriptorSetLayoutSupport(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkDescriptorSetLayoutCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    VkDescriptorSetLayoutSupport* out_pSupport = pSupport->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT, nullptr });
+    VkDescriptorSetLayoutSupport* out_pSupport = pSupport->IsNull() ? nullptr : pSupport->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT, nullptr });
 
     GetDeviceTable(in_device)->GetDescriptorSetLayoutSupport(in_device, in_pCreateInfo, out_pSupport);
 }
@@ -2265,7 +2265,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceSupportKHR(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     VkSurfaceKHR in_surface = MapHandle<SurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetSurfaceKHRInfo);
-    VkBool32* out_pSupported = pSupported->AllocateOutputData(1, static_cast<VkBool32>(0));
+    VkBool32* out_pSupported = pSupported->IsNull() ? nullptr : pSupported->AllocateOutputData(1, static_cast<VkBool32>(0));
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceSupportKHR(in_physicalDevice, queueFamilyIndex, in_surface, out_pSupported);
     CheckResult("vkGetPhysicalDeviceSurfaceSupportKHR", returnValue, replay_result);
@@ -2279,7 +2279,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     VkSurfaceKHR in_surface = MapHandle<SurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetSurfaceKHRInfo);
-    VkSurfaceCapabilitiesKHR* out_pSurfaceCapabilities = pSurfaceCapabilities->AllocateOutputData(1);
+    VkSurfaceCapabilitiesKHR* out_pSurfaceCapabilities = pSurfaceCapabilities->IsNull() ? nullptr : pSurfaceCapabilities->AllocateOutputData(1);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceCapabilitiesKHR(in_physicalDevice, in_surface, out_pSurfaceCapabilities);
     CheckResult("vkGetPhysicalDeviceSurfaceCapabilitiesKHR", returnValue, replay_result);
@@ -2294,7 +2294,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     VkSurfaceKHR in_surface = MapHandle<SurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetSurfaceKHRInfo);
-    uint32_t* out_pSurfaceFormatCount = pSurfaceFormatCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, SurfaceKHRInfo>("vkGetPhysicalDeviceSurfaceFormatsKHR", returnValue, surface, kSurfaceKHRArrayGetPhysicalDeviceSurfaceFormatsKHR, pSurfaceFormatCount, pSurfaceFormats, &VulkanObjectInfoTable::GetSurfaceKHRInfo));
+    uint32_t* out_pSurfaceFormatCount = pSurfaceFormatCount->IsNull() ? nullptr : pSurfaceFormatCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, SurfaceKHRInfo>("vkGetPhysicalDeviceSurfaceFormatsKHR", returnValue, surface, kSurfaceKHRArrayGetPhysicalDeviceSurfaceFormatsKHR, pSurfaceFormatCount, pSurfaceFormats, &VulkanObjectInfoTable::GetSurfaceKHRInfo));
     VkSurfaceFormatKHR* out_pSurfaceFormats = pSurfaceFormats->IsNull() ? nullptr : pSurfaceFormats->AllocateOutputData(*out_pSurfaceFormatCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceFormatsKHR(in_physicalDevice, in_surface, out_pSurfaceFormatCount, out_pSurfaceFormats);
@@ -2312,7 +2312,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     VkSurfaceKHR in_surface = MapHandle<SurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetSurfaceKHRInfo);
-    uint32_t* out_pPresentModeCount = pPresentModeCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, SurfaceKHRInfo>("vkGetPhysicalDeviceSurfacePresentModesKHR", returnValue, surface, kSurfaceKHRArrayGetPhysicalDeviceSurfacePresentModesKHR, pPresentModeCount, pPresentModes, &VulkanObjectInfoTable::GetSurfaceKHRInfo));
+    uint32_t* out_pPresentModeCount = pPresentModeCount->IsNull() ? nullptr : pPresentModeCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, SurfaceKHRInfo>("vkGetPhysicalDeviceSurfacePresentModesKHR", returnValue, surface, kSurfaceKHRArrayGetPhysicalDeviceSurfacePresentModesKHR, pPresentModeCount, pPresentModes, &VulkanObjectInfoTable::GetSurfaceKHRInfo));
     VkPresentModeKHR* out_pPresentModes = pPresentModes->IsNull() ? nullptr : pPresentModes->AllocateOutputData(*out_pPresentModeCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfacePresentModesKHR(in_physicalDevice, in_surface, out_pPresentModeCount, out_pPresentModes);
@@ -2362,7 +2362,7 @@ void VulkanReplayConsumer::Process_vkGetSwapchainImagesKHR(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkSwapchainKHR in_swapchain = MapHandle<SwapchainKHRInfo>(swapchain, &VulkanObjectInfoTable::GetSwapchainKHRInfo);
-    uint32_t* out_pSwapchainImageCount = pSwapchainImageCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, SwapchainKHRInfo>("vkGetSwapchainImagesKHR", returnValue, swapchain, kSwapchainKHRArrayGetSwapchainImagesKHR, pSwapchainImageCount, pSwapchainImages, &VulkanObjectInfoTable::GetSwapchainKHRInfo));
+    uint32_t* out_pSwapchainImageCount = pSwapchainImageCount->IsNull() ? nullptr : pSwapchainImageCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, SwapchainKHRInfo>("vkGetSwapchainImagesKHR", returnValue, swapchain, kSwapchainKHRArrayGetSwapchainImagesKHR, pSwapchainImageCount, pSwapchainImages, &VulkanObjectInfoTable::GetSwapchainKHRInfo));
     if (!pSwapchainImages->IsNull()) { pSwapchainImages->SetHandleLength(*out_pSwapchainImageCount); }
     VkImage* out_pSwapchainImages = pSwapchainImages->GetHandlePointer();
 
@@ -2386,7 +2386,7 @@ void VulkanReplayConsumer::Process_vkAcquireNextImageKHR(
     auto in_swapchain = GetObjectInfoTable().GetSwapchainKHRInfo(swapchain);
     auto in_semaphore = GetObjectInfoTable().GetSemaphoreInfo(semaphore);
     auto in_fence = GetObjectInfoTable().GetFenceInfo(fence);
-    pImageIndex->AllocateOutputData(1, static_cast<uint32_t>(0));
+    pImageIndex->IsNull() ? nullptr : pImageIndex->AllocateOutputData(1, static_cast<uint32_t>(0));
 
     VkResult replay_result = OverrideAcquireNextImageKHR(GetDeviceTable(in_device->handle)->AcquireNextImageKHR, returnValue, in_device, in_swapchain, timeout, in_semaphore, in_fence, pImageIndex);
     CheckResult("vkAcquireNextImageKHR", returnValue, replay_result);
@@ -2411,7 +2411,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupPresentCapabilitiesKHR(
     StructPointerDecoder<Decoded_VkDeviceGroupPresentCapabilitiesKHR>* pDeviceGroupPresentCapabilities)
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkDeviceGroupPresentCapabilitiesKHR* out_pDeviceGroupPresentCapabilities = pDeviceGroupPresentCapabilities->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_CAPABILITIES_KHR, nullptr });
+    VkDeviceGroupPresentCapabilitiesKHR* out_pDeviceGroupPresentCapabilities = pDeviceGroupPresentCapabilities->IsNull() ? nullptr : pDeviceGroupPresentCapabilities->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_CAPABILITIES_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetDeviceGroupPresentCapabilitiesKHR(in_device, out_pDeviceGroupPresentCapabilities);
     CheckResult("vkGetDeviceGroupPresentCapabilitiesKHR", returnValue, replay_result);
@@ -2425,7 +2425,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupSurfacePresentModesKHR(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkSurfaceKHR in_surface = MapHandle<SurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetSurfaceKHRInfo);
-    VkDeviceGroupPresentModeFlagsKHR* out_pModes = pModes->AllocateOutputData(1, static_cast<VkDeviceGroupPresentModeFlagsKHR>(0));
+    VkDeviceGroupPresentModeFlagsKHR* out_pModes = pModes->IsNull() ? nullptr : pModes->AllocateOutputData(1, static_cast<VkDeviceGroupPresentModeFlagsKHR>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetDeviceGroupSurfacePresentModesKHR(in_device, in_surface, out_pModes);
     CheckResult("vkGetDeviceGroupSurfacePresentModesKHR", returnValue, replay_result);
@@ -2440,7 +2440,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     VkSurfaceKHR in_surface = MapHandle<SurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetSurfaceKHRInfo);
-    uint32_t* out_pRectCount = pRectCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, SurfaceKHRInfo>("vkGetPhysicalDevicePresentRectanglesKHR", returnValue, surface, kSurfaceKHRArrayGetPhysicalDevicePresentRectanglesKHR, pRectCount, pRects, &VulkanObjectInfoTable::GetSurfaceKHRInfo));
+    uint32_t* out_pRectCount = pRectCount->IsNull() ? nullptr : pRectCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, SurfaceKHRInfo>("vkGetPhysicalDevicePresentRectanglesKHR", returnValue, surface, kSurfaceKHRArrayGetPhysicalDevicePresentRectanglesKHR, pRectCount, pRects, &VulkanObjectInfoTable::GetSurfaceKHRInfo));
     VkRect2D* out_pRects = pRects->IsNull() ? nullptr : pRects->AllocateOutputData(*out_pRectCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDevicePresentRectanglesKHR(in_physicalDevice, in_surface, out_pRectCount, out_pRects);
@@ -2458,7 +2458,7 @@ void VulkanReplayConsumer::Process_vkAcquireNextImage2KHR(
     auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
 
     MapStructHandles(pAcquireInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    pImageIndex->AllocateOutputData(1, static_cast<uint32_t>(0));
+    pImageIndex->IsNull() ? nullptr : pImageIndex->AllocateOutputData(1, static_cast<uint32_t>(0));
 
     VkResult replay_result = OverrideAcquireNextImage2KHR(GetDeviceTable(in_device->handle)->AcquireNextImage2KHR, returnValue, in_device, pAcquireInfo, pImageIndex);
     CheckResult("vkAcquireNextImage2KHR", returnValue, replay_result);
@@ -2471,7 +2471,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
     StructPointerDecoder<Decoded_VkDisplayPropertiesKHR>* pProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPropertiesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPropertiesKHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPropertiesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPropertiesKHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkDisplayPropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPropertiesKHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
@@ -2488,7 +2488,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
     StructPointerDecoder<Decoded_VkDisplayPlanePropertiesKHR>* pProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlanePropertiesKHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlanePropertiesKHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkDisplayPlanePropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPlanePropertiesKHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
@@ -2506,7 +2506,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
     HandlePointerDecoder<VkDisplayKHR>*         pDisplays)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pDisplayCount = pDisplayCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetDisplayPlaneSupportedDisplaysKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetDisplayPlaneSupportedDisplaysKHR, pDisplayCount, pDisplays, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+    uint32_t* out_pDisplayCount = pDisplayCount->IsNull() ? nullptr : pDisplayCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetDisplayPlaneSupportedDisplaysKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetDisplayPlaneSupportedDisplaysKHR, pDisplayCount, pDisplays, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     if (!pDisplays->IsNull()) { pDisplays->SetHandleLength(*out_pDisplayCount); }
     VkDisplayKHR* out_pDisplays = pDisplays->GetHandlePointer();
 
@@ -2526,7 +2526,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayModePropertiesKHR(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     VkDisplayKHR in_display = MapHandle<DisplayKHRInfo>(display, &VulkanObjectInfoTable::GetDisplayKHRInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DisplayKHRInfo>("vkGetDisplayModePropertiesKHR", returnValue, display, kDisplayKHRArrayGetDisplayModePropertiesKHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetDisplayKHRInfo));
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DisplayKHRInfo>("vkGetDisplayModePropertiesKHR", returnValue, display, kDisplayKHRArrayGetDisplayModePropertiesKHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetDisplayKHRInfo));
     VkDisplayModePropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayModePropertiesKHR(in_physicalDevice, in_display, out_pPropertyCount, out_pProperties);
@@ -2566,7 +2566,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayPlaneCapabilitiesKHR(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     VkDisplayModeKHR in_mode = MapHandle<DisplayModeKHRInfo>(mode, &VulkanObjectInfoTable::GetDisplayModeKHRInfo);
-    VkDisplayPlaneCapabilitiesKHR* out_pCapabilities = pCapabilities->AllocateOutputData(1);
+    VkDisplayPlaneCapabilitiesKHR* out_pCapabilities = pCapabilities->IsNull() ? nullptr : pCapabilities->AllocateOutputData(1);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayPlaneCapabilitiesKHR(in_physicalDevice, in_mode, planeIndex, out_pCapabilities);
     CheckResult("vkGetDisplayPlaneCapabilitiesKHR", returnValue, replay_result);
@@ -2756,7 +2756,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFeatures2KHR(
     StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    VkPhysicalDeviceFeatures2* out_pFeatures = pFeatures->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, nullptr });
+    VkPhysicalDeviceFeatures2* out_pFeatures = pFeatures->IsNull() ? nullptr : pFeatures->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceFeatures2KHR(in_physicalDevice, out_pFeatures);
 }
@@ -2766,7 +2766,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceProperties2KHR(
     StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties)
 {
     auto in_physicalDevice = GetObjectInfoTable().GetPhysicalDeviceInfo(physicalDevice);
-    pProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, nullptr });
+    pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, nullptr });
 
     OverrideGetPhysicalDeviceProperties2(GetInstanceTable(in_physicalDevice->handle)->GetPhysicalDeviceProperties2KHR, in_physicalDevice, pProperties);
 }
@@ -2777,7 +2777,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFormatProperties2KHR(
     StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    VkFormatProperties2* out_pFormatProperties = pFormatProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2, nullptr });
+    VkFormatProperties2* out_pFormatProperties = pFormatProperties->IsNull() ? nullptr : pFormatProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceFormatProperties2KHR(in_physicalDevice, format, out_pFormatProperties);
 }
@@ -2790,7 +2790,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceImageFormatInfo2* in_pImageFormatInfo = pImageFormatInfo->GetPointer();
-    VkImageFormatProperties2* out_pImageFormatProperties = pImageFormatProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2, nullptr });
+    VkImageFormatProperties2* out_pImageFormatProperties = pImageFormatProperties->IsNull() ? nullptr : pImageFormatProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceImageFormatProperties2KHR(in_physicalDevice, in_pImageFormatInfo, out_pImageFormatProperties);
     CheckResult("vkGetPhysicalDeviceImageFormatProperties2KHR", returnValue, replay_result);
@@ -2802,7 +2802,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
     StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceQueueFamilyProperties2KHR", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2KHR, pQueueFamilyPropertyCount, pQueueFamilyProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->IsNull() ? nullptr : pQueueFamilyPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceQueueFamilyProperties2KHR", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2KHR, pQueueFamilyPropertyCount, pQueueFamilyProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkQueueFamilyProperties2* out_pQueueFamilyProperties = pQueueFamilyProperties->IsNull() ? nullptr : pQueueFamilyProperties->AllocateOutputData(*out_pQueueFamilyPropertyCount, VkQueueFamilyProperties2{ VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceQueueFamilyProperties2KHR(in_physicalDevice, out_pQueueFamilyPropertyCount, out_pQueueFamilyProperties);
@@ -2815,7 +2815,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMemoryProperties2KHR(
     StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties)
 {
     auto in_physicalDevice = GetObjectInfoTable().GetPhysicalDeviceInfo(physicalDevice);
-    pMemoryProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2, nullptr });
+    pMemoryProperties->IsNull() ? nullptr : pMemoryProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2, nullptr });
 
     OverrideGetPhysicalDeviceMemoryProperties2(GetInstanceTable(in_physicalDevice->handle)->GetPhysicalDeviceMemoryProperties2KHR, in_physicalDevice, pMemoryProperties);
 }
@@ -2828,7 +2828,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceSparseImageFormatInfo2* in_pFormatInfo = pFormatInfo->GetPointer();
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSparseImageFormatProperties2KHR", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties2KHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSparseImageFormatProperties2KHR", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties2KHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkSparseImageFormatProperties2* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkSparseImageFormatProperties2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties2KHR(in_physicalDevice, in_pFormatInfo, out_pPropertyCount, out_pProperties);
@@ -2844,7 +2844,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(
     PointerDecoder<VkPeerMemoryFeatureFlags>*   pPeerMemoryFeatures)
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkPeerMemoryFeatureFlags* out_pPeerMemoryFeatures = pPeerMemoryFeatures->AllocateOutputData(1, static_cast<VkPeerMemoryFeatureFlags>(0));
+    VkPeerMemoryFeatureFlags* out_pPeerMemoryFeatures = pPeerMemoryFeatures->IsNull() ? nullptr : pPeerMemoryFeatures->AllocateOutputData(1, static_cast<VkPeerMemoryFeatureFlags>(0));
 
     GetDeviceTable(in_device)->GetDeviceGroupPeerMemoryFeaturesKHR(in_device, heapIndex, localDeviceIndex, remoteDeviceIndex, out_pPeerMemoryFeatures);
 }
@@ -2890,7 +2890,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
     StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties)
 {
     VkInstance in_instance = MapHandle<InstanceInfo>(instance, &VulkanObjectInfoTable::GetInstanceInfo);
-    uint32_t* out_pPhysicalDeviceGroupCount = pPhysicalDeviceGroupCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, InstanceInfo>("vkEnumeratePhysicalDeviceGroupsKHR", returnValue, instance, kInstanceArrayEnumeratePhysicalDeviceGroupsKHR, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, &VulkanObjectInfoTable::GetInstanceInfo));
+    uint32_t* out_pPhysicalDeviceGroupCount = pPhysicalDeviceGroupCount->IsNull() ? nullptr : pPhysicalDeviceGroupCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, InstanceInfo>("vkEnumeratePhysicalDeviceGroupsKHR", returnValue, instance, kInstanceArrayEnumeratePhysicalDeviceGroupsKHR, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, &VulkanObjectInfoTable::GetInstanceInfo));
     SetStructArrayHandleLengths<Decoded_VkPhysicalDeviceGroupProperties>(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength());
     VkPhysicalDeviceGroupProperties* out_pPhysicalDeviceGroupProperties = pPhysicalDeviceGroupProperties->IsNull() ? nullptr : pPhysicalDeviceGroupProperties->AllocateOutputData(*out_pPhysicalDeviceGroupCount, VkPhysicalDeviceGroupProperties{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES, nullptr });
 
@@ -2908,7 +2908,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalBufferPropertiesKH
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceExternalBufferInfo* in_pExternalBufferInfo = pExternalBufferInfo->GetPointer();
-    VkExternalBufferProperties* out_pExternalBufferProperties = pExternalBufferProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES, nullptr });
+    VkExternalBufferProperties* out_pExternalBufferProperties = pExternalBufferProperties->IsNull() ? nullptr : pExternalBufferProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceExternalBufferPropertiesKHR(in_physicalDevice, in_pExternalBufferInfo, out_pExternalBufferProperties);
 }
@@ -2922,7 +2922,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryWin32HandleKHR(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkMemoryGetWin32HandleInfoKHR* in_pGetWin32HandleInfo = pGetWin32HandleInfo->GetPointer();
     MapStructHandles(pGetWin32HandleInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    HANDLE* out_pHandle = reinterpret_cast<HANDLE*>(pHandle->AllocateOutputData(1));
+    HANDLE* out_pHandle = pHandle->IsNull() ? nullptr : reinterpret_cast<HANDLE*>(pHandle->AllocateOutputData(1));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryWin32HandleKHR(in_device, in_pGetWin32HandleInfo, out_pHandle);
     CheckResult("vkGetMemoryWin32HandleKHR", returnValue, replay_result);
@@ -2939,7 +2939,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryWin32HandlePropertiesKHR(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     HANDLE in_handle = static_cast<HANDLE>(PreProcessExternalObject(handle, format::ApiCallId::ApiCall_vkGetMemoryWin32HandlePropertiesKHR, "vkGetMemoryWin32HandlePropertiesKHR"));
-    VkMemoryWin32HandlePropertiesKHR* out_pMemoryWin32HandleProperties = pMemoryWin32HandleProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_WIN32_HANDLE_PROPERTIES_KHR, nullptr });
+    VkMemoryWin32HandlePropertiesKHR* out_pMemoryWin32HandleProperties = pMemoryWin32HandleProperties->IsNull() ? nullptr : pMemoryWin32HandleProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_WIN32_HANDLE_PROPERTIES_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryWin32HandlePropertiesKHR(in_device, handleType, in_handle, out_pMemoryWin32HandleProperties);
     CheckResult("vkGetMemoryWin32HandlePropertiesKHR", returnValue, replay_result);
@@ -2954,7 +2954,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryFdKHR(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkMemoryGetFdInfoKHR* in_pGetFdInfo = pGetFdInfo->GetPointer();
     MapStructHandles(pGetFdInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    int* out_pFd = pFd->AllocateOutputData(1, static_cast<int>(0));
+    int* out_pFd = pFd->IsNull() ? nullptr : pFd->AllocateOutputData(1, static_cast<int>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryFdKHR(in_device, in_pGetFdInfo, out_pFd);
     CheckResult("vkGetMemoryFdKHR", returnValue, replay_result);
@@ -2968,7 +2968,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryFdPropertiesKHR(
     StructPointerDecoder<Decoded_VkMemoryFdPropertiesKHR>* pMemoryFdProperties)
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkMemoryFdPropertiesKHR* out_pMemoryFdProperties = pMemoryFdProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR, nullptr });
+    VkMemoryFdPropertiesKHR* out_pMemoryFdProperties = pMemoryFdProperties->IsNull() ? nullptr : pMemoryFdProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryFdPropertiesKHR(in_device, handleType, fd, out_pMemoryFdProperties);
     CheckResult("vkGetMemoryFdPropertiesKHR", returnValue, replay_result);
@@ -2981,7 +2981,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalSemaphorePropertie
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceExternalSemaphoreInfo* in_pExternalSemaphoreInfo = pExternalSemaphoreInfo->GetPointer();
-    VkExternalSemaphoreProperties* out_pExternalSemaphoreProperties = pExternalSemaphoreProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES, nullptr });
+    VkExternalSemaphoreProperties* out_pExternalSemaphoreProperties = pExternalSemaphoreProperties->IsNull() ? nullptr : pExternalSemaphoreProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceExternalSemaphorePropertiesKHR(in_physicalDevice, in_pExternalSemaphoreInfo, out_pExternalSemaphoreProperties);
 }
@@ -3008,7 +3008,7 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreWin32HandleKHR(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkSemaphoreGetWin32HandleInfoKHR* in_pGetWin32HandleInfo = pGetWin32HandleInfo->GetPointer();
     MapStructHandles(pGetWin32HandleInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    HANDLE* out_pHandle = reinterpret_cast<HANDLE*>(pHandle->AllocateOutputData(1));
+    HANDLE* out_pHandle = pHandle->IsNull() ? nullptr : reinterpret_cast<HANDLE*>(pHandle->AllocateOutputData(1));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetSemaphoreWin32HandleKHR(in_device, in_pGetWin32HandleInfo, out_pHandle);
     CheckResult("vkGetSemaphoreWin32HandleKHR", returnValue, replay_result);
@@ -3038,7 +3038,7 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreFdKHR(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkSemaphoreGetFdInfoKHR* in_pGetFdInfo = pGetFdInfo->GetPointer();
     MapStructHandles(pGetFdInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    int* out_pFd = pFd->AllocateOutputData(1, static_cast<int>(0));
+    int* out_pFd = pFd->IsNull() ? nullptr : pFd->AllocateOutputData(1, static_cast<int>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetSemaphoreFdKHR(in_device, in_pGetFdInfo, out_pFd);
     CheckResult("vkGetSemaphoreFdKHR", returnValue, replay_result);
@@ -3164,7 +3164,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalFencePropertiesKHR
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceExternalFenceInfo* in_pExternalFenceInfo = pExternalFenceInfo->GetPointer();
-    VkExternalFenceProperties* out_pExternalFenceProperties = pExternalFenceProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES, nullptr });
+    VkExternalFenceProperties* out_pExternalFenceProperties = pExternalFenceProperties->IsNull() ? nullptr : pExternalFenceProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceExternalFencePropertiesKHR(in_physicalDevice, in_pExternalFenceInfo, out_pExternalFenceProperties);
 }
@@ -3191,7 +3191,7 @@ void VulkanReplayConsumer::Process_vkGetFenceWin32HandleKHR(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkFenceGetWin32HandleInfoKHR* in_pGetWin32HandleInfo = pGetWin32HandleInfo->GetPointer();
     MapStructHandles(pGetWin32HandleInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    HANDLE* out_pHandle = reinterpret_cast<HANDLE*>(pHandle->AllocateOutputData(1));
+    HANDLE* out_pHandle = pHandle->IsNull() ? nullptr : reinterpret_cast<HANDLE*>(pHandle->AllocateOutputData(1));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetFenceWin32HandleKHR(in_device, in_pGetWin32HandleInfo, out_pHandle);
     CheckResult("vkGetFenceWin32HandleKHR", returnValue, replay_result);
@@ -3221,7 +3221,7 @@ void VulkanReplayConsumer::Process_vkGetFenceFdKHR(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkFenceGetFdInfoKHR* in_pGetFdInfo = pGetFdInfo->GetPointer();
     MapStructHandles(pGetFdInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    int* out_pFd = pFd->AllocateOutputData(1, static_cast<int>(0));
+    int* out_pFd = pFd->IsNull() ? nullptr : pFd->AllocateOutputData(1, static_cast<int>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetFenceFdKHR(in_device, in_pGetFdInfo, out_pFd);
     CheckResult("vkGetFenceFdKHR", returnValue, replay_result);
@@ -3236,7 +3236,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceSurfaceInfo2KHR* in_pSurfaceInfo = pSurfaceInfo->GetPointer();
     MapStructHandles(pSurfaceInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    VkSurfaceCapabilities2KHR* out_pSurfaceCapabilities = pSurfaceCapabilities->AllocateOutputData(1, { VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR, nullptr });
+    VkSurfaceCapabilities2KHR* out_pSurfaceCapabilities = pSurfaceCapabilities->IsNull() ? nullptr : pSurfaceCapabilities->AllocateOutputData(1, { VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceCapabilities2KHR(in_physicalDevice, in_pSurfaceInfo, out_pSurfaceCapabilities);
     CheckResult("vkGetPhysicalDeviceSurfaceCapabilities2KHR", returnValue, replay_result);
@@ -3252,7 +3252,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceSurfaceInfo2KHR* in_pSurfaceInfo = pSurfaceInfo->GetPointer();
     MapStructHandles(pSurfaceInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pSurfaceFormatCount = pSurfaceFormatCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSurfaceFormats2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfaceFormats2KHR, pSurfaceFormatCount, pSurfaceFormats, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+    uint32_t* out_pSurfaceFormatCount = pSurfaceFormatCount->IsNull() ? nullptr : pSurfaceFormatCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSurfaceFormats2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfaceFormats2KHR, pSurfaceFormatCount, pSurfaceFormats, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkSurfaceFormat2KHR* out_pSurfaceFormats = pSurfaceFormats->IsNull() ? nullptr : pSurfaceFormats->AllocateOutputData(*out_pSurfaceFormatCount, VkSurfaceFormat2KHR{ VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceFormats2KHR(in_physicalDevice, in_pSurfaceInfo, out_pSurfaceFormatCount, out_pSurfaceFormats);
@@ -3268,7 +3268,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
     StructPointerDecoder<Decoded_VkDisplayProperties2KHR>* pProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayProperties2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayProperties2KHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayProperties2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayProperties2KHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkDisplayProperties2KHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkDisplayProperties2KHR{ VK_STRUCTURE_TYPE_DISPLAY_PROPERTIES_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayProperties2KHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
@@ -3285,7 +3285,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR
     StructPointerDecoder<Decoded_VkDisplayPlaneProperties2KHR>* pProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlaneProperties2KHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlaneProperties2KHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkDisplayPlaneProperties2KHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkDisplayPlaneProperties2KHR{ VK_STRUCTURE_TYPE_DISPLAY_PLANE_PROPERTIES_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPlaneProperties2KHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
@@ -3304,7 +3304,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayModeProperties2KHR(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     VkDisplayKHR in_display = MapHandle<DisplayKHRInfo>(display, &VulkanObjectInfoTable::GetDisplayKHRInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DisplayKHRInfo>("vkGetDisplayModeProperties2KHR", returnValue, display, kDisplayKHRArrayGetDisplayModeProperties2KHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetDisplayKHRInfo));
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DisplayKHRInfo>("vkGetDisplayModeProperties2KHR", returnValue, display, kDisplayKHRArrayGetDisplayModeProperties2KHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetDisplayKHRInfo));
     VkDisplayModeProperties2KHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkDisplayModeProperties2KHR{ VK_STRUCTURE_TYPE_DISPLAY_MODE_PROPERTIES_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayModeProperties2KHR(in_physicalDevice, in_display, out_pPropertyCount, out_pProperties);
@@ -3323,7 +3323,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkDisplayPlaneInfo2KHR* in_pDisplayPlaneInfo = pDisplayPlaneInfo->GetPointer();
     MapStructHandles(pDisplayPlaneInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    VkDisplayPlaneCapabilities2KHR* out_pCapabilities = pCapabilities->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DISPLAY_PLANE_CAPABILITIES_2_KHR, nullptr });
+    VkDisplayPlaneCapabilities2KHR* out_pCapabilities = pCapabilities->IsNull() ? nullptr : pCapabilities->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DISPLAY_PLANE_CAPABILITIES_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayPlaneCapabilities2KHR(in_physicalDevice, in_pDisplayPlaneInfo, out_pCapabilities);
     CheckResult("vkGetDisplayPlaneCapabilities2KHR", returnValue, replay_result);
@@ -3337,7 +3337,7 @@ void VulkanReplayConsumer::Process_vkGetImageMemoryRequirements2KHR(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkImageMemoryRequirementsInfo2* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
+    VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
 
     GetDeviceTable(in_device)->GetImageMemoryRequirements2KHR(in_device, in_pInfo, out_pMemoryRequirements);
 }
@@ -3350,7 +3350,7 @@ void VulkanReplayConsumer::Process_vkGetBufferMemoryRequirements2KHR(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkBufferMemoryRequirementsInfo2* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
+    VkMemoryRequirements2* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, nullptr });
 
     GetDeviceTable(in_device)->GetBufferMemoryRequirements2KHR(in_device, in_pInfo, out_pMemoryRequirements);
 }
@@ -3364,7 +3364,7 @@ void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements2KHR(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkImageSparseMemoryRequirementsInfo2* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DeviceInfo>("vkGetImageSparseMemoryRequirements2KHR", VK_SUCCESS, device, kDeviceArrayGetImageSparseMemoryRequirements2KHR, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &VulkanObjectInfoTable::GetDeviceInfo));
+    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->IsNull() ? nullptr : pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DeviceInfo>("vkGetImageSparseMemoryRequirements2KHR", VK_SUCCESS, device, kDeviceArrayGetImageSparseMemoryRequirements2KHR, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &VulkanObjectInfoTable::GetDeviceInfo));
     VkSparseImageMemoryRequirements2* out_pSparseMemoryRequirements = pSparseMemoryRequirements->IsNull() ? nullptr : pSparseMemoryRequirements->AllocateOutputData(*out_pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2, nullptr });
 
     GetDeviceTable(in_device)->GetImageSparseMemoryRequirements2KHR(in_device, in_pInfo, out_pSparseMemoryRequirementCount, out_pSparseMemoryRequirements);
@@ -3439,7 +3439,7 @@ void VulkanReplayConsumer::Process_vkGetDescriptorSetLayoutSupportKHR(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkDescriptorSetLayoutCreateInfo* in_pCreateInfo = pCreateInfo->GetPointer();
     MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    VkDescriptorSetLayoutSupport* out_pSupport = pSupport->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT, nullptr });
+    VkDescriptorSetLayoutSupport* out_pSupport = pSupport->IsNull() ? nullptr : pSupport->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT, nullptr });
 
     GetDeviceTable(in_device)->GetDescriptorSetLayoutSupportKHR(in_device, in_pCreateInfo, out_pSupport);
 }
@@ -3484,7 +3484,7 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreCounterValueKHR(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkSemaphore in_semaphore = MapHandle<SemaphoreInfo>(semaphore, &VulkanObjectInfoTable::GetSemaphoreInfo);
-    uint64_t* out_pValue = pValue->AllocateOutputData(1, static_cast<uint64_t>(0));
+    uint64_t* out_pValue = pValue->IsNull() ? nullptr : pValue->AllocateOutputData(1, static_cast<uint64_t>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetSemaphoreCounterValueKHR(in_device, in_semaphore, out_pValue);
     CheckResult("vkGetSemaphoreCounterValueKHR", returnValue, replay_result);
@@ -3527,7 +3527,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkPipelineInfoKHR* in_pPipelineInfo = pPipelineInfo->GetPointer();
     MapStructHandles(pPipelineInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pExecutableCount = pExecutableCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DeviceInfo>("vkGetPipelineExecutablePropertiesKHR", returnValue, device, kDeviceArrayGetPipelineExecutablePropertiesKHR, pExecutableCount, pProperties, &VulkanObjectInfoTable::GetDeviceInfo));
+    uint32_t* out_pExecutableCount = pExecutableCount->IsNull() ? nullptr : pExecutableCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DeviceInfo>("vkGetPipelineExecutablePropertiesKHR", returnValue, device, kDeviceArrayGetPipelineExecutablePropertiesKHR, pExecutableCount, pProperties, &VulkanObjectInfoTable::GetDeviceInfo));
     VkPipelineExecutablePropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pExecutableCount, VkPipelineExecutablePropertiesKHR{ VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_PROPERTIES_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineExecutablePropertiesKHR(in_device, in_pPipelineInfo, out_pExecutableCount, out_pProperties);
@@ -3546,7 +3546,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkPipelineExecutableInfoKHR* in_pExecutableInfo = pExecutableInfo->GetPointer();
     MapStructHandles(pExecutableInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pStatisticCount = pStatisticCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DeviceInfo>("vkGetPipelineExecutableStatisticsKHR", returnValue, device, kDeviceArrayGetPipelineExecutableStatisticsKHR, pStatisticCount, pStatistics, &VulkanObjectInfoTable::GetDeviceInfo));
+    uint32_t* out_pStatisticCount = pStatisticCount->IsNull() ? nullptr : pStatisticCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DeviceInfo>("vkGetPipelineExecutableStatisticsKHR", returnValue, device, kDeviceArrayGetPipelineExecutableStatisticsKHR, pStatisticCount, pStatistics, &VulkanObjectInfoTable::GetDeviceInfo));
     VkPipelineExecutableStatisticKHR* out_pStatistics = pStatistics->IsNull() ? nullptr : pStatistics->AllocateOutputData(*out_pStatisticCount, VkPipelineExecutableStatisticKHR{ VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_STATISTIC_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineExecutableStatisticsKHR(in_device, in_pExecutableInfo, out_pStatisticCount, out_pStatistics);
@@ -3565,7 +3565,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutableInternalRepresentation
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkPipelineExecutableInfoKHR* in_pExecutableInfo = pExecutableInfo->GetPointer();
     MapStructHandles(pExecutableInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pInternalRepresentationCount = pInternalRepresentationCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DeviceInfo>("vkGetPipelineExecutableInternalRepresentationsKHR", returnValue, device, kDeviceArrayGetPipelineExecutableInternalRepresentationsKHR, pInternalRepresentationCount, pInternalRepresentations, &VulkanObjectInfoTable::GetDeviceInfo));
+    uint32_t* out_pInternalRepresentationCount = pInternalRepresentationCount->IsNull() ? nullptr : pInternalRepresentationCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DeviceInfo>("vkGetPipelineExecutableInternalRepresentationsKHR", returnValue, device, kDeviceArrayGetPipelineExecutableInternalRepresentationsKHR, pInternalRepresentationCount, pInternalRepresentations, &VulkanObjectInfoTable::GetDeviceInfo));
     VkPipelineExecutableInternalRepresentationKHR* out_pInternalRepresentations = pInternalRepresentations->IsNull() ? nullptr : pInternalRepresentations->AllocateOutputData(*out_pInternalRepresentationCount, VkPipelineExecutableInternalRepresentationKHR{ VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INTERNAL_REPRESENTATION_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineExecutableInternalRepresentationsKHR(in_device, in_pExecutableInfo, out_pInternalRepresentationCount, out_pInternalRepresentations);
@@ -3812,7 +3812,7 @@ void VulkanReplayConsumer::Process_vkGetShaderInfoAMD(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkPipeline in_pipeline = MapHandle<PipelineInfo>(pipeline, &VulkanObjectInfoTable::GetPipelineInfo);
-    size_t* out_pInfoSize = pInfoSize->AllocateOutputData(1, GetOutputArrayCount<size_t, PipelineInfo>("vkGetShaderInfoAMD", returnValue, pipeline, kPipelineArrayGetShaderInfoAMD, pInfoSize, pInfo, &VulkanObjectInfoTable::GetPipelineInfo));
+    size_t* out_pInfoSize = pInfoSize->IsNull() ? nullptr : pInfoSize->AllocateOutputData(1, GetOutputArrayCount<size_t, PipelineInfo>("vkGetShaderInfoAMD", returnValue, pipeline, kPipelineArrayGetShaderInfoAMD, pInfoSize, pInfo, &VulkanObjectInfoTable::GetPipelineInfo));
     void* out_pInfo = pInfo->IsNull() ? nullptr : pInfo->AllocateOutputData(*out_pInfoSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetShaderInfoAMD(in_device, in_pipeline, shaderStage, infoType, out_pInfoSize, out_pInfo);
@@ -3852,7 +3852,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalImageFormatPropert
     StructPointerDecoder<Decoded_VkExternalImageFormatPropertiesNV>* pExternalImageFormatProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    VkExternalImageFormatPropertiesNV* out_pExternalImageFormatProperties = pExternalImageFormatProperties->AllocateOutputData(1);
+    VkExternalImageFormatPropertiesNV* out_pExternalImageFormatProperties = pExternalImageFormatProperties->IsNull() ? nullptr : pExternalImageFormatProperties->AllocateOutputData(1);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceExternalImageFormatPropertiesNV(in_physicalDevice, format, type, tiling, usage, flags, externalHandleType, out_pExternalImageFormatProperties);
     CheckResult("vkGetPhysicalDeviceExternalImageFormatPropertiesNV", returnValue, replay_result);
@@ -3867,7 +3867,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryWin32HandleNV(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkDeviceMemory in_memory = MapHandle<DeviceMemoryInfo>(memory, &VulkanObjectInfoTable::GetDeviceMemoryInfo);
-    HANDLE* out_pHandle = reinterpret_cast<HANDLE*>(pHandle->AllocateOutputData(1));
+    HANDLE* out_pHandle = pHandle->IsNull() ? nullptr : reinterpret_cast<HANDLE*>(pHandle->AllocateOutputData(1));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryWin32HandleNV(in_device, in_memory, handleType, out_pHandle);
     CheckResult("vkGetMemoryWin32HandleNV", returnValue, replay_result);
@@ -4020,8 +4020,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceGeneratedCommandsPropertie
     StructPointerDecoder<Decoded_VkDeviceGeneratedCommandsLimitsNVX>* pLimits)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    VkDeviceGeneratedCommandsFeaturesNVX* out_pFeatures = pFeatures->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DEVICE_GENERATED_COMMANDS_FEATURES_NVX, nullptr });
-    VkDeviceGeneratedCommandsLimitsNVX* out_pLimits = pLimits->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DEVICE_GENERATED_COMMANDS_LIMITS_NVX, nullptr });
+    VkDeviceGeneratedCommandsFeaturesNVX* out_pFeatures = pFeatures->IsNull() ? nullptr : pFeatures->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DEVICE_GENERATED_COMMANDS_FEATURES_NVX, nullptr });
+    VkDeviceGeneratedCommandsLimitsNVX* out_pLimits = pLimits->IsNull() ? nullptr : pLimits->AllocateOutputData(1, { VK_STRUCTURE_TYPE_DEVICE_GENERATED_COMMANDS_LIMITS_NVX, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceGeneratedCommandsPropertiesNVX(in_physicalDevice, out_pFeatures, out_pLimits);
 }
@@ -4090,7 +4090,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     VkSurfaceKHR in_surface = MapHandle<SurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetSurfaceKHRInfo);
-    VkSurfaceCapabilities2EXT* out_pSurfaceCapabilities = pSurfaceCapabilities->AllocateOutputData(1, { VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_EXT, nullptr });
+    VkSurfaceCapabilities2EXT* out_pSurfaceCapabilities = pSurfaceCapabilities->IsNull() ? nullptr : pSurfaceCapabilities->AllocateOutputData(1, { VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_EXT, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceCapabilities2EXT(in_physicalDevice, in_surface, out_pSurfaceCapabilities);
     CheckResult("vkGetPhysicalDeviceSurfaceCapabilities2EXT", returnValue, replay_result);
@@ -4159,7 +4159,7 @@ void VulkanReplayConsumer::Process_vkGetSwapchainCounterEXT(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkSwapchainKHR in_swapchain = MapHandle<SwapchainKHRInfo>(swapchain, &VulkanObjectInfoTable::GetSwapchainKHRInfo);
-    uint64_t* out_pCounterValue = pCounterValue->AllocateOutputData(1, static_cast<uint64_t>(0));
+    uint64_t* out_pCounterValue = pCounterValue->IsNull() ? nullptr : pCounterValue->AllocateOutputData(1, static_cast<uint64_t>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetSwapchainCounterEXT(in_device, in_swapchain, counter, out_pCounterValue);
     CheckResult("vkGetSwapchainCounterEXT", returnValue, replay_result);
@@ -4173,7 +4173,7 @@ void VulkanReplayConsumer::Process_vkGetRefreshCycleDurationGOOGLE(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkSwapchainKHR in_swapchain = MapHandle<SwapchainKHRInfo>(swapchain, &VulkanObjectInfoTable::GetSwapchainKHRInfo);
-    VkRefreshCycleDurationGOOGLE* out_pDisplayTimingProperties = pDisplayTimingProperties->AllocateOutputData(1);
+    VkRefreshCycleDurationGOOGLE* out_pDisplayTimingProperties = pDisplayTimingProperties->IsNull() ? nullptr : pDisplayTimingProperties->AllocateOutputData(1);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetRefreshCycleDurationGOOGLE(in_device, in_swapchain, out_pDisplayTimingProperties);
     CheckResult("vkGetRefreshCycleDurationGOOGLE", returnValue, replay_result);
@@ -4188,7 +4188,7 @@ void VulkanReplayConsumer::Process_vkGetPastPresentationTimingGOOGLE(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkSwapchainKHR in_swapchain = MapHandle<SwapchainKHRInfo>(swapchain, &VulkanObjectInfoTable::GetSwapchainKHRInfo);
-    uint32_t* out_pPresentationTimingCount = pPresentationTimingCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, SwapchainKHRInfo>("vkGetPastPresentationTimingGOOGLE", returnValue, swapchain, kSwapchainKHRArrayGetPastPresentationTimingGOOGLE, pPresentationTimingCount, pPresentationTimings, &VulkanObjectInfoTable::GetSwapchainKHRInfo));
+    uint32_t* out_pPresentationTimingCount = pPresentationTimingCount->IsNull() ? nullptr : pPresentationTimingCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, SwapchainKHRInfo>("vkGetPastPresentationTimingGOOGLE", returnValue, swapchain, kSwapchainKHRArrayGetPastPresentationTimingGOOGLE, pPresentationTimingCount, pPresentationTimings, &VulkanObjectInfoTable::GetSwapchainKHRInfo));
     VkPastPresentationTimingGOOGLE* out_pPresentationTimings = pPresentationTimings->IsNull() ? nullptr : pPresentationTimings->AllocateOutputData(*out_pPresentationTimingCount);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPastPresentationTimingGOOGLE(in_device, in_swapchain, out_pPresentationTimingCount, out_pPresentationTimings);
@@ -4390,7 +4390,7 @@ void VulkanReplayConsumer::Process_vkGetAndroidHardwareBufferPropertiesANDROID(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const struct AHardwareBuffer* in_buffer = static_cast<const struct AHardwareBuffer*>(PreProcessExternalObject(buffer, format::ApiCallId::ApiCall_vkGetAndroidHardwareBufferPropertiesANDROID, "vkGetAndroidHardwareBufferPropertiesANDROID"));
-    VkAndroidHardwareBufferPropertiesANDROID* out_pProperties = pProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID, nullptr });
+    VkAndroidHardwareBufferPropertiesANDROID* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetAndroidHardwareBufferPropertiesANDROID(in_device, in_buffer, out_pProperties);
     CheckResult("vkGetAndroidHardwareBufferPropertiesANDROID", returnValue, replay_result);
@@ -4405,7 +4405,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryAndroidHardwareBufferANDROID(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkMemoryGetAndroidHardwareBufferInfoANDROID* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    struct AHardwareBuffer** out_pBuffer = reinterpret_cast<struct AHardwareBuffer**>(pBuffer->AllocateOutputData(1));
+    struct AHardwareBuffer** out_pBuffer = pBuffer->IsNull() ? nullptr : reinterpret_cast<struct AHardwareBuffer**>(pBuffer->AllocateOutputData(1));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryAndroidHardwareBufferANDROID(in_device, in_pInfo, out_pBuffer);
     CheckResult("vkGetMemoryAndroidHardwareBufferANDROID", returnValue, replay_result);
@@ -4429,7 +4429,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(
     StructPointerDecoder<Decoded_VkMultisamplePropertiesEXT>* pMultisampleProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    VkMultisamplePropertiesEXT* out_pMultisampleProperties = pMultisampleProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MULTISAMPLE_PROPERTIES_EXT, nullptr });
+    VkMultisamplePropertiesEXT* out_pMultisampleProperties = pMultisampleProperties->IsNull() ? nullptr : pMultisampleProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MULTISAMPLE_PROPERTIES_EXT, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceMultisamplePropertiesEXT(in_physicalDevice, samples, out_pMultisampleProperties);
 }
@@ -4442,7 +4442,7 @@ void VulkanReplayConsumer::Process_vkGetImageDrmFormatModifierPropertiesEXT(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkImage in_image = MapHandle<ImageInfo>(image, &VulkanObjectInfoTable::GetImageInfo);
-    VkImageDrmFormatModifierPropertiesEXT* out_pProperties = pProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT, nullptr });
+    VkImageDrmFormatModifierPropertiesEXT* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetImageDrmFormatModifierPropertiesEXT(in_device, in_image, out_pProperties);
     CheckResult("vkGetImageDrmFormatModifierPropertiesEXT", returnValue, replay_result);
@@ -4503,7 +4503,7 @@ void VulkanReplayConsumer::Process_vkGetValidationCacheDataEXT(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkValidationCacheEXT in_validationCache = MapHandle<ValidationCacheEXTInfo>(validationCache, &VulkanObjectInfoTable::GetValidationCacheEXTInfo);
-    size_t* out_pDataSize = pDataSize->AllocateOutputData(1, GetOutputArrayCount<size_t, ValidationCacheEXTInfo>("vkGetValidationCacheDataEXT", returnValue, validationCache, kValidationCacheEXTArrayGetValidationCacheDataEXT, pDataSize, pData, &VulkanObjectInfoTable::GetValidationCacheEXTInfo));
+    size_t* out_pDataSize = pDataSize->IsNull() ? nullptr : pDataSize->AllocateOutputData(1, GetOutputArrayCount<size_t, ValidationCacheEXTInfo>("vkGetValidationCacheDataEXT", returnValue, validationCache, kValidationCacheEXTArrayGetValidationCacheDataEXT, pDataSize, pData, &VulkanObjectInfoTable::GetValidationCacheEXTInfo));
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(*out_pDataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetValidationCacheDataEXT(in_device, in_validationCache, out_pDataSize, out_pData);
@@ -4587,7 +4587,7 @@ void VulkanReplayConsumer::Process_vkGetAccelerationStructureMemoryRequirementsN
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkAccelerationStructureMemoryRequirementsInfoNV* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    VkMemoryRequirements2KHR* out_pMemoryRequirements = pMemoryRequirements->AllocateOutputData(1);
+    VkMemoryRequirements2KHR* out_pMemoryRequirements = pMemoryRequirements->IsNull() ? nullptr : pMemoryRequirements->AllocateOutputData(1);
 
     GetDeviceTable(in_device)->GetAccelerationStructureMemoryRequirementsNV(in_device, in_pInfo, out_pMemoryRequirements);
 }
@@ -4759,7 +4759,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryHostPointerPropertiesEXT(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const void* in_pHostPointer = PreProcessExternalObject(pHostPointer, format::ApiCallId::ApiCall_vkGetMemoryHostPointerPropertiesEXT, "vkGetMemoryHostPointerPropertiesEXT");
-    VkMemoryHostPointerPropertiesEXT* out_pMemoryHostPointerProperties = pMemoryHostPointerProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT, nullptr });
+    VkMemoryHostPointerPropertiesEXT* out_pMemoryHostPointerProperties = pMemoryHostPointerProperties->IsNull() ? nullptr : pMemoryHostPointerProperties->AllocateOutputData(1, { VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetMemoryHostPointerPropertiesEXT(in_device, handleType, in_pHostPointer, out_pMemoryHostPointerProperties);
     CheckResult("vkGetMemoryHostPointerPropertiesEXT", returnValue, replay_result);
@@ -4785,7 +4785,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEX
     PointerDecoder<VkTimeDomainEXT>*            pTimeDomains)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pTimeDomainCount = pTimeDomainCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCalibrateableTimeDomainsEXT, pTimeDomainCount, pTimeDomains, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+    uint32_t* out_pTimeDomainCount = pTimeDomainCount->IsNull() ? nullptr : pTimeDomainCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCalibrateableTimeDomainsEXT, pTimeDomainCount, pTimeDomains, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkTimeDomainEXT* out_pTimeDomains = pTimeDomains->IsNull() ? nullptr : pTimeDomains->AllocateOutputData(*out_pTimeDomainCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceCalibrateableTimeDomainsEXT(in_physicalDevice, out_pTimeDomainCount, out_pTimeDomains);
@@ -4805,7 +4805,7 @@ void VulkanReplayConsumer::Process_vkGetCalibratedTimestampsEXT(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkCalibratedTimestampInfoEXT* in_pTimestampInfos = pTimestampInfos->GetPointer();
     uint64_t* out_pTimestamps = pTimestamps->IsNull() ? nullptr : pTimestamps->AllocateOutputData(timestampCount);
-    uint64_t* out_pMaxDeviation = pMaxDeviation->AllocateOutputData(1, static_cast<uint64_t>(0));
+    uint64_t* out_pMaxDeviation = pMaxDeviation->IsNull() ? nullptr : pMaxDeviation->AllocateOutputData(1, static_cast<uint64_t>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetCalibratedTimestampsEXT(in_device, timestampCount, in_pTimestampInfos, out_pTimestamps, out_pMaxDeviation);
     CheckResult("vkGetCalibratedTimestampsEXT", returnValue, replay_result);
@@ -4878,7 +4878,7 @@ void VulkanReplayConsumer::Process_vkGetQueueCheckpointDataNV(
     StructPointerDecoder<Decoded_VkCheckpointDataNV>* pCheckpointData)
 {
     VkQueue in_queue = MapHandle<QueueInfo>(queue, &VulkanObjectInfoTable::GetQueueInfo);
-    uint32_t* out_pCheckpointDataCount = pCheckpointDataCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, QueueInfo>("vkGetQueueCheckpointDataNV", VK_SUCCESS, queue, kQueueArrayGetQueueCheckpointDataNV, pCheckpointDataCount, pCheckpointData, &VulkanObjectInfoTable::GetQueueInfo));
+    uint32_t* out_pCheckpointDataCount = pCheckpointDataCount->IsNull() ? nullptr : pCheckpointDataCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, QueueInfo>("vkGetQueueCheckpointDataNV", VK_SUCCESS, queue, kQueueArrayGetQueueCheckpointDataNV, pCheckpointDataCount, pCheckpointData, &VulkanObjectInfoTable::GetQueueInfo));
     VkCheckpointDataNV* out_pCheckpointData = pCheckpointData->IsNull() ? nullptr : pCheckpointData->AllocateOutputData(*out_pCheckpointDataCount, VkCheckpointDataNV{ VK_STRUCTURE_TYPE_CHECKPOINT_DATA_NV, nullptr });
 
     GetDeviceTable(in_queue)->GetQueueCheckpointDataNV(in_queue, out_pCheckpointDataCount, out_pCheckpointData);
@@ -4990,7 +4990,7 @@ void VulkanReplayConsumer::Process_vkGetPerformanceParameterINTEL(
     StructPointerDecoder<Decoded_VkPerformanceValueINTEL>* pValue)
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkPerformanceValueINTEL* out_pValue = pValue->AllocateOutputData(1);
+    VkPerformanceValueINTEL* out_pValue = pValue->IsNull() ? nullptr : pValue->AllocateOutputData(1);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPerformanceParameterINTEL(in_device, parameter, out_pValue);
     CheckResult("vkGetPerformanceParameterINTEL", returnValue, replay_result);
@@ -5064,7 +5064,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixPropertie
     StructPointerDecoder<Decoded_VkCooperativeMatrixPropertiesNV>* pProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCooperativeMatrixPropertiesNV, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+    uint32_t* out_pPropertyCount = pPropertyCount->IsNull() ? nullptr : pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCooperativeMatrixPropertiesNV, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkCooperativeMatrixPropertiesNV* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkCooperativeMatrixPropertiesNV{ VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_NV, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceCooperativeMatrixPropertiesNV(in_physicalDevice, out_pPropertyCount, out_pProperties);
@@ -5080,7 +5080,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedS
     StructPointerDecoder<Decoded_VkFramebufferMixedSamplesCombinationNV>* pCombinations)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pCombinationCount = pCombinationCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, pCombinationCount, pCombinations, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+    uint32_t* out_pCombinationCount = pCombinationCount->IsNull() ? nullptr : pCombinationCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, pCombinationCount, pCombinations, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkFramebufferMixedSamplesCombinationNV* out_pCombinations = pCombinations->IsNull() ? nullptr : pCombinations->AllocateOutputData(*out_pCombinationCount, VkFramebufferMixedSamplesCombinationNV{ VK_STRUCTURE_TYPE_FRAMEBUFFER_MIXED_SAMPLES_COMBINATION_NV, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(in_physicalDevice, out_pCombinationCount, out_pCombinations);
@@ -5099,7 +5099,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceSurfaceInfo2KHR* in_pSurfaceInfo = pSurfaceInfo->GetPointer();
     MapStructHandles(pSurfaceInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pPresentModeCount = pPresentModeCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSurfacePresentModes2EXT", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfacePresentModes2EXT, pPresentModeCount, pPresentModes, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+    uint32_t* out_pPresentModeCount = pPresentModeCount->IsNull() ? nullptr : pPresentModeCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSurfacePresentModes2EXT", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfacePresentModes2EXT, pPresentModeCount, pPresentModes, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkPresentModeKHR* out_pPresentModes = pPresentModes->IsNull() ? nullptr : pPresentModes->AllocateOutputData(*out_pPresentModeCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfacePresentModes2EXT(in_physicalDevice, in_pSurfaceInfo, out_pPresentModeCount, out_pPresentModes);
@@ -5141,7 +5141,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupSurfacePresentModes2EXT(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkPhysicalDeviceSurfaceInfo2KHR* in_pSurfaceInfo = pSurfaceInfo->GetPointer();
     MapStructHandles(pSurfaceInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    VkDeviceGroupPresentModeFlagsKHR* out_pModes = pModes->AllocateOutputData(1, static_cast<VkDeviceGroupPresentModeFlagsKHR>(0));
+    VkDeviceGroupPresentModeFlagsKHR* out_pModes = pModes->IsNull() ? nullptr : pModes->AllocateOutputData(1, static_cast<VkDeviceGroupPresentModeFlagsKHR>(0));
 
     VkResult replay_result = GetDeviceTable(in_device)->GetDeviceGroupSurfacePresentModes2EXT(in_device, in_pSurfaceInfo, out_pModes);
     CheckResult("vkGetDeviceGroupSurfacePresentModes2EXT", returnValue, replay_result);

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -63,7 +63,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDevices(
     HandlePointerDecoder<VkPhysicalDevice>*     pPhysicalDevices)
 {
     auto in_instance = GetObjectInfoTable().GetInstanceInfo(instance);
-    pPhysicalDeviceCount->AllocateOutputData(1, pPhysicalDeviceCount->IsNull() ? static_cast<uint32_t>(0) : (*pPhysicalDeviceCount->GetPointer()));
+    pPhysicalDeviceCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, InstanceInfo>("vkEnumeratePhysicalDevices", returnValue, instance, kInstanceArrayEnumeratePhysicalDevices, pPhysicalDeviceCount, pPhysicalDevices, &VulkanObjectInfoTable::GetInstanceInfo));
     if (!pPhysicalDevices->IsNull()) { pPhysicalDevices->SetHandleLength(*pPhysicalDeviceCount->GetOutputPointer()); }
     std::vector<PhysicalDeviceInfo> handle_info(*pPhysicalDeviceCount->GetOutputPointer());
     for (size_t i = 0; i < *pPhysicalDeviceCount->GetOutputPointer(); ++i) { pPhysicalDevices->SetConsumerData(i, &handle_info[i]); }
@@ -129,7 +129,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties(
     StructPointerDecoder<Decoded_VkQueueFamilyProperties>* pQueueFamilyProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->AllocateOutputData(1, pQueueFamilyPropertyCount->IsNull() ? static_cast<uint32_t>(0) : (*pQueueFamilyPropertyCount->GetPointer()));
+    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceQueueFamilyProperties", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties, pQueueFamilyPropertyCount, pQueueFamilyProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkQueueFamilyProperties* out_pQueueFamilyProperties = pQueueFamilyProperties->IsNull() ? nullptr : pQueueFamilyProperties->AllocateOutputData(*out_pQueueFamilyPropertyCount);
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceQueueFamilyProperties(in_physicalDevice, out_pQueueFamilyPropertyCount, out_pQueueFamilyProperties);
@@ -390,7 +390,7 @@ void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkImage in_image = MapHandle<ImageInfo>(image, &VulkanObjectInfoTable::GetImageInfo);
-    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->AllocateOutputData(1, pSparseMemoryRequirementCount->IsNull() ? static_cast<uint32_t>(0) : (*pSparseMemoryRequirementCount->GetPointer()));
+    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, ImageInfo>("vkGetImageSparseMemoryRequirements", VK_SUCCESS, image, kImageArrayGetImageSparseMemoryRequirements, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &VulkanObjectInfoTable::GetImageInfo));
     VkSparseImageMemoryRequirements* out_pSparseMemoryRequirements = pSparseMemoryRequirements->IsNull() ? nullptr : pSparseMemoryRequirements->AllocateOutputData(*out_pSparseMemoryRequirementCount);
 
     GetDeviceTable(in_device)->GetImageSparseMemoryRequirements(in_device, in_image, out_pSparseMemoryRequirementCount, out_pSparseMemoryRequirements);
@@ -409,7 +409,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
     StructPointerDecoder<Decoded_VkSparseImageFormatProperties>* pProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, pPropertyCount->IsNull() ? static_cast<uint32_t>(0) : (*pPropertyCount->GetPointer()));
+    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSparseImageFormatProperties", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkSparseImageFormatProperties* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties(in_physicalDevice, format, type, samples, usage, tiling, out_pPropertyCount, out_pProperties);
@@ -860,7 +860,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineCacheData(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkPipelineCache in_pipelineCache = MapHandle<PipelineCacheInfo>(pipelineCache, &VulkanObjectInfoTable::GetPipelineCacheInfo);
-    size_t* out_pDataSize = pDataSize->AllocateOutputData(1, pDataSize->IsNull() ? static_cast<size_t>(0) : (*pDataSize->GetPointer()));
+    size_t* out_pDataSize = pDataSize->AllocateOutputData(1, GetOutputArrayCount<size_t, PipelineCacheInfo>("vkGetPipelineCacheData", returnValue, pipelineCache, kPipelineCacheArrayGetPipelineCacheData, pDataSize, pData, &VulkanObjectInfoTable::GetPipelineCacheInfo));
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(*out_pDataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineCacheData(in_device, in_pipelineCache, out_pDataSize, out_pData);
@@ -1969,7 +1969,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroups(
     StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties)
 {
     VkInstance in_instance = MapHandle<InstanceInfo>(instance, &VulkanObjectInfoTable::GetInstanceInfo);
-    uint32_t* out_pPhysicalDeviceGroupCount = pPhysicalDeviceGroupCount->AllocateOutputData(1, pPhysicalDeviceGroupCount->IsNull() ? static_cast<uint32_t>(0) : (*pPhysicalDeviceGroupCount->GetPointer()));
+    uint32_t* out_pPhysicalDeviceGroupCount = pPhysicalDeviceGroupCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, InstanceInfo>("vkEnumeratePhysicalDeviceGroups", returnValue, instance, kInstanceArrayEnumeratePhysicalDeviceGroups, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, &VulkanObjectInfoTable::GetInstanceInfo));
     SetStructArrayHandleLengths<Decoded_VkPhysicalDeviceGroupProperties>(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength());
     VkPhysicalDeviceGroupProperties* out_pPhysicalDeviceGroupProperties = pPhysicalDeviceGroupProperties->IsNull() ? nullptr : pPhysicalDeviceGroupProperties->AllocateOutputData(*out_pPhysicalDeviceGroupCount, VkPhysicalDeviceGroupProperties{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES, nullptr });
 
@@ -2015,7 +2015,7 @@ void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements2(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkImageSparseMemoryRequirementsInfo2* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->AllocateOutputData(1, pSparseMemoryRequirementCount->IsNull() ? static_cast<uint32_t>(0) : (*pSparseMemoryRequirementCount->GetPointer()));
+    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DeviceInfo>("vkGetImageSparseMemoryRequirements2", VK_SUCCESS, device, kDeviceArrayGetImageSparseMemoryRequirements2, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &VulkanObjectInfoTable::GetDeviceInfo));
     VkSparseImageMemoryRequirements2* out_pSparseMemoryRequirements = pSparseMemoryRequirements->IsNull() ? nullptr : pSparseMemoryRequirements->AllocateOutputData(*out_pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2, nullptr });
 
     GetDeviceTable(in_device)->GetImageSparseMemoryRequirements2(in_device, in_pInfo, out_pSparseMemoryRequirementCount, out_pSparseMemoryRequirements);
@@ -2074,7 +2074,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2(
     StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->AllocateOutputData(1, pQueueFamilyPropertyCount->IsNull() ? static_cast<uint32_t>(0) : (*pQueueFamilyPropertyCount->GetPointer()));
+    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceQueueFamilyProperties2", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2, pQueueFamilyPropertyCount, pQueueFamilyProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkQueueFamilyProperties2* out_pQueueFamilyProperties = pQueueFamilyProperties->IsNull() ? nullptr : pQueueFamilyProperties->AllocateOutputData(*out_pQueueFamilyPropertyCount, VkQueueFamilyProperties2{ VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceQueueFamilyProperties2(in_physicalDevice, out_pQueueFamilyPropertyCount, out_pQueueFamilyProperties);
@@ -2100,7 +2100,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceSparseImageFormatInfo2* in_pFormatInfo = pFormatInfo->GetPointer();
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, pPropertyCount->IsNull() ? static_cast<uint32_t>(0) : (*pPropertyCount->GetPointer()));
+    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSparseImageFormatProperties2", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties2, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkSparseImageFormatProperties2* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkSparseImageFormatProperties2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties2(in_physicalDevice, in_pFormatInfo, out_pPropertyCount, out_pProperties);
@@ -2294,7 +2294,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     VkSurfaceKHR in_surface = MapHandle<SurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetSurfaceKHRInfo);
-    uint32_t* out_pSurfaceFormatCount = pSurfaceFormatCount->AllocateOutputData(1, pSurfaceFormatCount->IsNull() ? static_cast<uint32_t>(0) : (*pSurfaceFormatCount->GetPointer()));
+    uint32_t* out_pSurfaceFormatCount = pSurfaceFormatCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, SurfaceKHRInfo>("vkGetPhysicalDeviceSurfaceFormatsKHR", returnValue, surface, kSurfaceKHRArrayGetPhysicalDeviceSurfaceFormatsKHR, pSurfaceFormatCount, pSurfaceFormats, &VulkanObjectInfoTable::GetSurfaceKHRInfo));
     VkSurfaceFormatKHR* out_pSurfaceFormats = pSurfaceFormats->IsNull() ? nullptr : pSurfaceFormats->AllocateOutputData(*out_pSurfaceFormatCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceFormatsKHR(in_physicalDevice, in_surface, out_pSurfaceFormatCount, out_pSurfaceFormats);
@@ -2312,7 +2312,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     VkSurfaceKHR in_surface = MapHandle<SurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetSurfaceKHRInfo);
-    uint32_t* out_pPresentModeCount = pPresentModeCount->AllocateOutputData(1, pPresentModeCount->IsNull() ? static_cast<uint32_t>(0) : (*pPresentModeCount->GetPointer()));
+    uint32_t* out_pPresentModeCount = pPresentModeCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, SurfaceKHRInfo>("vkGetPhysicalDeviceSurfacePresentModesKHR", returnValue, surface, kSurfaceKHRArrayGetPhysicalDeviceSurfacePresentModesKHR, pPresentModeCount, pPresentModes, &VulkanObjectInfoTable::GetSurfaceKHRInfo));
     VkPresentModeKHR* out_pPresentModes = pPresentModes->IsNull() ? nullptr : pPresentModes->AllocateOutputData(*out_pPresentModeCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfacePresentModesKHR(in_physicalDevice, in_surface, out_pPresentModeCount, out_pPresentModes);
@@ -2362,7 +2362,7 @@ void VulkanReplayConsumer::Process_vkGetSwapchainImagesKHR(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkSwapchainKHR in_swapchain = MapHandle<SwapchainKHRInfo>(swapchain, &VulkanObjectInfoTable::GetSwapchainKHRInfo);
-    uint32_t* out_pSwapchainImageCount = pSwapchainImageCount->AllocateOutputData(1, pSwapchainImageCount->IsNull() ? static_cast<uint32_t>(0) : (*pSwapchainImageCount->GetPointer()));
+    uint32_t* out_pSwapchainImageCount = pSwapchainImageCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, SwapchainKHRInfo>("vkGetSwapchainImagesKHR", returnValue, swapchain, kSwapchainKHRArrayGetSwapchainImagesKHR, pSwapchainImageCount, pSwapchainImages, &VulkanObjectInfoTable::GetSwapchainKHRInfo));
     if (!pSwapchainImages->IsNull()) { pSwapchainImages->SetHandleLength(*out_pSwapchainImageCount); }
     VkImage* out_pSwapchainImages = pSwapchainImages->GetHandlePointer();
 
@@ -2440,7 +2440,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     VkSurfaceKHR in_surface = MapHandle<SurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetSurfaceKHRInfo);
-    uint32_t* out_pRectCount = pRectCount->AllocateOutputData(1, pRectCount->IsNull() ? static_cast<uint32_t>(0) : (*pRectCount->GetPointer()));
+    uint32_t* out_pRectCount = pRectCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, SurfaceKHRInfo>("vkGetPhysicalDevicePresentRectanglesKHR", returnValue, surface, kSurfaceKHRArrayGetPhysicalDevicePresentRectanglesKHR, pRectCount, pRects, &VulkanObjectInfoTable::GetSurfaceKHRInfo));
     VkRect2D* out_pRects = pRects->IsNull() ? nullptr : pRects->AllocateOutputData(*out_pRectCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDevicePresentRectanglesKHR(in_physicalDevice, in_surface, out_pRectCount, out_pRects);
@@ -2471,7 +2471,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
     StructPointerDecoder<Decoded_VkDisplayPropertiesKHR>* pProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, pPropertyCount->IsNull() ? static_cast<uint32_t>(0) : (*pPropertyCount->GetPointer()));
+    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPropertiesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPropertiesKHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkDisplayPropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPropertiesKHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
@@ -2488,7 +2488,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
     StructPointerDecoder<Decoded_VkDisplayPlanePropertiesKHR>* pProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, pPropertyCount->IsNull() ? static_cast<uint32_t>(0) : (*pPropertyCount->GetPointer()));
+    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlanePropertiesKHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkDisplayPlanePropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPlanePropertiesKHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
@@ -2506,7 +2506,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
     HandlePointerDecoder<VkDisplayKHR>*         pDisplays)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pDisplayCount = pDisplayCount->AllocateOutputData(1, pDisplayCount->IsNull() ? static_cast<uint32_t>(0) : (*pDisplayCount->GetPointer()));
+    uint32_t* out_pDisplayCount = pDisplayCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetDisplayPlaneSupportedDisplaysKHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetDisplayPlaneSupportedDisplaysKHR, pDisplayCount, pDisplays, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     if (!pDisplays->IsNull()) { pDisplays->SetHandleLength(*out_pDisplayCount); }
     VkDisplayKHR* out_pDisplays = pDisplays->GetHandlePointer();
 
@@ -2526,7 +2526,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayModePropertiesKHR(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     VkDisplayKHR in_display = MapHandle<DisplayKHRInfo>(display, &VulkanObjectInfoTable::GetDisplayKHRInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, pPropertyCount->IsNull() ? static_cast<uint32_t>(0) : (*pPropertyCount->GetPointer()));
+    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DisplayKHRInfo>("vkGetDisplayModePropertiesKHR", returnValue, display, kDisplayKHRArrayGetDisplayModePropertiesKHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetDisplayKHRInfo));
     VkDisplayModePropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayModePropertiesKHR(in_physicalDevice, in_display, out_pPropertyCount, out_pProperties);
@@ -2802,7 +2802,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
     StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->AllocateOutputData(1, pQueueFamilyPropertyCount->IsNull() ? static_cast<uint32_t>(0) : (*pQueueFamilyPropertyCount->GetPointer()));
+    uint32_t* out_pQueueFamilyPropertyCount = pQueueFamilyPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceQueueFamilyProperties2KHR", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2KHR, pQueueFamilyPropertyCount, pQueueFamilyProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkQueueFamilyProperties2* out_pQueueFamilyProperties = pQueueFamilyProperties->IsNull() ? nullptr : pQueueFamilyProperties->AllocateOutputData(*out_pQueueFamilyPropertyCount, VkQueueFamilyProperties2{ VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceQueueFamilyProperties2KHR(in_physicalDevice, out_pQueueFamilyPropertyCount, out_pQueueFamilyProperties);
@@ -2828,7 +2828,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceSparseImageFormatInfo2* in_pFormatInfo = pFormatInfo->GetPointer();
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, pPropertyCount->IsNull() ? static_cast<uint32_t>(0) : (*pPropertyCount->GetPointer()));
+    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSparseImageFormatProperties2KHR", VK_SUCCESS, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties2KHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkSparseImageFormatProperties2* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkSparseImageFormatProperties2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties2KHR(in_physicalDevice, in_pFormatInfo, out_pPropertyCount, out_pProperties);
@@ -2890,7 +2890,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
     StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties)
 {
     VkInstance in_instance = MapHandle<InstanceInfo>(instance, &VulkanObjectInfoTable::GetInstanceInfo);
-    uint32_t* out_pPhysicalDeviceGroupCount = pPhysicalDeviceGroupCount->AllocateOutputData(1, pPhysicalDeviceGroupCount->IsNull() ? static_cast<uint32_t>(0) : (*pPhysicalDeviceGroupCount->GetPointer()));
+    uint32_t* out_pPhysicalDeviceGroupCount = pPhysicalDeviceGroupCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, InstanceInfo>("vkEnumeratePhysicalDeviceGroupsKHR", returnValue, instance, kInstanceArrayEnumeratePhysicalDeviceGroupsKHR, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties, &VulkanObjectInfoTable::GetInstanceInfo));
     SetStructArrayHandleLengths<Decoded_VkPhysicalDeviceGroupProperties>(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength());
     VkPhysicalDeviceGroupProperties* out_pPhysicalDeviceGroupProperties = pPhysicalDeviceGroupProperties->IsNull() ? nullptr : pPhysicalDeviceGroupProperties->AllocateOutputData(*out_pPhysicalDeviceGroupCount, VkPhysicalDeviceGroupProperties{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES, nullptr });
 
@@ -3252,7 +3252,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceSurfaceInfo2KHR* in_pSurfaceInfo = pSurfaceInfo->GetPointer();
     MapStructHandles(pSurfaceInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pSurfaceFormatCount = pSurfaceFormatCount->AllocateOutputData(1, pSurfaceFormatCount->IsNull() ? static_cast<uint32_t>(0) : (*pSurfaceFormatCount->GetPointer()));
+    uint32_t* out_pSurfaceFormatCount = pSurfaceFormatCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSurfaceFormats2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfaceFormats2KHR, pSurfaceFormatCount, pSurfaceFormats, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkSurfaceFormat2KHR* out_pSurfaceFormats = pSurfaceFormats->IsNull() ? nullptr : pSurfaceFormats->AllocateOutputData(*out_pSurfaceFormatCount, VkSurfaceFormat2KHR{ VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceFormats2KHR(in_physicalDevice, in_pSurfaceInfo, out_pSurfaceFormatCount, out_pSurfaceFormats);
@@ -3268,7 +3268,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
     StructPointerDecoder<Decoded_VkDisplayProperties2KHR>* pProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, pPropertyCount->IsNull() ? static_cast<uint32_t>(0) : (*pPropertyCount->GetPointer()));
+    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayProperties2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayProperties2KHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkDisplayProperties2KHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkDisplayProperties2KHR{ VK_STRUCTURE_TYPE_DISPLAY_PROPERTIES_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayProperties2KHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
@@ -3285,7 +3285,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR
     StructPointerDecoder<Decoded_VkDisplayPlaneProperties2KHR>* pProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, pPropertyCount->IsNull() ? static_cast<uint32_t>(0) : (*pPropertyCount->GetPointer()));
+    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlaneProperties2KHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkDisplayPlaneProperties2KHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkDisplayPlaneProperties2KHR{ VK_STRUCTURE_TYPE_DISPLAY_PLANE_PROPERTIES_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPlaneProperties2KHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
@@ -3304,7 +3304,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayModeProperties2KHR(
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     VkDisplayKHR in_display = MapHandle<DisplayKHRInfo>(display, &VulkanObjectInfoTable::GetDisplayKHRInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, pPropertyCount->IsNull() ? static_cast<uint32_t>(0) : (*pPropertyCount->GetPointer()));
+    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DisplayKHRInfo>("vkGetDisplayModeProperties2KHR", returnValue, display, kDisplayKHRArrayGetDisplayModeProperties2KHR, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetDisplayKHRInfo));
     VkDisplayModeProperties2KHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkDisplayModeProperties2KHR{ VK_STRUCTURE_TYPE_DISPLAY_MODE_PROPERTIES_2_KHR, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayModeProperties2KHR(in_physicalDevice, in_display, out_pPropertyCount, out_pProperties);
@@ -3364,7 +3364,7 @@ void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements2KHR(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkImageSparseMemoryRequirementsInfo2* in_pInfo = pInfo->GetPointer();
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->AllocateOutputData(1, pSparseMemoryRequirementCount->IsNull() ? static_cast<uint32_t>(0) : (*pSparseMemoryRequirementCount->GetPointer()));
+    uint32_t* out_pSparseMemoryRequirementCount = pSparseMemoryRequirementCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DeviceInfo>("vkGetImageSparseMemoryRequirements2KHR", VK_SUCCESS, device, kDeviceArrayGetImageSparseMemoryRequirements2KHR, pSparseMemoryRequirementCount, pSparseMemoryRequirements, &VulkanObjectInfoTable::GetDeviceInfo));
     VkSparseImageMemoryRequirements2* out_pSparseMemoryRequirements = pSparseMemoryRequirements->IsNull() ? nullptr : pSparseMemoryRequirements->AllocateOutputData(*out_pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2, nullptr });
 
     GetDeviceTable(in_device)->GetImageSparseMemoryRequirements2KHR(in_device, in_pInfo, out_pSparseMemoryRequirementCount, out_pSparseMemoryRequirements);
@@ -3527,7 +3527,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkPipelineInfoKHR* in_pPipelineInfo = pPipelineInfo->GetPointer();
     MapStructHandles(pPipelineInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pExecutableCount = pExecutableCount->AllocateOutputData(1, pExecutableCount->IsNull() ? static_cast<uint32_t>(0) : (*pExecutableCount->GetPointer()));
+    uint32_t* out_pExecutableCount = pExecutableCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DeviceInfo>("vkGetPipelineExecutablePropertiesKHR", returnValue, device, kDeviceArrayGetPipelineExecutablePropertiesKHR, pExecutableCount, pProperties, &VulkanObjectInfoTable::GetDeviceInfo));
     VkPipelineExecutablePropertiesKHR* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pExecutableCount, VkPipelineExecutablePropertiesKHR{ VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_PROPERTIES_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineExecutablePropertiesKHR(in_device, in_pPipelineInfo, out_pExecutableCount, out_pProperties);
@@ -3546,7 +3546,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkPipelineExecutableInfoKHR* in_pExecutableInfo = pExecutableInfo->GetPointer();
     MapStructHandles(pExecutableInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pStatisticCount = pStatisticCount->AllocateOutputData(1, pStatisticCount->IsNull() ? static_cast<uint32_t>(0) : (*pStatisticCount->GetPointer()));
+    uint32_t* out_pStatisticCount = pStatisticCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DeviceInfo>("vkGetPipelineExecutableStatisticsKHR", returnValue, device, kDeviceArrayGetPipelineExecutableStatisticsKHR, pStatisticCount, pStatistics, &VulkanObjectInfoTable::GetDeviceInfo));
     VkPipelineExecutableStatisticKHR* out_pStatistics = pStatistics->IsNull() ? nullptr : pStatistics->AllocateOutputData(*out_pStatisticCount, VkPipelineExecutableStatisticKHR{ VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_STATISTIC_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineExecutableStatisticsKHR(in_device, in_pExecutableInfo, out_pStatisticCount, out_pStatistics);
@@ -3565,7 +3565,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutableInternalRepresentation
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkPipelineExecutableInfoKHR* in_pExecutableInfo = pExecutableInfo->GetPointer();
     MapStructHandles(pExecutableInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pInternalRepresentationCount = pInternalRepresentationCount->AllocateOutputData(1, pInternalRepresentationCount->IsNull() ? static_cast<uint32_t>(0) : (*pInternalRepresentationCount->GetPointer()));
+    uint32_t* out_pInternalRepresentationCount = pInternalRepresentationCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, DeviceInfo>("vkGetPipelineExecutableInternalRepresentationsKHR", returnValue, device, kDeviceArrayGetPipelineExecutableInternalRepresentationsKHR, pInternalRepresentationCount, pInternalRepresentations, &VulkanObjectInfoTable::GetDeviceInfo));
     VkPipelineExecutableInternalRepresentationKHR* out_pInternalRepresentations = pInternalRepresentations->IsNull() ? nullptr : pInternalRepresentations->AllocateOutputData(*out_pInternalRepresentationCount, VkPipelineExecutableInternalRepresentationKHR{ VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INTERNAL_REPRESENTATION_KHR, nullptr });
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineExecutableInternalRepresentationsKHR(in_device, in_pExecutableInfo, out_pInternalRepresentationCount, out_pInternalRepresentations);
@@ -3812,7 +3812,7 @@ void VulkanReplayConsumer::Process_vkGetShaderInfoAMD(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkPipeline in_pipeline = MapHandle<PipelineInfo>(pipeline, &VulkanObjectInfoTable::GetPipelineInfo);
-    size_t* out_pInfoSize = pInfoSize->AllocateOutputData(1, pInfoSize->IsNull() ? static_cast<size_t>(0) : (*pInfoSize->GetPointer()));
+    size_t* out_pInfoSize = pInfoSize->AllocateOutputData(1, GetOutputArrayCount<size_t, PipelineInfo>("vkGetShaderInfoAMD", returnValue, pipeline, kPipelineArrayGetShaderInfoAMD, pInfoSize, pInfo, &VulkanObjectInfoTable::GetPipelineInfo));
     void* out_pInfo = pInfo->IsNull() ? nullptr : pInfo->AllocateOutputData(*out_pInfoSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetShaderInfoAMD(in_device, in_pipeline, shaderStage, infoType, out_pInfoSize, out_pInfo);
@@ -4188,7 +4188,7 @@ void VulkanReplayConsumer::Process_vkGetPastPresentationTimingGOOGLE(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkSwapchainKHR in_swapchain = MapHandle<SwapchainKHRInfo>(swapchain, &VulkanObjectInfoTable::GetSwapchainKHRInfo);
-    uint32_t* out_pPresentationTimingCount = pPresentationTimingCount->AllocateOutputData(1, pPresentationTimingCount->IsNull() ? static_cast<uint32_t>(0) : (*pPresentationTimingCount->GetPointer()));
+    uint32_t* out_pPresentationTimingCount = pPresentationTimingCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, SwapchainKHRInfo>("vkGetPastPresentationTimingGOOGLE", returnValue, swapchain, kSwapchainKHRArrayGetPastPresentationTimingGOOGLE, pPresentationTimingCount, pPresentationTimings, &VulkanObjectInfoTable::GetSwapchainKHRInfo));
     VkPastPresentationTimingGOOGLE* out_pPresentationTimings = pPresentationTimings->IsNull() ? nullptr : pPresentationTimings->AllocateOutputData(*out_pPresentationTimingCount);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPastPresentationTimingGOOGLE(in_device, in_swapchain, out_pPresentationTimingCount, out_pPresentationTimings);
@@ -4503,7 +4503,7 @@ void VulkanReplayConsumer::Process_vkGetValidationCacheDataEXT(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkValidationCacheEXT in_validationCache = MapHandle<ValidationCacheEXTInfo>(validationCache, &VulkanObjectInfoTable::GetValidationCacheEXTInfo);
-    size_t* out_pDataSize = pDataSize->AllocateOutputData(1, pDataSize->IsNull() ? static_cast<size_t>(0) : (*pDataSize->GetPointer()));
+    size_t* out_pDataSize = pDataSize->AllocateOutputData(1, GetOutputArrayCount<size_t, ValidationCacheEXTInfo>("vkGetValidationCacheDataEXT", returnValue, validationCache, kValidationCacheEXTArrayGetValidationCacheDataEXT, pDataSize, pData, &VulkanObjectInfoTable::GetValidationCacheEXTInfo));
     void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(*out_pDataSize);
 
     VkResult replay_result = GetDeviceTable(in_device)->GetValidationCacheDataEXT(in_device, in_validationCache, out_pDataSize, out_pData);
@@ -4785,7 +4785,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEX
     PointerDecoder<VkTimeDomainEXT>*            pTimeDomains)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pTimeDomainCount = pTimeDomainCount->AllocateOutputData(1, pTimeDomainCount->IsNull() ? static_cast<uint32_t>(0) : (*pTimeDomainCount->GetPointer()));
+    uint32_t* out_pTimeDomainCount = pTimeDomainCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCalibrateableTimeDomainsEXT, pTimeDomainCount, pTimeDomains, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkTimeDomainEXT* out_pTimeDomains = pTimeDomains->IsNull() ? nullptr : pTimeDomains->AllocateOutputData(*out_pTimeDomainCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceCalibrateableTimeDomainsEXT(in_physicalDevice, out_pTimeDomainCount, out_pTimeDomains);
@@ -4878,7 +4878,7 @@ void VulkanReplayConsumer::Process_vkGetQueueCheckpointDataNV(
     StructPointerDecoder<Decoded_VkCheckpointDataNV>* pCheckpointData)
 {
     VkQueue in_queue = MapHandle<QueueInfo>(queue, &VulkanObjectInfoTable::GetQueueInfo);
-    uint32_t* out_pCheckpointDataCount = pCheckpointDataCount->AllocateOutputData(1, pCheckpointDataCount->IsNull() ? static_cast<uint32_t>(0) : (*pCheckpointDataCount->GetPointer()));
+    uint32_t* out_pCheckpointDataCount = pCheckpointDataCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, QueueInfo>("vkGetQueueCheckpointDataNV", VK_SUCCESS, queue, kQueueArrayGetQueueCheckpointDataNV, pCheckpointDataCount, pCheckpointData, &VulkanObjectInfoTable::GetQueueInfo));
     VkCheckpointDataNV* out_pCheckpointData = pCheckpointData->IsNull() ? nullptr : pCheckpointData->AllocateOutputData(*out_pCheckpointDataCount, VkCheckpointDataNV{ VK_STRUCTURE_TYPE_CHECKPOINT_DATA_NV, nullptr });
 
     GetDeviceTable(in_queue)->GetQueueCheckpointDataNV(in_queue, out_pCheckpointDataCount, out_pCheckpointData);
@@ -5064,7 +5064,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixPropertie
     StructPointerDecoder<Decoded_VkCooperativeMatrixPropertiesNV>* pProperties)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, pPropertyCount->IsNull() ? static_cast<uint32_t>(0) : (*pPropertyCount->GetPointer()));
+    uint32_t* out_pPropertyCount = pPropertyCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCooperativeMatrixPropertiesNV, pPropertyCount, pProperties, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkCooperativeMatrixPropertiesNV* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkCooperativeMatrixPropertiesNV{ VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_NV, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceCooperativeMatrixPropertiesNV(in_physicalDevice, out_pPropertyCount, out_pProperties);
@@ -5080,7 +5080,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedS
     StructPointerDecoder<Decoded_VkFramebufferMixedSamplesCombinationNV>* pCombinations)
 {
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    uint32_t* out_pCombinationCount = pCombinationCount->AllocateOutputData(1, pCombinationCount->IsNull() ? static_cast<uint32_t>(0) : (*pCombinationCount->GetPointer()));
+    uint32_t* out_pCombinationCount = pCombinationCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, pCombinationCount, pCombinations, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkFramebufferMixedSamplesCombinationNV* out_pCombinations = pCombinations->IsNull() ? nullptr : pCombinations->AllocateOutputData(*out_pCombinationCount, VkFramebufferMixedSamplesCombinationNV{ VK_STRUCTURE_TYPE_FRAMEBUFFER_MIXED_SAMPLES_COMBINATION_NV, nullptr });
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(in_physicalDevice, out_pCombinationCount, out_pCombinations);
@@ -5099,7 +5099,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
     VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
     const VkPhysicalDeviceSurfaceInfo2KHR* in_pSurfaceInfo = pSurfaceInfo->GetPointer();
     MapStructHandles(pSurfaceInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    uint32_t* out_pPresentModeCount = pPresentModeCount->AllocateOutputData(1, pPresentModeCount->IsNull() ? static_cast<uint32_t>(0) : (*pPresentModeCount->GetPointer()));
+    uint32_t* out_pPresentModeCount = pPresentModeCount->AllocateOutputData(1, GetOutputArrayCount<uint32_t, PhysicalDeviceInfo>("vkGetPhysicalDeviceSurfacePresentModes2EXT", returnValue, physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfacePresentModes2EXT, pPresentModeCount, pPresentModes, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
     VkPresentModeKHR* out_pPresentModes = pPresentModes->IsNull() ? nullptr : pPresentModes->AllocateOutputData(*out_pPresentModeCount);
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfacePresentModes2EXT(in_physicalDevice, in_pSurfaceInfo, out_pPresentModeCount, out_pPresentModes);

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -71,6 +71,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDevices(
     VkResult replay_result = OverrideEnumeratePhysicalDevices(GetInstanceTable(in_instance->handle)->EnumeratePhysicalDevices, returnValue, in_instance, pPhysicalDeviceCount, pPhysicalDevices);
     CheckResult("vkEnumeratePhysicalDevices", returnValue, replay_result);
 
+    if (pPhysicalDevices->IsNull()) { SetOutputArrayCount<InstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDevices, *pPhysicalDeviceCount->GetOutputPointer(), &VulkanObjectInfoTable::GetInstanceInfo); }
     AddHandles<PhysicalDeviceInfo>(pPhysicalDevices->GetPointer(), pPhysicalDevices->GetLength(), pPhysicalDevices->GetHandlePointer(), *pPhysicalDeviceCount->GetOutputPointer(), std::move(handle_info), &VulkanObjectInfoTable::AddPhysicalDeviceInfo);
 }
 
@@ -132,6 +133,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties(
     VkQueueFamilyProperties* out_pQueueFamilyProperties = pQueueFamilyProperties->IsNull() ? nullptr : pQueueFamilyProperties->AllocateOutputData(*out_pQueueFamilyPropertyCount);
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceQueueFamilyProperties(in_physicalDevice, out_pQueueFamilyPropertyCount, out_pQueueFamilyProperties);
+
+    if (pQueueFamilyProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties, *out_pQueueFamilyPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMemoryProperties(
@@ -391,6 +394,8 @@ void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements(
     VkSparseImageMemoryRequirements* out_pSparseMemoryRequirements = pSparseMemoryRequirements->IsNull() ? nullptr : pSparseMemoryRequirements->AllocateOutputData(*out_pSparseMemoryRequirementCount);
 
     GetDeviceTable(in_device)->GetImageSparseMemoryRequirements(in_device, in_image, out_pSparseMemoryRequirementCount, out_pSparseMemoryRequirements);
+
+    if (pSparseMemoryRequirements->IsNull()) { SetOutputArrayCount<ImageInfo>(image, kImageArrayGetImageSparseMemoryRequirements, *out_pSparseMemoryRequirementCount, &VulkanObjectInfoTable::GetImageInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties(
@@ -408,6 +413,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
     VkSparseImageFormatProperties* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount);
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties(in_physicalDevice, format, type, samples, usage, tiling, out_pPropertyCount, out_pProperties);
+
+    if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkQueueBindSparse(
@@ -858,6 +865,8 @@ void VulkanReplayConsumer::Process_vkGetPipelineCacheData(
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineCacheData(in_device, in_pipelineCache, out_pDataSize, out_pData);
     CheckResult("vkGetPipelineCacheData", returnValue, replay_result);
+
+    if (pData->IsNull()) { SetOutputArrayCount<PipelineCacheInfo>(pipelineCache, kPipelineCacheArrayGetPipelineCacheData, *out_pDataSize, &VulkanObjectInfoTable::GetPipelineCacheInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkMergePipelineCaches(
@@ -1967,6 +1976,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroups(
     VkResult replay_result = GetInstanceTable(in_instance)->EnumeratePhysicalDeviceGroups(in_instance, out_pPhysicalDeviceGroupCount, out_pPhysicalDeviceGroupProperties);
     CheckResult("vkEnumeratePhysicalDeviceGroups", returnValue, replay_result);
 
+    if (pPhysicalDeviceGroupProperties->IsNull()) { SetOutputArrayCount<InstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDeviceGroups, *out_pPhysicalDeviceGroupCount, &VulkanObjectInfoTable::GetInstanceInfo); }
     AddStructArrayHandles<Decoded_VkPhysicalDeviceGroupProperties>(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), out_pPhysicalDeviceGroupProperties, *out_pPhysicalDeviceGroupCount, GetObjectInfoTable());
 }
 
@@ -2009,6 +2019,8 @@ void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements2(
     VkSparseImageMemoryRequirements2* out_pSparseMemoryRequirements = pSparseMemoryRequirements->IsNull() ? nullptr : pSparseMemoryRequirements->AllocateOutputData(*out_pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2, nullptr });
 
     GetDeviceTable(in_device)->GetImageSparseMemoryRequirements2(in_device, in_pInfo, out_pSparseMemoryRequirementCount, out_pSparseMemoryRequirements);
+
+    if (pSparseMemoryRequirements->IsNull()) { SetOutputArrayCount<DeviceInfo>(device, kDeviceArrayGetImageSparseMemoryRequirements2, *out_pSparseMemoryRequirementCount, &VulkanObjectInfoTable::GetDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFeatures2(
@@ -2066,6 +2078,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2(
     VkQueueFamilyProperties2* out_pQueueFamilyProperties = pQueueFamilyProperties->IsNull() ? nullptr : pQueueFamilyProperties->AllocateOutputData(*out_pQueueFamilyPropertyCount, VkQueueFamilyProperties2{ VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceQueueFamilyProperties2(in_physicalDevice, out_pQueueFamilyPropertyCount, out_pQueueFamilyProperties);
+
+    if (pQueueFamilyProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2, *out_pQueueFamilyPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMemoryProperties2(
@@ -2090,6 +2104,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
     VkSparseImageFormatProperties2* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkSparseImageFormatProperties2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties2(in_physicalDevice, in_pFormatInfo, out_pPropertyCount, out_pProperties);
+
+    if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties2, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkTrimCommandPool(
@@ -2283,6 +2299,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceFormatsKHR(in_physicalDevice, in_surface, out_pSurfaceFormatCount, out_pSurfaceFormats);
     CheckResult("vkGetPhysicalDeviceSurfaceFormatsKHR", returnValue, replay_result);
+
+    if (pSurfaceFormats->IsNull()) { SetOutputArrayCount<SurfaceKHRInfo>(surface, kSurfaceKHRArrayGetPhysicalDeviceSurfaceFormatsKHR, *out_pSurfaceFormatCount, &VulkanObjectInfoTable::GetSurfaceKHRInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
@@ -2299,6 +2317,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfacePresentModesKHR(in_physicalDevice, in_surface, out_pPresentModeCount, out_pPresentModes);
     CheckResult("vkGetPhysicalDeviceSurfacePresentModesKHR", returnValue, replay_result);
+
+    if (pPresentModes->IsNull()) { SetOutputArrayCount<SurfaceKHRInfo>(surface, kSurfaceKHRArrayGetPhysicalDeviceSurfacePresentModesKHR, *out_pPresentModeCount, &VulkanObjectInfoTable::GetSurfaceKHRInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCreateSwapchainKHR(
@@ -2349,6 +2369,7 @@ void VulkanReplayConsumer::Process_vkGetSwapchainImagesKHR(
     VkResult replay_result = GetDeviceTable(in_device)->GetSwapchainImagesKHR(in_device, in_swapchain, out_pSwapchainImageCount, out_pSwapchainImages);
     CheckResult("vkGetSwapchainImagesKHR", returnValue, replay_result);
 
+    if (pSwapchainImages->IsNull()) { SetOutputArrayCount<SwapchainKHRInfo>(swapchain, kSwapchainKHRArrayGetSwapchainImagesKHR, *out_pSwapchainImageCount, &VulkanObjectInfoTable::GetSwapchainKHRInfo); }
     AddHandles<ImageInfo>(pSwapchainImages->GetPointer(), pSwapchainImages->GetLength(), out_pSwapchainImages, *out_pSwapchainImageCount, &VulkanObjectInfoTable::AddImageInfo);
 }
 
@@ -2424,6 +2445,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDevicePresentRectanglesKHR(in_physicalDevice, in_surface, out_pRectCount, out_pRects);
     CheckResult("vkGetPhysicalDevicePresentRectanglesKHR", returnValue, replay_result);
+
+    if (pRects->IsNull()) { SetOutputArrayCount<SurfaceKHRInfo>(surface, kSurfaceKHRArrayGetPhysicalDevicePresentRectanglesKHR, *out_pRectCount, &VulkanObjectInfoTable::GetSurfaceKHRInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkAcquireNextImage2KHR(
@@ -2454,6 +2477,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPropertiesKHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetPhysicalDeviceDisplayPropertiesKHR", returnValue, replay_result);
 
+    if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
     AddStructArrayHandles<Decoded_VkDisplayPropertiesKHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, GetObjectInfoTable());
 }
 
@@ -2470,6 +2494,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPlanePropertiesKHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", returnValue, replay_result);
 
+    if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlanePropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
     AddStructArrayHandles<Decoded_VkDisplayPlanePropertiesKHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, GetObjectInfoTable());
 }
 
@@ -2488,6 +2513,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayPlaneSupportedDisplaysKHR(in_physicalDevice, planeIndex, out_pDisplayCount, out_pDisplays);
     CheckResult("vkGetDisplayPlaneSupportedDisplaysKHR", returnValue, replay_result);
 
+    if (pDisplays->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetDisplayPlaneSupportedDisplaysKHR, *out_pDisplayCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
     AddHandles<DisplayKHRInfo>(pDisplays->GetPointer(), pDisplays->GetLength(), out_pDisplays, *out_pDisplayCount, &VulkanObjectInfoTable::AddDisplayKHRInfo);
 }
 
@@ -2506,6 +2532,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayModePropertiesKHR(
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayModePropertiesKHR(in_physicalDevice, in_display, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetDisplayModePropertiesKHR", returnValue, replay_result);
 
+    if (pProperties->IsNull()) { SetOutputArrayCount<DisplayKHRInfo>(display, kDisplayKHRArrayGetDisplayModePropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetDisplayKHRInfo); }
     AddStructArrayHandles<Decoded_VkDisplayModePropertiesKHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, GetObjectInfoTable());
 }
 
@@ -2779,6 +2806,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
     VkQueueFamilyProperties2* out_pQueueFamilyProperties = pQueueFamilyProperties->IsNull() ? nullptr : pQueueFamilyProperties->AllocateOutputData(*out_pQueueFamilyPropertyCount, VkQueueFamilyProperties2{ VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceQueueFamilyProperties2KHR(in_physicalDevice, out_pQueueFamilyPropertyCount, out_pQueueFamilyProperties);
+
+    if (pQueueFamilyProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceQueueFamilyProperties2KHR, *out_pQueueFamilyPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMemoryProperties2KHR(
@@ -2803,6 +2832,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
     VkSparseImageFormatProperties2* out_pProperties = pProperties->IsNull() ? nullptr : pProperties->AllocateOutputData(*out_pPropertyCount, VkSparseImageFormatProperties2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2, nullptr });
 
     GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSparseImageFormatProperties2KHR(in_physicalDevice, in_pFormatInfo, out_pPropertyCount, out_pProperties);
+
+    if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSparseImageFormatProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(
@@ -2866,6 +2897,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
     VkResult replay_result = GetInstanceTable(in_instance)->EnumeratePhysicalDeviceGroupsKHR(in_instance, out_pPhysicalDeviceGroupCount, out_pPhysicalDeviceGroupProperties);
     CheckResult("vkEnumeratePhysicalDeviceGroupsKHR", returnValue, replay_result);
 
+    if (pPhysicalDeviceGroupProperties->IsNull()) { SetOutputArrayCount<InstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDeviceGroupsKHR, *out_pPhysicalDeviceGroupCount, &VulkanObjectInfoTable::GetInstanceInfo); }
     AddStructArrayHandles<Decoded_VkPhysicalDeviceGroupProperties>(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), out_pPhysicalDeviceGroupProperties, *out_pPhysicalDeviceGroupCount, GetObjectInfoTable());
 }
 
@@ -3225,6 +3257,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceFormats2KHR(in_physicalDevice, in_pSurfaceInfo, out_pSurfaceFormatCount, out_pSurfaceFormats);
     CheckResult("vkGetPhysicalDeviceSurfaceFormats2KHR", returnValue, replay_result);
+
+    if (pSurfaceFormats->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfaceFormats2KHR, *out_pSurfaceFormatCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
@@ -3240,6 +3274,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayProperties2KHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetPhysicalDeviceDisplayProperties2KHR", returnValue, replay_result);
 
+    if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
     AddStructArrayHandles<Decoded_VkDisplayProperties2KHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, GetObjectInfoTable());
 }
 
@@ -3256,6 +3291,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceDisplayPlaneProperties2KHR(in_physicalDevice, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", returnValue, replay_result);
 
+    if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlaneProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
     AddStructArrayHandles<Decoded_VkDisplayPlaneProperties2KHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, GetObjectInfoTable());
 }
 
@@ -3274,6 +3310,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayModeProperties2KHR(
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetDisplayModeProperties2KHR(in_physicalDevice, in_display, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetDisplayModeProperties2KHR", returnValue, replay_result);
 
+    if (pProperties->IsNull()) { SetOutputArrayCount<DisplayKHRInfo>(display, kDisplayKHRArrayGetDisplayModeProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetDisplayKHRInfo); }
     AddStructArrayHandles<Decoded_VkDisplayModeProperties2KHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, GetObjectInfoTable());
 }
 
@@ -3331,6 +3368,8 @@ void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements2KHR(
     VkSparseImageMemoryRequirements2* out_pSparseMemoryRequirements = pSparseMemoryRequirements->IsNull() ? nullptr : pSparseMemoryRequirements->AllocateOutputData(*out_pSparseMemoryRequirementCount, VkSparseImageMemoryRequirements2{ VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2, nullptr });
 
     GetDeviceTable(in_device)->GetImageSparseMemoryRequirements2KHR(in_device, in_pInfo, out_pSparseMemoryRequirementCount, out_pSparseMemoryRequirements);
+
+    if (pSparseMemoryRequirements->IsNull()) { SetOutputArrayCount<DeviceInfo>(device, kDeviceArrayGetImageSparseMemoryRequirements2KHR, *out_pSparseMemoryRequirementCount, &VulkanObjectInfoTable::GetDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
@@ -3493,6 +3532,8 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineExecutablePropertiesKHR(in_device, in_pPipelineInfo, out_pExecutableCount, out_pProperties);
     CheckResult("vkGetPipelineExecutablePropertiesKHR", returnValue, replay_result);
+
+    if (pProperties->IsNull()) { SetOutputArrayCount<DeviceInfo>(device, kDeviceArrayGetPipelineExecutablePropertiesKHR, *out_pExecutableCount, &VulkanObjectInfoTable::GetDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
@@ -3510,6 +3551,8 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineExecutableStatisticsKHR(in_device, in_pExecutableInfo, out_pStatisticCount, out_pStatistics);
     CheckResult("vkGetPipelineExecutableStatisticsKHR", returnValue, replay_result);
+
+    if (pStatistics->IsNull()) { SetOutputArrayCount<DeviceInfo>(device, kDeviceArrayGetPipelineExecutableStatisticsKHR, *out_pStatisticCount, &VulkanObjectInfoTable::GetDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPipelineExecutableInternalRepresentationsKHR(
@@ -3527,6 +3570,8 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutableInternalRepresentation
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPipelineExecutableInternalRepresentationsKHR(in_device, in_pExecutableInfo, out_pInternalRepresentationCount, out_pInternalRepresentations);
     CheckResult("vkGetPipelineExecutableInternalRepresentationsKHR", returnValue, replay_result);
+
+    if (pInternalRepresentations->IsNull()) { SetOutputArrayCount<DeviceInfo>(device, kDeviceArrayGetPipelineExecutableInternalRepresentationsKHR, *out_pInternalRepresentationCount, &VulkanObjectInfoTable::GetDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCreateDebugReportCallbackEXT(
@@ -3772,6 +3817,8 @@ void VulkanReplayConsumer::Process_vkGetShaderInfoAMD(
 
     VkResult replay_result = GetDeviceTable(in_device)->GetShaderInfoAMD(in_device, in_pipeline, shaderStage, infoType, out_pInfoSize, out_pInfo);
     CheckResult("vkGetShaderInfoAMD", returnValue, replay_result);
+
+    if (pInfo->IsNull()) { SetOutputArrayCount<PipelineInfo>(pipeline, kPipelineArrayGetShaderInfoAMD, *out_pInfoSize, &VulkanObjectInfoTable::GetPipelineInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
@@ -4146,6 +4193,8 @@ void VulkanReplayConsumer::Process_vkGetPastPresentationTimingGOOGLE(
 
     VkResult replay_result = GetDeviceTable(in_device)->GetPastPresentationTimingGOOGLE(in_device, in_swapchain, out_pPresentationTimingCount, out_pPresentationTimings);
     CheckResult("vkGetPastPresentationTimingGOOGLE", returnValue, replay_result);
+
+    if (pPresentationTimings->IsNull()) { SetOutputArrayCount<SwapchainKHRInfo>(swapchain, kSwapchainKHRArrayGetPastPresentationTimingGOOGLE, *out_pPresentationTimingCount, &VulkanObjectInfoTable::GetSwapchainKHRInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDiscardRectangleEXT(
@@ -4459,6 +4508,8 @@ void VulkanReplayConsumer::Process_vkGetValidationCacheDataEXT(
 
     VkResult replay_result = GetDeviceTable(in_device)->GetValidationCacheDataEXT(in_device, in_validationCache, out_pDataSize, out_pData);
     CheckResult("vkGetValidationCacheDataEXT", returnValue, replay_result);
+
+    if (pData->IsNull()) { SetOutputArrayCount<ValidationCacheEXTInfo>(validationCache, kValidationCacheEXTArrayGetValidationCacheDataEXT, *out_pDataSize, &VulkanObjectInfoTable::GetValidationCacheEXTInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkCmdBindShadingRateImageNV(
@@ -4739,6 +4790,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEX
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceCalibrateableTimeDomainsEXT(in_physicalDevice, out_pTimeDomainCount, out_pTimeDomains);
     CheckResult("vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", returnValue, replay_result);
+
+    if (pTimeDomains->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCalibrateableTimeDomainsEXT, *out_pTimeDomainCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetCalibratedTimestampsEXT(
@@ -4829,6 +4882,8 @@ void VulkanReplayConsumer::Process_vkGetQueueCheckpointDataNV(
     VkCheckpointDataNV* out_pCheckpointData = pCheckpointData->IsNull() ? nullptr : pCheckpointData->AllocateOutputData(*out_pCheckpointDataCount, VkCheckpointDataNV{ VK_STRUCTURE_TYPE_CHECKPOINT_DATA_NV, nullptr });
 
     GetDeviceTable(in_queue)->GetQueueCheckpointDataNV(in_queue, out_pCheckpointDataCount, out_pCheckpointData);
+
+    if (pCheckpointData->IsNull()) { SetOutputArrayCount<QueueInfo>(queue, kQueueArrayGetQueueCheckpointDataNV, *out_pCheckpointDataCount, &VulkanObjectInfoTable::GetQueueInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkInitializePerformanceApiINTEL(
@@ -5014,6 +5069,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixPropertie
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceCooperativeMatrixPropertiesNV(in_physicalDevice, out_pPropertyCount, out_pProperties);
     CheckResult("vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", returnValue, replay_result);
+
+    if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceCooperativeMatrixPropertiesNV, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(
@@ -5028,6 +5085,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedS
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(in_physicalDevice, out_pCombinationCount, out_pCombinations);
     CheckResult("vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", returnValue, replay_result);
+
+    if (pCombinations->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV, *out_pCombinationCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
@@ -5045,6 +5104,8 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
 
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfacePresentModes2EXT(in_physicalDevice, in_pSurfaceInfo, out_pPresentModeCount, out_pPresentModes);
     CheckResult("vkGetPhysicalDeviceSurfacePresentModes2EXT", returnValue, replay_result);
+
+    if (pPresentModes->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceSurfacePresentModes2EXT, *out_pPresentModeCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
 }
 
 void VulkanReplayConsumer::Process_vkAcquireFullScreenExclusiveModeEXT(

--- a/framework/generated/generated_vulkan_replay_consumer.h
+++ b/framework/generated/generated_vulkan_replay_consumer.h
@@ -40,13 +40,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
 
     virtual void Process_vkCreateInstance(
         VkResult                                    returnValue,
-        const StructPointerDecoder<Decoded_VkInstanceCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkInstanceCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkInstance>*           pInstance) override;
 
     virtual void Process_vkDestroyInstance(
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkEnumeratePhysicalDevices(
         VkResult                                    returnValue,
@@ -89,13 +89,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCreateDevice(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkDeviceCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDeviceCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDevice>*             pDevice) override;
 
     virtual void Process_vkDestroyDevice(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetDeviceQueue(
         format::HandleId                            device,
@@ -107,7 +107,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    submitCount,
-        const StructPointerDecoder<Decoded_VkSubmitInfo>& pSubmits,
+        StructPointerDecoder<Decoded_VkSubmitInfo>* pSubmits,
         format::HandleId                            fence) override;
 
     virtual void Process_vkQueueWaitIdle(
@@ -121,14 +121,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkAllocateMemory(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkMemoryAllocateInfo>& pAllocateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkMemoryAllocateInfo>* pAllocateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDeviceMemory>*       pMemory) override;
 
     virtual void Process_vkFreeMemory(
         format::HandleId                            device,
         format::HandleId                            memory,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkMapMemory(
         VkResult                                    returnValue,
@@ -147,13 +147,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    memoryRangeCount,
-        const StructPointerDecoder<Decoded_VkMappedMemoryRange>& pMemoryRanges) override;
+        StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges) override;
 
     virtual void Process_vkInvalidateMappedMemoryRanges(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    memoryRangeCount,
-        const StructPointerDecoder<Decoded_VkMappedMemoryRange>& pMemoryRanges) override;
+        StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges) override;
 
     virtual void Process_vkGetDeviceMemoryCommitment(
         format::HandleId                            device,
@@ -204,26 +204,26 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindSparseInfo>& pBindInfo,
+        StructPointerDecoder<Decoded_VkBindSparseInfo>* pBindInfo,
         format::HandleId                            fence) override;
 
     virtual void Process_vkCreateFence(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkFenceCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkFenceCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkFence>*              pFence) override;
 
     virtual void Process_vkDestroyFence(
         format::HandleId                            device,
         format::HandleId                            fence,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkResetFences(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    fenceCount,
-        const HandlePointerDecoder<VkFence>&        pFences) override;
+        HandlePointerDecoder<VkFence>*              pFences) override;
 
     virtual void Process_vkGetFenceStatus(
         VkResult                                    returnValue,
@@ -234,33 +234,33 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    fenceCount,
-        const HandlePointerDecoder<VkFence>&        pFences,
+        HandlePointerDecoder<VkFence>*              pFences,
         VkBool32                                    waitAll,
         uint64_t                                    timeout) override;
 
     virtual void Process_vkCreateSemaphore(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSemaphoreCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSemaphoreCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSemaphore>*          pSemaphore) override;
 
     virtual void Process_vkDestroySemaphore(
         format::HandleId                            device,
         format::HandleId                            semaphore,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateEvent(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkEventCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkEventCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkEvent>*              pEvent) override;
 
     virtual void Process_vkDestroyEvent(
         format::HandleId                            device,
         format::HandleId                            event,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetEventStatus(
         VkResult                                    returnValue,
@@ -280,14 +280,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCreateQueryPool(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkQueryPoolCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkQueryPoolCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkQueryPool>*          pQueryPool) override;
 
     virtual void Process_vkDestroyQueryPool(
         format::HandleId                            device,
         format::HandleId                            queryPool,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetQueryPoolResults(
         VkResult                                    returnValue,
@@ -303,80 +303,80 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCreateBuffer(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkBufferCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkBufferCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkBuffer>*             pBuffer) override;
 
     virtual void Process_vkDestroyBuffer(
         format::HandleId                            device,
         format::HandleId                            buffer,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateBufferView(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkBufferViewCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkBufferViewCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkBufferView>*         pView) override;
 
     virtual void Process_vkDestroyBufferView(
         format::HandleId                            device,
         format::HandleId                            bufferView,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateImage(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkImageCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkImage>*              pImage) override;
 
     virtual void Process_vkDestroyImage(
         format::HandleId                            device,
         format::HandleId                            image,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetImageSubresourceLayout(
         format::HandleId                            device,
         format::HandleId                            image,
-        const StructPointerDecoder<Decoded_VkImageSubresource>& pSubresource,
+        StructPointerDecoder<Decoded_VkImageSubresource>* pSubresource,
         StructPointerDecoder<Decoded_VkSubresourceLayout>* pLayout) override;
 
     virtual void Process_vkCreateImageView(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageViewCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkImageViewCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkImageView>*          pView) override;
 
     virtual void Process_vkDestroyImageView(
         format::HandleId                            device,
         format::HandleId                            imageView,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateShaderModule(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkShaderModule>*       pShaderModule) override;
 
     virtual void Process_vkDestroyShaderModule(
         format::HandleId                            device,
         format::HandleId                            shaderModule,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreatePipelineCache(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkPipelineCache>*      pPipelineCache) override;
 
     virtual void Process_vkDestroyPipelineCache(
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetPipelineCacheData(
         VkResult                                    returnValue,
@@ -390,15 +390,15 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            device,
         format::HandleId                            dstCache,
         uint32_t                                    srcCacheCount,
-        const HandlePointerDecoder<VkPipelineCache>& pSrcCaches) override;
+        HandlePointerDecoder<VkPipelineCache>*      pSrcCaches) override;
 
     virtual void Process_vkCreateGraphicsPipelines(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
         uint32_t                                    createInfoCount,
-        const StructPointerDecoder<Decoded_VkGraphicsPipelineCreateInfo>& pCreateInfos,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkGraphicsPipelineCreateInfo>* pCreateInfos,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkPipeline>*           pPipelines) override;
 
     virtual void Process_vkCreateComputePipelines(
@@ -406,62 +406,62 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
         uint32_t                                    createInfoCount,
-        const StructPointerDecoder<Decoded_VkComputePipelineCreateInfo>& pCreateInfos,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkComputePipelineCreateInfo>* pCreateInfos,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkPipeline>*           pPipelines) override;
 
     virtual void Process_vkDestroyPipeline(
         format::HandleId                            device,
         format::HandleId                            pipeline,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreatePipelineLayout(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPipelineLayoutCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkPipelineLayoutCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkPipelineLayout>*     pPipelineLayout) override;
 
     virtual void Process_vkDestroyPipelineLayout(
         format::HandleId                            device,
         format::HandleId                            pipelineLayout,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateSampler(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSamplerCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSamplerCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSampler>*            pSampler) override;
 
     virtual void Process_vkDestroySampler(
         format::HandleId                            device,
         format::HandleId                            sampler,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateDescriptorSetLayout(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDescriptorSetLayout>* pSetLayout) override;
 
     virtual void Process_vkDestroyDescriptorSetLayout(
         format::HandleId                            device,
         format::HandleId                            descriptorSetLayout,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateDescriptorPool(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDescriptorPool>*     pDescriptorPool) override;
 
     virtual void Process_vkDestroyDescriptorPool(
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkResetDescriptorPool(
         VkResult                                    returnValue,
@@ -472,7 +472,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkAllocateDescriptorSets(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>& pAllocateInfo,
+        StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
         HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) override;
 
     virtual void Process_vkFreeDescriptorSets(
@@ -480,38 +480,38 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
         uint32_t                                    descriptorSetCount,
-        const HandlePointerDecoder<VkDescriptorSet>& pDescriptorSets) override;
+        HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) override;
 
     virtual void Process_vkUpdateDescriptorSets(
         format::HandleId                            device,
         uint32_t                                    descriptorWriteCount,
-        const StructPointerDecoder<Decoded_VkWriteDescriptorSet>& pDescriptorWrites,
+        StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites,
         uint32_t                                    descriptorCopyCount,
-        const StructPointerDecoder<Decoded_VkCopyDescriptorSet>& pDescriptorCopies) override;
+        StructPointerDecoder<Decoded_VkCopyDescriptorSet>* pDescriptorCopies) override;
 
     virtual void Process_vkCreateFramebuffer(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkFramebufferCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkFramebuffer>*        pFramebuffer) override;
 
     virtual void Process_vkDestroyFramebuffer(
         format::HandleId                            device,
         format::HandleId                            framebuffer,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateRenderPass(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkRenderPassCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkRenderPassCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkRenderPass>*         pRenderPass) override;
 
     virtual void Process_vkDestroyRenderPass(
         format::HandleId                            device,
         format::HandleId                            renderPass,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetRenderAreaGranularity(
         format::HandleId                            device,
@@ -521,14 +521,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCreateCommandPool(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkCommandPool>*        pCommandPool) override;
 
     virtual void Process_vkDestroyCommandPool(
         format::HandleId                            device,
         format::HandleId                            commandPool,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkResetCommandPool(
         VkResult                                    returnValue,
@@ -539,19 +539,19 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkAllocateCommandBuffers(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>& pAllocateInfo,
+        StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
         HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) override;
 
     virtual void Process_vkFreeCommandBuffers(
         format::HandleId                            device,
         format::HandleId                            commandPool,
         uint32_t                                    commandBufferCount,
-        const HandlePointerDecoder<VkCommandBuffer>& pCommandBuffers) override;
+        HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) override;
 
     virtual void Process_vkBeginCommandBuffer(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>& pBeginInfo) override;
+        StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo) override;
 
     virtual void Process_vkEndCommandBuffer(
         VkResult                                    returnValue,
@@ -571,13 +571,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
-        const StructPointerDecoder<Decoded_VkViewport>& pViewports) override;
+        StructPointerDecoder<Decoded_VkViewport>*   pViewports) override;
 
     virtual void Process_vkCmdSetScissor(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstScissor,
         uint32_t                                    scissorCount,
-        const StructPointerDecoder<Decoded_VkRect2D>& pScissors) override;
+        StructPointerDecoder<Decoded_VkRect2D>*     pScissors) override;
 
     virtual void Process_vkCmdSetLineWidth(
         format::HandleId                            commandBuffer,
@@ -591,7 +591,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
 
     virtual void Process_vkCmdSetBlendConstants(
         format::HandleId                            commandBuffer,
-        const PointerDecoder<float>&                blendConstants) override;
+        PointerDecoder<float>*                      blendConstants) override;
 
     virtual void Process_vkCmdSetDepthBounds(
         format::HandleId                            commandBuffer,
@@ -619,9 +619,9 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            layout,
         uint32_t                                    firstSet,
         uint32_t                                    descriptorSetCount,
-        const HandlePointerDecoder<VkDescriptorSet>& pDescriptorSets,
+        HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets,
         uint32_t                                    dynamicOffsetCount,
-        const PointerDecoder<uint32_t>&             pDynamicOffsets) override;
+        PointerDecoder<uint32_t>*                   pDynamicOffsets) override;
 
     virtual void Process_vkCmdBindIndexBuffer(
         format::HandleId                            commandBuffer,
@@ -633,8 +633,8 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
-        const HandlePointerDecoder<VkBuffer>&       pBuffers,
-        const PointerDecoder<VkDeviceSize>&         pOffsets) override;
+        HandlePointerDecoder<VkBuffer>*             pBuffers,
+        PointerDecoder<VkDeviceSize>*               pOffsets) override;
 
     virtual void Process_vkCmdDraw(
         format::HandleId                            commandBuffer,
@@ -681,7 +681,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            srcBuffer,
         format::HandleId                            dstBuffer,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkBufferCopy>& pRegions) override;
+        StructPointerDecoder<Decoded_VkBufferCopy>* pRegions) override;
 
     virtual void Process_vkCmdCopyImage(
         format::HandleId                            commandBuffer,
@@ -690,7 +690,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            dstImage,
         VkImageLayout                               dstImageLayout,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkImageCopy>& pRegions) override;
+        StructPointerDecoder<Decoded_VkImageCopy>*  pRegions) override;
 
     virtual void Process_vkCmdBlitImage(
         format::HandleId                            commandBuffer,
@@ -699,7 +699,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            dstImage,
         VkImageLayout                               dstImageLayout,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkImageBlit>& pRegions,
+        StructPointerDecoder<Decoded_VkImageBlit>*  pRegions,
         VkFilter                                    filter) override;
 
     virtual void Process_vkCmdCopyBufferToImage(
@@ -708,7 +708,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            dstImage,
         VkImageLayout                               dstImageLayout,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkBufferImageCopy>& pRegions) override;
+        StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions) override;
 
     virtual void Process_vkCmdCopyImageToBuffer(
         format::HandleId                            commandBuffer,
@@ -716,14 +716,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkImageLayout                               srcImageLayout,
         format::HandleId                            dstBuffer,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkBufferImageCopy>& pRegions) override;
+        StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions) override;
 
     virtual void Process_vkCmdUpdateBuffer(
         format::HandleId                            commandBuffer,
         format::HandleId                            dstBuffer,
         VkDeviceSize                                dstOffset,
         VkDeviceSize                                dataSize,
-        const PointerDecoder<uint8_t>&              pData) override;
+        PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkCmdFillBuffer(
         format::HandleId                            commandBuffer,
@@ -736,24 +736,24 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            commandBuffer,
         format::HandleId                            image,
         VkImageLayout                               imageLayout,
-        const StructPointerDecoder<Decoded_VkClearColorValue>& pColor,
+        StructPointerDecoder<Decoded_VkClearColorValue>* pColor,
         uint32_t                                    rangeCount,
-        const StructPointerDecoder<Decoded_VkImageSubresourceRange>& pRanges) override;
+        StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges) override;
 
     virtual void Process_vkCmdClearDepthStencilImage(
         format::HandleId                            commandBuffer,
         format::HandleId                            image,
         VkImageLayout                               imageLayout,
-        const StructPointerDecoder<Decoded_VkClearDepthStencilValue>& pDepthStencil,
+        StructPointerDecoder<Decoded_VkClearDepthStencilValue>* pDepthStencil,
         uint32_t                                    rangeCount,
-        const StructPointerDecoder<Decoded_VkImageSubresourceRange>& pRanges) override;
+        StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges) override;
 
     virtual void Process_vkCmdClearAttachments(
         format::HandleId                            commandBuffer,
         uint32_t                                    attachmentCount,
-        const StructPointerDecoder<Decoded_VkClearAttachment>& pAttachments,
+        StructPointerDecoder<Decoded_VkClearAttachment>* pAttachments,
         uint32_t                                    rectCount,
-        const StructPointerDecoder<Decoded_VkClearRect>& pRects) override;
+        StructPointerDecoder<Decoded_VkClearRect>*  pRects) override;
 
     virtual void Process_vkCmdResolveImage(
         format::HandleId                            commandBuffer,
@@ -762,7 +762,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            dstImage,
         VkImageLayout                               dstImageLayout,
         uint32_t                                    regionCount,
-        const StructPointerDecoder<Decoded_VkImageResolve>& pRegions) override;
+        StructPointerDecoder<Decoded_VkImageResolve>* pRegions) override;
 
     virtual void Process_vkCmdSetEvent(
         format::HandleId                            commandBuffer,
@@ -777,15 +777,15 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCmdWaitEvents(
         format::HandleId                            commandBuffer,
         uint32_t                                    eventCount,
-        const HandlePointerDecoder<VkEvent>&        pEvents,
+        HandlePointerDecoder<VkEvent>*              pEvents,
         VkPipelineStageFlags                        srcStageMask,
         VkPipelineStageFlags                        dstStageMask,
         uint32_t                                    memoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkMemoryBarrier>& pMemoryBarriers,
+        StructPointerDecoder<Decoded_VkMemoryBarrier>* pMemoryBarriers,
         uint32_t                                    bufferMemoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkBufferMemoryBarrier>& pBufferMemoryBarriers,
+        StructPointerDecoder<Decoded_VkBufferMemoryBarrier>* pBufferMemoryBarriers,
         uint32_t                                    imageMemoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkImageMemoryBarrier>& pImageMemoryBarriers) override;
+        StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers) override;
 
     virtual void Process_vkCmdPipelineBarrier(
         format::HandleId                            commandBuffer,
@@ -793,11 +793,11 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkPipelineStageFlags                        dstStageMask,
         VkDependencyFlags                           dependencyFlags,
         uint32_t                                    memoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkMemoryBarrier>& pMemoryBarriers,
+        StructPointerDecoder<Decoded_VkMemoryBarrier>* pMemoryBarriers,
         uint32_t                                    bufferMemoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkBufferMemoryBarrier>& pBufferMemoryBarriers,
+        StructPointerDecoder<Decoded_VkBufferMemoryBarrier>* pBufferMemoryBarriers,
         uint32_t                                    imageMemoryBarrierCount,
-        const StructPointerDecoder<Decoded_VkImageMemoryBarrier>& pImageMemoryBarriers) override;
+        StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers) override;
 
     virtual void Process_vkCmdBeginQuery(
         format::HandleId                            commandBuffer,
@@ -838,11 +838,11 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkShaderStageFlags                          stageFlags,
         uint32_t                                    offset,
         uint32_t                                    size,
-        const PointerDecoder<uint8_t>&              pValues) override;
+        PointerDecoder<uint8_t>*                    pValues) override;
 
     virtual void Process_vkCmdBeginRenderPass(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkRenderPassBeginInfo>& pRenderPassBegin,
+        StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
         VkSubpassContents                           contents) override;
 
     virtual void Process_vkCmdNextSubpass(
@@ -855,19 +855,19 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCmdExecuteCommands(
         format::HandleId                            commandBuffer,
         uint32_t                                    commandBufferCount,
-        const HandlePointerDecoder<VkCommandBuffer>& pCommandBuffers) override;
+        HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) override;
 
     virtual void Process_vkBindBufferMemory2(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>& pBindInfos) override;
+        StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos) override;
 
     virtual void Process_vkBindImageMemory2(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>& pBindInfos) override;
+        StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos) override;
 
     virtual void Process_vkGetDeviceGroupPeerMemoryFeatures(
         format::HandleId                            device,
@@ -897,17 +897,17 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
 
     virtual void Process_vkGetImageMemoryRequirements2(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetBufferMemoryRequirements2(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetImageSparseMemoryRequirements2(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) override;
 
@@ -927,7 +927,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties2(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>& pImageFormatInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
         StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties2(
@@ -941,7 +941,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties2(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>& pFormatInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties) override;
 
@@ -952,57 +952,57 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
 
     virtual void Process_vkGetDeviceQueue2(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDeviceQueueInfo2>& pQueueInfo,
+        StructPointerDecoder<Decoded_VkDeviceQueueInfo2>* pQueueInfo,
         HandlePointerDecoder<VkQueue>*              pQueue) override;
 
     virtual void Process_vkCreateSamplerYcbcrConversion(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion) override;
 
     virtual void Process_vkDestroySamplerYcbcrConversion(
         format::HandleId                            device,
         format::HandleId                            ycbcrConversion,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateDescriptorUpdateTemplate(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate) override;
 
     virtual void Process_vkDestroyDescriptorUpdateTemplate(
         format::HandleId                            device,
         format::HandleId                            descriptorUpdateTemplate,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalBufferProperties(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>& pExternalBufferInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
         StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalFenceProperties(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>& pExternalFenceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
         StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalSemaphoreProperties(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>& pExternalSemaphoreInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
         StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties) override;
 
     virtual void Process_vkGetDescriptorSetLayoutSupport(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>& pCreateInfo,
+        StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport) override;
 
     virtual void Process_vkDestroySurfaceKHR(
         format::HandleId                            instance,
         format::HandleId                            surface,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceSupportKHR(
         VkResult                                    returnValue,
@@ -1034,14 +1034,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCreateSwapchainKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSwapchainKHR>*       pSwapchain) override;
 
     virtual void Process_vkDestroySwapchainKHR(
         format::HandleId                            device,
         format::HandleId                            swapchain,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetSwapchainImagesKHR(
         VkResult                                    returnValue,
@@ -1062,7 +1062,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkQueuePresentKHR(
         VkResult                                    returnValue,
         format::HandleId                            queue,
-        const StructPointerDecoder<Decoded_VkPresentInfoKHR>& pPresentInfo) override;
+        StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo) override;
 
     virtual void Process_vkGetDeviceGroupPresentCapabilitiesKHR(
         VkResult                                    returnValue,
@@ -1085,7 +1085,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkAcquireNextImage2KHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>& pAcquireInfo,
+        StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>* pAcquireInfo,
         PointerDecoder<uint32_t>*                   pImageIndex) override;
 
     virtual void Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
@@ -1118,8 +1118,8 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display,
-        const StructPointerDecoder<Decoded_VkDisplayModeCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDisplayModeCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDisplayModeKHR>*     pMode) override;
 
     virtual void Process_vkGetDisplayPlaneCapabilitiesKHR(
@@ -1132,23 +1132,23 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCreateDisplayPlaneSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkDisplaySurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDisplaySurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCreateSharedSwapchainsKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    swapchainCount,
-        const StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>& pCreateInfos,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfos,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains) override;
 
     virtual void Process_vkCreateXlibSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
@@ -1161,8 +1161,8 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCreateXcbSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
@@ -1175,8 +1175,8 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCreateWaylandSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceWaylandPresentationSupportKHR(
@@ -1188,15 +1188,15 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCreateAndroidSurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCreateWin32SurfaceKHR(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceWin32PresentationSupportKHR(
@@ -1220,7 +1220,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>& pImageFormatInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
         StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
@@ -1234,7 +1234,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>& pFormatInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties) override;
 
@@ -1271,13 +1271,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
 
     virtual void Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>& pExternalBufferInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
         StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties) override;
 
     virtual void Process_vkGetMemoryWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkMemoryGetWin32HandleInfoKHR>& pGetWin32HandleInfo,
+        StructPointerDecoder<Decoded_VkMemoryGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) override;
 
     virtual void Process_vkGetMemoryWin32HandlePropertiesKHR(
@@ -1290,7 +1290,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkGetMemoryFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkMemoryGetFdInfoKHR>& pGetFdInfo,
+        StructPointerDecoder<Decoded_VkMemoryGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) override;
 
     virtual void Process_vkGetMemoryFdPropertiesKHR(
@@ -1302,29 +1302,29 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
 
     virtual void Process_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>& pExternalSemaphoreInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
         StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties) override;
 
     virtual void Process_vkImportSemaphoreWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>& pImportSemaphoreWin32HandleInfo) override;
+        StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>* pImportSemaphoreWin32HandleInfo) override;
 
     virtual void Process_vkGetSemaphoreWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>& pGetWin32HandleInfo,
+        StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) override;
 
     virtual void Process_vkImportSemaphoreFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>& pImportSemaphoreFdInfo) override;
+        StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>* pImportSemaphoreFdInfo) override;
 
     virtual void Process_vkGetSemaphoreFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSemaphoreGetFdInfoKHR>& pGetFdInfo,
+        StructPointerDecoder<Decoded_VkSemaphoreGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) override;
 
     virtual void Process_vkCmdPushDescriptorSetKHR(
@@ -1333,40 +1333,40 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            layout,
         uint32_t                                    set,
         uint32_t                                    descriptorWriteCount,
-        const StructPointerDecoder<Decoded_VkWriteDescriptorSet>& pDescriptorWrites) override;
+        StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites) override;
 
     virtual void Process_vkCreateDescriptorUpdateTemplateKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate) override;
 
     virtual void Process_vkDestroyDescriptorUpdateTemplateKHR(
         format::HandleId                            device,
         format::HandleId                            descriptorUpdateTemplate,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateRenderPass2KHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkRenderPassCreateInfo2KHR>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkRenderPassCreateInfo2KHR>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkRenderPass>*         pRenderPass) override;
 
     virtual void Process_vkCmdBeginRenderPass2KHR(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkRenderPassBeginInfo>& pRenderPassBegin,
-        const StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>& pSubpassBeginInfo) override;
+        StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
+        StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>* pSubpassBeginInfo) override;
 
     virtual void Process_vkCmdNextSubpass2KHR(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>& pSubpassBeginInfo,
-        const StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>& pSubpassEndInfo) override;
+        StructPointerDecoder<Decoded_VkSubpassBeginInfoKHR>* pSubpassBeginInfo,
+        StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>* pSubpassEndInfo) override;
 
     virtual void Process_vkCmdEndRenderPass2KHR(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>& pSubpassEndInfo) override;
+        StructPointerDecoder<Decoded_VkSubpassEndInfoKHR>* pSubpassEndInfo) override;
 
     virtual void Process_vkGetSwapchainStatusKHR(
         VkResult                                    returnValue,
@@ -1375,41 +1375,41 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
 
     virtual void Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>& pExternalFenceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
         StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties) override;
 
     virtual void Process_vkImportFenceWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImportFenceWin32HandleInfoKHR>& pImportFenceWin32HandleInfo) override;
+        StructPointerDecoder<Decoded_VkImportFenceWin32HandleInfoKHR>* pImportFenceWin32HandleInfo) override;
 
     virtual void Process_vkGetFenceWin32HandleKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkFenceGetWin32HandleInfoKHR>& pGetWin32HandleInfo,
+        StructPointerDecoder<Decoded_VkFenceGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) override;
 
     virtual void Process_vkImportFenceFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImportFenceFdInfoKHR>& pImportFenceFdInfo) override;
+        StructPointerDecoder<Decoded_VkImportFenceFdInfoKHR>* pImportFenceFdInfo) override;
 
     virtual void Process_vkGetFenceFdKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkFenceGetFdInfoKHR>& pGetFdInfo,
+        StructPointerDecoder<Decoded_VkFenceGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         StructPointerDecoder<Decoded_VkSurfaceCapabilities2KHR>* pSurfaceCapabilities) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         PointerDecoder<uint32_t>*                   pSurfaceFormatCount,
         StructPointerDecoder<Decoded_VkSurfaceFormat2KHR>* pSurfaceFormats) override;
 
@@ -1435,52 +1435,52 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkGetDisplayPlaneCapabilities2KHR(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkDisplayPlaneInfo2KHR>& pDisplayPlaneInfo,
+        StructPointerDecoder<Decoded_VkDisplayPlaneInfo2KHR>* pDisplayPlaneInfo,
         StructPointerDecoder<Decoded_VkDisplayPlaneCapabilities2KHR>* pCapabilities) override;
 
     virtual void Process_vkGetImageMemoryRequirements2KHR(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetBufferMemoryRequirements2KHR(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetImageSparseMemoryRequirements2KHR(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>& pInfo,
+        StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) override;
 
     virtual void Process_vkCreateSamplerYcbcrConversionKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion) override;
 
     virtual void Process_vkDestroySamplerYcbcrConversionKHR(
         format::HandleId                            device,
         format::HandleId                            ycbcrConversion,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkBindBufferMemory2KHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>& pBindInfos) override;
+        StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos) override;
 
     virtual void Process_vkBindImageMemory2KHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindImageMemoryInfo>& pBindInfos) override;
+        StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos) override;
 
     virtual void Process_vkGetDescriptorSetLayoutSupportKHR(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>& pCreateInfo,
+        StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport) override;
 
     virtual void Process_vkCmdDrawIndirectCountKHR(
@@ -1510,46 +1510,46 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkWaitSemaphoresKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSemaphoreWaitInfoKHR>& pWaitInfo,
+        StructPointerDecoder<Decoded_VkSemaphoreWaitInfoKHR>* pWaitInfo,
         uint64_t                                    timeout) override;
 
     virtual void Process_vkSignalSemaphoreKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkSemaphoreSignalInfoKHR>& pSignalInfo) override;
+        StructPointerDecoder<Decoded_VkSemaphoreSignalInfoKHR>* pSignalInfo) override;
 
     virtual void Process_vkGetPipelineExecutablePropertiesKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPipelineInfoKHR>& pPipelineInfo,
+        StructPointerDecoder<Decoded_VkPipelineInfoKHR>* pPipelineInfo,
         PointerDecoder<uint32_t>*                   pExecutableCount,
         StructPointerDecoder<Decoded_VkPipelineExecutablePropertiesKHR>* pProperties) override;
 
     virtual void Process_vkGetPipelineExecutableStatisticsKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>& pExecutableInfo,
+        StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
         PointerDecoder<uint32_t>*                   pStatisticCount,
         StructPointerDecoder<Decoded_VkPipelineExecutableStatisticKHR>* pStatistics) override;
 
     virtual void Process_vkGetPipelineExecutableInternalRepresentationsKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>& pExecutableInfo,
+        StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
         PointerDecoder<uint32_t>*                   pInternalRepresentationCount,
         StructPointerDecoder<Decoded_VkPipelineExecutableInternalRepresentationKHR>* pInternalRepresentations) override;
 
     virtual void Process_vkCreateDebugReportCallbackEXT(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDebugReportCallbackEXT>* pCallback) override;
 
     virtual void Process_vkDestroyDebugReportCallbackEXT(
         format::HandleId                            instance,
         format::HandleId                            callback,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkDebugReportMessageEXT(
         format::HandleId                            instance,
@@ -1558,51 +1558,51 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint64_t                                    object,
         size_t                                      location,
         int32_t                                     messageCode,
-        const StringDecoder&                        pLayerPrefix,
-        const StringDecoder&                        pMessage) override;
+        StringDecoder*                              pLayerPrefix,
+        StringDecoder*                              pMessage) override;
 
     virtual void Process_vkDebugMarkerSetObjectTagEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDebugMarkerObjectTagInfoEXT>& pTagInfo) override;
+        StructPointerDecoder<Decoded_VkDebugMarkerObjectTagInfoEXT>* pTagInfo) override;
 
     virtual void Process_vkDebugMarkerSetObjectNameEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDebugMarkerObjectNameInfoEXT>& pNameInfo) override;
+        StructPointerDecoder<Decoded_VkDebugMarkerObjectNameInfoEXT>* pNameInfo) override;
 
     virtual void Process_vkCmdDebugMarkerBeginEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>& pMarkerInfo) override;
+        StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo) override;
 
     virtual void Process_vkCmdDebugMarkerEndEXT(
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkCmdDebugMarkerInsertEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>& pMarkerInfo) override;
+        StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo) override;
 
     virtual void Process_vkCmdBindTransformFeedbackBuffersEXT(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
-        const HandlePointerDecoder<VkBuffer>&       pBuffers,
-        const PointerDecoder<VkDeviceSize>&         pOffsets,
-        const PointerDecoder<VkDeviceSize>&         pSizes) override;
+        HandlePointerDecoder<VkBuffer>*             pBuffers,
+        PointerDecoder<VkDeviceSize>*               pOffsets,
+        PointerDecoder<VkDeviceSize>*               pSizes) override;
 
     virtual void Process_vkCmdBeginTransformFeedbackEXT(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstCounterBuffer,
         uint32_t                                    counterBufferCount,
-        const HandlePointerDecoder<VkBuffer>&       pCounterBuffers,
-        const PointerDecoder<VkDeviceSize>&         pCounterBufferOffsets) override;
+        HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
+        PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets) override;
 
     virtual void Process_vkCmdEndTransformFeedbackEXT(
         format::HandleId                            commandBuffer,
         uint32_t                                    firstCounterBuffer,
         uint32_t                                    counterBufferCount,
-        const HandlePointerDecoder<VkBuffer>&       pCounterBuffers,
-        const PointerDecoder<VkDeviceSize>&         pCounterBufferOffsets) override;
+        HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
+        PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets) override;
 
     virtual void Process_vkCmdBeginQueryIndexedEXT(
         format::HandleId                            commandBuffer,
@@ -1629,7 +1629,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkGetImageViewHandleNVX(
         uint32_t                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>& pInfo) override;
+        StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>* pInfo) override;
 
     virtual void Process_vkCmdDrawIndirectCountAMD(
         format::HandleId                            commandBuffer,
@@ -1661,8 +1661,8 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCreateStreamDescriptorSurfaceGGP(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkStreamDescriptorSurfaceCreateInfoGGP>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkStreamDescriptorSurfaceCreateInfoGGP>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(
@@ -1686,56 +1686,56 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCreateViSurfaceNN(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkViSurfaceCreateInfoNN>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkViSurfaceCreateInfoNN>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCmdBeginConditionalRenderingEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>& pConditionalRenderingBegin) override;
+        StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>* pConditionalRenderingBegin) override;
 
     virtual void Process_vkCmdEndConditionalRenderingEXT(
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkCmdProcessCommandsNVX(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkCmdProcessCommandsInfoNVX>& pProcessCommandsInfo) override;
+        StructPointerDecoder<Decoded_VkCmdProcessCommandsInfoNVX>* pProcessCommandsInfo) override;
 
     virtual void Process_vkCmdReserveSpaceForCommandsNVX(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkCmdReserveSpaceForCommandsInfoNVX>& pReserveSpaceInfo) override;
+        StructPointerDecoder<Decoded_VkCmdReserveSpaceForCommandsInfoNVX>* pReserveSpaceInfo) override;
 
     virtual void Process_vkCreateIndirectCommandsLayoutNVX(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkIndirectCommandsLayoutCreateInfoNVX>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkIndirectCommandsLayoutCreateInfoNVX>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkIndirectCommandsLayoutNVX>* pIndirectCommandsLayout) override;
 
     virtual void Process_vkDestroyIndirectCommandsLayoutNVX(
         format::HandleId                            device,
         format::HandleId                            indirectCommandsLayout,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateObjectTableNVX(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkObjectTableCreateInfoNVX>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkObjectTableCreateInfoNVX>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkObjectTableNVX>*     pObjectTable) override;
 
     virtual void Process_vkDestroyObjectTableNVX(
         format::HandleId                            device,
         format::HandleId                            objectTable,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkUnregisterObjectsNVX(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            objectTable,
         uint32_t                                    objectCount,
-        const PointerDecoder<VkObjectEntryTypeNVX>& pObjectEntryTypes,
-        const PointerDecoder<uint32_t>&             pObjectIndices) override;
+        PointerDecoder<VkObjectEntryTypeNVX>*       pObjectEntryTypes,
+        PointerDecoder<uint32_t>*                   pObjectIndices) override;
 
     virtual void Process_vkGetPhysicalDeviceGeneratedCommandsPropertiesNVX(
         format::HandleId                            physicalDevice,
@@ -1746,7 +1746,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
-        const StructPointerDecoder<Decoded_VkViewportWScalingNV>& pViewportWScalings) override;
+        StructPointerDecoder<Decoded_VkViewportWScalingNV>* pViewportWScalings) override;
 
     virtual void Process_vkReleaseDisplayEXT(
         VkResult                                    returnValue,
@@ -1776,21 +1776,21 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            display,
-        const StructPointerDecoder<Decoded_VkDisplayPowerInfoEXT>& pDisplayPowerInfo) override;
+        StructPointerDecoder<Decoded_VkDisplayPowerInfoEXT>* pDisplayPowerInfo) override;
 
     virtual void Process_vkRegisterDeviceEventEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDeviceEventInfoEXT>& pDeviceEventInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDeviceEventInfoEXT>* pDeviceEventInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkFence>*              pFence) override;
 
     virtual void Process_vkRegisterDisplayEventEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            display,
-        const StructPointerDecoder<Decoded_VkDisplayEventInfoEXT>& pDisplayEventInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDisplayEventInfoEXT>* pDisplayEventInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkFence>*              pFence) override;
 
     virtual void Process_vkGetSwapchainCounterEXT(
@@ -1817,77 +1817,77 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstDiscardRectangle,
         uint32_t                                    discardRectangleCount,
-        const StructPointerDecoder<Decoded_VkRect2D>& pDiscardRectangles) override;
+        StructPointerDecoder<Decoded_VkRect2D>*     pDiscardRectangles) override;
 
     virtual void Process_vkSetHdrMetadataEXT(
         format::HandleId                            device,
         uint32_t                                    swapchainCount,
-        const HandlePointerDecoder<VkSwapchainKHR>& pSwapchains,
-        const StructPointerDecoder<Decoded_VkHdrMetadataEXT>& pMetadata) override;
+        HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains,
+        StructPointerDecoder<Decoded_VkHdrMetadataEXT>* pMetadata) override;
 
     virtual void Process_vkCreateIOSSurfaceMVK(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkIOSSurfaceCreateInfoMVK>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkIOSSurfaceCreateInfoMVK>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCreateMacOSSurfaceMVK(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkMacOSSurfaceCreateInfoMVK>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkMacOSSurfaceCreateInfoMVK>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkSetDebugUtilsObjectNameEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>& pNameInfo) override;
+        StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* pNameInfo) override;
 
     virtual void Process_vkSetDebugUtilsObjectTagEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>& pTagInfo) override;
+        StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>* pTagInfo) override;
 
     virtual void Process_vkQueueBeginDebugUtilsLabelEXT(
         format::HandleId                            queue,
-        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) override;
+        StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) override;
 
     virtual void Process_vkQueueEndDebugUtilsLabelEXT(
         format::HandleId                            queue) override;
 
     virtual void Process_vkQueueInsertDebugUtilsLabelEXT(
         format::HandleId                            queue,
-        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) override;
+        StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) override;
 
     virtual void Process_vkCmdBeginDebugUtilsLabelEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) override;
+        StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) override;
 
     virtual void Process_vkCmdEndDebugUtilsLabelEXT(
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkCmdInsertDebugUtilsLabelEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>& pLabelInfo) override;
+        StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) override;
 
     virtual void Process_vkCreateDebugUtilsMessengerEXT(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDebugUtilsMessengerEXT>* pMessenger) override;
 
     virtual void Process_vkDestroyDebugUtilsMessengerEXT(
         format::HandleId                            instance,
         format::HandleId                            messenger,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkSubmitDebugUtilsMessageEXT(
         format::HandleId                            instance,
         VkDebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,
         VkDebugUtilsMessageTypeFlagsEXT             messageTypes,
-        const StructPointerDecoder<Decoded_VkDebugUtilsMessengerCallbackDataEXT>& pCallbackData) override;
+        StructPointerDecoder<Decoded_VkDebugUtilsMessengerCallbackDataEXT>* pCallbackData) override;
 
     virtual void Process_vkGetAndroidHardwareBufferPropertiesANDROID(
         VkResult                                    returnValue,
@@ -1898,12 +1898,12 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkGetMemoryAndroidHardwareBufferANDROID(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID>& pInfo,
+        StructPointerDecoder<Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID>* pInfo,
         PointerDecoder<uint64_t, void*>*            pBuffer) override;
 
     virtual void Process_vkCmdSetSampleLocationsEXT(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkSampleLocationsInfoEXT>& pSampleLocationsInfo) override;
+        StructPointerDecoder<Decoded_VkSampleLocationsInfoEXT>* pSampleLocationsInfo) override;
 
     virtual void Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(
         format::HandleId                            physicalDevice,
@@ -1919,21 +1919,21 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCreateValidationCacheEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkValidationCacheCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkValidationCacheCreateInfoEXT>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkValidationCacheEXT>* pValidationCache) override;
 
     virtual void Process_vkDestroyValidationCacheEXT(
         format::HandleId                            device,
         format::HandleId                            validationCache,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkMergeValidationCachesEXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            dstCache,
         uint32_t                                    srcCacheCount,
-        const HandlePointerDecoder<VkValidationCacheEXT>& pSrcCaches) override;
+        HandlePointerDecoder<VkValidationCacheEXT>* pSrcCaches) override;
 
     virtual void Process_vkGetValidationCacheDataEXT(
         VkResult                                    returnValue,
@@ -1951,40 +1951,40 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
-        const StructPointerDecoder<Decoded_VkShadingRatePaletteNV>& pShadingRatePalettes) override;
+        StructPointerDecoder<Decoded_VkShadingRatePaletteNV>* pShadingRatePalettes) override;
 
     virtual void Process_vkCmdSetCoarseSampleOrderNV(
         format::HandleId                            commandBuffer,
         VkCoarseSampleOrderTypeNV                   sampleOrderType,
         uint32_t                                    customSampleOrderCount,
-        const StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>& pCustomSampleOrders) override;
+        StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>* pCustomSampleOrders) override;
 
     virtual void Process_vkCreateAccelerationStructureNV(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoNV>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoNV>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructure) override;
 
     virtual void Process_vkDestroyAccelerationStructureNV(
         format::HandleId                            device,
         format::HandleId                            accelerationStructure,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator) override;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetAccelerationStructureMemoryRequirementsNV(
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkAccelerationStructureMemoryRequirementsInfoNV>& pInfo,
+        StructPointerDecoder<Decoded_VkAccelerationStructureMemoryRequirementsInfoNV>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2KHR>* pMemoryRequirements) override;
 
     virtual void Process_vkBindAccelerationStructureMemoryNV(
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
-        const StructPointerDecoder<Decoded_VkBindAccelerationStructureMemoryInfoNV>& pBindInfos) override;
+        StructPointerDecoder<Decoded_VkBindAccelerationStructureMemoryInfoNV>* pBindInfos) override;
 
     virtual void Process_vkCmdBuildAccelerationStructureNV(
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>& pInfo,
+        StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>* pInfo,
         format::HandleId                            instanceData,
         VkDeviceSize                                instanceOffset,
         VkBool32                                    update,
@@ -2021,8 +2021,8 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
         uint32_t                                    createInfoCount,
-        const StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoNV>& pCreateInfos,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoNV>* pCreateInfos,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkPipeline>*           pPipelines) override;
 
     virtual void Process_vkGetRayTracingShaderGroupHandlesNV(
@@ -2044,7 +2044,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCmdWriteAccelerationStructuresPropertiesNV(
         format::HandleId                            commandBuffer,
         uint32_t                                    accelerationStructureCount,
-        const HandlePointerDecoder<VkAccelerationStructureNV>& pAccelerationStructures,
+        HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructures,
         VkQueryType                                 queryType,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery) override;
@@ -2079,7 +2079,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    timestampCount,
-        const StructPointerDecoder<Decoded_VkCalibratedTimestampInfoEXT>& pTimestampInfos,
+        StructPointerDecoder<Decoded_VkCalibratedTimestampInfoEXT>* pTimestampInfos,
         PointerDecoder<uint64_t>*                   pTimestamps,
         PointerDecoder<uint64_t>*                   pMaxDeviation) override;
 
@@ -2108,7 +2108,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            commandBuffer,
         uint32_t                                    firstExclusiveScissor,
         uint32_t                                    exclusiveScissorCount,
-        const StructPointerDecoder<Decoded_VkRect2D>& pExclusiveScissors) override;
+        StructPointerDecoder<Decoded_VkRect2D>*     pExclusiveScissors) override;
 
     virtual void Process_vkCmdSetCheckpointNV(
         format::HandleId                            commandBuffer,
@@ -2122,7 +2122,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkInitializePerformanceApiINTEL(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkInitializePerformanceApiInfoINTEL>& pInitializeInfo) override;
+        StructPointerDecoder<Decoded_VkInitializePerformanceApiInfoINTEL>* pInitializeInfo) override;
 
     virtual void Process_vkUninitializePerformanceApiINTEL(
         format::HandleId                            device) override;
@@ -2130,22 +2130,22 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCmdSetPerformanceMarkerINTEL(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkPerformanceMarkerInfoINTEL>& pMarkerInfo) override;
+        StructPointerDecoder<Decoded_VkPerformanceMarkerInfoINTEL>* pMarkerInfo) override;
 
     virtual void Process_vkCmdSetPerformanceStreamMarkerINTEL(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkPerformanceStreamMarkerInfoINTEL>& pMarkerInfo) override;
+        StructPointerDecoder<Decoded_VkPerformanceStreamMarkerInfoINTEL>* pMarkerInfo) override;
 
     virtual void Process_vkCmdSetPerformanceOverrideINTEL(
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
-        const StructPointerDecoder<Decoded_VkPerformanceOverrideInfoINTEL>& pOverrideInfo) override;
+        StructPointerDecoder<Decoded_VkPerformanceOverrideInfoINTEL>* pOverrideInfo) override;
 
     virtual void Process_vkAcquirePerformanceConfigurationINTEL(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPerformanceConfigurationAcquireInfoINTEL>& pAcquireInfo,
+        StructPointerDecoder<Decoded_VkPerformanceConfigurationAcquireInfoINTEL>* pAcquireInfo,
         HandlePointerDecoder<VkPerformanceConfigurationINTEL>* pConfiguration) override;
 
     virtual void Process_vkReleasePerformanceConfigurationINTEL(
@@ -2172,21 +2172,21 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkCreateImagePipeSurfaceFUCHSIA(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCreateMetalSurfaceEXT(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetBufferDeviceAddressEXT(
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkBufferDeviceAddressInfoEXT>& pInfo) override;
+        StructPointerDecoder<Decoded_VkBufferDeviceAddressInfoEXT>* pInfo) override;
 
     virtual void Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(
         VkResult                                    returnValue,
@@ -2203,7 +2203,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         PointerDecoder<uint32_t>*                   pPresentModeCount,
         PointerDecoder<VkPresentModeKHR>*           pPresentModes) override;
 
@@ -2220,14 +2220,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual void Process_vkGetDeviceGroupSurfacePresentModes2EXT(
         VkResult                                    returnValue,
         format::HandleId                            device,
-        const StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>& pSurfaceInfo,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         PointerDecoder<VkDeviceGroupPresentModeFlagsKHR>* pModes) override;
 
     virtual void Process_vkCreateHeadlessSurfaceEXT(
         VkResult                                    returnValue,
         format::HandleId                            instance,
-        const StructPointerDecoder<Decoded_VkHeadlessSurfaceCreateInfoEXT>& pCreateInfo,
-        const StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator,
+        StructPointerDecoder<Decoded_VkHeadlessSurfaceCreateInfoEXT>* pCreateInfo,
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCmdSetLineStippleEXT(

--- a/framework/generated/generated_vulkan_struct_decoders.cpp
+++ b/framework/generated/generated_vulkan_struct_decoders.cpp
@@ -528,15 +528,15 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubmitI
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->waitSemaphoreCount));
     bytes_read += wrapper->pWaitSemaphores.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pWaitSemaphores = wrapper->pWaitSemaphores.GetHandlePointer();
+    value->pWaitSemaphores = nullptr;
     bytes_read += wrapper->pWaitDstStageMask.DecodeFlags((buffer + bytes_read), (buffer_size - bytes_read));
     value->pWaitDstStageMask = wrapper->pWaitDstStageMask.GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->commandBufferCount));
     bytes_read += wrapper->pCommandBuffers.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pCommandBuffers = wrapper->pCommandBuffers.GetHandlePointer();
+    value->pCommandBuffers = nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->signalSemaphoreCount));
     bytes_read += wrapper->pSignalSemaphores.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pSignalSemaphores = wrapper->pSignalSemaphores.GetHandlePointer();
+    value->pSignalSemaphores = nullptr;
 
     return bytes_read;
 }
@@ -755,7 +755,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindSpa
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->waitSemaphoreCount));
     bytes_read += wrapper->pWaitSemaphores.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pWaitSemaphores = wrapper->pWaitSemaphores.GetHandlePointer();
+    value->pWaitSemaphores = nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->bufferBindCount));
     wrapper->pBufferBinds = std::make_unique<StructPointerDecoder<Decoded_VkSparseBufferMemoryBindInfo>>();
     bytes_read += wrapper->pBufferBinds->Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -770,7 +770,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindSpa
     value->pImageBinds = wrapper->pImageBinds->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->signalSemaphoreCount));
     bytes_read += wrapper->pSignalSemaphores.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pSignalSemaphores = wrapper->pSignalSemaphores.GetHandlePointer();
+    value->pSignalSemaphores = nullptr;
 
     return bytes_read;
 }
@@ -1497,7 +1497,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->setLayoutCount));
     bytes_read += wrapper->pSetLayouts.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pSetLayouts = wrapper->pSetLayouts.GetHandlePointer();
+    value->pSetLayouts = nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->pushConstantRangeCount));
     wrapper->pPushConstantRanges = std::make_unique<StructPointerDecoder<Decoded_VkPushConstantRange>>();
     bytes_read += wrapper->pPushConstantRanges->Decode((buffer + bytes_read), (buffer_size - bytes_read));
@@ -1548,7 +1548,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescrip
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->descriptorCount));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->stageFlags));
     bytes_read += wrapper->pImmutableSamplers.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pImmutableSamplers = wrapper->pImmutableSamplers.GetHandlePointer();
+    value->pImmutableSamplers = nullptr;
 
     return bytes_read;
 }
@@ -1619,7 +1619,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescrip
     value->descriptorPool = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->descriptorSetCount));
     bytes_read += wrapper->pSetLayouts.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pSetLayouts = wrapper->pSetLayouts.GetHandlePointer();
+    value->pSetLayouts = nullptr;
 
     return bytes_read;
 }
@@ -1677,7 +1677,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFramebu
     value->renderPass = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->attachmentCount));
     bytes_read += wrapper->pAttachments.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pAttachments = wrapper->pAttachments.GetHandlePointer();
+    value->pAttachments = nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->width));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->height));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->layers));
@@ -2437,7 +2437,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceG
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->physicalDeviceCount));
     bytes_read += wrapper->pPhysicalDevices.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pPhysicalDevices = wrapper->pPhysicalDevices.GetHandlePointer();
+    value->pPhysicalDevices = nullptr;
 
     return bytes_read;
 }
@@ -3409,10 +3409,10 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresent
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->waitSemaphoreCount));
     bytes_read += wrapper->pWaitSemaphores.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pWaitSemaphores = wrapper->pWaitSemaphores.GetHandlePointer();
+    value->pWaitSemaphores = nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->swapchainCount));
     bytes_read += wrapper->pSwapchains.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pSwapchains = wrapper->pSwapchains.GetHandlePointer();
+    value->pSwapchains = nullptr;
     bytes_read += wrapper->pImageIndices.DecodeUInt32((buffer + bytes_read), (buffer_size - bytes_read));
     value->pImageIndices = wrapper->pImageIndices.GetPointer();
     bytes_read += wrapper->pResults.DecodeEnum((buffer + bytes_read), (buffer_size - bytes_read));
@@ -3917,14 +3917,14 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWin32Ke
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->acquireCount));
     bytes_read += wrapper->pAcquireSyncs.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pAcquireSyncs = wrapper->pAcquireSyncs.GetHandlePointer();
+    value->pAcquireSyncs = nullptr;
     bytes_read += wrapper->pAcquireKeys.DecodeUInt64((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAcquireKeys = wrapper->pAcquireKeys.GetPointer();
     bytes_read += wrapper->pAcquireTimeouts.DecodeUInt32((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAcquireTimeouts = wrapper->pAcquireTimeouts.GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->releaseCount));
     bytes_read += wrapper->pReleaseSyncs.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pReleaseSyncs = wrapper->pReleaseSyncs.GetHandlePointer();
+    value->pReleaseSyncs = nullptr;
     bytes_read += wrapper->pReleaseKeys.DecodeUInt64((buffer + bytes_read), (buffer_size - bytes_read));
     value->pReleaseKeys = wrapper->pReleaseKeys.GetPointer();
 
@@ -4195,7 +4195,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderP
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->attachmentCount));
     bytes_read += wrapper->pAttachments.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pAttachments = wrapper->pAttachments.GetHandlePointer();
+    value->pAttachments = nullptr;
 
     return bytes_read;
 }
@@ -4865,7 +4865,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSemapho
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->semaphoreCount));
     bytes_read += wrapper->pSemaphores.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pSemaphores = wrapper->pSemaphores.GetHandlePointer();
+    value->pSemaphores = nullptr;
     bytes_read += wrapper->pValues.DecodeUInt64((buffer + bytes_read), (buffer_size - bytes_read));
     value->pValues = wrapper->pValues.GetPointer();
 
@@ -5438,14 +5438,14 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWin32Ke
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->acquireCount));
     bytes_read += wrapper->pAcquireSyncs.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pAcquireSyncs = wrapper->pAcquireSyncs.GetHandlePointer();
+    value->pAcquireSyncs = nullptr;
     bytes_read += wrapper->pAcquireKeys.DecodeUInt64((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAcquireKeys = wrapper->pAcquireKeys.GetPointer();
     bytes_read += wrapper->pAcquireTimeoutMilliseconds.DecodeUInt32((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAcquireTimeoutMilliseconds = wrapper->pAcquireTimeoutMilliseconds.GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->releaseCount));
     bytes_read += wrapper->pReleaseSyncs.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pReleaseSyncs = wrapper->pReleaseSyncs.GetHandlePointer();
+    value->pReleaseSyncs = nullptr;
     bytes_read += wrapper->pReleaseKeys.DecodeUInt64((buffer + bytes_read), (buffer_size - bytes_read));
     value->pReleaseKeys = wrapper->pReleaseKeys.GetPointer();
 
@@ -7384,7 +7384,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkWriteDe
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->accelerationStructureCount));
     bytes_read += wrapper->pAccelerationStructures.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    value->pAccelerationStructures = wrapper->pAccelerationStructures.GetHandlePointer();
+    value->pAccelerationStructures = nullptr;
 
     return bytes_read;
 }

--- a/framework/generated/generated_vulkan_struct_handle_mappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.h
@@ -268,6 +268,20 @@ void AddStructArrayHandles(const T* id_wrappers, size_t id_len, const typename T
     }
 }
 
+void SetStructHandleLengths(Decoded_VkPhysicalDeviceGroupProperties* wrapper);
+
+template <typename T>
+void SetStructArrayHandleLengths(T* wrappers, size_t len)
+{
+    if (wrappers != nullptr)
+    {
+        for (size_t i = 0; i < len; ++i)
+        {
+            SetStructHandleLengths(&wrappers[i]);
+        }
+    }
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3 -i
 #
 # Copyright (c) 2013-2016 The Khronos Group Inc.
-# Copyright (c) 2018-2019 Valve Corporation
-# Copyright (c) 2018-2019 LunarG, Inc.
+# Copyright (c) 2018-2020 Valve Corporation
+# Copyright (c) 2018-2020 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -737,12 +737,8 @@ class BaseGenerator(OutputGenerator):
         for value in values:
             paramType = self.makeDecodedParamType(value)
 
-            # Pass pointer decoder classes by const reference when input and pointer when output.
-            if 'Decoder' in paramType or 'Decoded_' in paramType:
-                if (self.isOutputParameter(value)):
-                    paramType = '{}*'.format(paramType)
-                else:
-                    paramType = 'const {}&'.format(paramType)
+            if 'Decoder' in paramType:
+                paramType = '{}*'.format(paramType)
 
             paramDecl = self.makeAlignedParamDecl(paramType, value.name, self.INDENT_SIZE, self.genOpts.alignFuncParam)
             paramDecls.append(paramDecl)

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -206,6 +206,8 @@ class BaseGenerator(OutputGenerator):
         if self.processStructs:
             self.featureStructMembers = dict()            # Map of struct names to lists of per-member ValueInfo
             self.featureStructAliases = dict()            # Map of struct names to aliases
+            self.extensionStructsWithHandles = dict()     # Map of extension struct names to a Boolean value indicating that a struct member has a handle type
+            self.extensionStructsWithHandlePtrs = dict()  # Map of extension struct names to a Boolean value indicating that a struct member with a handle type is a pointer
         if self.processCmds:
             self.featureCmdParams = dict()                # Map of cmd names to lists of per-parameter ValueInfo
 
@@ -558,38 +560,76 @@ class BaseGenerator(OutputGenerator):
     #
     # Determines if the specified struct type can reference pNext extension structs that contain handles.
     def checkStructPNextHandles(self, typename):
+        foundHandles = False
+        foundHandlePtrs = False
         validExtensionStructs = self.registry.validextensionstructs.get(typename)
         if validExtensionStructs:
             # Need to search the XML tree for pNext structures that have not been processed yet.
             for structName in validExtensionStructs:
-                typeInfo = self.registry.lookupElementInfo(structName, self.registry.typedict)
-                if typeInfo:
-                    memberTypes = [member.text for member in typeInfo.elem.findall('.//member/type')]
-                    if memberTypes:
-                        for memberType in memberTypes:
-                            found = self.registry.tree.find("types/type/[name='" + memberType + "'][@category='handle']")
-                            if found:
-                                return True
-        return False
+                # Check for cached results from a previous check for this struct
+                if structName in self.extensionStructsWithHandles:
+                    if self.extensionStructsWithHandles[structName]:
+                        foundHandles = True
+                    if self.extensionStructsWithHandlePtrs[structName]:
+                        foundHandlePtrs = True
+                else:
+                    # If a pre-existing result was not found, check the XML registry for the struct
+                    hasHandles = False
+                    hasHandlePtrs = False
+                    typeInfo = self.registry.lookupElementInfo(structName, self.registry.typedict)
+                    if typeInfo:
+                        memberInfos = [member for member in typeInfo.elem.findall('.//member/type')]
+                        if memberInfos:
+                            for memberInfo in memberInfos:
+                                found = self.registry.tree.find("types/type/[name='" + memberInfo.text + "'][@category='handle']")
+                                if found:
+                                    hasHandles = True
+                                    self.extensionStructsWithHandles[structName] = True
+                                    if memberInfo.tail and ('*' in memberInfo.tail):
+                                        self.extensionStructsWithHandlePtrs[structName] = True
+                                        hasHandlePtrs = True
+                                    else:
+                                        self.extensionStructsWithHandlePtrs[structName] = False
+
+                    if hasHandles:
+                        foundHandles = True
+                        if hasHandlePtrs:
+                            fountHandlePtrs = True
+                    else:
+                        self.extensionStructsWithHandles[structName] = False
+                        self.extensionStructsWithHandlePtrs[structName] = False
+
+        return foundHandles, foundHandlePtrs
 
     #
     # Determines if the specified struct type contains members that have a handle type or are structs that contain handles.
-    # Structs with member handles are added to a dictionary, where the key is teh structure type and the value is a list of the handle members.
-    def checkStructMemberHandles(self, typename, structsWithHandles):
+    # Structs with member handles are added to a dictionary, where the key is the structure type and the value is a list of the handle members.
+    # An optional list of structure types that contain handle members with pointer types may also be generated.
+    def checkStructMemberHandles(self, typename, structsWithHandles, structsWithHandlePtrs = None):
         handles = []
+        hasHandlePointer = False
         for value in self.featureStructMembers[typename]:
             if self.isHandle(value.baseType):
                 # The member is a handle.
                 handles.append(value)
+                if (not structsWithHandlePtrs is None) and (value.isPointer or value.isArray):
+                    hasHandlePointer = True
             elif self.isStruct(value.baseType) and (value.baseType in structsWithHandles):
                 # The member is a struct that contains a handle.
                 handles.append(value)
+                if (not structsWithHandlePtrs is None)  and (value.name in structsWithHandlePtrs):
+                    hasHandlePointer = True
             elif 'pNext' in value.name:
                 # The pNext chain may include a struct with handles.
-                if self.checkStructPNextHandles(typename):
+                hasPNextHandles, hasPNextHandlePtrs = self.checkStructPNextHandles(typename)
+                if hasPNextHandles:
                     handles.append(value)
+                    if (not structsWithHandlePtrs is None) and hasPNextHandlePtrs:
+                        hasHandlePointer = True
         if handles:
             structsWithHandles[typename] = handles
+            if (not structsWithHandlePtrs is None) and hasHandlePointer:
+                structsWithHandlePtrs.append(typename)
             return True
         return False
 

--- a/framework/generated/vulkan_generators/vulkan_decoder_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_decoder_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2018-2020 Valve Corporation
+# Copyright (c) 2018-2020 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -123,7 +123,7 @@ class VulkanDecoderBodyGenerator(BaseGenerator):
         for value in values:
             decodeType = self.makeDecodedParamType(value)
             body += '    {} {};\n'.format(decodeType, value.name)
-            if self.isOutputParameter(value):
+            if 'Decoder' in decodeType:
                 argNames.append('&{}'.format(value.name))
             else:
                 argNames.append(value.name)

--- a/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2018-2019 Valve Corporation
-# Copyright (c) 2018-2019 LunarG, Inc.
+# Copyright (c) 2018-2020 Valve Corporation
+# Copyright (c) 2018-2020 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -228,7 +228,7 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
                         if needTempValue:
                             lengthName = 'in_' + lengthName
                         else:
-                            lengthName = lengthName.replace('->', '.GetPointer()->')
+                            lengthName = lengthName.replace('->', '->GetPointer()->')
 
                 if not needTempValue:
                     args.append(value.name)
@@ -262,21 +262,21 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
                     elif self.isHandle(value.baseType):
                         # We received an array of 64-bit integer IDs from the decoder.
                         if needTempValue:
-                            expr = expr.replace('const', '').lstrip() + '{}.GetHandlePointer();'.format(value.name)
+                            expr = expr.replace('const', '').lstrip() + '{}->GetHandlePointer();'.format(value.name)
                             preexpr.append(expr)
-                            expr = 'MapHandles<{type}Info>({paramname}.GetPointer(), {paramname}.GetLength(), {}, {}, &VulkanObjectInfoTable::Get{type}Info);'.format(argName, lengthName, type=value.baseType[2:], paramname=value.name)
+                            expr = 'MapHandles<{type}Info>({paramname}->GetPointer(), {paramname}->GetLength(), {}, {}, &VulkanObjectInfoTable::Get{type}Info);'.format(argName, lengthName, type=value.baseType[2:], paramname=value.name)
                         else:
-                            expr = 'MapHandles<{type}Info>({paramname}.GetPointer(), {paramname}.GetLength(), {paramname}.GetHandlePointer(), {}, &VulkanObjectInfoTable::Get{type}Info);'.format(lengthName, type=value.baseType[2:], paramname=value.name)
+                            expr = 'MapHandles<{type}Info>({paramname}->GetPointer(), {paramname}->GetLength(), {paramname}->GetHandlePointer(), {}, &VulkanObjectInfoTable::Get{type}Info);'.format(lengthName, type=value.baseType[2:], paramname=value.name)
                     else:
                         if needTempValue:
-                            expr += '{}.GetPointer();'.format(value.name)
+                            expr += '{}->GetPointer();'.format(value.name)
 
                         if value.baseType in self.structsWithHandles:
                             preexpr.append(expr)
                             if value.isArray:
-                                expr = 'MapStructArrayHandles({name}.GetMetaStructPointer(), {name}.GetLength(), GetObjectInfoTable());'.format(name=value.name)
+                                expr = 'MapStructArrayHandles({name}->GetMetaStructPointer(), {name}->GetLength(), GetObjectInfoTable());'.format(name=value.name)
                             else:
-                                expr = 'MapStructHandles({}.GetMetaStructPointer(), GetObjectInfoTable());'.format(value.name)
+                                expr = 'MapStructHandles({}->GetMetaStructPointer(), GetObjectInfoTable());'.format(value.name)
                 else:
                     # Initialize output pointer.
                     if value.isArray:

--- a/framework/generated/vulkan_generators/vulkan_struct_decoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_decoders_body_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2018 Valve Corporation
-# Copyright (c) 2018 LunarG, Inc.
+# Copyright (c) 2018-2020 Valve Corporation
+# Copyright (c) 2018-2020 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -160,7 +160,7 @@ class VulkanStructDecodersBodyGenerator(BaseGenerator):
                 if not isStaticArray:
                     if isHandle:
                         # Point the real struct's member pointer to the handle pointer decoder's handle memory.
-                        body += '    value->{name} = wrapper->{name}.GetHandlePointer();\n'.format(name=value.name)
+                        body += '    value->{} = nullptr;\n'.format(value.name)
                     else:
                         # Point the real struct's member pointer to the pointer decoder's memory.
                         body += '    value->{name} = wrapper->{name}{}GetPointer();\n'.format(accessOp, name=value.name)

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -25,6 +25,7 @@
 
 #include "vulkan/vulkan.h"
 
+#include <cassert>
 #include <limits>
 #include <set>
 #include <string>
@@ -116,14 +117,16 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
     }
 
     virtual void Process_vkCreateInstance(
-        VkResult                                                                                      returnValue,
-        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkInstanceCreateInfo>& pCreateInfo,
-        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>&,
+        VkResult                                                                                returnValue,
+        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkInstanceCreateInfo>* pCreateInfo,
+        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>*,
         gfxrecon::decode::HandlePointerDecoder<VkInstance>*) override
     {
-        if ((returnValue >= 0) && !pCreateInfo.IsNull())
+        assert(pCreateInfo != nullptr);
+
+        if ((returnValue >= 0) && !pCreateInfo->IsNull())
         {
-            auto create_info = pCreateInfo.GetPointer();
+            auto create_info = pCreateInfo->GetPointer();
             auto app_info    = create_info->pApplicationInfo;
             if (app_info != nullptr)
             {
@@ -171,12 +174,12 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
         }
     }
 
-    virtual void Process_vkCreateDevice(
-        VkResult                   returnValue,
-        gfxrecon::format::HandleId physicalDevice,
-        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkDeviceCreateInfo>&,
-        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>&,
-        gfxrecon::decode::HandlePointerDecoder<VkDevice>*) override
+    virtual void
+    Process_vkCreateDevice(VkResult                   returnValue,
+                           gfxrecon::format::HandleId physicalDevice,
+                           gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkDeviceCreateInfo>*,
+                           gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>*,
+                           gfxrecon::decode::HandlePointerDecoder<VkDevice>*) override
     {
         if (returnValue >= 0)
         {
@@ -189,8 +192,8 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
         gfxrecon::format::HandleId,
         gfxrecon::format::HandleId,
         uint32_t createInfoCount,
-        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkGraphicsPipelineCreateInfo>&,
-        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>&,
+        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkGraphicsPipelineCreateInfo>*,
+        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>*,
         gfxrecon::decode::HandlePointerDecoder<VkPipeline>*) override
     {
         if (returnValue >= 0)
@@ -204,8 +207,8 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
         gfxrecon::format::HandleId,
         gfxrecon::format::HandleId,
         uint32_t createInfoCount,
-        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkComputePipelineCreateInfo>&,
-        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>&,
+        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkComputePipelineCreateInfo>*,
+        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>*,
         gfxrecon::decode::HandlePointerDecoder<VkPipeline>*) override
     {
         if (returnValue >= 0)
@@ -340,17 +343,19 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
     virtual void Process_vkAllocateMemory(
         VkResult returnValue,
         gfxrecon::format::HandleId,
-        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkMemoryAllocateInfo>& pAllocateInfo,
-        const gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>&,
+        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkMemoryAllocateInfo>* pAllocateInfo,
+        gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>*,
         gfxrecon::decode::HandlePointerDecoder<VkDeviceMemory>*) override
     {
+        assert(pAllocateInfo != nullptr);
+
         if (returnValue >= 0)
         {
             ++allocation_count_;
 
-            if (!pAllocateInfo.IsNull())
+            if (!pAllocateInfo->IsNull())
             {
-                auto allocate_info = pAllocateInfo.GetPointer();
+                auto allocate_info = pAllocateInfo->GetPointer();
 
                 if (allocate_info->allocationSize < min_allocation_size_)
                 {


### PR DESCRIPTION
For replay of API calls that retrieve arrays with variable sizes, adjust the size of each array to match the size returned by the replay size query.  Previous behavior was to use the size that was recorded on capture, which could produce VK_INCOMPELTE errors when capture and replay sizes did not match.

Fixes #189 