### PR TITLE
Handle vkEnumeratePhysicalDevices Capture/Replay Differences

### DIFF
--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -76,11 +76,20 @@ class ApiDecoder
 
     virtual void DispatchDestroyHardwareBufferCommand(format::ThreadId thread_id, uint64_t buffer_id) {}
 
+    virtual void DispatchSetDevicePropertiesCommand(format::ThreadId   thread_id,
+                                                    format::HandleId   physical_device_id,
+                                                    uint32_t           api_version,
+                                                    uint32_t           driver_version,
+                                                    uint32_t           vendor_id,
+                                                    uint32_t           device_id,
+                                                    uint32_t           device_type,
+                                                    const uint8_t      pipeline_cache_uuid[format::kUuidSize],
+                                                    const std::string& device_name)
+    {}
+
     virtual void DispatchSetDeviceMemoryPropertiesCommand(format::ThreadId thread_id,
                                                           format::HandleId physical_device_id,
-                                                          uint32_t         memory_type_count,
                                                           const std::vector<format::DeviceMemoryType>& memory_types,
-                                                          uint32_t memory_heap_count,
                                                           const std::vector<format::DeviceMemoryHeap>& memory_heaps)
     {}
 

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -61,10 +61,18 @@ class VulkanConsumerBase
 
     virtual void ProcessDestroyHardwareBufferCommand(uint64_t buffer_id) {}
 
+    virtual void ProcessSetDevicePropertiesCommand(format::HandleId   physical_device_id,
+                                                   uint32_t           api_version,
+                                                   uint32_t           driver_version,
+                                                   uint32_t           vendor_id,
+                                                   uint32_t           device_id,
+                                                   uint32_t           device_type,
+                                                   const uint8_t      pipeline_cache_uuid[format::kUuidSize],
+                                                   const std::string& device_name)
+    {}
+
     virtual void ProcessSetDeviceMemoryPropertiesCommand(format::HandleId physical_device_id,
-                                                         uint32_t         memory_type_count,
                                                          const std::vector<format::DeviceMemoryType>& memory_types,
-                                                         uint32_t                                     memory_heap_count,
                                                          const std::vector<format::DeviceMemoryHeap>& memory_heaps)
     {}
 

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -105,20 +105,42 @@ void VulkanDecoderBase::DispatchDestroyHardwareBufferCommand(format::ThreadId th
     }
 }
 
+void VulkanDecoderBase::DispatchSetDevicePropertiesCommand(format::ThreadId   thread_id,
+                                                           format::HandleId   physical_device_id,
+                                                           uint32_t           api_version,
+                                                           uint32_t           driver_version,
+                                                           uint32_t           vendor_id,
+                                                           uint32_t           device_id,
+                                                           uint32_t           device_type,
+                                                           const uint8_t      pipeline_cache_uuid[format::kUuidSize],
+                                                           const std::string& device_name)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(thread_id);
+
+    for (auto consumer : consumers_)
+    {
+        consumer->ProcessSetDevicePropertiesCommand(physical_device_id,
+                                                    api_version,
+                                                    driver_version,
+                                                    vendor_id,
+                                                    device_id,
+                                                    device_type,
+                                                    pipeline_cache_uuid,
+                                                    device_name);
+    }
+}
+
 void VulkanDecoderBase::DispatchSetDeviceMemoryPropertiesCommand(
     format::ThreadId                             thread_id,
     format::HandleId                             physical_device_id,
-    uint32_t                                     memory_type_count,
     const std::vector<format::DeviceMemoryType>& memory_types,
-    uint32_t                                     memory_heap_count,
     const std::vector<format::DeviceMemoryHeap>& memory_heaps)
 {
     GFXRECON_UNREFERENCED_PARAMETER(thread_id);
 
     for (auto consumer : consumers_)
     {
-        consumer->ProcessSetDeviceMemoryPropertiesCommand(
-            physical_device_id, memory_type_count, memory_types, memory_heap_count, memory_heaps);
+        consumer->ProcessSetDeviceMemoryPropertiesCommand(physical_device_id, memory_types, memory_heaps);
     }
 }
 

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -86,12 +86,20 @@ class VulkanDecoderBase : public ApiDecoder
 
     virtual void DispatchDestroyHardwareBufferCommand(format::ThreadId thread_id, uint64_t buffer_id) override;
 
+    virtual void DispatchSetDevicePropertiesCommand(format::ThreadId   thread_id,
+                                                    format::HandleId   physical_device_id,
+                                                    uint32_t           api_version,
+                                                    uint32_t           driver_version,
+                                                    uint32_t           vendor_id,
+                                                    uint32_t           device_id,
+                                                    uint32_t           device_type,
+                                                    const uint8_t      pipeline_cache_uuid[format::kUuidSize],
+                                                    const std::string& device_name) override;
+
     virtual void
     DispatchSetDeviceMemoryPropertiesCommand(format::ThreadId                             thread_id,
                                              format::HandleId                             physical_device_id,
-                                             uint32_t                                     memory_type_count,
                                              const std::vector<format::DeviceMemoryType>& memory_types,
-                                             uint32_t                                     memory_heap_count,
                                              const std::vector<format::DeviceMemoryHeap>& memory_heaps) override;
 
     virtual void

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -172,10 +172,23 @@ struct InstanceInfo : public VulkanObjectInfo<VkInstance>
 
 struct PhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
 {
-    VkInstance                           parent{ VK_NULL_HANDLE };
-    uint32_t                             parent_api_version{ 0 };
-    VkPhysicalDeviceMemoryProperties     capture_memory_properties{};
-    VkPhysicalDeviceMemoryProperties     replay_memory_properties{};
+    VkInstance parent{ VK_NULL_HANDLE };
+    uint32_t   parent_api_version{ 0 };
+
+    // Capture device properties.
+    uint32_t    capture_api_version;
+    uint32_t    capture_driver_version;
+    uint32_t    capture_vendor_id;
+    uint32_t    capture_device_id;
+    uint32_t    capture_device_type;
+    uint8_t     capture_pipeline_cache_uuid[16];
+    std::string capture_device_name;
+
+    VkPhysicalDeviceProperties replay_properties{};
+
+    VkPhysicalDeviceMemoryProperties capture_memory_properties{};
+    VkPhysicalDeviceMemoryProperties replay_memory_properties{};
+
     std::unordered_map<uint32_t, size_t> array_counts;
 };
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -86,11 +86,18 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     virtual void ProcessDestroyHardwareBufferCommand(uint64_t buffer_id) override;
 
+    virtual void ProcessSetDevicePropertiesCommand(format::HandleId   physical_device_id,
+                                                   uint32_t           api_version,
+                                                   uint32_t           driver_version,
+                                                   uint32_t           vendor_id,
+                                                   uint32_t           device_id,
+                                                   uint32_t           device_type,
+                                                   const uint8_t      pipeline_cache_uuid[format::kUuidSize],
+                                                   const std::string& device_name) override;
+
     virtual void
     ProcessSetDeviceMemoryPropertiesCommand(format::HandleId                             physical_device_id,
-                                            uint32_t                                     memory_type_count,
                                             const std::vector<format::DeviceMemoryType>& memory_types,
-                                            uint32_t                                     memory_heap_count,
                                             const std::vector<format::DeviceMemoryHeap>& memory_heaps) override;
 
     virtual void

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -955,6 +955,8 @@ class TraceManager
                                       AHardwareBuffer*                                    buffer,
                                       const std::vector<format::HardwareBufferPlaneInfo>& plane_info);
     void WriteDestroyHardwareBufferCmd(AHardwareBuffer* buffer);
+    void WriteSetDevicePropertiesCommand(format::HandleId                  physical_device_id,
+                                         const VkPhysicalDeviceProperties& properties);
     void WriteSetDeviceMemoryPropertiesCommand(format::HandleId                        physical_device_id,
                                                const VkPhysicalDeviceMemoryProperties& memory_properties);
 

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -161,6 +161,8 @@ class VulkanStateWriter
 
     void WriteSwapchainImageState(const VulkanStateTable& state_table);
 
+    void WritePhysicalDevicePropertiesMetaData(const PhysicalDeviceWrapper* physical_device_wrapper);
+
     template <typename T>
     void WriteGetPhysicalDeviceQueueFamilyProperties(format::ApiCallId call_id,
                                                      format::HandleId  physical_device_id,
@@ -245,6 +247,9 @@ class VulkanStateWriter
     void WriteCreateHardwareBufferCmd(format::HandleId                                    memory_id,
                                       AHardwareBuffer*                                    hardware_buffer,
                                       const std::vector<format::HardwareBufferPlaneInfo>& plane_info);
+
+    void WriteSetDevicePropertiesCommand(format::HandleId                  physical_device_id,
+                                         const VkPhysicalDeviceProperties& properties);
 
     void WriteSetDeviceMemoryPropertiesCommand(format::HandleId                        physical_device_id,
                                                const VkPhysicalDeviceMemoryProperties& memory_properties);

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -45,7 +45,9 @@ typedef uint16_t WCharEncodeType; // Encoding type for LPCWSTR (UTF-16) strings.
 typedef HandleEncodeType HandleId;
 typedef uint64_t         ThreadId;
 
-const uint32_t kCompressedBlockTypeBit = 0x80000000;
+const uint32_t kCompressedBlockTypeBit    = 0x80000000;
+const size_t   kUuidSize                  = 16;
+const size_t   kMaxPhysicalDeviceNameSize = 256;
 
 constexpr uint32_t MakeCompressedBlockType(uint32_t block_type)
 {
@@ -328,6 +330,20 @@ struct DeviceMemoryHeap
 {
     uint64_t size;
     uint32_t flags;
+};
+
+struct SetDevicePropertiesCommand
+{
+    MetaDataHeader   meta_header;
+    format::ThreadId thread_id;
+    format::HandleId physical_device_id;
+    uint32_t         api_version;
+    uint32_t         driver_version;
+    uint32_t         vendor_id;
+    uint32_t         device_id;
+    uint32_t         device_type;
+    uint8_t          pipeline_cache_uuid[kUuidSize];
+    uint32_t         device_name_len;
 };
 
 #pragma pack(pop)


### PR DESCRIPTION
Update replay to handle the case where switchable graphics layers for managing iGPU/dGPU device selection will reorder or remove entries from the list of physical device handles returned by vkEnumeratePhysicalDevices.  The capture layer can intercept vkEnumeratePhysicalDevices before the list of physical devices is modified, while replay receives the modified list.  

At device creation, replay will now compare the vendor and device IDs from the capture device with the IDs from the available replay devices.  If the device list was reordered, logical device creation will use the physical device with matching IDs.  If the device was removed, replay will warn that there is no match for the capture device.