### PR TITLE
Fix trim issue with non-zero memory offsets

### DIFF
--- a/framework/decode/vulkan_resource_initializer.cpp
+++ b/framework/decode/vulkan_resource_initializer.cpp
@@ -86,7 +86,7 @@ VkResult VulkanResourceInitializer::LoadData(VkDeviceMemory                     
     {
         GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, size);
         size_t copy_size = static_cast<size_t>(size);
-        resource_allocator_->WriteMappedMemoryRange(allocator_data, offset, size, data);
+        resource_allocator_->WriteMappedMemoryRange(allocator_data, 0, size, data);
         resource_allocator_->UnmapMemory(memory, allocator_data);
     }
 


### PR DESCRIPTION
Fixes a memory offset issue when creating and loading data to buffer and image resources during state setup for trimmed files.  The memory offset was specified when mapping memory and was later added to the mapped memory address, resulting in the offset being applied twice.  The offset is no longer applied to the mapped memory address.
