### PR TITLE
Adjust Loader Search Order

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -44,7 +44,7 @@ const std::vector<std::string> kLoaderLibNames = {
 #if defined(WIN32)
     "vulkan-1.dll"
 #else
-    "libvulkan.so", "libvulkan.so.1"
+    "libvulkan.so.1", "libvulkan.so"
 #endif
 };
 


### PR DESCRIPTION
For replay on Linux, check for libvulkan.so.1 before libvulkan.so when attempting to dlopen the Vulkan loader.
