### PR TITLE
Minor Build Fixes

### DIFF
--- a/framework/decode/value_decoder.h
+++ b/framework/decode/value_decoder.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018-2019 Valve Corporation
-** Copyright (c) 2018-2019 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ class ValueDecoder
     static size_t DecodeVkDeviceSizeValue(const uint8_t* buffer, size_t buffer_size, VkDeviceSize* value)           { return DecodeValueFrom<format::DeviceSizeEncodeType>(buffer, buffer_size, value); }
     static size_t DecodeVkDeviceAddressValue(const uint8_t* buffer, size_t buffer_size, VkDeviceAddress* value)     { return DecodeValueFrom<format::DeviceSizeEncodeType>(buffer, buffer_size, value); }
     static size_t DecodeSizeTValue(const uint8_t* buffer, size_t buffer_size, size_t* value)                        { return DecodeValueFrom<format::SizeTEncodeType>(buffer, buffer_size, value); }
-#if defined(VK_USE_PLATFORM_XLIB_KHR) && !defined(GFXRECON_ARCH64)
+#if (defined(VK_USE_PLATFORM_XLIB_KHR) || defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT)) && !defined(GFXRECON_ARCH64)
     // Oveload for the 32-bit XID type.  Pointers from the 32-bit XID typedef of unsigned long are not compatible with size_t pointers.
     static size_t DecodeSizeTValue(const uint8_t* buffer, size_t buffer_size, unsigned long* value)                 { return DecodeValueFrom<format::SizeTEncodeType>(buffer, buffer_size, value); }
 #endif

--- a/framework/format/platform_types.h
+++ b/framework/format/platform_types.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018-2019 Valve Corporation
-** Copyright (c) 2018-2019 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -813,16 +813,19 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceXcbPresentationSupportK
 }
 #endif // VK_USE_PLATFORM_XCB_KHR
 
-#if !defined(VK_USE_PLATFORM_XLIB_KHR)
-#define VK_KHR_XLIB_SURFACE_EXTENSION_NAME "VK_KHR_xlib_surface"
-
-typedef VkFlags VkXlibSurfaceCreateFlagsKHR;
-
+// Xlib type definitions common to both XLIB_KHR and XLIB_XRANDR_KHR
+#if !defined(VK_USE_PLATFORM_XLIB_KHR) && !defined(VK_USE_PLATFORM_XLIB_XRANDR_EXT)
 typedef size_t XID;
 typedef size_t VisualID;
 typedef XID    Window;
 
 struct Display;
+#endif // VK_USE_PLATFORM_XLIB_KHR && VK_USE_PLATFORM_XLIB_XRANDR_EXT
+
+#if !defined(VK_USE_PLATFORM_XLIB_KHR)
+#define VK_KHR_XLIB_SURFACE_EXTENSION_NAME "VK_KHR_xlib_surface"
+
+typedef VkFlags VkXlibSurfaceCreateFlagsKHR;
 
 struct VkXlibSurfaceCreateInfoKHR
 {

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(gfxrecon_util platform_specific ${CMAKE_DL_LIBS})
 
 if (UNIX AND NOT APPLE)
     # Check for clock_gettime in libc
+    include(CheckLibraryExists)
     check_library_exists(c clock_gettime "" HAVE_GETTIME)
     if (NOT HAVE_GETTIME)
         # If not in libc, check librt


### PR DESCRIPTION
* Ensure that CheckLibraryExists.cmake is included in CMakeLists.txt prior to using the CHECK_LIBRARY_EXISTS macro.
* Support building with VK_USE_PLATFORM_XLIB_XRANDR_EXT enabled when VK_USE_PLATFORM_XLIB_KHR is disabled.