### PR TITLE
Fixes for Replay Memory Translation

### DIFF
--- a/framework/decode/vulkan_default_allocator.cpp
+++ b/framework/decode/vulkan_default_allocator.cpp
@@ -21,6 +21,8 @@
 #include "generated/generated_vulkan_struct_decoders.h"
 #include "util/platform.h"
 
+#include <cassert>
+
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
@@ -114,7 +116,8 @@ VkResult VulkanDefaultAllocator::AllocateMemory(const VkMemoryAllocateInfo*  all
 {
     VkResult result = VK_ERROR_INITIALIZATION_FAILED;
 
-    if ((allocate_info != nullptr) && (allocator_data != nullptr))
+    if ((allocate_info != nullptr) && (allocator_data != nullptr) &&
+        (allocate_info->memoryTypeIndex < memory_properties_.memoryTypeCount))
     {
         result = Allocate(allocate_info, allocation_callbacks, memory, allocator_data);
     }

--- a/framework/decode/vulkan_default_allocator.cpp
+++ b/framework/decode/vulkan_default_allocator.cpp
@@ -41,6 +41,7 @@ VkResult VulkanDefaultAllocator::Initialize(uint32_t                            
                                             VkPhysicalDevice                        physical_device,
                                             VkDevice                                device,
                                             const std::vector<std::string>&         enabled_device_extensions,
+                                            VkPhysicalDeviceType                    capture_device_type,
                                             const VkPhysicalDeviceMemoryProperties& capture_memory_properties,
                                             const VkPhysicalDeviceMemoryProperties& replay_memory_properties,
                                             const Functions&                        functions)
@@ -50,6 +51,7 @@ VkResult VulkanDefaultAllocator::Initialize(uint32_t                            
     GFXRECON_UNREFERENCED_PARAMETER(physical_device);
     GFXRECON_UNREFERENCED_PARAMETER(device);
     GFXRECON_UNREFERENCED_PARAMETER(enabled_device_extensions);
+    GFXRECON_UNREFERENCED_PARAMETER(capture_device_type);
     GFXRECON_UNREFERENCED_PARAMETER(capture_memory_properties);
 
     device_            = device;

--- a/framework/decode/vulkan_default_allocator.h
+++ b/framework/decode/vulkan_default_allocator.h
@@ -39,6 +39,7 @@ class VulkanDefaultAllocator : public VulkanResourceAllocator
                                 VkPhysicalDevice                        physical_device,
                                 VkDevice                                device,
                                 const std::vector<std::string>&         enabled_device_extensions,
+                                VkPhysicalDeviceType                    capture_device_type,
                                 const VkPhysicalDeviceMemoryProperties& capture_memory_properties,
                                 const VkPhysicalDeviceMemoryProperties& replay_memory_properties,
                                 const Functions&                        functions) override;

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -203,7 +203,7 @@ struct PhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
     uint32_t                         capture_driver_version{ 0 };
     uint32_t                         capture_vendor_id{ 0 };
     uint32_t                         capture_device_id{ 0 };
-    uint32_t                         capture_device_type{ 0 };
+    VkPhysicalDeviceType             capture_device_type{ VK_PHYSICAL_DEVICE_TYPE_OTHER };
     uint8_t                          capture_pipeline_cache_uuid[format::kUuidSize]{};
     std::string                      capture_device_name;
     VkPhysicalDeviceMemoryProperties capture_memory_properties{};

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -774,9 +774,10 @@ VkResult VulkanRebindAllocator::WriteMappedMemoryRange(MemoryData     allocator_
             // Update the reconstructed memory, which is written to memory allocations created at resource bind to
             // ensure they contain the correct data.
             GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, size);
-            size_t copy_size = static_cast<size_t>(size);
+            size_t   copy_size = static_cast<size_t>(size);
+            uint8_t* copy_dst  = memory_alloc_info->original_content.get() + memory_alloc_info->mapped_offset + offset;
 
-            util::platform::MemoryCopy(memory_alloc_info->original_content.get() + offset, copy_size, data, copy_size);
+            util::platform::MemoryCopy(copy_dst, copy_size, data, copy_size);
 
             VkDeviceSize write_start = memory_alloc_info->mapped_offset + offset;
             VkDeviceSize write_end   = write_start + size;

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -43,6 +43,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                                 VkPhysicalDevice                        physical_device,
                                 VkDevice                                device,
                                 const std::vector<std::string>&         enabled_device_extensions,
+                                VkPhysicalDeviceType                    capture_device_type,
                                 const VkPhysicalDeviceMemoryProperties& capture_memory_properties,
                                 const VkPhysicalDeviceMemoryProperties& replay_memory_properties,
                                 const Functions&                        functions) override;
@@ -243,6 +244,7 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
     VmaAllocator                     allocator_;
     Functions                        functions_;
     VmaVulkanFunctions               vma_functions_;
+    VkPhysicalDeviceType             capture_device_type_;
     VkPhysicalDeviceMemoryProperties capture_memory_properties_;
     VkPhysicalDeviceMemoryProperties replay_memory_properties_;
 };

--- a/framework/decode/vulkan_remap_allocator.cpp
+++ b/framework/decode/vulkan_remap_allocator.cpp
@@ -22,6 +22,8 @@
 #include "generated/generated_vulkan_struct_decoders.h"
 #include "util/logging.h"
 
+#include <cassert>
+
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
@@ -95,6 +97,8 @@ VkResult VulkanRemapAllocator::AllocateMemory(const VkMemoryAllocateInfo*  alloc
 
     if ((allocate_info != nullptr) && (allocator_data != nullptr))
     {
+        assert(allocate_info->memoryTypeIndex < index_map_.size());
+
         VkMemoryAllocateInfo replay_allocate_info = *allocate_info;
 
         replay_allocate_info.memoryTypeIndex = index_map_[allocate_info->memoryTypeIndex];

--- a/framework/decode/vulkan_remap_allocator.cpp
+++ b/framework/decode/vulkan_remap_allocator.cpp
@@ -32,6 +32,7 @@ VkResult VulkanRemapAllocator::Initialize(uint32_t                              
                                           VkPhysicalDevice                        physical_device,
                                           VkDevice                                device,
                                           const std::vector<std::string>&         enabled_device_extensions,
+                                          VkPhysicalDeviceType                    capture_device_type,
                                           const VkPhysicalDeviceMemoryProperties& capture_memory_properties,
                                           const VkPhysicalDeviceMemoryProperties& replay_memory_properties,
                                           const Functions&                        functions)
@@ -43,6 +44,7 @@ VkResult VulkanRemapAllocator::Initialize(uint32_t                              
                                        physical_device,
                                        device,
                                        enabled_device_extensions,
+                                       capture_device_type,
                                        capture_memory_properties,
                                        replay_memory_properties,
                                        functions);

--- a/framework/decode/vulkan_remap_allocator.h
+++ b/framework/decode/vulkan_remap_allocator.h
@@ -39,6 +39,7 @@ class VulkanRemapAllocator : public VulkanDefaultAllocator
                                 VkPhysicalDevice                        physical_device,
                                 VkDevice                                device,
                                 const std::vector<std::string>&         enabled_device_extensions,
+                                VkPhysicalDeviceType                    capture_device_type,
                                 const VkPhysicalDeviceMemoryProperties& capture_memory_properties,
                                 const VkPhysicalDeviceMemoryProperties& replay_memory_properties,
                                 const Functions&                        functions) override;

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -492,7 +492,7 @@ void VulkanReplayConsumerBase::ProcessSetDevicePropertiesCommand(format::HandleI
         physical_device_info->capture_driver_version = driver_version;
         physical_device_info->capture_vendor_id      = vendor_id;
         physical_device_info->capture_device_id      = device_id;
-        physical_device_info->capture_device_type    = device_type;
+        physical_device_info->capture_device_type    = static_cast<VkPhysicalDeviceType>(device_type);
         physical_device_info->capture_device_name    = device_name;
 
         util::platform::MemoryCopy(physical_device_info->capture_pipeline_cache_uuid,
@@ -1892,6 +1892,7 @@ void VulkanReplayConsumerBase::InitializeResourceAllocator(const PhysicalDeviceI
                                             physical_device_info->handle,
                                             device,
                                             enabled_device_extensions,
+                                            physical_device_info->capture_device_type,
                                             physical_device_info->capture_memory_properties,
                                             *replay_device_info->memory_properties,
                                             functions);

--- a/framework/decode/vulkan_resource_allocator.h
+++ b/framework/decode/vulkan_resource_allocator.h
@@ -76,6 +76,7 @@ class VulkanResourceAllocator
                                 VkPhysicalDevice                        physical_device,
                                 VkDevice                                device,
                                 const std::vector<std::string>&         enabled_device_extensions,
+                                VkPhysicalDeviceType                    capture_device_type,
                                 const VkPhysicalDeviceMemoryProperties& capture_memory_properties,
                                 const VkPhysicalDeviceMemoryProperties& replay_memory_properties,
                                 const Functions&                        functions) = 0;


### PR DESCRIPTION
* Fix memory offset calculation in VulkanRebindAllocator when reconstructing mapped memory writes on replay.
* Check vkAllocateMemory parameters for valid memory type index at replay, and recommend enabling memory translation when index is valid.
* Update VulkanRebindAllocator memory type selection to ensure that memory allocations captured on discrete GPUs for memory types with both the HOST_VISIBLE and DEVICE_LOCAL properties remain HOST_VISIBLE on replay.