### PR TITLE
Eliminate Duplicate Handle Mapping Code

### DIFF
--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_default_allocator.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_default_allocator.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_enum_util.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_handle_mapping_util.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_object_info.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_object_info_table.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_rebind_allocator.h

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(gfxrecon_decode
                    vulkan_default_allocator.h
                    vulkan_default_allocator.cpp
                    vulkan_enum_util.h
+                   vulkan_handle_mapping_util.h
                    vulkan_object_info.h
                    vulkan_object_info_table.h
                    vulkan_rebind_allocator.h

--- a/framework/decode/custom_vulkan_struct_handle_mappers.cpp
+++ b/framework/decode/custom_vulkan_struct_handle_mappers.cpp
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2019 LunarG, Inc.
+** Copyright (c) 2019-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -14,56 +14,16 @@
 ** limitations under the License.
 */
 
-/*
-** This file is generated from the Khronos Vulkan XML API Registry.
-**
-*/
-
 #include "decode/custom_vulkan_struct_handle_mappers.h"
 
 #include "decode/custom_vulkan_struct_decoders.h"
+#include "decode/vulkan_handle_mapping_util.h"
 #include "decode/vulkan_object_info.h"
 #include "generated/generated_vulkan_struct_decoders.h"
 #include "generated/generated_vulkan_struct_handle_mappers.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
-
-template <typename T>
-static typename T::HandleType MapHandle(format::HandleId             id,
-                                        const VulkanObjectInfoTable& object_mapper,
-                                        const T* (VulkanObjectInfoTable::*MapFunc)(format::HandleId) const)
-{
-    typename T::HandleType handle = VK_NULL_HANDLE;
-    const T*               info   = (object_mapper.*MapFunc)(id);
-
-    if (info != nullptr)
-    {
-        handle = info->handle;
-    }
-
-    return handle;
-}
-
-template <typename T>
-static void MapHandleArray(const format::HandleId*      ids,
-                           typename T::HandleType*      handles,
-                           size_t                       len,
-                           const VulkanObjectInfoTable& object_info_table,
-                           const T* (VulkanObjectInfoTable::*MapFunc)(format::HandleId) const)
-{
-    if ((ids != nullptr) && (handles != nullptr))
-    {
-        for (size_t i = 0; i < len; ++i)
-        {
-            const T* info = (object_info_table.*MapFunc)(ids[i]);
-            if (info != nullptr)
-            {
-                handles[i] = info->handle;
-            }
-        }
-    }
-}
 
 void MapStructHandles(VkDescriptorType               type,
                       Decoded_VkDescriptorImageInfo* wrapper,
@@ -76,13 +36,13 @@ void MapStructHandles(VkDescriptorType               type,
         if ((type == VK_DESCRIPTOR_TYPE_SAMPLER) || (type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER))
         {
             // TODO: This should be ignored if the descriptor set layout was created with an immutable sampler.
-            value->sampler =
-                MapHandle<SamplerInfo>(wrapper->sampler, object_info_table, &VulkanObjectInfoTable::GetSamplerInfo);
+            value->sampler = handle_mapping::MapHandle<SamplerInfo>(
+                wrapper->sampler, object_info_table, &VulkanObjectInfoTable::GetSamplerInfo);
         }
 
         if (type != VK_DESCRIPTOR_TYPE_SAMPLER)
         {
-            value->imageView = MapHandle<ImageViewInfo>(
+            value->imageView = handle_mapping::MapHandle<ImageViewInfo>(
                 wrapper->imageView, object_info_table, &VulkanObjectInfoTable::GetImageViewInfo);
         }
     }
@@ -99,8 +59,8 @@ void MapStructHandles(Decoded_VkWriteDescriptorSet* wrapper, const VulkanObjectI
             MapPNextStructHandles(wrapper->pNext->GetPointer(), wrapper->pNext->GetMetaStructPointer(), object_mapper);
         }
 
-        value->dstSet =
-            MapHandle<DescriptorSetInfo>(wrapper->dstSet, object_mapper, &VulkanObjectInfoTable::GetDescriptorSetInfo);
+        value->dstSet = handle_mapping::MapHandle<DescriptorSetInfo>(
+            wrapper->dstSet, object_mapper, &VulkanObjectInfoTable::GetDescriptorSetInfo);
 
         switch (value->descriptorType)
         {
@@ -128,11 +88,8 @@ void MapStructHandles(Decoded_VkWriteDescriptorSet* wrapper, const VulkanObjectI
                 break;
             case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
             case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-                MapHandleArray<BufferViewInfo>(wrapper->pTexelBufferView.GetPointer(),
-                                               wrapper->pTexelBufferView.GetHandlePointer(),
-                                               wrapper->pTexelBufferView.GetLength(),
-                                               object_mapper,
-                                               &VulkanObjectInfoTable::GetBufferViewInfo);
+                value->pTexelBufferView = handle_mapping::MapHandleArray<BufferViewInfo>(
+                    &wrapper->pTexelBufferView, object_mapper, &VulkanObjectInfoTable::GetBufferViewInfo);
                 break;
             case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
                 // TODO

--- a/framework/decode/vulkan_handle_mapping_util.h
+++ b/framework/decode/vulkan_handle_mapping_util.h
@@ -1,0 +1,164 @@
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef GFXRECON_DECODE_VULKAN_HANDLE_MAPPING_UTIL_H
+#define GFXRECON_DECODE_VULKAN_HANDLE_MAPPING_UTIL_H
+
+#include "decode/vulkan_object_info_table.h"
+#include "format/format.h"
+
+#include "vulkan/vulkan.h"
+
+#include <cassert>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+GFXRECON_BEGIN_NAMESPACE(handle_mapping)
+
+template <typename T>
+static typename T::HandleType MapHandle(format::HandleId             id,
+                                        const VulkanObjectInfoTable& object_info_table,
+                                        const T* (VulkanObjectInfoTable::*MapFunc)(format::HandleId) const)
+{
+    typename T::HandleType handle = VK_NULL_HANDLE;
+    const T*               info   = (object_info_table.*MapFunc)(id);
+
+    if (info != nullptr)
+    {
+        handle = info->handle;
+    }
+
+    return handle;
+}
+
+template <typename T>
+static typename T::HandleType* MapHandleArray(HandlePointerDecoder<typename T::HandleType>* handle_pointer,
+                                              const VulkanObjectInfoTable&                  object_info_table,
+                                              const T* (VulkanObjectInfoTable::*MapFunc)(format::HandleId) const)
+{
+    assert(handle_pointer != nullptr);
+
+    typename T::HandleType* handles = nullptr;
+
+    if (!handle_pointer->IsNull())
+    {
+        size_t                  len = handle_pointer->GetLength();
+        const format::HandleId* ids = handle_pointer->GetPointer();
+
+        handle_pointer->SetHandleLength(len);
+
+        handles = handle_pointer->GetHandlePointer();
+
+        for (size_t i = 0; i < len; ++i)
+        {
+            const T* info = (object_info_table.*MapFunc)(ids[i]);
+            if (info != nullptr)
+            {
+                handles[i] = info->handle;
+            }
+            else
+            {
+                handles[i] = VK_NULL_HANDLE;
+            }
+        }
+    }
+
+    return handles;
+}
+
+template <typename T>
+static void AddHandle(const format::HandleId       id,
+                      const typename T::HandleType handle,
+                      T&&                          initial_info,
+                      VulkanObjectInfoTable*       object_info_table,
+                      void (VulkanObjectInfoTable::*AddFunc)(T&&))
+{
+    assert(object_info_table != nullptr);
+
+    initial_info.handle     = handle;
+    initial_info.capture_id = id;
+    (object_info_table->*AddFunc)(std::forward<T>(initial_info));
+}
+
+template <typename T>
+static void AddHandle(format::HandleId       id,
+                      typename T::HandleType handle,
+                      VulkanObjectInfoTable* object_info_table,
+                      void (VulkanObjectInfoTable::*AddFunc)(T&&))
+{
+    assert(object_info_table != nullptr);
+
+    T info;
+    info.handle     = handle;
+    info.capture_id = id;
+    (object_info_table->*AddFunc)(std::move(info));
+}
+
+template <typename T>
+static void AddHandleArray(const format::HandleId*       ids,
+                           size_t                        ids_len,
+                           const typename T::HandleType* handles,
+                           size_t                        handles_len,
+                           std::vector<T>&&              initial_infos,
+                           VulkanObjectInfoTable*        object_info_table,
+                           void (VulkanObjectInfoTable::*AddFunc)(T&&))
+{
+    assert(object_info_table != nullptr);
+
+    if ((ids != nullptr) && (handles != nullptr))
+    {
+        size_t len = std::min(ids_len, handles_len);
+
+        assert(len <= initial_infos.size());
+
+        for (size_t i = 0; i < len; ++i)
+        {
+            auto info_iter        = std::next(initial_infos.begin(), i);
+            info_iter->handle     = handles[i];
+            info_iter->capture_id = ids[i];
+            (object_info_table->*AddFunc)(std::move(*info_iter));
+        }
+    }
+}
+
+template <typename T>
+static void AddHandleArray(const format::HandleId*       ids,
+                           size_t                        ids_len,
+                           const typename T::HandleType* handles,
+                           size_t                        handles_len,
+                           VulkanObjectInfoTable*        object_info_table,
+                           void (VulkanObjectInfoTable::*AddFunc)(T&&))
+{
+    assert(object_info_table != nullptr);
+
+    if ((ids != nullptr) && (handles != nullptr))
+    {
+        size_t len = std::min(ids_len, handles_len);
+        for (size_t i = 0; i < len; ++i)
+        {
+            T info;
+            info.handle     = handles[i];
+            info.capture_id = ids[i];
+            (object_info_table->*AddFunc)(std::move(info));
+        }
+    }
+}
+
+GFXRECON_END_NAMESPACE(handle_mapping)
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_VULKAN_HANDLE_MAPPING_UTIL_H

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -1977,7 +1977,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroups(
     CheckResult("vkEnumeratePhysicalDeviceGroups", returnValue, replay_result);
 
     if (pPhysicalDeviceGroupProperties->IsNull()) { SetOutputArrayCount<InstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDeviceGroups, *out_pPhysicalDeviceGroupCount, &VulkanObjectInfoTable::GetInstanceInfo); }
-    AddStructArrayHandles<Decoded_VkPhysicalDeviceGroupProperties>(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), out_pPhysicalDeviceGroupProperties, *out_pPhysicalDeviceGroupCount, GetObjectInfoTable());
+    AddStructArrayHandles<Decoded_VkPhysicalDeviceGroupProperties>(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), out_pPhysicalDeviceGroupProperties, *out_pPhysicalDeviceGroupCount, &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkGetImageMemoryRequirements2(
@@ -2653,7 +2653,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
     CheckResult("vkGetPhysicalDeviceDisplayPropertiesKHR", returnValue, replay_result);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
-    AddStructArrayHandles<Decoded_VkDisplayPropertiesKHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, GetObjectInfoTable());
+    AddStructArrayHandles<Decoded_VkDisplayPropertiesKHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
@@ -2670,7 +2670,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
     CheckResult("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", returnValue, replay_result);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlanePropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
-    AddStructArrayHandles<Decoded_VkDisplayPlanePropertiesKHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, GetObjectInfoTable());
+    AddStructArrayHandles<Decoded_VkDisplayPlanePropertiesKHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
@@ -2708,7 +2708,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayModePropertiesKHR(
     CheckResult("vkGetDisplayModePropertiesKHR", returnValue, replay_result);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<DisplayKHRInfo>(display, kDisplayKHRArrayGetDisplayModePropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetDisplayKHRInfo); }
-    AddStructArrayHandles<Decoded_VkDisplayModePropertiesKHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, GetObjectInfoTable());
+    AddStructArrayHandles<Decoded_VkDisplayModePropertiesKHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkCreateDisplayModeKHR(
@@ -3073,7 +3073,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
     CheckResult("vkEnumeratePhysicalDeviceGroupsKHR", returnValue, replay_result);
 
     if (pPhysicalDeviceGroupProperties->IsNull()) { SetOutputArrayCount<InstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDeviceGroupsKHR, *out_pPhysicalDeviceGroupCount, &VulkanObjectInfoTable::GetInstanceInfo); }
-    AddStructArrayHandles<Decoded_VkPhysicalDeviceGroupProperties>(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), out_pPhysicalDeviceGroupProperties, *out_pPhysicalDeviceGroupCount, GetObjectInfoTable());
+    AddStructArrayHandles<Decoded_VkPhysicalDeviceGroupProperties>(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), out_pPhysicalDeviceGroupProperties, *out_pPhysicalDeviceGroupCount, &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR(
@@ -3502,7 +3502,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
     CheckResult("vkGetPhysicalDeviceDisplayProperties2KHR", returnValue, replay_result);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
-    AddStructArrayHandles<Decoded_VkDisplayProperties2KHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, GetObjectInfoTable());
+    AddStructArrayHandles<Decoded_VkDisplayProperties2KHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(
@@ -3519,7 +3519,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR
     CheckResult("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", returnValue, replay_result);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlaneProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
-    AddStructArrayHandles<Decoded_VkDisplayPlaneProperties2KHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, GetObjectInfoTable());
+    AddStructArrayHandles<Decoded_VkDisplayPlaneProperties2KHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkGetDisplayModeProperties2KHR(
@@ -3538,7 +3538,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayModeProperties2KHR(
     CheckResult("vkGetDisplayModeProperties2KHR", returnValue, replay_result);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<DisplayKHRInfo>(display, kDisplayKHRArrayGetDisplayModeProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetDisplayKHRInfo); }
-    AddStructArrayHandles<Decoded_VkDisplayModeProperties2KHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, GetObjectInfoTable());
+    AddStructArrayHandles<Decoded_VkDisplayModeProperties2KHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(

--- a/framework/generated/generated_vulkan_struct_handle_mappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.h
@@ -242,22 +242,22 @@ void MapStructArrayHandles(T* structs, size_t len, const VulkanObjectInfoTable& 
     }
 }
 
-void AddStructHandles(const Decoded_VkPhysicalDeviceGroupProperties* id_wrapper, const VkPhysicalDeviceGroupProperties* handle_struct, VulkanObjectInfoTable& object_info_table);
+void AddStructHandles(const Decoded_VkPhysicalDeviceGroupProperties* id_wrapper, const VkPhysicalDeviceGroupProperties* handle_struct, VulkanObjectInfoTable* object_info_table);
 
-void AddStructHandles(const Decoded_VkDisplayPropertiesKHR* id_wrapper, const VkDisplayPropertiesKHR* handle_struct, VulkanObjectInfoTable& object_info_table);
+void AddStructHandles(const Decoded_VkDisplayPropertiesKHR* id_wrapper, const VkDisplayPropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table);
 
-void AddStructHandles(const Decoded_VkDisplayPlanePropertiesKHR* id_wrapper, const VkDisplayPlanePropertiesKHR* handle_struct, VulkanObjectInfoTable& object_info_table);
+void AddStructHandles(const Decoded_VkDisplayPlanePropertiesKHR* id_wrapper, const VkDisplayPlanePropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table);
 
-void AddStructHandles(const Decoded_VkDisplayModePropertiesKHR* id_wrapper, const VkDisplayModePropertiesKHR* handle_struct, VulkanObjectInfoTable& object_info_table);
+void AddStructHandles(const Decoded_VkDisplayModePropertiesKHR* id_wrapper, const VkDisplayModePropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table);
 
-void AddStructHandles(const Decoded_VkDisplayProperties2KHR* id_wrapper, const VkDisplayProperties2KHR* handle_struct, VulkanObjectInfoTable& object_info_table);
+void AddStructHandles(const Decoded_VkDisplayProperties2KHR* id_wrapper, const VkDisplayProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table);
 
-void AddStructHandles(const Decoded_VkDisplayPlaneProperties2KHR* id_wrapper, const VkDisplayPlaneProperties2KHR* handle_struct, VulkanObjectInfoTable& object_info_table);
+void AddStructHandles(const Decoded_VkDisplayPlaneProperties2KHR* id_wrapper, const VkDisplayPlaneProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table);
 
-void AddStructHandles(const Decoded_VkDisplayModeProperties2KHR* id_wrapper, const VkDisplayModeProperties2KHR* handle_struct, VulkanObjectInfoTable& object_info_table);
+void AddStructHandles(const Decoded_VkDisplayModeProperties2KHR* id_wrapper, const VkDisplayModeProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table);
 
 template <typename T>
-void AddStructArrayHandles(const T* id_wrappers, size_t id_len, const typename T::struct_type* handle_structs, size_t handle_len, VulkanObjectInfoTable& object_info_table)
+void AddStructArrayHandles(const T* id_wrappers, size_t id_len, const typename T::struct_type* handle_structs, size_t handle_len, VulkanObjectInfoTable* object_info_table)
 {
     if (id_wrappers != nullptr && handle_structs != nullptr)
     {

--- a/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -352,14 +352,14 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
                                 if value.baseType in self.structsWithHandles:
                                     if value.baseType in self.structsWithHandlePtrs:
                                         preexpr.append('SetStructArrayHandleLengths<Decoded_{}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength());'.format(value.baseType, paramname=value.name))
-                                    postexpr.append('AddStructArrayHandles<Decoded_{basetype}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength(), {}, {}, GetObjectInfoTable());'.format(argName, lengthName, paramname=value.name, basetype=value.baseType))
+                                    postexpr.append('AddStructArrayHandles<Decoded_{basetype}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength(), {}, {}, &GetObjectInfoTable());'.format(argName, lengthName, paramname=value.name, basetype=value.baseType))
                             else:
                                 expr += 'if (!{paramname}->IsNull()) {{ {paramname}->{} }}'.format(allocExpr, paramname=value.name)
                                 # If this is a struct with handles, we need to add replay mappings for the embedded handles.
                                 if value.baseType in self.structsWithHandles:
                                     if value.baseType in self.structsWithHandlePtrs:
                                         preexpr.append('SetStructArrayHandleLengths<Decoded_{}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength());'.format(value.baseType, paramname=value.name))
-                                    postexpr.append('AddStructArrayHandles<Decoded_{basetype}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength(), {paramname}->GetOutputPointer(), {}, GetObjectInfoTable());'.format(lengthName, paramname=value.name, basetype=value.baseType))
+                                    postexpr.append('AddStructArrayHandles<Decoded_{basetype}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength(), {paramname}->GetOutputPointer(), {}, &GetObjectInfoTable());'.format(lengthName, paramname=value.name, basetype=value.baseType))
                         else:
                             if needTempValue:
                                 expr += '{paramname}->IsNull() ? nullptr : {paramname}->AllocateOutputData({});'.format(lengthName, paramname=value.name)
@@ -407,11 +407,11 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
                                     if needTempValue:
                                         if value.baseType in self.structsWithHandlePtrs:
                                             preexpr.append('SetStructHandleLengths<Decoded_{}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength());'.format(value.baseType, paramname=value.name))
-                                        postexpr.append('AddStructHandles<Decoded_{basetype}>({name}->GetMetaStructPointer(), {}, GetObjectInfoTable());'.format(argName, name=value.name, basetype=value.baseType))
+                                        postexpr.append('AddStructHandles<Decoded_{basetype}>({name}->GetMetaStructPointer(), {}, &GetObjectInfoTable());'.format(argName, name=value.name, basetype=value.baseType))
                                     else:
                                         if value.baseType in self.structsWithHandlePtrs:
                                             preexpr.append('SetStructHandleLengths<Decoded_{}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength());'.format(value.baseType, paramname=value.name))
-                                        postexpr.append('AddStructHandles<Decoded_{basetype}>({name}->GetMetaStructPointer(), {name}->GetOutputPointer(), GetObjectTable());'.format(name=value.name, basetype=value.baseType))
+                                        postexpr.append('AddStructHandles<Decoded_{basetype}>({name}->GetMetaStructPointer(), {name}->GetOutputPointer(), &GetObjectInfoTable());'.format(name=value.name, basetype=value.baseType))
                             else:
                                 expr += '{paramname}->IsNull() ? nullptr : {paramname}->AllocateOutputData(1, static_cast<{}>(0));'.format(value.baseType, paramname=value.name)
                 if expr:

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
@@ -87,11 +87,11 @@ class VulkanStructHandleMappersHeaderGenerator(BaseGenerator):
         self.newline()
 
         for struct in self.outputStructsWithHandles:
-            write('void AddStructHandles(const Decoded_{type}* id_wrapper, const {type}* handle_struct, VulkanObjectInfoTable& object_info_table);'.format(type=struct), file=self.outFile)
+            write('void AddStructHandles(const Decoded_{type}* id_wrapper, const {type}* handle_struct, VulkanObjectInfoTable* object_info_table);'.format(type=struct), file=self.outFile)
             self.newline()
 
         write('template <typename T>', file=self.outFile)
-        write('void AddStructArrayHandles(const T* id_wrappers, size_t id_len, const typename T::struct_type* handle_structs, size_t handle_len, VulkanObjectInfoTable& object_info_table)', file=self.outFile)
+        write('void AddStructArrayHandles(const T* id_wrappers, size_t id_len, const typename T::struct_type* handle_structs, size_t handle_len, VulkanObjectInfoTable* object_info_table)', file=self.outFile)
         write('{', file=self.outFile)
         write('    if (id_wrappers != nullptr && handle_structs != nullptr)', file=self.outFile)
         write('    {', file=self.outFile)


### PR DESCRIPTION
Consolidate duplicate utility code for mapping object IDs to handles created on replay.  Some of the duplicated code was not properly updated for a recent change, which led to a replay issue with descriptor updates.
