### PR TITLE
Fix 32-bit debug build warning

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1624,10 +1624,8 @@ void VulkanReplayConsumerBase::SelectPhysicalDevice(PhysicalDeviceInfo* physical
 
 bool VulkanReplayConsumerBase::GetOverrideDevice(InstanceInfo* instance_info, PhysicalDeviceInfo* physical_device_info)
 {
-    const auto& replay_devices = instance_info->replay_devices;
-
-    GFXRECON_CHECK_CONVERSION_DATA_LOSS(int32_t, replay_devices.size());
-    int32_t replay_devices_size = static_cast<int32_t>(replay_devices.size());
+    const auto& replay_devices      = instance_info->replay_devices;
+    int32_t     replay_devices_size = static_cast<int32_t>(replay_devices.size());
 
     // Check for a valid override device index.
     if (options_.override_gpu_index >= replay_devices_size)


### PR DESCRIPTION
Fixes a warning with a signed/unsigned comparison in an assert statement that was generated by a size_t to int32_t conversion check for a vector of VkPhysicalDevice handles retrieved with vkEnumeratePhysicalDevices.
