### PR TITLE
Update Build and Contributing Documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -178,20 +178,31 @@ sudo dnf install git cmake libxcb-devel libX11-devel xcb-util-keysyms-devel \
 ```
 
 ### Linux Build
-The general approach is to run CMake to generate make files. Then either run
+The general approach is to run CMake to generate makefiles. Then either run
 CMake with the `--build` option or `make` to build from the command line.
 
-#### Use CMake to Create the Make Files
+#### Use CMake to Create the Makefiles
 Change your current directory to the top level directory for the cloned
 GFXReconstruct repository, create a build folder, and generate the make
 files.
+
+The following example demonstrates makefile generation for a 64-bit Debug build:
 ```
 cd gfxreconstruct
 mkdir build
 cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug
 ```
 
-Use `-DCMAKE_BUILD_TYPE` to specify a `Debug` or `Release` build profile.
+The following commands can be used to generate makefiles for different
+variations of Debug and Release 32-bit and 64-bit build configurations,
+where `-DCMAKE_BUILD_TYPE` is used to specify `Debug` or `Release` build
+profiles:
+ * 64-bit Release: cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release
+ * 32-bit Debug: cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS=-m32 -DCMAKE_SHARED_LINKER_FLAGS=-m32
+ * 32-bit Release: cmake -H. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-m32 -DCMAKE_SHARED_LINKER_FLAGS=-m32
+
+For 32-bit builds, the 32-bit versions of the required packages specified above
+must be installed.
 
 #### Build the Project
 Run either the `make` or `cmake --build .` command from the build directory

--- a/BUILD.md
+++ b/BUILD.md
@@ -3,19 +3,18 @@ Instructions for building the GFXReconstruct project source code on Linux,
 Windows, and Android platforms.
 
 ## Index
-1. [Contributing](#contributing-to-the-repository)
+1. [Introduction](#introduction)
 2. [Repository Content](#repository-content)
 3. [Repository Set-Up](#repository-set-up)
 4. [Windows Build](#building-on-windows)
 5. [Linux Build](#building-on-linux)
 6. [Android Build](#android)
 
-## Contributing to the Repository
-The preferred work flow for external contributions is to develop the
-contribution in a fork of the GFXReconstruct repository and to submit a pull
-request for the completed contribution.
-
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
+## Introduction
+The following documentation provides end user build instructions for
+the GFXReconstruct software.  Developers interested in contributing to the
+project should also see [CONTRIBUTING.md](CONTRIBUTING.md) for additional
+setup instructions.
 
 ## Repository Content
 The GFXReconstruct repository contains the source code for a Vulkan API
@@ -37,11 +36,13 @@ organized with the following file structure:
 | layer | | GFXReconstruct capture layer for recording Vulkan API data. |
 | tools | | Tools for processing capture files. |
 | | compress | Tool to compress or decompress GFXR capture files. |
+| | extract | Tool to extract SPIR-V binaries from GFXR capture files. |
+| | info | Tool to print information describing GFXR capture files. |
 | | replay | Tool to replay GFXR capture files. |
 | | toascii | Tool to convert GFXR capture files to an ASCII listing of API calls. |
 
 ## Repository Set-Up
-### Download the Repository
+### Clone the Repository
 Use the following Git command to create a local copy of the GFXReconstruct
 repository:
 ```
@@ -72,51 +73,44 @@ Submodules will need to be updated when the repository status (e.g.
 after a repository update (e.g. `git pull`).
 
 ## Common build instructions
-- There is a Python-3 `build.py` script at the repo root that can be used to update
-  all dependencies, and build the project on both Windows and Linux.
-  Run the script with the `-h` option to get help on how to run the build using
-  the script.  
-  The script requires Python 3.5 and above.
-- There is an optional pre-build step for every target to run `clang-format`
-  to apply the GFXReconstruct code style on the code.  
-  This requires `clang-format` to be installed on the system.
-  (`clang-format` version 9 is recommended.)
-  Use the `-DAPPLY_CPP_CODE_STYLE=ON` option to enable this pre-build step.
-  Use the `--code-style` option if building with the build script.
-  Code style is not applied to generated files.
-- It is recommended to run static analysis on the code before submission.
-  Use the `-DRUN_STATIC_ANALYSIS=ON` to run a post-build static analysis using
-  `clang-tidy`.
-  Use the `--static-analysis` option if building with the build script.
+For desktop builds, there is a Python 3 build script, `scripts/build.py`, that can
+be used to update Git submodule dependencies, configure, and build the GFXReconstruct
+software.  The script works with both Windows and Linux, and requires Python 3.5 or
+above.
+
+By default, the script performs some optional build steps that are intended for
+developer builds.  If the target build system has not been configured for
+developer builds as described in [CONTRIBUTING.md](CONTRIBUTING.md), the script
+can be run with the following options to disable the developer build steps:
+```
+python scripts/build.py --skip-check-code-style --skip-tests
+```
+Run the script with the `-h` option for additional usage information.
 
 ## Building for Windows
 ### Windows Development Environment Requirements
 - Microsoft [Visual Studio](https://www.visualstudio.com/)
-  - Versions
+  - Supported Versions
+    - [2019](https://www.visualstudio.com/vs/downloads/)
+    - [2017](https://www.visualstudio.com/vs/older-downloads/)
     - [2015](https://www.visualstudio.com/vs/older-downloads/)
-    - [2017](https://www.visualstudio.com/vs/downloads/)
-  - The Community Edition for each of the above versions is sufficient.
+  - The Community Edition for each of the above versions is sufficient
 - [CMake](http://www.cmake.org/download/) (Version 3.1 or better)
-  - Use the installer option to add CMake to the system PATH
+  - The build instructions assume that CMake has been added to the system PATH
 - Git Client Support
   - [Git for Windows](http://git-scm.com/download/win) is a popular solution
     for Windows
   - Some IDEs (e.g., [Visual Studio](https://www.visualstudio.com/),
     [GitHub Desktop](https://desktop.github.com/)) have integrated
     Git client support
-- Clang-format and Clang-tidy can be installed by installing the Windows Clang 9
-  package from https://releases.llvm.org/download.html; you can install either
-  the [32-bit package](https://releases.llvm.org/9.0.0/LLVM-9.0.0-win32.exe)
-  or the [64-bit package](https://releases.llvm.org/9.0.0/LLVM-9.0.0-win64.exe)
 
 ### Windows Build - Microsoft Visual Studio
-The general approach is to run CMake to generate the Visual Studio project
-files.
-Then either run CMake with the `--build` option to build from the command line
-or use the Visual Studio IDE to open the generated solution and work with the
+The general approach is to first run CMake to generate the Visual Studio project
+files.  Then either run CMake with the `--build` option to build from the command
+line or use the Visual Studio IDE to open the generated solution and work with the
 solution interactively.
 
-#### Use `CMake` to Create the Visual Studio Project Files
+#### Generate Visual Studio Project Files with `CMake`
 Change your current directory to the top level directory for the cloned
 GFXReconstruct repository, create a build folder, and generate the Visual
 Studio project files.
@@ -128,7 +122,6 @@ cd gfxreconstruct
 mkdir build
 cmake -H. -Bbuild -G "Visual Studio 15 Win64"
 ```
-
 The following commands can be used to generate project files for different
 variations of the Visual Studio 2015 and 2017 WIN32 and x64 build
 configurations:
@@ -136,7 +129,7 @@ configurations:
  * 32-bit for VS 2017: cmake -H. -Bbuild -G "Visual Studio 15"
  * 32-bit for VS 2015: cmake -H. -Bbuild -G "Visual Studio 14"
 
-The above steps create a Windows solution file named
+Running any of the above commands will create a Windows solution file named
 `GFXReconstruct.sln` in the build directory.
 
 At this point, you can build the solution from the command line or open the
@@ -156,17 +149,7 @@ cmake --build . --config Release
 ```
 
 #### Build the Solution With Visual Studio
-Launch **Visual Studio**.
-
-If you're using **Visual Studio 2017**, under **Tools->Options...**, expand **Text Editor > C/C++ > Formatting**.  At the bottom is a checkbox for **Use custom clang-format.exe file**.
-Select this, and browse to the `clang-format.exe` from the installer you installed.
-(If you used the default installer settings, this will be
-`C:\Program Files\LLVM\bin\clang-format.exe`.)
-
-If you're using **Visual Studio 2019**, this is unnecessary, as `clang-format-9` 
-is used by default.  If you're using **Visual Studio 2015**, there is no such option.
-
-Then open the `GFXReconstruct.sln` solution file
+Launch **Visual Studio** and open the `GFXReconstruct.sln` solution file
 from the build folder. You may select "Debug" or "Release" from the Solution
 Configurations drop-down list. Start a build by selecting the Build->Build
 Solution menu item.
@@ -178,46 +161,20 @@ Building on Linux requires the installation of the following packages:
 * Git
 * CMake
 * X11 + XCB and/or Wayland development libraries
-* `clang-format-9` package
-
-The following optional packages are also recommended:
-* `clang-tidy-9` package
 
 ##### Ubuntu
-On Ubuntu 20, `clang-format-9` is the default chosen by the installer.
-On earlier versions of Ubuntu, install the correct `clang-format` from the
-[LLVM toolchain repository](https://apt.llvm.org), either using the processes
-described there, or the summary here:
-- Ubuntu 18 (Bionic)
+For Ubuntu, the required packages can be installed with the following command:
 ```
-echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main" | sudo tee /etc/apt/sources.list.d/llvm.list
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-```
-- Ubuntu 16 (Xenial)
-```
-echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" | sudo tee /etc/apt/sources.list.d/llvm.list
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-```
-
-On any version of Ubuntu, continue with:
-```
-sudo apt update
 sudo apt-get install git cmake build-essential libx11-xcb-dev libxcb-keysyms1-dev \
-        libwayland-dev libxrandr-dev liblz4-dev libzstd-dev clang-format-9 clang-tidy-9
+        libwayland-dev libxrandr-dev liblz4-dev libzstd-dev
 ```
 
-Configure `clang-format` and `clang-tidy` so that the new version is used by default:
-```
-sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-9 900
-sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 900
-```
-
-##### Fedora Core
-On Fedora Core, the required packages can be installed with the following
+##### Fedora
+For Fedora, the required packages can be installed with the following
 command:
 ```
 sudo dnf install git cmake libxcb-devel libX11-devel xcb-util-keysyms-devel \
-        libXrandr-devel wayland-devel lz4-devel libzstd-devel clang clang-tools-extra
+        libXrandr-devel wayland-devel lz4-devel libzstd-devel
 ```
 
 ### Linux Build
@@ -240,13 +197,14 @@ Use `-DCMAKE_BUILD_TYPE` to specify a `Debug` or `Release` build profile.
 Run either the `make` or `cmake --build .` command from the build directory
 to build the GFXReconstruct project source.
 
-For faster builds on multi-core systems with `make`, use `make -j` to
-specify the number of cores to use for the build. For example:
+For faster builds on multi-core systems with `make`, use `make -jN` to
+specify the number of jobs that are allowed to run at the same time with
+the build.  For example:
 ```
 make -j4
 ```
 
-For build systems that support ccache, enable it with the CMake
+For build systems that support ccache, it can be enabled with the CMake
 `-DUSE_CCACHE=On` option.
 
 ## Install the project

--- a/BUILD.md
+++ b/BUILD.md
@@ -72,21 +72,22 @@ Submodules will need to be updated when the repository status (e.g.
 after a repository update (e.g. `git pull`).
 
 ## Common build instructions
-- There is a Python-3 build.py script at the repo root that can be used to update
+- There is a Python-3 `build.py` script at the repo root that can be used to update
   all dependencies, and build the project on both Windows and Linux.
-  Run the script with the -h option to get help on how to run the build using
+  Run the script with the `-h` option to get help on how to run the build using
   the script.  
   The script requires Python 3.5 and above.
-- There is an optional pre-build step for every target to run clang-format
+- There is an optional pre-build step for every target to run `clang-format`
   to apply the GFXReconstruct code style on the code.  
-  This requires clang-format to be installed on the system.
+  This requires `clang-format` to be installed on the system.
+  (`clang-format` version 9 is recommended.)
   Use the `-DAPPLY_CPP_CODE_STYLE=ON` option to enable this pre-build step.
-  Use the --code-style option if building with the build script.
+  Use the `--code-style` option if building with the build script.
   Code style is not applied to generated files.
 - It is recommended to run static analysis on the code before submission.
-  Use the -DRUN_STATIC_ANALYSIS=ON to run a post-build static analysis using
-  clang-tidy.
-  Use the --static-analysis option if building with the build script.
+  Use the `-DRUN_STATIC_ANALYSIS=ON` to run a post-build static analysis using
+  `clang-tidy`.
+  Use the `--static-analysis` option if building with the build script.
 
 ## Building for Windows
 ### Windows Development Environment Requirements
@@ -103,8 +104,10 @@ after a repository update (e.g. `git pull`).
   - Some IDEs (e.g., [Visual Studio](https://www.visualstudio.com/),
     [GitHub Desktop](https://desktop.github.com/)) have integrated
     Git client support
-- Clang-format and Clang-tidy can be installed by installing the Windows Clang
-  package from http://llvm.org/builds/
+- Clang-format and Clang-tidy can be installed by installing the Windows Clang 9
+  package from https://releases.llvm.org/download.html; you can install either
+  the [32-bit package](https://releases.llvm.org/9.0.0/LLVM-9.0.0-win32.exe)
+  or the [64-bit package](https://releases.llvm.org/9.0.0/LLVM-9.0.0-win64.exe)
 
 ### Windows Build - Microsoft Visual Studio
 The general approach is to run CMake to generate the Visual Studio project
@@ -153,7 +156,17 @@ cmake --build . --config Release
 ```
 
 #### Build the Solution With Visual Studio
-Launch Visual Studio and open the `GFXReconstruct.sln` solution file
+Launch **Visual Studio**.
+
+If you're using **Visual Studio 2017**, under **Tools->Options...**, expand **Text Editor > C/C++ > Formatting**.  At the bottom is a checkbox for **Use custom clang-format.exe file**.
+Select this, and browse to the `clang-format.exe` from the installer you installed.
+(If you used the default installer settings, this will be
+`C:\Program Files\LLVM\bin\clang-format.exe`.)
+
+If you're using **Visual Studio 2019**, this is unnecessary, as `clang-format-9` 
+is used by default.  If you're using **Visual Studio 2015**, there is no such option.
+
+Then open the `GFXReconstruct.sln` solution file
 from the build folder. You may select "Debug" or "Release" from the Solution
 Configurations drop-down list. Start a build by selecting the Build->Build
 Solution menu item.
@@ -165,17 +178,38 @@ Building on Linux requires the installation of the following packages:
 * Git
 * CMake
 * X11 + XCB and/or Wayland development libraries
-* clang-format package
+* `clang-format-9` package
 
 The following optional packages are also recommended:
-* clang-tidy package
+* `clang-tidy-9` package
 
 ##### Ubuntu
-On Ubuntu, the required packages can be installed with the following
-command:
+On Ubuntu 20, `clang-format-9` is the default chosen by the installer.
+On earlier versions of Ubuntu, install the correct `clang-format` from the
+[LLVM toolchain repository](https://apt.llvm.org), either using the processes
+described there, or the summary here:
+- Ubuntu 18 (Bionic)
 ```
+echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main" | sudo tee /etc/apt/sources.list.d/llvm.list
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+```
+- Ubuntu 16 (Xenial)
+```
+echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" | sudo tee /etc/apt/sources.list.d/llvm.list
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+```
+
+On any version of Ubuntu, continue with:
+```
+sudo apt update
 sudo apt-get install git cmake build-essential libx11-xcb-dev libxcb-keysyms1-dev \
-        libwayland-dev libxrandr-dev liblz4-dev libzstd-dev clang-format clang-tidy
+        libwayland-dev libxrandr-dev liblz4-dev libzstd-dev clang-format-9 clang-tidy-9
+```
+
+Configure `clang-format` and `clang-tidy` so that the new version is used by default:
+```
+sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-9 900
+sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 900
 ```
 
 ##### Fedora Core
@@ -224,7 +258,7 @@ variable. For example, to install to a "/tmp/gfxreconstruct" directory, run `cma
 from gfxreconstruct's root source directory. Then install with `make install`.
 
 ## Android
-### Android Develpment Requirements
+### Android Development Requirements
  * The latest version of [Android Studio](https://developer.android.com/studio/) with additional items:
    * The [Android Platform tools](https://developer.android.com/studio/releases/platform-tools) for your specific platform
    * The [Android NDK](https://developer.android.com/ndk/guides/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ While there are often active and organized development efforts underway to
 improve the functionality
 and coverage of this layer, there are always opportunities for anyone to help
 by contributing.
-The easiest method for contribuiting is to examine the
+The easiest method for contributing is to examine the
 [issues list](https://github.com/LunarG/gfxreconstruct/issues) in this repository
 and look for issues that are of interest
 
@@ -50,7 +50,7 @@ GitHub under Issues and Pull Requests.
 
 #### **Coding Conventions and Formatting**
 * The coding style is a custom clang-format style defined in the .clang-format
-  file at the base of the repo tree.
+  file at the base of the repo tree, and using **clang-format-9**.
 * Run **clang-format** on your changes to maintain consistent formatting
     * There are `.clang-format files` present in the repository to define
       clang-format settings which are found and used automatically by clang-format.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,66 +1,60 @@
-## How to Contribute to the GFXReconstruct Repository
+## Contributing to the GFXReconstruct Project
 
+### **Introduction**
 
-### **The Repository**
-
-The source code for GFXReconstruct tools is sponsored by Valve and LunarG.
-* [GFXReconstruct](https://github.com/LunarG/gfxreconstruct)
-
-
-### **The Vulkan Ecosystem Needs Your Help**
-
-The Vulkan VK_LAYER_LUNARG_gfxreconstruct layer and tools are important
-components in the Vulkan Ecosystem.
-While there are often active and organized development efforts underway to
-improve the functionality
-and coverage of this layer, there are always opportunities for anyone to help
-by contributing.
-The easiest method for contributing is to examine the
-[issues list](https://github.com/LunarG/gfxreconstruct/issues) in this repository
-and look for issues that are of interest
-
-Of course, if you have your own work in mind, please open an issue to describe
-it and assign it to yourself.
-Finally, please feel free to contact any of the developers that are actively
-contributing should you wish to coordinate further.
+Although the GFXReconstruct project is under active development, external
+contributions are always welcome.  Open issues and available tasks can
+can be found in the project
+[issues list](https://github.com/LunarG/gfxreconstruct/issues).  When
+working on changes that are not already in the issues list, please
+consider creating a new issue to avoid duplication of effort, and
+feel free to contact any of the project developers should you wish to
+coordinate further.
 
 Repository Issue labels:
-
 * _Bug_:          These issues refer to invalid or broken functionality and
  are the highest priority.
-* _Enhancement_:  These issues refer to ideas for extending or improving the
- GFXReconstruct layer or tools.
+* _Enhancement_:  These issues refer to tasks for extending or improving the
+ GFXReconstruct software.
 
-It is the maintainers goal for all issues to be assigned within one business
-day of their submission.
-If you choose to work on an issue that is assigned, simply coordinate with the
-current assignee.
+If you would like to work on an issue that is already assigned, please coordinate
+with the current assignee.
 
 
-### **How to Submit Fixes**
+### **How to Submit Changes**
 
-* **Ensure that the bug was not already reported or fixed** by searching on
-GitHub under Issues and Pull Requests.
-* Use the existing GitHub forking and pull request process.
-  This will involve [forking the repository](https://help.github.com/articles/fork-a-repo/),
+Changes to the GFXReconstruct project should be made on the `dev` branch, which
+is periodically merged to the `master` branch for project releases.  Incoming
+submissions should adhere to the following:
+* Ensure that the issue has not already been addressed by searching the project's
+GitHub Issues and Pull Requests.
+* Use the existing GitHub fork and pull request process.
+  This involves [forking the repository](https://help.github.com/articles/fork-a-repo/),
   creating a branch with your commits, and then [submitting a pull request](https://help.github.com/articles/using-pull-requests/).
-* Please read and adhere to the style and process [guidelines ](#coding-conventions-and-formatting) enumerated below.
-* Please base your fixes on the master branch.
+* Implement and submit changes against the `dev` branch.
+* Please read and adhere to the style and process [guidelines](#coding-conventions-and-formatting) documented below.
 
 
 #### **Coding Conventions and Formatting**
-* The coding style is a custom clang-format style defined in the .clang-format
-  file at the base of the repo tree, and using **clang-format-9**.
-* Run **clang-format** on your changes to maintain consistent formatting
-    * There are `.clang-format files` present in the repository to define
-      clang-format settings which are found and used automatically by clang-format.
+* Changes to the GFXReconstruct project should conform to the coding style
+  defined by the
+  (Google C++ Style Guide)[https://google.github.io/styleguide/cppguide.html].
+* Code formatting is managed with a custom ClangFormat configuration file.
+  This is the `.clang-format` file found at the base of the repo tree.
+  It is intended for use with **ClangFormat version 9.0.1**.
+    * ClangFormat version 9.0.1 can be obtained by installing the LLVM 9.0.1
+      package available from https://releases.llvm.org/download.html, or see
+      below for platform-specific installation notes.
+* Formatting can be applied to pending changes with the `clang-format` or
+  `git clang-format` commands.
     * A sample git workflow may look like:
-
 >        # Make changes to the source.
 >        $ git add -u .
->        $ git clang-format --style=file
->        # Check to see if clang-format made any changes and if they are OK.
+>        $ git clang-format
+>
+>        # Check for changes applied by clang-format, and if so:
 >        $ git add -u .
+>
 >        $ git commit
 
 * **Commit Messages**
@@ -71,7 +65,7 @@ GitHub under Issues and Pull Requests.
     * Capitalize the subject line
     * Do not end the subject line with a period
     * Use the body to explain what and why vs. how
-    * Use the imperative mode in the subject line. This just means to write it
+    * Use the imperative mode in the subject line; this just means to write it
       as a command (e.g. Fix the sprocket)
 
 Strive for commits that implement a single or related set of functionality,
@@ -79,10 +73,21 @@ using as many commits as is necessary (more is better).
 That said, please ensure that the repository compiles and passes tests without
 error for each commit in your pull request.
 
-**NOTE:** to be accepted into the repository, the pull request must
+**NOTE:** To be accepted into the repository, the pull request must
 [pass all tests](#testing your changes) on all supported platforms
 -- the automatic Github Travis and AppVeyor continuous integration features will
 assist in enforcing this requirement.
+
+
+#### **Verifying Changes with the Build Script**
+For desktop, the Python 3 `scripts\build.py` script can be used to verify changes
+before they are committed.  By default, the script performs a pre-build step to
+verify that the formatting of uncommitted changes adheres to the project's
+ClangFormat style.
+
+The build script also has an option to apply `clang-format` to project files
+before build.  Run the script with the `-h` option for additional usage
+information.
 
 
 #### **Testing Your Changes**
@@ -115,3 +120,48 @@ Apache 2.0 license and any new files need to include this license and any
 applicable copyrights.
 
 You can include your individual copyright after any existing copyrights.
+
+
+### **Platform-specific ClangFormat Installation**
+The following is a collection of notes for obtaining ClangFormat version 9.0.1
+on various platforms.
+
+#### **Visual Studio**
+* Visual Studio 2019 has built-in support for ClangFormat version 9.
+* Visual Studio 2017 has built-in support for ClangFormat version 7,
+  but can be changed to use a separately installed ClangFormat version 9
+  by following the instructions described here:
+    * Under **Tools->Options...**, expand **Text Editor > C/C++ > Formatting**.
+      At the bottom is a checkbox for **Use custom clang-format.exe file**.
+      Select this, and browse to the location of the 9.0.1 version of
+      `clang-format.exe` that was installed separately.
+
+#### **Ubuntu**
+For Ubuntu 20, `clang-format-9` is the default provided by the package manager.
+
+For earlier versions of Ubuntu, the required version of `clang-format` can be
+obtained through the [LLVM toolchain repository](https://apt.llvm.org) by
+following the instructions described here:
+- Ubuntu 18 (Bionic)
+```
+echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main" | sudo tee /etc/apt/sources.list.d/llvm.list
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+```
+- Ubuntu 16 (Xenial)
+```
+echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" | sudo tee /etc/apt/sources.list.d/llvm.list
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+```
+On any version of Ubuntu, continue with:
+
+```
+sudo apt update
+sudo apt-get install clang-format-9 clang-tidy-9
+```
+
+Configure `clang-format` and `clang-tidy` so that the new version is used by default:
+```
+sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-9 900
+sudo update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 900
+```
+


### PR DESCRIPTION
- Move clang-format installation instructions from BUILD.md to CONTRIBUTING.md
- Update CONSTRIBUTING.md to specify that changes be submitted against the dev branch
- Add 32-bit build instructions for Linux to BUILD.md

Includes changes from #357 