### PR TITLE
Add missing meta-data types to gfxrecon-compress

### DIFF
--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -46,35 +46,33 @@ class ApiDecoder
                                     const uint8_t*     buffer,
                                     size_t             buffer_size) = 0;
 
-    virtual void DispatchStateBeginMarker(uint64_t frame_number) {}
+    virtual void DispatchStateBeginMarker(uint64_t frame_number) = 0;
 
-    virtual void DispatchStateEndMarker(uint64_t frame_number) {}
+    virtual void DispatchStateEndMarker(uint64_t frame_number) = 0;
 
-    virtual void DispatchDisplayMessageCommand(format::ThreadId thread_id, const std::string& message) {}
+    virtual void DispatchDisplayMessageCommand(format::ThreadId thread_id, const std::string& message) = 0;
 
     virtual void DispatchFillMemoryCommand(
-        format::ThreadId thread_id, uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data)
-    {}
+        format::ThreadId thread_id, uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data) = 0;
 
     virtual void DispatchResizeWindowCommand(format::ThreadId thread_id,
                                              format::HandleId surface_id,
                                              uint32_t         width,
-                                             uint32_t         height)
-    {}
+                                             uint32_t         height) = 0;
 
-    virtual void DispatchCreateHardwareBufferCommand(format::ThreadId                                    thread_id,
-                                                     format::HandleId                                    memory_id,
-                                                     uint64_t                                            buffer_id,
-                                                     uint32_t                                            format,
-                                                     uint32_t                                            width,
-                                                     uint32_t                                            height,
-                                                     uint32_t                                            stride,
-                                                     uint32_t                                            usage,
-                                                     uint32_t                                            layers,
-                                                     const std::vector<format::HardwareBufferPlaneInfo>& plane_info)
-    {}
+    virtual void
+    DispatchCreateHardwareBufferCommand(format::ThreadId                                    thread_id,
+                                        format::HandleId                                    memory_id,
+                                        uint64_t                                            buffer_id,
+                                        uint32_t                                            format,
+                                        uint32_t                                            width,
+                                        uint32_t                                            height,
+                                        uint32_t                                            stride,
+                                        uint32_t                                            usage,
+                                        uint32_t                                            layers,
+                                        const std::vector<format::HardwareBufferPlaneInfo>& plane_info) = 0;
 
-    virtual void DispatchDestroyHardwareBufferCommand(format::ThreadId thread_id, uint64_t buffer_id) {}
+    virtual void DispatchDestroyHardwareBufferCommand(format::ThreadId thread_id, uint64_t buffer_id) = 0;
 
     virtual void DispatchSetDevicePropertiesCommand(format::ThreadId   thread_id,
                                                     format::HandleId   physical_device_id,
@@ -84,36 +82,33 @@ class ApiDecoder
                                                     uint32_t           device_id,
                                                     uint32_t           device_type,
                                                     const uint8_t      pipeline_cache_uuid[format::kUuidSize],
-                                                    const std::string& device_name)
-    {}
+                                                    const std::string& device_name) = 0;
 
-    virtual void DispatchSetDeviceMemoryPropertiesCommand(format::ThreadId thread_id,
-                                                          format::HandleId physical_device_id,
-                                                          const std::vector<format::DeviceMemoryType>& memory_types,
-                                                          const std::vector<format::DeviceMemoryHeap>& memory_heaps)
-    {}
+    virtual void
+    DispatchSetDeviceMemoryPropertiesCommand(format::ThreadId                             thread_id,
+                                             format::HandleId                             physical_device_id,
+                                             const std::vector<format::DeviceMemoryType>& memory_types,
+                                             const std::vector<format::DeviceMemoryHeap>& memory_heaps) = 0;
 
-    virtual void DispatchSetSwapchainImageStateCommand(format::ThreadId thread_id,
-                                                       format::HandleId device_id,
-                                                       format::HandleId swapchain_id,
-                                                       uint32_t         last_presented_image,
-                                                       const std::vector<format::SwapchainImageStateInfo>& image_state)
-    {}
+    virtual void
+    DispatchSetSwapchainImageStateCommand(format::ThreadId                                    thread_id,
+                                          format::HandleId                                    device_id,
+                                          format::HandleId                                    swapchain_id,
+                                          uint32_t                                            last_presented_image,
+                                          const std::vector<format::SwapchainImageStateInfo>& image_state) = 0;
 
     virtual void DispatchBeginResourceInitCommand(format::ThreadId thread_id,
                                                   format::HandleId device_id,
                                                   uint64_t         max_resource_size,
-                                                  uint64_t         max_copy_size)
-    {}
+                                                  uint64_t         max_copy_size) = 0;
 
-    virtual void DispatchEndResourceInitCommand(format::ThreadId thread_id, format::HandleId device_id) {}
+    virtual void DispatchEndResourceInitCommand(format::ThreadId thread_id, format::HandleId device_id) = 0;
 
     virtual void DispatchInitBufferCommand(format::ThreadId thread_id,
                                            format::HandleId device_id,
                                            format::HandleId buffer_id,
                                            uint64_t         data_size,
-                                           const uint8_t*   data)
-    {}
+                                           const uint8_t*   data) = 0;
 
     virtual void DispatchInitImageCommand(format::ThreadId             thread_id,
                                           format::HandleId             device_id,
@@ -122,8 +117,7 @@ class ApiDecoder
                                           uint32_t                     aspect,
                                           uint32_t                     layout,
                                           const std::vector<uint64_t>& level_sizes,
-                                          const uint8_t*               data)
-    {}
+                                          const uint8_t*               data) = 0;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/compression_converter.h
+++ b/framework/decode/compression_converter.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018-2019 Valve Corporation
-** Copyright (c) 2018-2019 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -67,6 +67,36 @@ class CompressionConverter : public ApiDecoder
                                              format::HandleId surface_id,
                                              uint32_t         width,
                                              uint32_t         height) override;
+
+    virtual void
+    DispatchCreateHardwareBufferCommand(format::ThreadId                                    thread_id,
+                                        format::HandleId                                    memory_id,
+                                        uint64_t                                            buffer_id,
+                                        uint32_t                                            format,
+                                        uint32_t                                            width,
+                                        uint32_t                                            height,
+                                        uint32_t                                            stride,
+                                        uint32_t                                            usage,
+                                        uint32_t                                            layers,
+                                        const std::vector<format::HardwareBufferPlaneInfo>& plane_info) override;
+
+    virtual void DispatchDestroyHardwareBufferCommand(format::ThreadId thread_id, uint64_t buffer_id) override;
+
+    virtual void DispatchSetDevicePropertiesCommand(format::ThreadId   thread_id,
+                                                    format::HandleId   physical_device_id,
+                                                    uint32_t           api_version,
+                                                    uint32_t           driver_version,
+                                                    uint32_t           vendor_id,
+                                                    uint32_t           device_id,
+                                                    uint32_t           device_type,
+                                                    const uint8_t      pipeline_cache_uuid[format::kUuidSize],
+                                                    const std::string& device_name) override;
+
+    virtual void
+    DispatchSetDeviceMemoryPropertiesCommand(format::ThreadId                             thread_id,
+                                             format::HandleId                             physical_device_id,
+                                             const std::vector<format::DeviceMemoryType>& memory_types,
+                                             const std::vector<format::DeviceMemoryHeap>& memory_heaps) override;
 
     virtual void
     DispatchSetSwapchainImageStateCommand(format::ThreadId                                    thread_id,

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -793,7 +793,7 @@ void TraceManager::WriteCreateHardwareBufferCmd(format::HandleId                
         else
         {
             create_buffer_cmd.planes = static_cast<uint32_t>(plane_info.size());
-            // Update size of packet with compressed or uncompressed data size.
+            // Update size of packet with size of plane info.
             planes_size = sizeof(plane_info[0]) * plane_info.size();
             create_buffer_cmd.meta_header.block_header.size += planes_size;
         }


### PR DESCRIPTION
- Add implementations for the virtual methods responsible for processing AHB, device property, and device memory property meta-data to the CompressionConverter class.
- Change the virtual meta-data dispatch methods declared in the ApiDecoder base class to pure virtual to avoid this problem in the future.