### PR TITLE
Send all Xcb intern atom requests before waiting for a reply

### DIFF
--- a/framework/application/xcb_window.h
+++ b/framework/application/xcb_window.h
@@ -81,7 +81,10 @@ class XcbWindow : public decode::Window
   private:
     void SetFullscreen(bool fullscreen);
 
-    xcb_atom_t GetAtom(const char* name, uint8_t only_if_exists) const;
+    xcb_intern_atom_cookie_t
+    SendAtomRequest(xcb_connection_t* connection, const char* name, uint8_t only_if_exists) const;
+
+    xcb_atom_t GetAtomReply(xcb_connection_t* connection, const char* name, xcb_intern_atom_cookie_t cookie) const;
 
     void InitializeAtoms();
 


### PR DESCRIPTION
Send all Xcb atom requests before waiting for a reply. Splits the XcbWindow::GetAtom method into separate SendAtomRequest and GetAtomReply methods.
