### PR TITLE
Add -h option to command line utilities

### DIFF
--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -59,7 +59,7 @@ void android_main(struct android_app* app)
 
     bool run = true;
 
-    if (PrintVersion(kApplicationName, arg_parser))
+    if (CheckOptionPrintUsage(kApplicationName, arg_parser) || CheckOptionPrintVersion(kApplicationName, arg_parser))
     {
         run = false;
     }

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -52,15 +52,15 @@ const char kLayerEnvVar[] = "VK_INSTANCE_LAYERS";
 
 int main(int argc, const char** argv)
 {
-    int         return_code = 0;
-    std::string filename;
+    int return_code = 0;
 
     gfxrecon::util::Log::Init();
 
     gfxrecon::util::ArgumentParser arg_parser(argc, argv, kOptions, kArguments);
 
-    if (PrintVersion(argv[0], arg_parser))
+    if (CheckOptionPrintVersion(argv[0], arg_parser) || CheckOptionPrintUsage(argv[0], arg_parser))
     {
+        gfxrecon::util::Log::Release();
         exit(0);
     }
     else if (arg_parser.IsInvalid() || (arg_parser.GetPositionalArgumentsCount() != 1))
@@ -71,15 +71,14 @@ int main(int argc, const char** argv)
     }
     else
     {
-        const std::vector<std::string>& positional_arguments = arg_parser.GetPositionalArguments();
-        filename                                             = positional_arguments[0];
         ProcessDisableDebugPopup(arg_parser);
     }
 
-    auto wsi_platform = GetWsiPlatform(arg_parser);
-
     try
     {
+        const std::vector<std::string>& positional_arguments = arg_parser.GetPositionalArguments();
+        std::string                     filename             = positional_arguments[0];
+
         gfxrecon::decode::FileProcessor                     file_processor;
         std::unique_ptr<gfxrecon::application::Application> application;
         std::unique_ptr<gfxrecon::decode::WindowFactory>    window_factory;
@@ -90,6 +89,8 @@ int main(int argc, const char** argv)
         }
         else
         {
+            auto wsi_platform = GetWsiPlatform(arg_parser);
+
             // Setup platform specific application and window factory.
 #if defined(WIN32)
 #if defined(VK_USE_PLATFORM_WIN32_KHR)

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -35,6 +35,8 @@
 const char kApplicationName[] = "GFXReconstruct Replay";
 const char kCaptureLayer[]    = "VK_LAYER_LUNARG_gfxreconstruct";
 
+const char kHelpShortOption[]                  = "-h";
+const char kHelpLongOption[]                   = "--help";
 const char kVersionOption[]                    = "--version";
 const char kOverrideGpuArgument[]              = "--gpu";
 const char kPausedOption[]                     = "--paused";
@@ -50,7 +52,7 @@ const char kShaderReplaceArgument[]            = "--replace-shaders";
 const char kNoDebugPopup[]                     = "--no-debug-popup";
 
 const char kOptions[] =
-    "--version,--paused,--sfa|--skip-failed-allocations,--opcd|--omit-pipeline-cache-data,--no-debug-popup";
+    "-h|--help,--version,--paused,--sfa|--skip-failed-allocations,--opcd|--omit-pipeline-cache-data,--no-debug-popup";
 const char kArguments[] = "--gpu,--pause-frame,--wsi,-m|--memory-translation,--replace-shaders";
 
 enum class WsiPlatform
@@ -242,7 +244,7 @@ static gfxrecon::decode::ReplayOptions GetReplayOptions(const gfxrecon::util::Ar
     return replay_options;
 }
 
-static bool PrintVersion(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
+static bool CheckOptionPrintVersion(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
 {
     if (arg_parser.IsOptionSet(kVersionOption))
     {
@@ -279,9 +281,9 @@ static void PrintUsage(const char* exe_name)
 
     GFXRECON_WRITE_CONSOLE("\n%s - A tool to replay GFXReconstruct capture files.\n", app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");
-    GFXRECON_WRITE_CONSOLE("  %s\t[--version] [--gpu <index>] [--pause-frame <N>]", app_name.c_str());
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--paused] [--sfa | --skip-failed-allocations]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--replace-shaders <dir>]");
+    GFXRECON_WRITE_CONSOLE("  %s\t[-h | --help] [--version] [--gpu <index>]", app_name.c_str());
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--pause-frame <N>] [--paused]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--sfa | --skip-failed-allocations] [--replace-shaders <dir>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--opcd | --omit-pipeline-cache-data] [--wsi <platform>]");
 #if defined(WIN32) && defined(_DEBUG)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--no-debug-popup]");
@@ -290,6 +292,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("Required arguments:");
     GFXRECON_WRITE_CONSOLE("  <file>\t\tPath to the capture file to replay.");
     GFXRECON_WRITE_CONSOLE("\nOptional arguments:");
+    GFXRECON_WRITE_CONSOLE("  -h\t\t\tPrint usage information and exit (same as --help).");
     GFXRECON_WRITE_CONSOLE("  --version\t\tPrint version information and exit.");
     GFXRECON_WRITE_CONSOLE("  --gpu <index>\t\tUse the specified device for replay, where index");
     GFXRECON_WRITE_CONSOLE("          \t\tis the zero-based index to the array of physical devices");
@@ -328,6 +331,17 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\t         \tto different allocations with different");
     GFXRECON_WRITE_CONSOLE("          \t\t         \toffsets.  Uses VMA to manage allocations");
     GFXRECON_WRITE_CONSOLE("          \t\t         \tand suballocations.");
+}
+
+static bool CheckOptionPrintUsage(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
+{
+    if (arg_parser.IsOptionSet(kHelpShortOption) || arg_parser.IsOptionSet(kHelpLongOption))
+    {
+        PrintUsage(exe_name);
+        return true;
+    }
+
+    return false;
 }
 
 #endif // GFXRECON_REPLAY_SETTINGS_H

--- a/tools/toascii/main.cpp
+++ b/tools/toascii/main.cpp
@@ -28,12 +28,48 @@
 
 #include <cstdlib>
 
-const char kVersionOption[] = "--version";
-const char kNoDebugPopup[]  = "--no-debug-popup";
+const char kHelpShortOption[] = "-h";
+const char kHelpLongOption[]  = "--help";
+const char kVersionOption[]   = "--version";
+const char kNoDebugPopup[]    = "--no-debug-popup";
 
-const char kOptions[] = "--version,--no-debug-popup";
+const char kOptions[] = "-h|--help,--version,--no-debug-popup";
 
-static bool PrintVersion(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
+static void PrintUsage(const char* exe_name)
+{
+    std::string app_name     = exe_name;
+    size_t      dir_location = app_name.find_last_of("/\\");
+    if (dir_location >= 0)
+    {
+        app_name.replace(0, dir_location + 1, "");
+    }
+    GFXRECON_WRITE_CONSOLE("\n%s - A tool to convert GFXReconstruct capture files to text.\n", app_name.c_str());
+    GFXRECON_WRITE_CONSOLE("Usage:");
+    GFXRECON_WRITE_CONSOLE("  %s [-h | --help] [--version] <file>\n", app_name.c_str());
+    GFXRECON_WRITE_CONSOLE("Required arguments:");
+    GFXRECON_WRITE_CONSOLE("  <file>\t\tPath to the GFXReconstruct capture file to be converted");
+    GFXRECON_WRITE_CONSOLE("        \t\tto text.");
+    GFXRECON_WRITE_CONSOLE("\nOptional arguments:");
+    GFXRECON_WRITE_CONSOLE("  -h\t\t\tPrint usage information and exit (same as --help).");
+    GFXRECON_WRITE_CONSOLE("  --version\t\tPrint version information and exit.");
+#if defined(WIN32) && defined(_DEBUG)
+    GFXRECON_WRITE_CONSOLE("  --no-debug-popup\tDisable the 'Abort, Retry, Ignore' message box");
+    GFXRECON_WRITE_CONSOLE("        \t\tdisplayed when abort() is called (Windows debug only).");
+#endif
+}
+
+static bool CheckOptionPrintUsage(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
+{
+    if (arg_parser.IsOptionSet(kHelpShortOption) || arg_parser.IsOptionSet(kHelpLongOption))
+    {
+        PrintUsage(exe_name);
+        return true;
+    }
+
+    return false;
+}
+
+static bool CheckOptionPrintVersion(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
 {
     if (arg_parser.IsOptionSet(kVersionOption))
     {
@@ -58,38 +94,15 @@ static bool PrintVersion(const char* exe_name, const gfxrecon::util::ArgumentPar
     return false;
 }
 
-void PrintUsage(const char* exe_name)
-{
-    std::string app_name     = exe_name;
-    size_t      dir_location = app_name.find_last_of("/\\");
-    if (dir_location >= 0)
-    {
-        app_name.replace(0, dir_location + 1, "");
-    }
-    GFXRECON_WRITE_CONSOLE("\n%s - A tool to convert GFXReconstruct capture files to text.\n", app_name.c_str());
-    GFXRECON_WRITE_CONSOLE("Usage:");
-    GFXRECON_WRITE_CONSOLE("  %s [--version] <file>\n", app_name.c_str());
-    GFXRECON_WRITE_CONSOLE("Required arguments:");
-    GFXRECON_WRITE_CONSOLE("  <file>\t\tPath to the GFXReconstruct capture file to be converted");
-    GFXRECON_WRITE_CONSOLE("        \t\tto text.");
-    GFXRECON_WRITE_CONSOLE("\nOptional arguments:");
-    GFXRECON_WRITE_CONSOLE("  --version\t\tPrint version information and exit.");
-#if defined(WIN32) && defined(_DEBUG)
-    GFXRECON_WRITE_CONSOLE("  --no-debug-popup\tDisable the 'Abort, Retry, Ignore' message box");
-    GFXRECON_WRITE_CONSOLE("        \t\tdisplayed when abort() is called (Windows debug only).");
-#endif
-}
-
 int main(int argc, const char** argv)
 {
-    std::string                     input_filename;
-    gfxrecon::decode::FileProcessor file_processor;
-    gfxrecon::util::ArgumentParser  arg_parser(argc, argv, kOptions, "");
-
     gfxrecon::util::Log::Init();
 
-    if (PrintVersion(argv[0], arg_parser))
+    gfxrecon::util::ArgumentParser arg_parser(argc, argv, kOptions, "");
+
+    if (CheckOptionPrintUsage(argv[0], arg_parser) || CheckOptionPrintVersion(argv[0], arg_parser))
     {
+        gfxrecon::util::Log::Release();
         exit(0);
     }
     else if (arg_parser.IsInvalid() || (arg_parser.GetPositionalArgumentsCount() != 1))
@@ -100,9 +113,6 @@ int main(int argc, const char** argv)
     }
     else
     {
-        const std::vector<std::string>& positional_arguments = arg_parser.GetPositionalArguments();
-        input_filename                                       = positional_arguments[0];
-
 #if defined(WIN32) && defined(_DEBUG)
         if (arg_parser.IsOptionSet(kNoDebugPopup))
         {
@@ -111,8 +121,10 @@ int main(int argc, const char** argv)
 #endif
     }
 
-    std::string output_filename = input_filename;
-    size_t      suffix_pos      = output_filename.find(GFXRECON_FILE_EXTENSION);
+    const std::vector<std::string>& positional_arguments = arg_parser.GetPositionalArguments();
+    std::string                     input_filename       = positional_arguments[0];
+    std::string                     output_filename      = input_filename;
+    size_t                          suffix_pos           = output_filename.find(GFXRECON_FILE_EXTENSION);
     if (suffix_pos != std::string::npos)
     {
         output_filename = output_filename.substr(0, suffix_pos);
@@ -120,6 +132,7 @@ int main(int argc, const char** argv)
 
     output_filename += ".txt";
 
+    gfxrecon::decode::FileProcessor file_processor;
     if (file_processor.Initialize(input_filename))
     {
         gfxrecon::decode::VulkanDecoder       decoder;


### PR DESCRIPTION
Add -h and --help options to command line utilities, which will print usage information and exit with a zero return code.

Fixes: #368 