### PR TITLE
Consider swapchain pre-transform value when determining Android screen orientation

### DIFF
--- a/framework/application/android_window.h
+++ b/framework/application/android_window.h
@@ -48,6 +48,9 @@ class AndroidWindow : public decode::Window
 
     virtual void SetSize(const uint32_t width, const uint32_t height) override;
 
+    virtual void
+    SetSizePreTransform(const uint32_t width, const uint32_t height, const uint32_t pre_transform) override;
+
     virtual void SetVisibility(bool) override {}
 
     virtual void SetForeground() override {}
@@ -64,6 +67,7 @@ class AndroidWindow : public decode::Window
     ANativeWindow*      window_;
     uint32_t            width_;
     uint32_t            height_;
+    uint32_t            pre_transform_;
 };
 
 class AndroidWindowFactory : public decode::WindowFactory

--- a/framework/application/wayland_window.cpp
+++ b/framework/application/wayland_window.cpp
@@ -135,6 +135,12 @@ void WaylandWindow::SetSize(const uint32_t width, const uint32_t height)
     }
 }
 
+void WaylandWindow::SetSizePreTransform(const uint32_t width, const uint32_t height, const uint32_t pre_transform)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(pre_transform);
+    SetSize(width, height);
+}
+
 void WaylandWindow::SetVisibility(bool show)
 {
     GFXRECON_UNREFERENCED_PARAMETER(show);

--- a/framework/application/wayland_window.h
+++ b/framework/application/wayland_window.h
@@ -52,6 +52,9 @@ class WaylandWindow : public decode::Window
 
     virtual void SetSize(const uint32_t width, const uint32_t height) override;
 
+    virtual void
+    SetSizePreTransform(const uint32_t width, const uint32_t height, const uint32_t pre_transform) override;
+
     virtual void SetVisibility(bool show) override;
 
     virtual void SetForeground() override;

--- a/framework/application/win32_window.cpp
+++ b/framework/application/win32_window.cpp
@@ -221,6 +221,12 @@ void Win32Window::SetSize(const uint32_t width, const uint32_t height)
     }
 }
 
+void Win32Window::SetSizePreTransform(const uint32_t width, const uint32_t height, const uint32_t pre_transform)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(pre_transform);
+    SetSize(width, height);
+}
+
 void Win32Window::SetVisibility(bool show)
 {
     ShowWindow(hwnd_, show ? SW_SHOWDEFAULT : SW_HIDE);

--- a/framework/application/win32_window.h
+++ b/framework/application/win32_window.h
@@ -49,6 +49,9 @@ class Win32Window : public decode::Window
 
     virtual void SetSize(const uint32_t width, const uint32_t height) override;
 
+    virtual void
+    SetSizePreTransform(const uint32_t width, const uint32_t height, const uint32_t pre_transform) override;
+
     virtual void SetVisibility(bool show) override;
 
     virtual void SetForeground() override;

--- a/framework/application/xcb_window.cpp
+++ b/framework/application/xcb_window.cpp
@@ -269,6 +269,12 @@ void XcbWindow::SetSize(const uint32_t width, const uint32_t height)
     }
 }
 
+void XcbWindow::SetSizePreTransform(const uint32_t width, const uint32_t height, const uint32_t pre_transform)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(pre_transform);
+    SetSize(width, height);
+}
+
 void XcbWindow::SetFullscreen(bool fullscreen)
 {
     if (fullscreen != fullscreen_)

--- a/framework/application/xcb_window.h
+++ b/framework/application/xcb_window.h
@@ -67,6 +67,9 @@ class XcbWindow : public decode::Window
 
     virtual void SetSize(const uint32_t width, const uint32_t height) override;
 
+    virtual void
+    SetSizePreTransform(const uint32_t width, const uint32_t height, const uint32_t pre_transform) override;
+
     virtual void SetVisibility(bool show) override;
 
     virtual void SetForeground() override;

--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -60,6 +60,12 @@ class ApiDecoder
                                              uint32_t         width,
                                              uint32_t         height) = 0;
 
+    virtual void DispatchResizeWindowCommand2(format::ThreadId thread_id,
+                                              format::HandleId surface_id,
+                                              uint32_t         width,
+                                              uint32_t         height,
+                                              uint32_t         pre_transform) = 0;
+
     virtual void
     DispatchCreateHardwareBufferCommand(format::ThreadId                                    thread_id,
                                         format::HandleId                                    memory_id,

--- a/framework/decode/compression_converter.cpp
+++ b/framework/decode/compression_converter.cpp
@@ -257,6 +257,24 @@ void CompressionConverter::DispatchResizeWindowCommand(format::ThreadId thread_i
     bytes_written_ += file_stream_->Write(&resize_cmd, sizeof(resize_cmd));
 }
 
+void CompressionConverter::DispatchResizeWindowCommand2(
+    format::ThreadId thread_id, format::HandleId surface_id, uint32_t width, uint32_t height, uint32_t pre_transform)
+{
+    format::ResizeWindowCommand2 resize_cmd2;
+    resize_cmd2.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
+    resize_cmd2.meta_header.block_header.size = sizeof(resize_cmd2.meta_header.meta_data_type) +
+                                                sizeof(resize_cmd2.thread_id) + sizeof(resize_cmd2.surface_id) +
+                                                sizeof(resize_cmd2.width) + sizeof(resize_cmd2.height);
+    resize_cmd2.meta_header.meta_data_type = format::MetaDataType::kResizeWindowCommand;
+    resize_cmd2.thread_id                  = thread_id;
+    resize_cmd2.surface_id                 = surface_id;
+    resize_cmd2.width                      = width;
+    resize_cmd2.height                     = height;
+    resize_cmd2.pre_transform              = pre_transform;
+
+    bytes_written_ += file_stream_->Write(&resize_cmd2, sizeof(resize_cmd2));
+}
+
 void CompressionConverter::DispatchCreateHardwareBufferCommand(
     format::ThreadId                                    thread_id,
     format::HandleId                                    memory_id,

--- a/framework/decode/compression_converter.h
+++ b/framework/decode/compression_converter.h
@@ -68,6 +68,12 @@ class CompressionConverter : public ApiDecoder
                                              uint32_t         width,
                                              uint32_t         height) override;
 
+    virtual void DispatchResizeWindowCommand2(format::ThreadId thread_id,
+                                              format::HandleId surface_id,
+                                              uint32_t         width,
+                                              uint32_t         height,
+                                              uint32_t         pre_transform) override;
+
     virtual void
     DispatchCreateHardwareBufferCommand(format::ThreadId                                    thread_id,
                                         format::HandleId                                    memory_id,

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -506,6 +506,32 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             HandleBlockReadError(kErrorReadingBlockData, "Failed to read resize window meta-data block");
         }
     }
+    else if (meta_type == format::MetaDataType::kResizeWindowCommand2)
+    {
+        // This command does not support compression.
+        assert(block_header.type != format::BlockType::kCompressedMetaDataBlock);
+
+        format::ResizeWindowCommand2 command;
+
+        success = ReadBytes(&command.thread_id, sizeof(command.thread_id));
+        success = success && ReadBytes(&command.surface_id, sizeof(command.surface_id));
+        success = success && ReadBytes(&command.width, sizeof(command.width));
+        success = success && ReadBytes(&command.height, sizeof(command.height));
+        success = success && ReadBytes(&command.pre_transform, sizeof(command.pre_transform));
+
+        if (success)
+        {
+            for (auto decoder : decoders_)
+            {
+                decoder->DispatchResizeWindowCommand2(
+                    command.thread_id, command.surface_id, command.width, command.height, command.pre_transform);
+            }
+        }
+        else
+        {
+            HandleBlockReadError(kErrorReadingBlockData, "Failed to read resize window 2 meta-data block");
+        }
+    }
     else if (meta_type == format::MetaDataType::kDisplayMessageCommand)
     {
         // This command does not support compression.

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -50,6 +50,10 @@ class VulkanConsumerBase
 
     virtual void ProcessResizeWindowCommand(format::HandleId surface_id, uint32_t width, uint32_t height) {}
 
+    virtual void
+    ProcessResizeWindowCommand2(format::HandleId surface_id, uint32_t width, uint32_t height, uint32_t pre_transform)
+    {}
+
     virtual void ProcessCreateHardwareBufferCommand(format::HandleId                                    memory_id,
                                                     uint64_t                                            buffer_id,
                                                     uint32_t                                            format,

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -74,6 +74,17 @@ void VulkanDecoderBase::DispatchResizeWindowCommand(format::ThreadId thread_id,
     }
 }
 
+void VulkanDecoderBase::DispatchResizeWindowCommand2(
+    format::ThreadId thread_id, format::HandleId surface_id, uint32_t width, uint32_t height, uint32_t pre_transform)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(thread_id);
+
+    for (auto consumer : consumers_)
+    {
+        consumer->ProcessResizeWindowCommand2(surface_id, width, height, pre_transform);
+    }
+}
+
 void VulkanDecoderBase::DispatchCreateHardwareBufferCommand(
     format::ThreadId                                    thread_id,
     format::HandleId                                    memory_id,

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -72,6 +72,12 @@ class VulkanDecoderBase : public ApiDecoder
                                              uint32_t         width,
                                              uint32_t         height) override;
 
+    virtual void DispatchResizeWindowCommand2(format::ThreadId thread_id,
+                                              format::HandleId surface_id,
+                                              uint32_t         width,
+                                              uint32_t         height,
+                                              uint32_t         pre_transform) override;
+
     virtual void
     DispatchCreateHardwareBufferCommand(format::ThreadId                                    thread_id,
                                         format::HandleId                                    memory_id,

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -335,6 +335,35 @@ void VulkanReplayConsumerBase::ProcessResizeWindowCommand(format::HandleId surfa
     }
 }
 
+void VulkanReplayConsumerBase::ProcessResizeWindowCommand2(format::HandleId surface_id,
+                                                           uint32_t         width,
+                                                           uint32_t         height,
+                                                           uint32_t         pre_transform)
+{
+    // We need to find the surface associated with this ID, and then lookup its window.
+    const SurfaceKHRInfo* surface_info = object_info_table_.GetSurfaceKHRInfo(surface_id);
+
+    if (surface_info != nullptr)
+    {
+        Window* window = surface_info->window;
+
+        if (window != nullptr)
+        {
+            window->SetSizePreTransform(width, height, pre_transform);
+        }
+        else
+        {
+            GFXRECON_LOG_WARNING("Skipping window resize for VkSurface object (ID = %" PRIu64
+                                 ") without an associated window",
+                                 surface_id);
+        }
+    }
+    else
+    {
+        GFXRECON_LOG_WARNING("Skipping window resize for unrecognized VkSurface object (ID = %" PRIu64 ")", surface_id);
+    }
+}
+
 void VulkanReplayConsumerBase::ProcessCreateHardwareBufferCommand(
     format::HandleId                                    memory_id,
     uint64_t                                            buffer_id,

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -75,6 +75,11 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     virtual void ProcessResizeWindowCommand(format::HandleId surface_id, uint32_t width, uint32_t height) override;
 
+    virtual void ProcessResizeWindowCommand2(format::HandleId surface_id,
+                                             uint32_t         width,
+                                             uint32_t         height,
+                                             uint32_t         pre_transform) override;
+
     virtual void
     ProcessCreateHardwareBufferCommand(format::HandleId                                    memory_id,
                                        uint64_t                                            buffer_id,

--- a/framework/decode/window.h
+++ b/framework/decode/window.h
@@ -63,6 +63,8 @@ class Window
 
     virtual void SetSize(const uint32_t width, const uint32_t height) = 0;
 
+    virtual void SetSizePreTransform(const uint32_t width, const uint32_t height, const uint32_t pre_transform) = 0;
+
     virtual void SetVisibility(bool show) = 0;
 
     virtual void SetForeground() = 0;

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -694,6 +694,59 @@ void TraceManager::WriteResizeWindowCmd(format::HandleId surface_id, uint32_t wi
     }
 }
 
+void TraceManager::WriteResizeWindowCmd2(format::HandleId              surface_id,
+                                         uint32_t                      width,
+                                         uint32_t                      height,
+                                         VkSurfaceTransformFlagBitsKHR pre_transform)
+{
+    if ((capture_mode_ & kModeWrite) == kModeWrite)
+    {
+        format::ResizeWindowCommand2 resize_cmd2;
+        resize_cmd2.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
+        resize_cmd2.meta_header.block_header.size = sizeof(resize_cmd2.meta_header.meta_data_type) +
+                                                    sizeof(resize_cmd2.thread_id) + sizeof(resize_cmd2.surface_id) +
+                                                    sizeof(resize_cmd2.width) + sizeof(resize_cmd2.height);
+        resize_cmd2.meta_header.meta_data_type = format::MetaDataType::kResizeWindowCommand2;
+        resize_cmd2.thread_id                  = GetThreadData()->thread_id_;
+
+        resize_cmd2.surface_id = surface_id;
+        resize_cmd2.width      = width;
+        resize_cmd2.height     = height;
+
+        switch (pre_transform)
+        {
+            default:
+            case VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR:
+            case VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR:
+            case VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR:
+                resize_cmd2.pre_transform = format::ResizeWindowPreTransform::kPreTransform0;
+                break;
+            case VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR:
+            case VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR:
+                resize_cmd2.pre_transform = format::ResizeWindowPreTransform::kPreTransform90;
+                break;
+            case VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR:
+            case VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR:
+                resize_cmd2.pre_transform = format::ResizeWindowPreTransform::kPreTransform180;
+                break;
+            case VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR:
+            case VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR:
+                resize_cmd2.pre_transform = format::ResizeWindowPreTransform::kPreTransform270;
+                break;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(file_lock_);
+            bytes_written_ += file_stream_->Write(&resize_cmd2, sizeof(resize_cmd2));
+
+            if (force_file_flush_)
+            {
+                file_stream_->Flush();
+            }
+        }
+    }
+}
+
 void TraceManager::WriteFillMemoryCmd(format::HandleId memory_id,
                                       VkDeviceSize     offset,
                                       VkDeviceSize     size,
@@ -1670,8 +1723,10 @@ void TraceManager::PreProcess_vkCreateSwapchain(VkDevice                        
 
     if (pCreateInfo)
     {
-        WriteResizeWindowCmd(
-            GetWrappedId(pCreateInfo->surface), pCreateInfo->imageExtent.width, pCreateInfo->imageExtent.height);
+        WriteResizeWindowCmd2(GetWrappedId(pCreateInfo->surface),
+                              pCreateInfo->imageExtent.width,
+                              pCreateInfo->imageExtent.height,
+                              pCreateInfo->preTransform);
     }
 }
 

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -950,6 +950,10 @@ class TraceManager
     ParameterEncoder* InitApiCallTrace(format::ApiCallId call_id);
 
     void WriteResizeWindowCmd(format::HandleId surface_id, uint32_t width, uint32_t height);
+    void WriteResizeWindowCmd2(format::HandleId              surface_id,
+                               uint32_t                      width,
+                               uint32_t                      height,
+                               VkSurfaceTransformFlagBitsKHR pre_transform);
     void WriteFillMemoryCmd(format::HandleId memory_id, VkDeviceSize offset, VkDeviceSize size, const void* data);
     void WriteCreateHardwareBufferCmd(format::HandleId                                    memory_id,
                                       AHardwareBuffer*                                    buffer,

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -349,6 +349,7 @@ struct SwapchainKHRWrapper : public HandleWrapper<VkSwapchainKHR>
     uint32_t                       queue_family_index{ 0 };
     VkFormat                       format{ VK_FORMAT_UNDEFINED };
     VkExtent3D                     extent{ 0, 0, 0 };
+    VkSurfaceTransformFlagBitsKHR  pre_transform{ VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR };
     uint32_t                       array_layers{ 0 };
     uint32_t                       last_presented_image{ std::numeric_limits<uint32_t>::max() };
     std::vector<ImageAcquiredInfo> image_acquired_info;

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -526,11 +526,12 @@ InitializeState<VkDevice, SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(VkDevic
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device       = reinterpret_cast<DeviceWrapper*>(parent_handle);
-    wrapper->surface      = reinterpret_cast<SurfaceKHRWrapper*>(create_info->surface);
-    wrapper->format       = create_info->imageFormat;
-    wrapper->extent       = { create_info->imageExtent.width, create_info->imageExtent.height, 0 };
-    wrapper->array_layers = create_info->imageArrayLayers;
+    wrapper->device        = reinterpret_cast<DeviceWrapper*>(parent_handle);
+    wrapper->surface       = reinterpret_cast<SurfaceKHRWrapper*>(create_info->surface);
+    wrapper->format        = create_info->imageFormat;
+    wrapper->extent        = { create_info->imageExtent.width, create_info->imageExtent.height, 0 };
+    wrapper->pre_transform = create_info->preTransform;
+    wrapper->array_layers  = create_info->imageArrayLayers;
 
     if ((create_info->queueFamilyIndexCount > 0) && (create_info->pQueueFamilyIndices != nullptr))
     {

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -244,6 +244,11 @@ class VulkanStateWriter
 
     void WriteResizeWindowCmd(format::HandleId surface_id, uint32_t width, uint32_t height);
 
+    void WriteResizeWindowCmd2(format::HandleId              surface_id,
+                               uint32_t                      width,
+                               uint32_t                      height,
+                               VkSurfaceTransformFlagBitsKHR pre_transform);
+
     void WriteCreateHardwareBufferCmd(format::HandleId                                    memory_id,
                                       AHardwareBuffer*                                    hardware_buffer,
                                       const std::vector<format::HardwareBufferPlaneInfo>& plane_info);

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -87,7 +87,8 @@ enum MetaDataType : uint32_t
     kCreateHardwareBufferCommand        = 9,
     kDestroyHardwareBufferCommand       = 10,
     kSetDevicePropertiesCommand         = 11,
-    kSetDeviceMemoryPropertiesCommand   = 12
+    kSetDeviceMemoryPropertiesCommand   = 12,
+    kResizeWindowCommand2               = 13
 };
 
 enum CompressionType : uint32_t
@@ -121,6 +122,14 @@ enum PointerAttributes : uint32_t
     // What was encoded
     kHasAddress     = 0x40, // The address of the pointer was encoded (always comes before data).
     kHasData        = 0x80, // The data pointed to was encoded.
+};
+
+enum ResizeWindowPreTransform : uint32_t
+{
+    kPreTransform0   = 0,
+    kPreTransform90  = 1,
+    kPreTransform180 = 2,
+    kPreTransform270 = 3
 };
 // clang-format on
 
@@ -218,6 +227,18 @@ struct ResizeWindowCommand
     HandleId         surface_id;
     uint32_t         width;
     uint32_t         height;
+};
+
+// Not a header because this command does not include a variable length data payload.
+// All of the command data is present in the struct.
+struct ResizeWindowCommand2
+{
+    MetaDataHeader   meta_header;
+    format::ThreadId thread_id;
+    HandleId         surface_id;
+    uint32_t         width;
+    uint32_t         height;
+    uint32_t         pre_transform;
 };
 
 struct CreateHardwareBufferCommandHeader


### PR DESCRIPTION
When determining screen orientation for Android replay, consider both the swapchain width/height and pre-transform values.  Adds a new resize window meta-data type that includes width, height, and pre-transform value.

Fixes #347 