### PR TITLE
Fix invalid block ID from compression conversion

### DIFF
--- a/framework/decode/compression_converter.cpp
+++ b/framework/decode/compression_converter.cpp
@@ -265,7 +265,7 @@ void CompressionConverter::DispatchResizeWindowCommand2(
     resize_cmd2.meta_header.block_header.size = sizeof(resize_cmd2.meta_header.meta_data_type) +
                                                 sizeof(resize_cmd2.thread_id) + sizeof(resize_cmd2.surface_id) +
                                                 sizeof(resize_cmd2.width) + sizeof(resize_cmd2.height);
-    resize_cmd2.meta_header.meta_data_type = format::MetaDataType::kResizeWindowCommand;
+    resize_cmd2.meta_header.meta_data_type = format::MetaDataType::kResizeWindowCommand2;
     resize_cmd2.thread_id                  = thread_id;
     resize_cmd2.surface_id                 = surface_id;
     resize_cmd2.width                      = width;

--- a/framework/decode/compression_converter.cpp
+++ b/framework/decode/compression_converter.cpp
@@ -262,15 +262,13 @@ void CompressionConverter::DispatchResizeWindowCommand2(
 {
     format::ResizeWindowCommand2 resize_cmd2;
     resize_cmd2.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
-    resize_cmd2.meta_header.block_header.size = sizeof(resize_cmd2.meta_header.meta_data_type) +
-                                                sizeof(resize_cmd2.thread_id) + sizeof(resize_cmd2.surface_id) +
-                                                sizeof(resize_cmd2.width) + sizeof(resize_cmd2.height);
-    resize_cmd2.meta_header.meta_data_type = format::MetaDataType::kResizeWindowCommand2;
-    resize_cmd2.thread_id                  = thread_id;
-    resize_cmd2.surface_id                 = surface_id;
-    resize_cmd2.width                      = width;
-    resize_cmd2.height                     = height;
-    resize_cmd2.pre_transform              = pre_transform;
+    resize_cmd2.meta_header.block_header.size = sizeof(resize_cmd2) - sizeof(resize_cmd2.meta_header.block_header);
+    resize_cmd2.meta_header.meta_data_type    = format::MetaDataType::kResizeWindowCommand2;
+    resize_cmd2.thread_id                     = thread_id;
+    resize_cmd2.surface_id                    = surface_id;
+    resize_cmd2.width                         = width;
+    resize_cmd2.height                        = height;
+    resize_cmd2.pre_transform                 = pre_transform;
 
     bytes_written_ += file_stream_->Write(&resize_cmd2, sizeof(resize_cmd2));
 }

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -704,11 +704,9 @@ void TraceManager::WriteResizeWindowCmd2(format::HandleId              surface_i
     {
         format::ResizeWindowCommand2 resize_cmd2;
         resize_cmd2.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
-        resize_cmd2.meta_header.block_header.size = sizeof(resize_cmd2.meta_header.meta_data_type) +
-                                                    sizeof(resize_cmd2.thread_id) + sizeof(resize_cmd2.surface_id) +
-                                                    sizeof(resize_cmd2.width) + sizeof(resize_cmd2.height);
-        resize_cmd2.meta_header.meta_data_type = format::MetaDataType::kResizeWindowCommand2;
-        resize_cmd2.thread_id                  = GetThreadData()->thread_id_;
+        resize_cmd2.meta_header.block_header.size = sizeof(resize_cmd2) - sizeof(resize_cmd2.meta_header.block_header);
+        resize_cmd2.meta_header.meta_data_type    = format::MetaDataType::kResizeWindowCommand2;
+        resize_cmd2.thread_id                     = GetThreadData()->thread_id_;
 
         resize_cmd2.surface_id = surface_id;
         resize_cmd2.width      = width;

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2451,11 +2451,9 @@ void VulkanStateWriter::WriteResizeWindowCmd2(format::HandleId              surf
 {
     format::ResizeWindowCommand2 resize_cmd2;
     resize_cmd2.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
-    resize_cmd2.meta_header.block_header.size = sizeof(resize_cmd2.meta_header.meta_data_type) +
-                                                sizeof(resize_cmd2.thread_id) + sizeof(resize_cmd2.surface_id) +
-                                                sizeof(resize_cmd2.width) + sizeof(resize_cmd2.height);
-    resize_cmd2.meta_header.meta_data_type = format::MetaDataType::kResizeWindowCommand2;
-    resize_cmd2.thread_id                  = thread_id_;
+    resize_cmd2.meta_header.block_header.size = sizeof(resize_cmd2) - sizeof(resize_cmd2.meta_header.block_header);
+    resize_cmd2.meta_header.meta_data_type    = format::MetaDataType::kResizeWindowCommand2;
+    resize_cmd2.thread_id                     = thread_id_;
 
     resize_cmd2.surface_id = surface_id;
     resize_cmd2.width      = width;


### PR DESCRIPTION
The compression converter was writing a meta-data block with an invalid ID. 
CompressionConverter::DispatchResizeWindowCommand2 was using the kResizeWindowCommand ID instead of the kResizeWindowCommand2 ID, which produced a decode failure on replay.
