### PR TITLE
Update gfxrecon-compress option handling

### DIFF
--- a/framework/decode/compression_converter.cpp
+++ b/framework/decode/compression_converter.cpp
@@ -52,9 +52,8 @@ bool CompressionConverter::Initialize(std::string                               
         decompressing_ = false;
         compressor_    = format::CreateCompressor(target_compression_type);
 
-        if (nullptr == compressor_)
+        if (compressor_ == nullptr)
         {
-            GFXRECON_LOG_WARNING("Failed to initialized file compression module (type = %u)", target_compression_type);
             return false;
         }
     }

--- a/framework/format/format_util.cpp
+++ b/framework/format/format_util.cpp
@@ -47,27 +47,24 @@ util::Compressor* CreateCompressor(CompressionType type)
     switch (type)
     {
         case kLz4:
-#ifdef ENABLE_LZ4_COMPRESSION
+#if defined(ENABLE_LZ4_COMPRESSION)
             compressor = new util::Lz4Compressor();
 #else
             GFXRECON_LOG_ERROR("Failed to initialize compression module: LZ4 compression is disabled.");
-            assert(false);
 #endif // ENABLE_LZ4_COMPRESSION
             break;
         case kZlib:
-#ifdef ENABLE_ZLIB_COMPRESSION
+#if defined(ENABLE_ZLIB_COMPRESSION)
             compressor = new util::ZlibCompressor();
 #else
             GFXRECON_LOG_ERROR("Failed to initialize compression module: zlib compression is disabled.");
-            assert(false);
 #endif // ENABLE_ZLIB_COMPRESSION
             break;
         case kZstd:
-#ifdef ENABLE_ZSTD_COMPRESSION
+#if defined(ENABLE_ZSTD_COMPRESSION)
             compressor = new util::ZstdCompressor();
 #else
             GFXRECON_LOG_ERROR("Failed to initialize compression module: Zstandard compression is disabled.");
-            assert(false);
 #endif // ENABLE_ZSTD_COMPRESSION
             break;
         case kNone:
@@ -75,7 +72,6 @@ util::Compressor* CreateCompressor(CompressionType type)
             break;
         default:
             GFXRECON_LOG_ERROR("Failed to initialize compression module: Unrecognized compression type ID %d", type);
-            assert(false);
             break;
     }
 


### PR DESCRIPTION
Updates to gfxrecon-compress:
- Help will no longer list compression types that were disabled at compile time.
- Cleanup error reporting for unsupported/unrecognized formats.
