### PR TITLE
Add compression format to gfxrecon-info

### DIFF
--- a/framework/format/format_util.cpp
+++ b/framework/format/format_util.cpp
@@ -82,5 +82,24 @@ util::Compressor* CreateCompressor(CompressionType type)
     return compressor;
 }
 
+std::string GetCompressionTypeName(CompressionType type)
+{
+    switch (type)
+    {
+        case kLz4:
+            return "LZ4";
+        case kZlib:
+            return "zlib";
+        case kZstd:
+            return "Zstandard";
+        case kNone:
+            return "None";
+        default:
+            break;
+    }
+
+    return "";
+}
+
 GFXRECON_END_NAMESPACE(format)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/format/format_util.h
+++ b/framework/format/format_util.h
@@ -22,6 +22,8 @@
 #include "util/compressor.h"
 #include "util/defines.h"
 
+#include <string>
+
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(format)
 
@@ -71,6 +73,8 @@ bool ValidateFileHeader(const FileHeader& header);
 
 // Utilities for object creation.
 util::Compressor* CreateCompressor(CompressionType type);
+
+std::string GetCompressionTypeName(CompressionType type);
 
 GFXRECON_END_NAMESPACE(format)
 GFXRECON_END_NAMESPACE(gfxrecon)


### PR DESCRIPTION
Update gfxrecon-info to report the capture file's compression format.

Fixes: #410 
