### PR TITLE
Add meta-data block size utility functions

### DIFF
--- a/framework/decode/compression_converter.cpp
+++ b/framework/decode/compression_converter.cpp
@@ -187,10 +187,9 @@ void CompressionConverter::DispatchDisplayMessageCommand(format::ThreadId thread
     size_t                              message_length = message.size();
     format::DisplayMessageCommandHeader message_cmd;
     message_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
-    message_cmd.meta_header.block_header.size =
-        sizeof(message_cmd.meta_header.meta_data_type) + sizeof(message_cmd.thread_id) + message_length;
-    message_cmd.meta_header.meta_data_type = format::MetaDataType::kDisplayMessageCommand;
-    message_cmd.thread_id                  = thread_id;
+    message_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(message_cmd) + message_length;
+    message_cmd.meta_header.meta_data_type    = format::MetaDataType::kDisplayMessageCommand;
+    message_cmd.thread_id                     = thread_id;
 
     bytes_written_ += file_stream_->Write(&message_cmd, sizeof(message_cmd));
     bytes_written_ += file_stream_->Write(message.c_str(), message_length);
@@ -229,9 +228,7 @@ void CompressionConverter::DispatchFillMemoryCommand(
     }
 
     // Calculate size of packet with compressed or uncompressed data size.
-    fill_cmd.meta_header.block_header.size = sizeof(fill_cmd.meta_header.meta_data_type) + sizeof(fill_cmd.thread_id) +
-                                             sizeof(fill_cmd.memory_id) + sizeof(fill_cmd.memory_offset) +
-                                             sizeof(fill_cmd.memory_size) + write_size;
+    fill_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(fill_cmd) + write_size;
 
     bytes_written_ += file_stream_->Write(&fill_cmd, sizeof(fill_cmd));
     bytes_written_ += file_stream_->Write(write_address, write_size);
@@ -244,14 +241,12 @@ void CompressionConverter::DispatchResizeWindowCommand(format::ThreadId thread_i
 {
     format::ResizeWindowCommand resize_cmd;
     resize_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
-    resize_cmd.meta_header.block_header.size = sizeof(resize_cmd.meta_header.meta_data_type) +
-                                               sizeof(resize_cmd.thread_id) + sizeof(resize_cmd.surface_id) +
-                                               sizeof(resize_cmd.width) + sizeof(resize_cmd.height);
-    resize_cmd.meta_header.meta_data_type = format::MetaDataType::kResizeWindowCommand;
-    resize_cmd.thread_id                  = thread_id;
-    resize_cmd.surface_id                 = surface_id;
-    resize_cmd.width                      = width;
-    resize_cmd.height                     = height;
+    resize_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(resize_cmd);
+    resize_cmd.meta_header.meta_data_type    = format::MetaDataType::kResizeWindowCommand;
+    resize_cmd.thread_id                     = thread_id;
+    resize_cmd.surface_id                    = surface_id;
+    resize_cmd.width                         = width;
+    resize_cmd.height                        = height;
 
     bytes_written_ += file_stream_->Write(&resize_cmd, sizeof(resize_cmd));
 }
@@ -261,7 +256,7 @@ void CompressionConverter::DispatchResizeWindowCommand2(
 {
     format::ResizeWindowCommand2 resize_cmd2;
     resize_cmd2.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
-    resize_cmd2.meta_header.block_header.size = sizeof(resize_cmd2) - sizeof(resize_cmd2.meta_header.block_header);
+    resize_cmd2.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(resize_cmd2);
     resize_cmd2.meta_header.meta_data_type    = format::MetaDataType::kResizeWindowCommand2;
     resize_cmd2.thread_id                     = thread_id;
     resize_cmd2.surface_id                    = surface_id;
@@ -286,18 +281,17 @@ void CompressionConverter::DispatchCreateHardwareBufferCommand(
 {
     format::CreateHardwareBufferCommandHeader create_buffer_cmd;
     create_buffer_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
-    create_buffer_cmd.meta_header.block_header.size =
-        sizeof(create_buffer_cmd) - sizeof(create_buffer_cmd.meta_header.block_header);
-    create_buffer_cmd.meta_header.meta_data_type = format::MetaDataType::kCreateHardwareBufferCommand;
-    create_buffer_cmd.thread_id                  = thread_id;
-    create_buffer_cmd.memory_id                  = memory_id;
-    create_buffer_cmd.buffer_id                  = buffer_id;
-    create_buffer_cmd.format                     = format;
-    create_buffer_cmd.width                      = width;
-    create_buffer_cmd.height                     = height;
-    create_buffer_cmd.stride                     = stride;
-    create_buffer_cmd.usage                      = usage;
-    create_buffer_cmd.layers                     = layers;
+    create_buffer_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(create_buffer_cmd);
+    create_buffer_cmd.meta_header.meta_data_type    = format::MetaDataType::kCreateHardwareBufferCommand;
+    create_buffer_cmd.thread_id                     = thread_id;
+    create_buffer_cmd.memory_id                     = memory_id;
+    create_buffer_cmd.buffer_id                     = buffer_id;
+    create_buffer_cmd.format                        = format;
+    create_buffer_cmd.width                         = width;
+    create_buffer_cmd.height                        = height;
+    create_buffer_cmd.stride                        = stride;
+    create_buffer_cmd.usage                         = usage;
+    create_buffer_cmd.layers                        = layers;
 
     size_t planes_size = 0;
 
@@ -325,11 +319,10 @@ void CompressionConverter::DispatchDestroyHardwareBufferCommand(format::ThreadId
 {
     format::DestroyHardwareBufferCommand destroy_buffer_cmd;
     destroy_buffer_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
-    destroy_buffer_cmd.meta_header.block_header.size =
-        sizeof(destroy_buffer_cmd) - sizeof(destroy_buffer_cmd.meta_header.block_header);
-    destroy_buffer_cmd.meta_header.meta_data_type = format::MetaDataType::kDestroyHardwareBufferCommand;
-    destroy_buffer_cmd.thread_id                  = thread_id;
-    destroy_buffer_cmd.buffer_id                  = buffer_id;
+    destroy_buffer_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(destroy_buffer_cmd);
+    destroy_buffer_cmd.meta_header.meta_data_type    = format::MetaDataType::kDestroyHardwareBufferCommand;
+    destroy_buffer_cmd.thread_id                     = thread_id;
+    destroy_buffer_cmd.buffer_id                     = buffer_id;
 
     bytes_written_ += file_stream_->Write(&destroy_buffer_cmd, sizeof(destroy_buffer_cmd));
 }
@@ -348,16 +341,15 @@ void CompressionConverter::DispatchSetDevicePropertiesCommand(format::ThreadId  
 
     format::SetDevicePropertiesCommand properties_cmd;
     properties_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
-    properties_cmd.meta_header.block_header.size =
-        (sizeof(properties_cmd) - sizeof(properties_cmd.meta_header.block_header)) + device_name_len;
-    properties_cmd.meta_header.meta_data_type = format::MetaDataType::kSetDevicePropertiesCommand;
-    properties_cmd.thread_id                  = thread_id;
-    properties_cmd.physical_device_id         = physical_device_id;
-    properties_cmd.api_version                = api_version;
-    properties_cmd.driver_version             = driver_version;
-    properties_cmd.vendor_id                  = vendor_id;
-    properties_cmd.device_id                  = device_id;
-    properties_cmd.device_type                = device_type;
+    properties_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(properties_cmd) + device_name_len;
+    properties_cmd.meta_header.meta_data_type    = format::MetaDataType::kSetDevicePropertiesCommand;
+    properties_cmd.thread_id                     = thread_id;
+    properties_cmd.physical_device_id            = physical_device_id;
+    properties_cmd.api_version                   = api_version;
+    properties_cmd.driver_version                = driver_version;
+    properties_cmd.vendor_id                     = vendor_id;
+    properties_cmd.device_id                     = device_id;
+    properties_cmd.device_type                   = device_type;
     util::platform::MemoryCopy(
         properties_cmd.pipeline_cache_uuid, format::kUuidSize, pipeline_cache_uuid, VK_UUID_SIZE);
     properties_cmd.device_name_len = device_name_len;
@@ -377,9 +369,9 @@ void CompressionConverter::DispatchSetDeviceMemoryPropertiesCommand(
 
     format::SetDeviceMemoryPropertiesCommand memory_properties_cmd;
     memory_properties_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
-    memory_properties_cmd.meta_header.block_header.size =
-        (sizeof(memory_properties_cmd) - sizeof(memory_properties_cmd.meta_header.block_header)) +
-        (sizeof(format::DeviceMemoryType) * memory_type_count) + (sizeof(format::DeviceMemoryHeap) * memory_heap_count);
+    memory_properties_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(memory_properties_cmd) +
+                                                          (sizeof(format::DeviceMemoryType) * memory_type_count) +
+                                                          (sizeof(format::DeviceMemoryHeap) * memory_heap_count);
     memory_properties_cmd.meta_header.meta_data_type = format::MetaDataType::kSetDeviceMemoryPropertiesCommand;
     memory_properties_cmd.thread_id                  = thread_id;
     memory_properties_cmd.physical_device_id         = physical_device_id;
@@ -411,9 +403,7 @@ void CompressionConverter::DispatchSetSwapchainImageStateCommand(
     size_t                                      image_state_size = 0;
 
     // Initialize standard block header.
-    header.meta_header.block_header.size = sizeof(header.meta_header.meta_data_type) + sizeof(header.thread_id) +
-                                           sizeof(header.device_id) + sizeof(header.swapchain_id) +
-                                           sizeof(header.last_presented_image) + sizeof(header.image_info_count);
+    header.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(header);
     header.meta_header.block_header.type = format::kMetaDataBlock;
 
     if (image_count > 0)
@@ -440,7 +430,7 @@ void CompressionConverter::DispatchBeginResourceInitCommand(format::ThreadId thr
                                                             uint64_t         max_copy_size)
 {
     format::BeginResourceInitCommand begin_cmd;
-    begin_cmd.meta_header.block_header.size = sizeof(begin_cmd) - sizeof(begin_cmd.meta_header.block_header);
+    begin_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(begin_cmd);
     begin_cmd.meta_header.block_header.type = format::kMetaDataBlock;
     begin_cmd.meta_header.meta_data_type    = format::kBeginResourceInitCommand;
     begin_cmd.thread_id                     = thread_id;
@@ -454,7 +444,7 @@ void CompressionConverter::DispatchBeginResourceInitCommand(format::ThreadId thr
 void CompressionConverter::DispatchEndResourceInitCommand(format::ThreadId thread_id, format::HandleId device_id)
 {
     format::EndResourceInitCommand end_cmd;
-    end_cmd.meta_header.block_header.size = sizeof(end_cmd) - sizeof(end_cmd.meta_header.block_header);
+    end_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(end_cmd);
     end_cmd.meta_header.block_header.type = format::kMetaDataBlock;
     end_cmd.meta_header.meta_data_type    = format::kEndResourceInitCommand;
     end_cmd.thread_id                     = thread_id;
@@ -497,8 +487,7 @@ void CompressionConverter::DispatchInitBufferCommand(format::ThreadId thread_id,
     }
 
     // Calculate size of packet with compressed or uncompressed data size.
-    init_cmd.meta_header.block_header.size =
-        (sizeof(init_cmd) - sizeof(init_cmd.meta_header.block_header)) + write_size;
+    init_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(init_cmd) + write_size;
 
     bytes_written_ += file_stream_->Write(&init_cmd, sizeof(init_cmd));
     bytes_written_ += file_stream_->Write(write_address, write_size);
@@ -516,7 +505,7 @@ void CompressionConverter::DispatchInitImageCommand(format::ThreadId            
     format::InitImageCommandHeader init_cmd;
 
     // Packet size without the resource data.
-    init_cmd.meta_header.block_header.size = sizeof(init_cmd) - sizeof(init_cmd.meta_header.block_header);
+    init_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(init_cmd);
     init_cmd.meta_header.block_header.type = format::kMetaDataBlock;
     init_cmd.meta_header.meta_data_type    = format::kInitImageCommand;
     init_cmd.thread_id                     = thread_id;

--- a/framework/format/format_util.h
+++ b/framework/format/format_util.h
@@ -68,6 +68,13 @@ inline BlockType RemoveCompressedBlockBit(BlockType type)
     return static_cast<BlockType>(type & ~kCompressedBlockTypeBit);
 }
 
+// Utilities for file encoding.
+template <typename T>
+uint64_t GetMetaDataBlockBaseSize(const T& block)
+{
+    return (sizeof(block) - sizeof(block.meta_header.block_header));
+}
+
 // Utilities for format validation.
 bool ValidateFileHeader(const FileHeader& header);
 


### PR DESCRIPTION
Add a utility function to compute the base size of meta-data blocks.
