### PR TITLE
Refine replay layer check

### DIFF
--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -154,7 +154,7 @@ int main(int argc, const char** argv)
                 application->SetPauseFrame(GetPauseFrame(arg_parser));
 
                 // Warn if the capture layer is active.
-                CheckActiveLayers(kLayerEnvVar);
+                CheckActiveLayers(gfxrecon::util::platform::GetEnv(kLayerEnvVar));
 
                 // Grab the start frame/time information for the FPS result.
                 uint32_t start_frame = 1;

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -90,15 +90,37 @@ static void ProcessDisableDebugPopup(const gfxrecon::util::ArgumentParser& arg_p
 #endif
 }
 
-static void CheckActiveLayers(const char* env_var)
+static void CheckActiveLayers(const std::string& list)
 {
-    std::string result = gfxrecon::util::platform::GetEnv(env_var);
-
-    if (!result.empty())
+    if (!list.empty())
     {
-        if (result.find(kCaptureLayer) != std::string::npos)
+        // Check for the presence of the layer name in the list of active layers.
+        size_t start = list.find(kCaptureLayer);
+
+        if (start != std::string::npos)
         {
-            GFXRECON_LOG_WARNING("Replay tool has detected that the capture layer is enabled");
+            size_t end         = start + gfxrecon::util::platform::StringLength(kCaptureLayer);
+            bool   match_start = false;
+            bool   match_end   = false;
+
+            // For an exact match, the start of the layer name is either at the start of the list or comes after a path
+            // separator.
+            if ((start == 0) || ((list[start - 1] == ';') || (list[start - 1] == ':')))
+            {
+                match_start = true;
+            }
+
+            // For an exact match, the end of the layer name is either at the end of the list or comes before a path
+            // separator.
+            if ((list.length() == end) || ((list[end] == ';') || (list[end] == ':')))
+            {
+                match_end = true;
+            }
+
+            if (match_start && match_end)
+            {
+                GFXRECON_LOG_WARNING("Replay tool has detected that the capture layer is enabled");
+            }
         }
     }
 }


### PR DESCRIPTION
Update the replay code that checks for the capture layer name in the list of layers enabled through the VK_INSTANCE_LAYERS environment variable.  It now only reports exact matches for the layer name and does not report a match for values like 'xxVK_LAYER_LUNARG_gfxreconstructXX'.

Fixes: #293 
