### PR TITLE
Changes to build.py output directories

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -53,14 +53,15 @@ jobs:
         cp LICENSE_ThirdParty.txt ${{ matrix.config.build_dir }}/linux/x64/output/bin/
         cp USAGE_desktop.md ${{ matrix.config.build_dir }}/linux/x64/output/bin/
         cp layer/vk_layer_settings.txt ${{ matrix.config.build_dir }}/linux/x64/output/bin/
-        rm -rf ${{ matrix.config.build_dir }}/linux/x64/output/bin/staging-json
         mv ${{ matrix.config.build_dir }}/linux/x64/output/bin gfxreconstruct-dev
+        mv ${{ matrix.config.build_dir }}/linux/x64/output/lib*/*.so gfxreconstruct-dev/
+        mv ${{ matrix.config.build_dir }}/linux/x64/output/share/vulkan/explicit_layer.d/*.json gfxreconstruct-dev/
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:
         name: ${{ matrix.config.artifact }}
         path: ./gfxreconstruct-dev
-  
+
   windows:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -49,12 +49,12 @@ jobs:
         fi
     - name: Prepare artifacts
       run: |
-        cp LICENSE.txt ${{ matrix.config.build_dir }}/linux/x64/bin/
-        cp LICENSE_ThirdParty.txt ${{ matrix.config.build_dir }}/linux/x64/bin/
-        cp USAGE_desktop.md ${{ matrix.config.build_dir }}/linux/x64/bin/
-        cp layer/vk_layer_settings.txt ${{ matrix.config.build_dir }}/linux/x64/bin/
-        rm -rf ${{ matrix.config.build_dir }}/linux/x64/bin/staging-json
-        mv ${{ matrix.config.build_dir }}/linux/x64/bin gfxreconstruct-dev
+        cp LICENSE.txt ${{ matrix.config.build_dir }}/linux/x64/output/bin/
+        cp LICENSE_ThirdParty.txt ${{ matrix.config.build_dir }}/linux/x64/output/bin/
+        cp USAGE_desktop.md ${{ matrix.config.build_dir }}/linux/x64/output/bin/
+        cp layer/vk_layer_settings.txt ${{ matrix.config.build_dir }}/linux/x64/output/bin/
+        rm -rf ${{ matrix.config.build_dir }}/linux/x64/output/bin/staging-json
+        mv ${{ matrix.config.build_dir }}/linux/x64/output/bin gfxreconstruct-dev
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:
@@ -73,6 +73,7 @@ jobs:
             os: windows-latest,
             artifact: "gfxreconstruct-dev-windows-msvc-release",
             type: "release",
+            build_dir: "build",
             cc: "cl", cxx: "cl"
           }
         - {
@@ -80,6 +81,7 @@ jobs:
             os: windows-latest,
             artifact: "gfxreconstruct-dev-windows-msvc-debug",
             type: "debug",
+            build_dir: "dbuild",
             cc: "cl", cxx: "cl"
           }
     steps:
@@ -90,11 +92,11 @@ jobs:
         python scripts\build.py --skip-check-code-style --skip-tests --config ${{ matrix.config.type }}
     - name: Prepare artifacts
       run: |
-        copy LICENSE.txt build\windows\x64\bin\
-        copy LICENSE_ThirdParty.txt build\windows\x64\bin\
-        copy USAGE_desktop.md build\windows\x64\bin\
-        copy layer\vk_layer_settings.txt build\windows\x64\bin\
-        move build\windows\x64\bin gfxreconstruct-dev
+        copy LICENSE.txt ${{ matrix.config.build_dir }}\windows\x64\output\bin\
+        copy LICENSE_ThirdParty.txt ${{ matrix.config.build_dir }}\windows\x64\output\bin\
+        copy USAGE_desktop.md ${{ matrix.config.build_dir }}\windows\x64\output\bin\
+        copy layer\vk_layer_settings.txt ${{ matrix.config.build_dir }}\windows\x64\output\bin\
+        move ${{ matrix.config.build_dir }}\windows\x64\output\bin gfxreconstruct-dev
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -22,7 +22,7 @@ name: Release Build
 
 on:
   push:
-    tags:       
+    tags:
       - v*
 
 jobs:
@@ -54,14 +54,15 @@ jobs:
         cp LICENSE_ThirdParty.txt build/linux/x64/output/bin/
         cp USAGE_desktop.md build/linux/x64/output/bin/
         cp layer/vk_layer_settings.txt build/linux/x64/output/bin/
-        rm -rf build/linux/x64/output/bin/staging-json
         mv build/linux/x64/output/bin gfxreconstruct-dev
+        mv build/linux/x64/output/lib*/*.so gfxreconstruct-dev/
+        mv build/linux/x64/output/share/vulkan/explicit_layer.d/*.json gfxreconstruct-dev/
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:
         name: ${{ matrix.config.artifact }}
         path: ./gfxreconstruct-dev
-  
+
   windows:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -50,12 +50,12 @@ jobs:
         python3 scripts/build.py --skip-check-code-style --skip-tests
     - name: Prepare artifacts
       run: |
-        cp LICENSE.txt build/linux/x64/bin/
-        cp LICENSE_ThirdParty.txt build/linux/x64/bin/
-        cp USAGE_desktop.md build/linux/x64/bin/
-        cp layer/vk_layer_settings.txt build/linux/x64/bin/
-        rm -rf build/linux/x64/bin/staging-json
-        mv build/linux/x64/bin gfxreconstruct-dev
+        cp LICENSE.txt build/linux/x64/output/bin/
+        cp LICENSE_ThirdParty.txt build/linux/x64/output/bin/
+        cp USAGE_desktop.md build/linux/x64/output/bin/
+        cp layer/vk_layer_settings.txt build/linux/x64/output/bin/
+        rm -rf build/linux/x64/output/bin/staging-json
+        mv build/linux/x64/output/bin gfxreconstruct-dev
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:
@@ -83,11 +83,11 @@ jobs:
         python scripts\build.py --skip-check-code-style --skip-tests
     - name: Prepare artifacts
       run: |
-        copy LICENSE.txt build\windows\x64\bin\
-        copy LICENSE_ThirdParty.txt build\windows\x64\bin\
-        copy USAGE_desktop.md build\windows\x64\bin\
-        copy layer\vk_layer_settings.txt build\windows\x64\bin\
-        move build\windows\x64\bin gfxreconstruct-dev
+        copy LICENSE.txt build\windows\x64\output\bin\
+        copy LICENSE_ThirdParty.txt build\windows\x64\output\bin\
+        copy USAGE_desktop.md build\windows\x64\output\bin\
+        copy layer\vk_layer_settings.txt build\windows\x64\output\bin\
+        move build\windows\x64\output\bin gfxreconstruct-dev
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/sdk_android_build.yml
+++ b/.github/workflows/sdk_android_build.yml
@@ -17,7 +17,7 @@ name: SDK Android Build
 
 on:
   push:
-    tags:       
+    tags:
       - sdk-*
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-build/
-dbuild/
+build*/
+dbuild*/
 Debug/
 Release/
 __pycache__/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,8 @@ configure_file("${CMAKE_SOURCE_DIR}/project_version.h.in" "${CMAKE_BINARY_DIR}/p
 
 # Code checks
 include("CodeStyle")
-include("Test")
 include("Lint")
+include("Test")
 include("FindVulkanVersion")
 
 # Apply misc build directives to the given target

--- a/cmake/CodeStyle.cmake
+++ b/cmake/CodeStyle.cmake
@@ -45,29 +45,28 @@ macro(generate_target_source_files TARGET TARGET_SOURCE_FILES)
 endmacro()
 
 # Apply code style build directives
-macro(target_code_style_build_directives TARGET)
+function(target_code_style_build_directives TARGET)
+    generate_target_source_files(${TARGET} TARGET_SRC_FILES TARGET_SOURCE_FILES)
     if(${APPLY_CPP_CODE_STYLE})
         if(CLANG_FORMAT-NOTFOUND STREQUAL ${CLANG_FORMAT})
             message(FATAL_ERROR "Failed to find clang-format in system path")
         endif()
         # If apply code style is on, turn off check code style
         set(CHECK_CPP_CODE_STYLE OFF)
-        generate_target_source_files(${TARGET} OUTPUT TARGET_SOURCE_FILES)
         add_custom_target("${TARGET}ClangFormat"
-                COMMAND ${CLANG_FORMAT} -i ${OUTPUT}
+                COMMAND ${CLANG_FORMAT} -i ${TARGET_SRC_FILES}
                 WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
                 COMMENT "Run clang format for ${TARGET}"
                 COMMAND_EXPAND_LISTS)
         add_dependencies(${TARGET} "${TARGET}ClangFormat")
     endif()
     if(${CHECK_CPP_CODE_STYLE})
-        generate_target_source_files(${TARGET} OUTPUT TARGET_SOURCE_FILES)
         # Call the script to check formatting
         add_custom_target("${TARGET}CodeStyleCheck"
-                COMMAND "${PYTHON}" ${GFXReconstruct_SOURCE_DIR}/scripts/check_code_style.py
-                --sourcefile ${OUTPUT} --base ${CHECK_CPP_CODE_STYLE_BASE}
+                COMMAND "${PYTHON}" ${CMAKE_SOURCE_DIR}/scripts/check_code_style.py
+                --sourcefile ${TARGET_SRC_FILES} --base ${CHECK_CPP_CODE_STYLE_BASE}
                 WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
                 COMMENT "Check code style for ${TARGET}")
         add_dependencies(${TARGET} "${TARGET}CodeStyleCheck")
     endif()
-endmacro()
+endfunction()

--- a/cmake/Test.cmake
+++ b/cmake/Test.cmake
@@ -90,9 +90,9 @@ if (${RUN_TESTS})
     function(generate_test_package TEST_ARCHIVE)
         get_property(TEST_ARCHIVE_FILES GLOBAL PROPERTY TEST_ARCHIVE_FILES)
         if(${GENERATE_TEST_ARCHIVE})
+            set(TEST_ARCHIVE_DIR ${CMAKE_INSTALL_PREFIX})
+            file(MAKE_DIRECTORY ${TEST_ARCHIVE_DIR})
             if(CMAKE_HOST_WIN32)
-                set(TEST_ARCHIVE_DIR build/packages/windows/${ARCHITECTURE})
-                file(MAKE_DIRECTORY ${TEST_ARCHIVE_DIR})
                 add_custom_target(GenerateTestPackage ALL
                     COMMAND cmake -E tar "vcf" ${TEST_ARCHIVE_DIR}/${TEST_ARCHIVE}.zip --format=zip --
                         ${TEST_ARCHIVE_FILES}
@@ -100,8 +100,6 @@ if (${RUN_TESTS})
                     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
                     COMMENT "Generate Windows test package")
             elseif(CMAKE_HOST_UNIX)
-                set(TEST_ARCHIVE_DIR build/packages/linux/${ARCHITECTURE})
-                file(MAKE_DIRECTORY ${TEST_ARCHIVE_DIR})
                 add_custom_target(GenerateTestPackage ALL
                     COMMAND cmake -E tar "cf" ${TEST_ARCHIVE_DIR}/${TEST_ARCHIVE}.tar --format=gnutar --
                         ${TEST_ARCHIVE_FILES}

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -210,11 +210,15 @@ def cmake_generate_build_files(args):
     if 'windows' == system:
         if 'x64' == args.architecture:
             cmake_generate_args.extend(['-A', 'x64'])
+        elif 'x86' == args.architecture:
+            cmake_generate_args.extend(['-A', 'Win32'])
     else:
         if 'debug' == args.configuration:
             cmake_generate_args.append('-DCMAKE_BUILD_TYPE=Debug')
         else:
             cmake_generate_args.append('-DCMAKE_BUILD_TYPE=Release')
+        if 'x86' == args.architecture:
+            cmake_generate_args.extend(['-DCMAKE_CXX_FLAGS=-m32', '-DCMAKE_SHARED_LINKER_FLAGS=-m32'])
     cmake_generate_args.append('-DPYTHON={0}'.format(sys.executable))
     cmake_generate_args.extend(cmake_generate_options(args))
     work_dir = BUILD_ROOT

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 '''
-GFX reconstruct build script
+GFXReconstruct test script
 '''
 
 import argparse
@@ -135,6 +135,7 @@ if '__main__' == __name__:
                     build_script.BUILD_CONFIGS[args.configuration],
                     platform.system().lower(),
                     args.architecture,
+                    'output',
                     'bin')
             test_exe = os.path.join(test_exe_dir, test[0])
             test_args = copy.deepcopy(test[1])
@@ -145,3 +146,4 @@ if '__main__' == __name__:
         tests = [(args.test_exe, args.test_args)]
     for test_exe, test_args in tests:
         run_test(test_exe, test_args)
+    sys.exit(0)


### PR DESCRIPTION
Updates to PR #417 to add configurable build and install directories to the build.py script.  Includes the following:
* New --build-dir and --install-dir options for build.py
* Each configuration + platform + architecture configuration now has it's own output directory
* Each configuration + platform + architecture configuration now has it's own cmake files output directory

