### PR TITLE
Add trimmed file "optimization" utility

### DIFF
--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -24,6 +24,8 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/portability.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/resource_util.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/resource_util.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/referenced_resource_table.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/referenced_resource_table.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/string_array_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/string_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/struct_pointer_decoder.h
@@ -44,6 +46,8 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_realign_allocator.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_rebind_allocator.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_rebind_allocator.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_referenced_resource_consumer_base.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_referenced_resource_consumer_base.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_remap_allocator.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_remap_allocator.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_replay_consumer_base.h

--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -68,6 +68,8 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_consumer.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_decoder.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_referenced_resource_consumer.h
+                   ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_replay_consumer.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_replay_consumer.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_struct_decoders_forward.h

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -90,6 +90,8 @@ target_sources(gfxrecon_decode
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_consumer.h
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_decoder.h
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_decoder.cpp
+                    ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_referenced_resource_consumer.h
+                    ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_replay_consumer.h
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_replay_consumer.cpp
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_struct_decoders_forward.h

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -44,6 +44,8 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/pointer_decoder.h
                     ${CMAKE_CURRENT_LIST_DIR}/portability.h
                     ${CMAKE_CURRENT_LIST_DIR}/portability.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/referenced_resource_table.h
+                    ${CMAKE_CURRENT_LIST_DIR}/referenced_resource_table.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/resource_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/resource_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/string_array_decoder.h
@@ -66,6 +68,8 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_realign_allocator.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_rebind_allocator.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_rebind_allocator.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_referenced_resource_consumer_base.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_referenced_resource_consumer_base.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_remap_allocator.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_remap_allocator.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_replay_consumer_base.h

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -345,7 +345,7 @@ void FileProcessor::HandleBlockReadError(Error error_code, const char* error_mes
     else
     {
         GFXRECON_LOG_ERROR("%s", error_message);
-        error_state_ = kErrorReadingCompressedBlockData;
+        error_state_ = error_code;
     }
 }
 

--- a/framework/decode/referenced_resource_table.cpp
+++ b/framework/decode/referenced_resource_table.cpp
@@ -75,7 +75,7 @@ void ReferencedResourceTable::AddResource(size_t                  parent_id_coun
 
 void ReferencedResourceTable::AddResourceToContainer(format::HandleId container_id,
                                                      format::HandleId resource_id,
-                                                     int32_t          binding,
+                                                     uint32_t         binding,
                                                      uint32_t         element)
 {
     if ((container_id != format::kNullHandleId) && (resource_id != format::kNullHandleId))
@@ -92,11 +92,7 @@ void ReferencedResourceTable::AddResourceToContainer(format::HandleId container_
                 assert((container_info != nullptr) && (resource_info != nullptr));
 
                 container_info->resource_infos.emplace(resource_id, std::weak_ptr<ResourceInfo>{ resource_info });
-
-                if (binding >= 0)
-                {
-                    container_info->resource_bindings[binding].insert(std::make_pair(element, resource_id));
-                }
+                container_info->resource_bindings[binding].insert(std::make_pair(element, resource_id));
             }
         }
     }
@@ -325,10 +321,10 @@ void ReferencedResourceTable::ClearUsers(format::HandleId pool_id)
 }
 
 void ReferencedResourceTable::CopyContainerEntry(format::HandleId source_container_id,
-                                                 int32_t          source_binding,
+                                                 uint32_t         source_binding,
                                                  uint32_t         source_element,
                                                  format::HandleId destination_container_id,
-                                                 int32_t          destination_binding,
+                                                 uint32_t         destination_binding,
                                                  uint32_t         destination_element)
 {
     if (source_container_id != format::kNullHandleId)

--- a/framework/decode/referenced_resource_table.cpp
+++ b/framework/decode/referenced_resource_table.cpp
@@ -1,0 +1,410 @@
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include "decode/referenced_resource_table.h"
+
+#include <cassert>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+void ReferencedResourceTable::AddResource(format::HandleId resource_id)
+{
+    if (resource_id != format::kNullHandleId)
+    {
+        resources_.emplace(resource_id, std::make_shared<ResourceInfo>());
+    }
+}
+
+void ReferencedResourceTable::AddResource(format::HandleId parent_id, format::HandleId resource_id)
+{
+    if ((parent_id != format::kNullHandleId) && (resource_id != format::kNullHandleId))
+    {
+        auto parent_entry = resources_.find(parent_id);
+
+        if (parent_entry != resources_.end())
+        {
+            auto& parent_info = parent_entry->second;
+            assert(parent_info != nullptr);
+
+            auto resource_entry = resources_.find(resource_id);
+            if (resource_entry == resources_.end())
+            {
+                // The resource is not in the table, so add it to both the table and to the parent's child list.
+                auto resource_info      = std::make_shared<ResourceInfo>();
+                resource_info->is_child = true;
+
+                parent_info->child_infos.emplace_back(std::weak_ptr<ResourceInfo>{ resource_info });
+                resources_.emplace(resource_id, resource_info);
+            }
+            else
+            {
+                // The resource has already been added to the table, but has multiple parent objects (e.g. a framebuffer
+                // is created from multiple image views), so we add it to the parent's child list.
+                parent_info->child_infos.emplace_back(std::weak_ptr<ResourceInfo>{ resource_entry->second });
+            }
+        }
+    }
+}
+
+void ReferencedResourceTable::AddResource(size_t                  parent_id_count,
+                                          const format::HandleId* parent_ids,
+                                          format::HandleId        resource_id)
+{
+    if ((parent_ids != nullptr) && (resource_id != format::kNullHandleId))
+    {
+        for (size_t i = 0; i < parent_id_count; ++i)
+        {
+            AddResource(parent_ids[i], resource_id);
+        }
+    }
+}
+
+void ReferencedResourceTable::AddResourceToContainer(format::HandleId container_id, format::HandleId resource_id)
+{
+    if ((container_id != format::kNullHandleId) && (resource_id != format::kNullHandleId))
+    {
+        auto container_entry = containers_.find(container_id);
+        if (container_entry != containers_.end())
+        {
+            auto& container_info = container_entry->second;
+            auto  resource_entry = resources_.find(resource_id);
+
+            if (resource_entry != resources_.end())
+            {
+                auto& resource_info = resource_entry->second;
+                assert((container_info != nullptr) && (resource_info != nullptr));
+
+                container_info->resource_infos.emplace(resource_id, std::weak_ptr<ResourceInfo>{ resource_info });
+            }
+        }
+    }
+}
+
+void ReferencedResourceTable::AddResourceToUser(format::HandleId user_id, format::HandleId resource_id)
+{
+    if ((user_id != format::kNullHandleId) && (resource_id != format::kNullHandleId))
+    {
+        auto user_entry = users_.find(user_id);
+        if (user_entry != users_.end())
+        {
+            auto& user_info      = user_entry->second;
+            auto  resource_entry = resources_.find(resource_id);
+
+            if (resource_entry != resources_.end())
+            {
+                auto& resource_info = resource_entry->second;
+                assert((user_info != nullptr) && (resource_info != nullptr));
+
+                user_info->resource_infos.emplace(resource_id, std::weak_ptr<ResourceInfo>{ resource_info });
+            }
+        }
+    }
+}
+
+void ReferencedResourceTable::AddContainerToUser(format::HandleId user_id, format::HandleId container_id)
+{
+    if ((user_id != format::kNullHandleId) && (container_id != format::kNullHandleId))
+    {
+        auto user_entry = users_.find(user_id);
+        if (user_entry != users_.end())
+        {
+            auto& user_info       = user_entry->second;
+            auto  container_entry = containers_.find(container_id);
+
+            if (container_entry != containers_.end())
+            {
+                auto& container_info = container_entry->second;
+                assert((user_info != nullptr) && (container_info != nullptr));
+
+                user_info->container_infos.emplace(container_id,
+                                                   std::weak_ptr<ResourceContainerInfo>{ container_info });
+            }
+        }
+    }
+}
+
+void ReferencedResourceTable::AddUserToUser(format::HandleId user_id, format::HandleId source_user_id)
+{
+    if ((user_id != format::kNullHandleId) && (source_user_id != format::kNullHandleId))
+    {
+        auto user_entry = users_.find(user_id);
+        if (user_entry != users_.end())
+        {
+            auto& user_info         = user_entry->second;
+            auto  source_user_entry = users_.find(source_user_id);
+
+            if (source_user_entry != users_.end())
+            {
+                auto& source_user_info = source_user_entry->second;
+                assert((user_info != nullptr) && (source_user_info != nullptr));
+
+                // Copy resource and container info from source user to destination user.
+                auto&       resource_infos         = user_info->resource_infos;
+                auto&       container_infos        = user_info->container_infos;
+                const auto& source_resource_infos  = source_user_info->resource_infos;
+                const auto& source_container_infos = source_user_info->container_infos;
+
+                for (auto& source_resource_info : source_resource_infos)
+                {
+                    if (!source_resource_info.second.expired())
+                    {
+                        resource_infos.insert(source_resource_info);
+                    }
+                }
+
+                for (auto& source_container_info : source_container_infos)
+                {
+                    if (!source_container_info.second.expired())
+                    {
+                        container_infos.insert(source_container_info);
+                    }
+                }
+            }
+        }
+    }
+}
+
+void ReferencedResourceTable::AddContainer(format::HandleId pool_id, format::HandleId container_id)
+{
+    if ((pool_id != format::kNullHandleId) && (container_id != format::kNullHandleId))
+    {
+        auto container_info     = std::make_shared<ResourceContainerInfo>();
+        container_info->pool_id = pool_id;
+        containers_.emplace(container_id, std::move(container_info));
+        container_pool_handles_[pool_id].insert(container_id);
+    }
+}
+
+void ReferencedResourceTable::AddUser(format::HandleId pool_id, format::HandleId user_id)
+{
+    if ((pool_id != format::kNullHandleId) && (user_id != format::kNullHandleId))
+    {
+        auto user_info     = std::make_shared<ResourceUserInfo>();
+        user_info->pool_id = pool_id;
+        users_.emplace(user_id, std::move(user_info));
+        user_pool_handles_[pool_id].insert(user_id);
+    }
+}
+
+void ReferencedResourceTable::RemoveContainer(format::HandleId container_id)
+{
+    if (container_id != format::kNullHandleId)
+    {
+        auto container_entry = containers_.find(container_id);
+        if (container_entry != containers_.end())
+        {
+            auto& container_info = container_entry->second;
+            assert(container_info != nullptr);
+
+            container_pool_handles_[container_info->pool_id].erase(container_id);
+            containers_.erase(container_entry);
+        }
+    }
+}
+
+void ReferencedResourceTable::RemoveUser(format::HandleId user_id)
+{
+    if (user_id != format::kNullHandleId)
+    {
+        auto user_entry = users_.find(user_id);
+        if (user_entry != users_.end())
+        {
+            auto& user_info = user_entry->second;
+            assert(user_info != nullptr);
+
+            user_pool_handles_[user_info->pool_id].erase(user_id);
+            users_.erase(user_entry);
+        }
+    }
+}
+
+void ReferencedResourceTable::ResetContainer(format::HandleId container_id)
+{
+    if (container_id != format::kNullHandleId)
+    {
+        auto container_entry = containers_.find(container_id);
+        if (container_entry != containers_.end())
+        {
+            auto& container_info = container_entry->second;
+            assert(container_info != nullptr);
+
+            container_info->resource_infos.clear();
+        }
+    }
+}
+
+void ReferencedResourceTable::ResetUser(format::HandleId user_id)
+{
+    if (user_id != format::kNullHandleId)
+    {
+        auto user_entry = users_.find(user_id);
+        if (user_entry != users_.end())
+        {
+            auto& user_info = user_entry->second;
+            assert(user_info != nullptr);
+
+            user_info->resource_infos.clear();
+            user_info->container_infos.clear();
+        }
+    }
+}
+
+void ReferencedResourceTable::ResetContainers(format::HandleId pool_id)
+{
+    if (pool_id != format::kNullHandleId)
+    {
+        auto& container_ids = container_pool_handles_[pool_id];
+        for (auto container_id : container_ids)
+        {
+            ResetContainer(container_id);
+        }
+    }
+}
+
+void ReferencedResourceTable::ResetUsers(format::HandleId pool_id)
+{
+    if (pool_id != format::kNullHandleId)
+    {
+        auto& user_ids = user_pool_handles_[pool_id];
+        for (auto user_id : user_ids)
+        {
+            ResetUser(user_id);
+        }
+    }
+}
+
+void ReferencedResourceTable::ClearContainers(format::HandleId pool_id)
+{
+    if (pool_id != format::kNullHandleId)
+    {
+        auto& container_ids = container_pool_handles_[pool_id];
+        for (auto container_id : container_ids)
+        {
+            containers_.erase(container_id);
+        }
+
+        container_ids.clear();
+    }
+}
+
+void ReferencedResourceTable::ClearUsers(format::HandleId pool_id)
+{
+    if (pool_id != format::kNullHandleId)
+    {
+        auto& user_ids = user_pool_handles_[pool_id];
+        for (auto user_id : user_ids)
+        {
+            users_.erase(user_id);
+        }
+
+        user_ids.clear();
+    }
+}
+
+void ReferencedResourceTable::ProcessUserSubmission(format::HandleId user_id)
+{
+    if (user_id != format::kNullHandleId)
+    {
+        auto user_entry = users_.find(user_id);
+        if (user_entry != users_.end())
+        {
+            auto& user_info = user_entry->second;
+            assert(user_info != nullptr);
+
+            auto& resource_infos  = user_info->resource_infos;
+            auto& container_infos = user_info->container_infos;
+
+            for (auto& resource_info : resource_infos)
+            {
+                if (!resource_info.second.expired())
+                {
+                    auto resource_info_ptr  = resource_info.second.lock();
+                    resource_info_ptr->used = true;
+                }
+            }
+
+            for (auto& container_info : container_infos)
+            {
+                if (!container_info.second.expired())
+                {
+                    auto container_info_ptr = container_info.second.lock();
+                    for (auto& resource_info : container_info_ptr->resource_infos)
+                    {
+                        if (!resource_info.second.expired())
+                        {
+                            auto resource_info_ptr  = resource_info.second.lock();
+                            resource_info_ptr->used = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+void ReferencedResourceTable::GetReferencedResourceIds(std::unordered_set<format::HandleId>* referenced_ids,
+                                                       std::unordered_set<format::HandleId>* unreferenced_ids) const
+{
+    for (auto resource_entry : resources_)
+    {
+        auto& resource_info = resource_entry.second;
+
+        if (!resource_info->is_child)
+        {
+            bool used = IsUsed(resource_info.get());
+
+            if (used && (referenced_ids != nullptr))
+            {
+                referenced_ids->insert(resource_entry.first);
+            }
+            else if (!used && (unreferenced_ids != nullptr))
+            {
+                unreferenced_ids->insert(resource_entry.first);
+            }
+        }
+    }
+}
+
+bool ReferencedResourceTable::IsUsed(const ResourceInfo* resource_info) const
+{
+    assert(resource_info != nullptr);
+
+    if (resource_info->used)
+    {
+        return true;
+    }
+    else
+    {
+        // If the resource was not used directly, check to see if it was used indirectly through a child.
+        for (const auto& child_info : resource_info->child_infos)
+        {
+            if (!child_info.expired())
+            {
+                const auto child_info_ptr = child_info.lock();
+                if (IsUsed(child_info_ptr.get()))
+                {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/referenced_resource_table.h
+++ b/framework/decode/referenced_resource_table.h
@@ -1,0 +1,115 @@
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef GFXRECON_DECODE_REFERENCED_RESOURCE_TABLE_H
+#define GFXRECON_DECODE_REFERENCED_RESOURCE_TABLE_H
+
+#include "format/format.h"
+#include "util/defines.h"
+
+#include "vulkan/vulkan.h"
+
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+class ReferencedResourceTable
+{
+  public:
+    void AddResource(format::HandleId resource_id);
+
+    void AddResource(format::HandleId parent_id, format::HandleId resource_id);
+
+    void AddResource(size_t parent_id_count, const format::HandleId* parent_ids, format::HandleId resource_id);
+
+    void AddResourceToContainer(format::HandleId container_id, format::HandleId resource_id);
+
+    void AddResourceToUser(format::HandleId user_id, format::HandleId resource_id);
+
+    void AddContainerToUser(format::HandleId user_id, format::HandleId container_id);
+
+    void AddUserToUser(format::HandleId user_id, format::HandleId source_user_id);
+
+    void AddContainer(format::HandleId pool_id, format::HandleId container_id);
+
+    void AddUser(format::HandleId pool_id, format::HandleId user_id);
+
+    void RemoveContainer(format::HandleId container_id);
+
+    void RemoveUser(format::HandleId user_id);
+
+    void ResetContainer(format::HandleId container_id);
+
+    void ResetUser(format::HandleId user_id);
+
+    void ResetContainers(format::HandleId pool_id);
+
+    void ResetUsers(format::HandleId pool_id);
+
+    void ClearContainers(format::HandleId pool_id);
+
+    void ClearUsers(format::HandleId pool_id);
+
+    void ProcessUserSubmission(format::HandleId user_id);
+
+    void GetReferencedResourceIds(std::unordered_set<format::HandleId>* referenced_ids,
+                                  std::unordered_set<format::HandleId>* unreferenced_ids) const;
+
+  private:
+    // Track the referenced/used state of a resource (buffer, image, view, framebuffer).
+    struct ResourceInfo
+    {
+        bool                                     used{ false };
+        bool                                     is_child{ false };
+        std::vector<std::weak_ptr<ResourceInfo>> child_infos;
+    };
+
+    // Track the referenced/used state of a resource container (descriptor set).
+    struct ResourceContainerInfo
+    {
+        format::HandleId                                                  pool_id{ format::kNullHandleId };
+        std::unordered_map<format::HandleId, std::weak_ptr<ResourceInfo>> resource_infos;
+    };
+
+    // Track the state of a resource user (command buffer).
+    struct ResourceUserInfo
+    {
+        format::HandleId                                                           pool_id{ format::kNullHandleId };
+        std::unordered_map<format::HandleId, std::weak_ptr<ResourceInfo>>          resource_infos;
+        std::unordered_map<format::HandleId, std::weak_ptr<ResourceContainerInfo>> container_infos;
+    };
+
+    typedef std::unordered_set<format::HandleId> PoolHandles;
+
+  private:
+    bool IsUsed(const ResourceInfo* resource_info) const;
+
+  private:
+    std::unordered_map<format::HandleId, std::shared_ptr<ResourceInfo>>          resources_;
+    std::unordered_map<format::HandleId, std::shared_ptr<ResourceContainerInfo>> containers_;
+    std::unordered_map<format::HandleId, std::shared_ptr<ResourceUserInfo>>      users_;
+    std::unordered_map<format::HandleId, PoolHandles>                            container_pool_handles_;
+    std::unordered_map<format::HandleId, PoolHandles>                            user_pool_handles_;
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_REFERENCED_RESOURCE_TABLE_H

--- a/framework/decode/referenced_resource_table.h
+++ b/framework/decode/referenced_resource_table.h
@@ -41,7 +41,7 @@ class ReferencedResourceTable
 
     void AddResourceToContainer(format::HandleId container_id,
                                 format::HandleId resource_id,
-                                int32_t          binding,
+                                uint32_t         binding,
                                 uint32_t         element);
 
     void AddResourceToUser(format::HandleId user_id, format::HandleId resource_id);
@@ -71,10 +71,10 @@ class ReferencedResourceTable
     void ClearUsers(format::HandleId pool_id);
 
     void CopyContainerEntry(format::HandleId source_container_id,
-                            int32_t          source_binding,
+                            uint32_t         source_binding,
                             uint32_t         source_element,
                             format::HandleId destination_container_id,
-                            int32_t          destination_binding,
+                            uint32_t         destination_binding,
                             uint32_t         destination_element);
 
     void ProcessUserSubmission(format::HandleId user_id);
@@ -99,7 +99,7 @@ class ReferencedResourceTable
 
         // Table mapping a container binding to a handle.  Each binding contains a table of handles keyed by array
         // element index.
-        std::unordered_map<int32_t, std::unordered_map<uint32_t, format::HandleId>> resource_bindings;
+        std::unordered_map<uint32_t, std::unordered_map<uint32_t, format::HandleId>> resource_bindings;
     };
 
     // Track the state of a resource user (command buffer).

--- a/framework/decode/referenced_resource_table.h
+++ b/framework/decode/referenced_resource_table.h
@@ -39,7 +39,10 @@ class ReferencedResourceTable
 
     void AddResource(size_t parent_id_count, const format::HandleId* parent_ids, format::HandleId resource_id);
 
-    void AddResourceToContainer(format::HandleId container_id, format::HandleId resource_id);
+    void AddResourceToContainer(format::HandleId container_id,
+                                format::HandleId resource_id,
+                                int32_t          binding,
+                                uint32_t         element);
 
     void AddResourceToUser(format::HandleId user_id, format::HandleId resource_id);
 
@@ -67,6 +70,13 @@ class ReferencedResourceTable
 
     void ClearUsers(format::HandleId pool_id);
 
+    void CopyContainerEntry(format::HandleId source_container_id,
+                            int32_t          source_binding,
+                            uint32_t         source_element,
+                            format::HandleId destination_container_id,
+                            int32_t          destination_binding,
+                            uint32_t         destination_element);
+
     void ProcessUserSubmission(format::HandleId user_id);
 
     void GetReferencedResourceIds(std::unordered_set<format::HandleId>* referenced_ids,
@@ -86,6 +96,10 @@ class ReferencedResourceTable
     {
         format::HandleId                                                  pool_id{ format::kNullHandleId };
         std::unordered_map<format::HandleId, std::weak_ptr<ResourceInfo>> resource_infos;
+
+        // Table mapping a container binding to a handle.  Each binding contains a table of handles keyed by array
+        // element index.
+        std::unordered_map<int32_t, std::unordered_map<uint32_t, format::HandleId>> resource_bindings;
     };
 
     // Track the state of a resource user (command buffer).

--- a/framework/decode/vulkan_referenced_resource_consumer_base.cpp
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.cpp
@@ -1,0 +1,595 @@
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include "decode/vulkan_referenced_resource_consumer_base.h"
+
+#include <cassert>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+VulkanReferencedResourceConsumerBase::VulkanReferencedResourceConsumerBase() : loading_state_(false) {}
+
+void VulkanReferencedResourceConsumerBase::Process_vkQueueSubmit(VkResult         returnValue,
+                                                                 format::HandleId queue,
+                                                                 uint32_t         submitCount,
+                                                                 StructPointerDecoder<Decoded_VkSubmitInfo>* pSubmits,
+                                                                 format::HandleId                            fence)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(returnValue);
+    GFXRECON_UNREFERENCED_PARAMETER(queue);
+    GFXRECON_UNREFERENCED_PARAMETER(submitCount);
+    GFXRECON_UNREFERENCED_PARAMETER(fence);
+
+    assert(pSubmits != nullptr);
+
+    if (!pSubmits->IsNull() && pSubmits->HasData())
+    {
+        size_t     submit_count = pSubmits->GetLength();
+        const auto submits      = pSubmits->GetMetaStructPointer();
+
+        for (size_t i = 0; i < submit_count; ++i)
+        {
+            size_t     command_buffer_count = submits[i].pCommandBuffers.GetLength();
+            const auto command_buffer_ids   = submits[i].pCommandBuffers.GetPointer();
+
+            for (size_t j = 0; j < command_buffer_count; ++j)
+            {
+                table_.ProcessUserSubmission(command_buffer_ids[j]);
+            }
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkCreateBuffer(
+    VkResult                                             returnValue,
+    format::HandleId                                     device,
+    StructPointerDecoder<Decoded_VkBufferCreateInfo>*    pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+    HandlePointerDecoder<VkBuffer>*                      pBuffer)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(returnValue);
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+    GFXRECON_UNREFERENCED_PARAMETER(pCreateInfo);
+    GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
+
+    assert(pBuffer != nullptr);
+
+    // Only track buffers that were created by the trimmed file state snapshot.
+    if (IsStateLoading() && !pBuffer->IsNull() && pBuffer->HasData())
+    {
+        table_.AddResource(*pBuffer->GetPointer());
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkCreateBufferView(
+    VkResult                                              returnValue,
+    format::HandleId                                      device,
+    StructPointerDecoder<Decoded_VkBufferViewCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>*  pAllocator,
+    HandlePointerDecoder<VkBufferView>*                   pView)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(returnValue);
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+    GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
+
+    assert((pCreateInfo != nullptr) && (pView != nullptr));
+
+    if (!pCreateInfo->IsNull() && pCreateInfo->HasData() && !pView->IsNull() && pView->HasData())
+    {
+        const auto create_info = pCreateInfo->GetMetaStructPointer();
+        table_.AddResource(create_info->buffer, *pView->GetPointer());
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkCreateImage(
+    VkResult                                             returnValue,
+    format::HandleId                                     device,
+    StructPointerDecoder<Decoded_VkImageCreateInfo>*     pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+    HandlePointerDecoder<VkImage>*                       pImage)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(returnValue);
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+    GFXRECON_UNREFERENCED_PARAMETER(pCreateInfo);
+    GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
+
+    assert(pImage != nullptr);
+
+    // Only track images that were created by the trimmed file state snapshot.
+    if (IsStateLoading() && !pImage->IsNull() && pImage->HasData())
+    {
+        table_.AddResource(*pImage->GetPointer());
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkCreateImageView(
+    VkResult                                             returnValue,
+    format::HandleId                                     device,
+    StructPointerDecoder<Decoded_VkImageViewCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+    HandlePointerDecoder<VkImageView>*                   pView)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(returnValue);
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+    GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
+
+    assert((pCreateInfo != nullptr) && (pView != nullptr));
+
+    if (!pCreateInfo->IsNull() && pCreateInfo->HasData() && !pView->IsNull() && pView->HasData())
+    {
+        const auto create_info = pCreateInfo->GetMetaStructPointer();
+        table_.AddResource(create_info->image, *pView->GetPointer());
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkCreateFramebuffer(
+    VkResult                                               returnValue,
+    format::HandleId                                       device,
+    StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* pCreateInfo,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>*   pAllocator,
+    HandlePointerDecoder<VkFramebuffer>*                   pFramebuffer)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(returnValue);
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+    GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
+
+    assert((pCreateInfo != nullptr) && (pFramebuffer != nullptr));
+
+    if (!pCreateInfo->IsNull() && pCreateInfo->HasData() && !pFramebuffer->IsNull() && pFramebuffer->HasData())
+    {
+        const auto create_info = pCreateInfo->GetMetaStructPointer();
+        auto       view_count  = create_info->pAttachments.GetLength();
+        const auto views       = create_info->pAttachments.GetPointer();
+
+        table_.AddResource(view_count, views, *pFramebuffer->GetPointer());
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkDestroyDescriptorPool(
+    format::HandleId                                     device,
+    format::HandleId                                     descriptorPool,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+    GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
+
+    table_.ClearContainers(descriptorPool);
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkResetDescriptorPool(VkResult                   returnValue,
+                                                                         format::HandleId           device,
+                                                                         format::HandleId           descriptorPool,
+                                                                         VkDescriptorPoolResetFlags flags)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(returnValue);
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+    GFXRECON_UNREFERENCED_PARAMETER(flags);
+
+    table_.ClearContainers(descriptorPool);
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkAllocateDescriptorSets(
+    VkResult                                                   returnValue,
+    format::HandleId                                           device,
+    StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
+    HandlePointerDecoder<VkDescriptorSet>*                     pDescriptorSets)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(returnValue);
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+
+    assert((pAllocateInfo != nullptr) && (pDescriptorSets != nullptr));
+
+    if (!pAllocateInfo->IsNull() && pAllocateInfo->HasData() && !pDescriptorSets->IsNull() &&
+        pDescriptorSets->HasData())
+    {
+        const auto alloc_info      = pAllocateInfo->GetPointer();
+        const auto alloc_meta_info = pAllocateInfo->GetMetaStructPointer();
+        const auto sets            = pDescriptorSets->GetPointer();
+        auto       pool            = alloc_meta_info->descriptorPool;
+        auto       count           = alloc_info->descriptorSetCount;
+
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            table_.AddContainer(pool, sets[i]);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkFreeDescriptorSets(
+    VkResult                               returnValue,
+    format::HandleId                       device,
+    format::HandleId                       descriptorPool,
+    uint32_t                               descriptorSetCount,
+    HandlePointerDecoder<VkDescriptorSet>* pDescriptorSets)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(returnValue);
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+    GFXRECON_UNREFERENCED_PARAMETER(descriptorPool);
+
+    assert(pDescriptorSets != nullptr);
+
+    if (!pDescriptorSets->IsNull() && pDescriptorSets->HasData())
+    {
+        const auto sets = pDescriptorSets->GetPointer();
+
+        for (uint32_t i = 0; i < descriptorSetCount; ++i)
+        {
+            table_.RemoveContainer(sets[i]);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkUpdateDescriptorSets(
+    format::HandleId                                    device,
+    uint32_t                                            descriptorWriteCount,
+    StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites,
+    uint32_t                                            descriptorCopyCount,
+    StructPointerDecoder<Decoded_VkCopyDescriptorSet>*  pDescriptorCopies)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+
+    assert((pDescriptorWrites != nullptr) && (pDescriptorCopies != nullptr));
+
+    if (!pDescriptorWrites->IsNull() && pDescriptorWrites->HasData())
+    {
+        const auto writes      = pDescriptorWrites->GetPointer();
+        const auto meta_writes = pDescriptorWrites->GetMetaStructPointer();
+
+        for (uint32_t i = 0; i < descriptorWriteCount; ++i)
+        {
+            switch (writes[i].descriptorType)
+            {
+                case VK_DESCRIPTOR_TYPE_SAMPLER:
+                case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
+                case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+                    // Descriptor types that do not need to be tracked.
+                    break;
+                case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+                case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+                case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+                case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+                {
+                    const auto image_info = meta_writes->pImageInfo.get();
+                    assert(image_info != nullptr);
+
+                    if (!image_info->IsNull() && image_info->HasData())
+                    {
+                        AddImagesToContainer(
+                            meta_writes[i].dstSet, writes[i].descriptorCount, image_info->GetMetaStructPointer());
+                    }
+
+                    break;
+                }
+                case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+                case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+                case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+                case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+                {
+                    const auto buffer_info = meta_writes->pBufferInfo.get();
+                    assert(buffer_info != nullptr);
+
+                    if (!buffer_info->IsNull() && buffer_info->HasData())
+                    {
+                        AddBuffersToContainer(
+                            meta_writes[i].dstSet, writes[i].descriptorCount, buffer_info->GetMetaStructPointer());
+                    }
+
+                    break;
+                }
+                case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+                case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+                {
+                    const auto& views = meta_writes->pTexelBufferView;
+
+                    if (!views.IsNull() && views.HasData())
+                    {
+                        AddTexelBufferViewsToContainer(
+                            meta_writes[i].dstSet, writes[i].descriptorCount, views.GetPointer());
+                    }
+
+                    break;
+                }
+                default:
+                    GFXRECON_LOG_WARNING("Ingoring unrecognized descriptor type %d", writes[i].descriptorType);
+                    break;
+            }
+        }
+    }
+
+    if (!pDescriptorCopies->IsNull() && pDescriptorCopies->HasData())
+    {
+        // TODO: Containers need to support indexes for copies.
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(
+    format::HandleId                 device,
+    format::HandleId                 descriptorSet,
+    format::HandleId                 descriptorUpdateTemplate,
+    DescriptorUpdateTemplateDecoder* pData)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+    GFXRECON_UNREFERENCED_PARAMETER(descriptorUpdateTemplate);
+
+    UpdateDescriptorSetWithTemplate(descriptorSet, pData);
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(
+    format::HandleId                 commandBuffer,
+    format::HandleId                 descriptorUpdateTemplate,
+    format::HandleId                 layout,
+    uint32_t                         set,
+    DescriptorUpdateTemplateDecoder* pData)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(descriptorUpdateTemplate);
+    GFXRECON_UNREFERENCED_PARAMETER(layout);
+    GFXRECON_UNREFERENCED_PARAMETER(set);
+
+    PushDescriptorSetWithTemplate(commandBuffer, pData);
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(
+    format::HandleId                 device,
+    format::HandleId                 descriptorSet,
+    format::HandleId                 descriptorUpdateTemplate,
+    DescriptorUpdateTemplateDecoder* pData)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+    GFXRECON_UNREFERENCED_PARAMETER(descriptorUpdateTemplate);
+
+    UpdateDescriptorSetWithTemplate(descriptorSet, pData);
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkDestroyCommandPool(
+    format::HandleId                                     device,
+    format::HandleId                                     commandPool,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+    GFXRECON_UNREFERENCED_PARAMETER(pAllocator);
+
+    table_.ClearUsers(commandPool);
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkResetCommandPool(VkResult                returnValue,
+                                                                      format::HandleId        device,
+                                                                      format::HandleId        commandPool,
+                                                                      VkCommandPoolResetFlags flags)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(returnValue);
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+    GFXRECON_UNREFERENCED_PARAMETER(flags);
+
+    table_.ResetUsers(commandPool);
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkAllocateCommandBuffers(
+    VkResult                                                   returnValue,
+    format::HandleId                                           device,
+    StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
+    HandlePointerDecoder<VkCommandBuffer>*                     pCommandBuffers)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(returnValue);
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+
+    assert((pAllocateInfo != nullptr) && (pCommandBuffers != nullptr));
+
+    if (!pAllocateInfo->IsNull() && pAllocateInfo->HasData() && !pCommandBuffers->IsNull() &&
+        pCommandBuffers->HasData())
+    {
+        const auto alloc_info      = pAllocateInfo->GetPointer();
+        const auto alloc_meta_info = pAllocateInfo->GetMetaStructPointer();
+        const auto command_buffers = pCommandBuffers->GetPointer();
+        auto       pool            = alloc_meta_info->commandPool;
+        auto       count           = alloc_info->commandBufferCount;
+
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            table_.AddUser(pool, command_buffers[i]);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkFreeCommandBuffers(
+    format::HandleId                       device,
+    format::HandleId                       commandPool,
+    uint32_t                               commandBufferCount,
+    HandlePointerDecoder<VkCommandBuffer>* pCommandBuffers)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(device);
+    GFXRECON_UNREFERENCED_PARAMETER(commandPool);
+
+    assert(pCommandBuffers != nullptr);
+
+    if (!pCommandBuffers->IsNull() && pCommandBuffers->HasData())
+    {
+        const auto command_buffers = pCommandBuffers->GetPointer();
+
+        for (uint32_t i = 0; i < commandBufferCount; ++i)
+        {
+            table_.RemoveUser(command_buffers[i]);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkBeginCommandBuffer(
+    VkResult                                                returnValue,
+    format::HandleId                                        commandBuffer,
+    StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(returnValue);
+    GFXRECON_UNREFERENCED_PARAMETER(pBeginInfo);
+
+    table_.ResetUser(commandBuffer);
+}
+
+void VulkanReferencedResourceConsumerBase::Process_vkResetCommandBuffer(VkResult                  returnValue,
+                                                                        format::HandleId          commandBuffer,
+                                                                        VkCommandBufferResetFlags flags)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(returnValue);
+    GFXRECON_UNREFERENCED_PARAMETER(flags);
+
+    table_.ResetUser(commandBuffer);
+}
+
+void VulkanReferencedResourceConsumerBase::AddImagesToContainer(format::HandleId                     container_id,
+                                                                size_t                               count,
+                                                                const Decoded_VkDescriptorImageInfo* image_info)
+{
+    assert(image_info != nullptr);
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        table_.AddResourceToContainer(container_id, image_info[i].imageView);
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::AddBuffersToContainer(format::HandleId                      container_id,
+                                                                 size_t                                count,
+                                                                 const Decoded_VkDescriptorBufferInfo* buffer_info)
+{
+    assert(buffer_info != nullptr);
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        table_.AddResourceToContainer(container_id, buffer_info[i].buffer);
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::AddTexelBufferViewsToContainer(format::HandleId        container_id,
+                                                                          size_t                  count,
+                                                                          const format::HandleId* view_ids)
+{
+    assert(view_ids != nullptr);
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        table_.AddResourceToContainer(container_id, view_ids[i]);
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::UpdateDescriptorSetWithTemplate(
+    format::HandleId container_id, const DescriptorUpdateTemplateDecoder* decoder)
+{
+    assert(decoder != nullptr);
+
+    size_t image_info_count        = decoder->GetImageInfoCount();
+    size_t buffer_info_count       = decoder->GetBufferInfoCount();
+    size_t texel_buffer_view_count = decoder->GetTexelBufferViewCount();
+
+    if (image_info_count > 0)
+    {
+        // TODO: Get descriptor type from template creation so that sampler only writes can be ignored. Worst case is a
+        // handle with an uninitialized value, which will never be referenced, is added to the tracker.
+        const auto image_info = decoder->GetImageInfoMetaStructPointer();
+        assert(image_info != nullptr);
+
+        AddImagesToContainer(container_id, image_info_count, image_info);
+    }
+
+    if (buffer_info_count > 0)
+    {
+        const auto buffer_info = decoder->GetBufferInfoMetaStructPointer();
+        assert(buffer_info != nullptr);
+
+        AddBuffersToContainer(container_id, buffer_info_count, buffer_info);
+    }
+
+    if (texel_buffer_view_count > 0)
+    {
+        auto view_ids = decoder->GetTexelBufferViewHandleIdsPointer();
+        assert(view_ids != nullptr);
+
+        AddTexelBufferViewsToContainer(container_id, texel_buffer_view_count, view_ids);
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::AddImagesToUser(format::HandleId                     user_id,
+                                                           size_t                               count,
+                                                           const Decoded_VkDescriptorImageInfo* image_info)
+{
+    assert(image_info != nullptr);
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        table_.AddResourceToUser(user_id, image_info[i].imageView);
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::AddBuffersToUser(format::HandleId                      user_id,
+                                                            size_t                                count,
+                                                            const Decoded_VkDescriptorBufferInfo* buffer_info)
+{
+    assert(buffer_info != nullptr);
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        table_.AddResourceToUser(user_id, buffer_info[i].buffer);
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::AddTexelBufferViewsToUser(format::HandleId        user_id,
+                                                                     size_t                  count,
+                                                                     const format::HandleId* view_ids)
+{
+    assert(view_ids != nullptr);
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        table_.AddResourceToUser(user_id, view_ids[i]);
+    }
+}
+
+void VulkanReferencedResourceConsumerBase::PushDescriptorSetWithTemplate(format::HandleId                       user_id,
+                                                                         const DescriptorUpdateTemplateDecoder* decoder)
+{
+    assert(decoder != nullptr);
+
+    size_t image_info_count        = decoder->GetImageInfoCount();
+    size_t buffer_info_count       = decoder->GetBufferInfoCount();
+    size_t texel_buffer_view_count = decoder->GetTexelBufferViewCount();
+
+    if (image_info_count > 0)
+    {
+        // TODO: Get descriptor type from template creation so that sampler only writes can be ignored. Worst case is a
+        // handle with an uninitialized value, which will never be referenced, is added to the tracker.
+        const auto image_info = decoder->GetImageInfoMetaStructPointer();
+        assert(image_info != nullptr);
+
+        AddImagesToUser(user_id, image_info_count, image_info);
+    }
+
+    if (buffer_info_count > 0)
+    {
+        const auto buffer_info = decoder->GetBufferInfoMetaStructPointer();
+        assert(buffer_info != nullptr);
+
+        AddBuffersToUser(user_id, buffer_info_count, buffer_info);
+    }
+
+    if (texel_buffer_view_count > 0)
+    {
+        auto view_ids = decoder->GetTexelBufferViewHandleIdsPointer();
+        assert(view_ids != nullptr);
+
+        AddTexelBufferViewsToUser(user_id, texel_buffer_view_count, view_ids);
+    }
+}
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_referenced_resource_consumer_base.h
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.h
@@ -44,7 +44,11 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
 
     virtual void ProcessStateBeginMarker(uint64_t) override { loading_state_ = true; }
 
-    virtual void ProcessStateEndMarker(uint64_t) override { loading_state_ = false; }
+    virtual void ProcessStateEndMarker(uint64_t) override
+    {
+        loading_state_ = false;
+        loaded_state_  = true;
+    }
 
     virtual void Process_vkQueueSubmit(VkResult                                    returnValue,
                                        format::HandleId                            queue,
@@ -257,6 +261,7 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
 
   private:
     bool                    loading_state_;
+    bool                    loaded_state_;
     ReferencedResourceTable table_;
     LayoutBindingCounts     layout_binding_counts_;
     SetLayouts              set_layouts_;

--- a/framework/decode/vulkan_referenced_resource_consumer_base.h
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.h
@@ -159,14 +159,23 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
     ReferencedResourceTable& GetTable() { return table_; }
 
   private:
-    void
-    AddImagesToContainer(format::HandleId container_id, size_t count, const Decoded_VkDescriptorImageInfo* image_info);
+    void AddImagesToContainer(format::HandleId                     container_id,
+                              int32_t                              binding,
+                              uint32_t                             element,
+                              uint32_t                             count,
+                              const Decoded_VkDescriptorImageInfo* image_info);
 
     void AddBuffersToContainer(format::HandleId                      container_id,
-                               size_t                                count,
+                               int32_t                               binding,
+                               uint32_t                              element,
+                               uint32_t                              count,
                                const Decoded_VkDescriptorBufferInfo* buffer_info);
 
-    void AddTexelBufferViewsToContainer(format::HandleId container_id, size_t count, const format::HandleId* view_ids);
+    void AddTexelBufferViewsToContainer(format::HandleId        container_id,
+                                        int32_t                 binding,
+                                        uint32_t                element,
+                                        uint32_t                count,
+                                        const format::HandleId* view_ids);
 
     void UpdateDescriptorSetWithTemplate(format::HandleId container_id, const DescriptorUpdateTemplateDecoder* decoder);
 

--- a/framework/decode/vulkan_referenced_resource_consumer_base.h
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.h
@@ -153,11 +153,12 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
                                               format::HandleId          commandBuffer,
                                               VkCommandBufferResetFlags flags) override;
 
-  private:
+  protected:
     bool IsStateLoading() const { return loading_state_; }
 
     ReferencedResourceTable& GetTable() { return table_; }
 
+  private:
     void
     AddImagesToContainer(format::HandleId container_id, size_t count, const Decoded_VkDescriptorImageInfo* image_info);
 

--- a/framework/decode/vulkan_referenced_resource_consumer_base.h
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.h
@@ -1,0 +1,188 @@
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef GFXRECON_DECODE_VULKAN_REFERENCED_RESOURCE_CONSUMER_BASE_H
+#define GFXRECON_DECODE_VULKAN_REFERENCED_RESOURCE_CONSUMER_BASE_H
+
+#include "decode/referenced_resource_table.h"
+#include "generated/generated_vulkan_consumer.h"
+#include "util/defines.h"
+
+#include "vulkan/vulkan.h"
+
+#include <unordered_set>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+class VulkanReferencedResourceConsumerBase : public VulkanConsumer
+{
+  public:
+    VulkanReferencedResourceConsumerBase();
+
+    void GetReferencedResourceIds(std::unordered_set<format::HandleId>* referenced_ids,
+                                  std::unordered_set<format::HandleId>* unreferenced_ids) const
+    {
+        table_.GetReferencedResourceIds(referenced_ids, unreferenced_ids);
+    }
+
+    virtual void ProcessStateBeginMarker(uint64_t) override { loading_state_ = true; }
+
+    virtual void ProcessStateEndMarker(uint64_t) override { loading_state_ = false; }
+
+    virtual void Process_vkQueueSubmit(VkResult                                    returnValue,
+                                       format::HandleId                            queue,
+                                       uint32_t                                    submitCount,
+                                       StructPointerDecoder<Decoded_VkSubmitInfo>* pSubmits,
+                                       format::HandleId                            fence) override;
+
+    virtual void Process_vkCreateBuffer(VkResult                                             returnValue,
+                                        format::HandleId                                     device,
+                                        StructPointerDecoder<Decoded_VkBufferCreateInfo>*    pCreateInfo,
+                                        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+                                        HandlePointerDecoder<VkBuffer>*                      pBuffer) override;
+
+    virtual void Process_vkCreateBufferView(VkResult                                              returnValue,
+                                            format::HandleId                                      device,
+                                            StructPointerDecoder<Decoded_VkBufferViewCreateInfo>* pCreateInfo,
+                                            StructPointerDecoder<Decoded_VkAllocationCallbacks>*  pAllocator,
+                                            HandlePointerDecoder<VkBufferView>*                   pView) override;
+
+    virtual void Process_vkCreateImage(VkResult                                             returnValue,
+                                       format::HandleId                                     device,
+                                       StructPointerDecoder<Decoded_VkImageCreateInfo>*     pCreateInfo,
+                                       StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+                                       HandlePointerDecoder<VkImage>*                       pImage) override;
+
+    virtual void Process_vkCreateImageView(VkResult                                             returnValue,
+                                           format::HandleId                                     device,
+                                           StructPointerDecoder<Decoded_VkImageViewCreateInfo>* pCreateInfo,
+                                           StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
+                                           HandlePointerDecoder<VkImageView>*                   pView) override;
+
+    virtual void Process_vkCreateFramebuffer(VkResult                                               returnValue,
+                                             format::HandleId                                       device,
+                                             StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* pCreateInfo,
+                                             StructPointerDecoder<Decoded_VkAllocationCallbacks>*   pAllocator,
+                                             HandlePointerDecoder<VkFramebuffer>* pFramebuffer) override;
+
+    virtual void
+    Process_vkDestroyDescriptorPool(format::HandleId                                     device,
+                                    format::HandleId                                     descriptorPool,
+                                    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
+
+    virtual void Process_vkResetDescriptorPool(VkResult                   returnValue,
+                                               format::HandleId           device,
+                                               format::HandleId           descriptorPool,
+                                               VkDescriptorPoolResetFlags flags) override;
+
+    virtual void
+    Process_vkAllocateDescriptorSets(VkResult                                                   returnValue,
+                                     format::HandleId                                           device,
+                                     StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
+                                     HandlePointerDecoder<VkDescriptorSet>* pDescriptorSets) override;
+
+    virtual void Process_vkFreeDescriptorSets(VkResult                               returnValue,
+                                              format::HandleId                       device,
+                                              format::HandleId                       descriptorPool,
+                                              uint32_t                               descriptorSetCount,
+                                              HandlePointerDecoder<VkDescriptorSet>* pDescriptorSets) override;
+
+    virtual void
+    Process_vkUpdateDescriptorSets(format::HandleId                                    device,
+                                   uint32_t                                            descriptorWriteCount,
+                                   StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites,
+                                   uint32_t                                            descriptorCopyCount,
+                                   StructPointerDecoder<Decoded_VkCopyDescriptorSet>*  pDescriptorCopies) override;
+
+    virtual void Process_vkUpdateDescriptorSetWithTemplate(format::HandleId                 device,
+                                                           format::HandleId                 descriptorSet,
+                                                           format::HandleId                 descriptorUpdateTemplate,
+                                                           DescriptorUpdateTemplateDecoder* pData) override;
+
+    virtual void Process_vkCmdPushDescriptorSetWithTemplateKHR(format::HandleId commandBuffer,
+                                                               format::HandleId descriptorUpdateTemplate,
+                                                               format::HandleId layout,
+                                                               uint32_t         set,
+                                                               DescriptorUpdateTemplateDecoder* pData) override;
+
+    virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(format::HandleId                 device,
+                                                              format::HandleId                 descriptorSet,
+                                                              format::HandleId                 descriptorUpdateTemplate,
+                                                              DescriptorUpdateTemplateDecoder* pData) override;
+
+    virtual void Process_vkDestroyCommandPool(format::HandleId                                     device,
+                                              format::HandleId                                     commandPool,
+                                              StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
+
+    virtual void Process_vkResetCommandPool(VkResult                returnValue,
+                                            format::HandleId        device,
+                                            format::HandleId        commandPool,
+                                            VkCommandPoolResetFlags flags) override;
+
+    virtual void
+    Process_vkAllocateCommandBuffers(VkResult                                                   returnValue,
+                                     format::HandleId                                           device,
+                                     StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
+                                     HandlePointerDecoder<VkCommandBuffer>* pCommandBuffers) override;
+
+    virtual void Process_vkFreeCommandBuffers(format::HandleId                       device,
+                                              format::HandleId                       commandPool,
+                                              uint32_t                               commandBufferCount,
+                                              HandlePointerDecoder<VkCommandBuffer>* pCommandBuffers) override;
+
+    virtual void
+    Process_vkBeginCommandBuffer(VkResult                                                returnValue,
+                                 format::HandleId                                        commandBuffer,
+                                 StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo) override;
+
+    virtual void Process_vkResetCommandBuffer(VkResult                  returnValue,
+                                              format::HandleId          commandBuffer,
+                                              VkCommandBufferResetFlags flags) override;
+
+  private:
+    bool IsStateLoading() const { return loading_state_; }
+
+    ReferencedResourceTable& GetTable() { return table_; }
+
+    void
+    AddImagesToContainer(format::HandleId container_id, size_t count, const Decoded_VkDescriptorImageInfo* image_info);
+
+    void AddBuffersToContainer(format::HandleId                      container_id,
+                               size_t                                count,
+                               const Decoded_VkDescriptorBufferInfo* buffer_info);
+
+    void AddTexelBufferViewsToContainer(format::HandleId container_id, size_t count, const format::HandleId* view_ids);
+
+    void UpdateDescriptorSetWithTemplate(format::HandleId container_id, const DescriptorUpdateTemplateDecoder* decoder);
+
+    void AddImagesToUser(format::HandleId user_id, size_t count, const Decoded_VkDescriptorImageInfo* image_info);
+
+    void AddBuffersToUser(format::HandleId user_id, size_t count, const Decoded_VkDescriptorBufferInfo* buffer_info);
+
+    void AddTexelBufferViewsToUser(format::HandleId user_id, size_t count, const format::HandleId* view_ids);
+
+    void PushDescriptorSetWithTemplate(format::HandleId user_id, const DescriptorUpdateTemplateDecoder* decoder);
+
+  private:
+    bool                    loading_state_;
+    ReferencedResourceTable table_;
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_VULKAN_REFERENCED_RESOURCE_CONSUMER_BASE_H

--- a/framework/generated/generate_vulkan.py
+++ b/framework/generated/generate_vulkan.py
@@ -49,6 +49,8 @@ generate_targets = [
     'generated_vulkan_ascii_consumer.cpp',
     'generated_vulkan_replay_consumer.h',
     'generated_vulkan_replay_consumer.cpp',
+    'generated_vulkan_referenced_resource_consumer.h',
+    'generated_vulkan_referenced_resource_consumer.cpp',
     'generated_vulkan_struct_handle_mappers.h',
     'generated_vulkan_struct_handle_mappers.cpp'
 ]

--- a/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
@@ -1,0 +1,1203 @@
+/*
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+/*
+** This file is generated from the Khronos Vulkan XML API Registry.
+**
+*/
+
+#include "generated/generated_vulkan_referenced_resource_consumer.h"
+
+#include <cassert>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+void VulkanReferencedResourceConsumer::Process_vkBeginCommandBuffer(
+    VkResult                                    returnValue,
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo)
+{
+    assert(pBeginInfo != nullptr);
+
+    if (!pBeginInfo->IsNull() && (pBeginInfo->HasData()))
+    {
+        auto pBeginInfo_ptr = pBeginInfo->GetMetaStructPointer();
+        if (!pBeginInfo_ptr->pInheritanceInfo->IsNull() && (pBeginInfo_ptr->pInheritanceInfo->HasData()))
+        {
+            auto pInheritanceInfo_ptr = pBeginInfo_ptr->pInheritanceInfo->GetMetaStructPointer();
+            GetTable().AddResourceToUser(commandBuffer, pInheritanceInfo_ptr->framebuffer);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdBindDescriptorSets(
+    format::HandleId                            commandBuffer,
+    VkPipelineBindPoint                         pipelineBindPoint,
+    format::HandleId                            layout,
+    uint32_t                                    firstSet,
+    uint32_t                                    descriptorSetCount,
+    HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets,
+    uint32_t                                    dynamicOffsetCount,
+    PointerDecoder<uint32_t>*                   pDynamicOffsets)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(pipelineBindPoint);
+    GFXRECON_UNREFERENCED_PARAMETER(layout);
+    GFXRECON_UNREFERENCED_PARAMETER(firstSet);
+    GFXRECON_UNREFERENCED_PARAMETER(descriptorSetCount);
+    GFXRECON_UNREFERENCED_PARAMETER(dynamicOffsetCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pDynamicOffsets);
+
+    assert(pDescriptorSets != nullptr);
+
+    if (!pDescriptorSets->IsNull() && (pDescriptorSets->HasData()))
+    {
+        auto pDescriptorSets_ptr = pDescriptorSets->GetPointer();
+        size_t pDescriptorSets_count = pDescriptorSets->GetLength();
+        for (size_t pDescriptorSets_index = 0; pDescriptorSets_index < pDescriptorSets_count; ++pDescriptorSets_index)
+        {
+            GetTable().AddContainerToUser(commandBuffer, pDescriptorSets_ptr[pDescriptorSets_index]);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdBindIndexBuffer(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    VkIndexType                                 indexType)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(offset);
+    GFXRECON_UNREFERENCED_PARAMETER(indexType);
+
+    GetTable().AddResourceToUser(commandBuffer, buffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdBindVertexBuffers(
+    format::HandleId                            commandBuffer,
+    uint32_t                                    firstBinding,
+    uint32_t                                    bindingCount,
+    HandlePointerDecoder<VkBuffer>*             pBuffers,
+    PointerDecoder<VkDeviceSize>*               pOffsets)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(firstBinding);
+    GFXRECON_UNREFERENCED_PARAMETER(bindingCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pOffsets);
+
+    assert(pBuffers != nullptr);
+
+    if (!pBuffers->IsNull() && (pBuffers->HasData()))
+    {
+        auto pBuffers_ptr = pBuffers->GetPointer();
+        size_t pBuffers_count = pBuffers->GetLength();
+        for (size_t pBuffers_index = 0; pBuffers_index < pBuffers_count; ++pBuffers_index)
+        {
+            GetTable().AddResourceToUser(commandBuffer, pBuffers_ptr[pBuffers_index]);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndirect(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    uint32_t                                    drawCount,
+    uint32_t                                    stride)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(offset);
+    GFXRECON_UNREFERENCED_PARAMETER(drawCount);
+    GFXRECON_UNREFERENCED_PARAMETER(stride);
+
+    GetTable().AddResourceToUser(commandBuffer, buffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndexedIndirect(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    uint32_t                                    drawCount,
+    uint32_t                                    stride)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(offset);
+    GFXRECON_UNREFERENCED_PARAMETER(drawCount);
+    GFXRECON_UNREFERENCED_PARAMETER(stride);
+
+    GetTable().AddResourceToUser(commandBuffer, buffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdDispatchIndirect(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(offset);
+
+    GetTable().AddResourceToUser(commandBuffer, buffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdCopyBuffer(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            srcBuffer,
+    format::HandleId                            dstBuffer,
+    uint32_t                                    regionCount,
+    StructPointerDecoder<Decoded_VkBufferCopy>* pRegions)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(regionCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pRegions);
+
+    GetTable().AddResourceToUser(commandBuffer, srcBuffer);
+    GetTable().AddResourceToUser(commandBuffer, dstBuffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdCopyImage(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            srcImage,
+    VkImageLayout                               srcImageLayout,
+    format::HandleId                            dstImage,
+    VkImageLayout                               dstImageLayout,
+    uint32_t                                    regionCount,
+    StructPointerDecoder<Decoded_VkImageCopy>*  pRegions)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(srcImageLayout);
+    GFXRECON_UNREFERENCED_PARAMETER(dstImageLayout);
+    GFXRECON_UNREFERENCED_PARAMETER(regionCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pRegions);
+
+    GetTable().AddResourceToUser(commandBuffer, srcImage);
+    GetTable().AddResourceToUser(commandBuffer, dstImage);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdBlitImage(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            srcImage,
+    VkImageLayout                               srcImageLayout,
+    format::HandleId                            dstImage,
+    VkImageLayout                               dstImageLayout,
+    uint32_t                                    regionCount,
+    StructPointerDecoder<Decoded_VkImageBlit>*  pRegions,
+    VkFilter                                    filter)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(srcImageLayout);
+    GFXRECON_UNREFERENCED_PARAMETER(dstImageLayout);
+    GFXRECON_UNREFERENCED_PARAMETER(regionCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pRegions);
+    GFXRECON_UNREFERENCED_PARAMETER(filter);
+
+    GetTable().AddResourceToUser(commandBuffer, srcImage);
+    GetTable().AddResourceToUser(commandBuffer, dstImage);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdCopyBufferToImage(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            srcBuffer,
+    format::HandleId                            dstImage,
+    VkImageLayout                               dstImageLayout,
+    uint32_t                                    regionCount,
+    StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(dstImageLayout);
+    GFXRECON_UNREFERENCED_PARAMETER(regionCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pRegions);
+
+    GetTable().AddResourceToUser(commandBuffer, srcBuffer);
+    GetTable().AddResourceToUser(commandBuffer, dstImage);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdCopyImageToBuffer(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            srcImage,
+    VkImageLayout                               srcImageLayout,
+    format::HandleId                            dstBuffer,
+    uint32_t                                    regionCount,
+    StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(srcImageLayout);
+    GFXRECON_UNREFERENCED_PARAMETER(regionCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pRegions);
+
+    GetTable().AddResourceToUser(commandBuffer, srcImage);
+    GetTable().AddResourceToUser(commandBuffer, dstBuffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdUpdateBuffer(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            dstBuffer,
+    VkDeviceSize                                dstOffset,
+    VkDeviceSize                                dataSize,
+    PointerDecoder<uint8_t>*                    pData)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(dstOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(dataSize);
+    GFXRECON_UNREFERENCED_PARAMETER(pData);
+
+    GetTable().AddResourceToUser(commandBuffer, dstBuffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdFillBuffer(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            dstBuffer,
+    VkDeviceSize                                dstOffset,
+    VkDeviceSize                                size,
+    uint32_t                                    data)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(dstOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(size);
+    GFXRECON_UNREFERENCED_PARAMETER(data);
+
+    GetTable().AddResourceToUser(commandBuffer, dstBuffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdClearColorImage(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            image,
+    VkImageLayout                               imageLayout,
+    StructPointerDecoder<Decoded_VkClearColorValue>* pColor,
+    uint32_t                                    rangeCount,
+    StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(imageLayout);
+    GFXRECON_UNREFERENCED_PARAMETER(pColor);
+    GFXRECON_UNREFERENCED_PARAMETER(rangeCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pRanges);
+
+    GetTable().AddResourceToUser(commandBuffer, image);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdClearDepthStencilImage(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            image,
+    VkImageLayout                               imageLayout,
+    StructPointerDecoder<Decoded_VkClearDepthStencilValue>* pDepthStencil,
+    uint32_t                                    rangeCount,
+    StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(imageLayout);
+    GFXRECON_UNREFERENCED_PARAMETER(pDepthStencil);
+    GFXRECON_UNREFERENCED_PARAMETER(rangeCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pRanges);
+
+    GetTable().AddResourceToUser(commandBuffer, image);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdResolveImage(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            srcImage,
+    VkImageLayout                               srcImageLayout,
+    format::HandleId                            dstImage,
+    VkImageLayout                               dstImageLayout,
+    uint32_t                                    regionCount,
+    StructPointerDecoder<Decoded_VkImageResolve>* pRegions)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(srcImageLayout);
+    GFXRECON_UNREFERENCED_PARAMETER(dstImageLayout);
+    GFXRECON_UNREFERENCED_PARAMETER(regionCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pRegions);
+
+    GetTable().AddResourceToUser(commandBuffer, srcImage);
+    GetTable().AddResourceToUser(commandBuffer, dstImage);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdWaitEvents(
+    format::HandleId                            commandBuffer,
+    uint32_t                                    eventCount,
+    HandlePointerDecoder<VkEvent>*              pEvents,
+    VkPipelineStageFlags                        srcStageMask,
+    VkPipelineStageFlags                        dstStageMask,
+    uint32_t                                    memoryBarrierCount,
+    StructPointerDecoder<Decoded_VkMemoryBarrier>* pMemoryBarriers,
+    uint32_t                                    bufferMemoryBarrierCount,
+    StructPointerDecoder<Decoded_VkBufferMemoryBarrier>* pBufferMemoryBarriers,
+    uint32_t                                    imageMemoryBarrierCount,
+    StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(eventCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pEvents);
+    GFXRECON_UNREFERENCED_PARAMETER(srcStageMask);
+    GFXRECON_UNREFERENCED_PARAMETER(dstStageMask);
+    GFXRECON_UNREFERENCED_PARAMETER(memoryBarrierCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pMemoryBarriers);
+    GFXRECON_UNREFERENCED_PARAMETER(bufferMemoryBarrierCount);
+    GFXRECON_UNREFERENCED_PARAMETER(imageMemoryBarrierCount);
+
+    assert(pBufferMemoryBarriers != nullptr);
+
+    if (!pBufferMemoryBarriers->IsNull() && (pBufferMemoryBarriers->HasData()))
+    {
+        auto pBufferMemoryBarriers_ptr = pBufferMemoryBarriers->GetMetaStructPointer();
+        size_t pBufferMemoryBarriers_count = pBufferMemoryBarriers->GetLength();
+        for (size_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < pBufferMemoryBarriers_count; ++pBufferMemoryBarriers_index)
+        {
+            GetTable().AddResourceToUser(commandBuffer, pBufferMemoryBarriers_ptr[pBufferMemoryBarriers_index].buffer);
+        }
+    }
+
+    assert(pImageMemoryBarriers != nullptr);
+
+    if (!pImageMemoryBarriers->IsNull() && (pImageMemoryBarriers->HasData()))
+    {
+        auto pImageMemoryBarriers_ptr = pImageMemoryBarriers->GetMetaStructPointer();
+        size_t pImageMemoryBarriers_count = pImageMemoryBarriers->GetLength();
+        for (size_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < pImageMemoryBarriers_count; ++pImageMemoryBarriers_index)
+        {
+            GetTable().AddResourceToUser(commandBuffer, pImageMemoryBarriers_ptr[pImageMemoryBarriers_index].image);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdPipelineBarrier(
+    format::HandleId                            commandBuffer,
+    VkPipelineStageFlags                        srcStageMask,
+    VkPipelineStageFlags                        dstStageMask,
+    VkDependencyFlags                           dependencyFlags,
+    uint32_t                                    memoryBarrierCount,
+    StructPointerDecoder<Decoded_VkMemoryBarrier>* pMemoryBarriers,
+    uint32_t                                    bufferMemoryBarrierCount,
+    StructPointerDecoder<Decoded_VkBufferMemoryBarrier>* pBufferMemoryBarriers,
+    uint32_t                                    imageMemoryBarrierCount,
+    StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(srcStageMask);
+    GFXRECON_UNREFERENCED_PARAMETER(dstStageMask);
+    GFXRECON_UNREFERENCED_PARAMETER(dependencyFlags);
+    GFXRECON_UNREFERENCED_PARAMETER(memoryBarrierCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pMemoryBarriers);
+    GFXRECON_UNREFERENCED_PARAMETER(bufferMemoryBarrierCount);
+    GFXRECON_UNREFERENCED_PARAMETER(imageMemoryBarrierCount);
+
+    assert(pBufferMemoryBarriers != nullptr);
+
+    if (!pBufferMemoryBarriers->IsNull() && (pBufferMemoryBarriers->HasData()))
+    {
+        auto pBufferMemoryBarriers_ptr = pBufferMemoryBarriers->GetMetaStructPointer();
+        size_t pBufferMemoryBarriers_count = pBufferMemoryBarriers->GetLength();
+        for (size_t pBufferMemoryBarriers_index = 0; pBufferMemoryBarriers_index < pBufferMemoryBarriers_count; ++pBufferMemoryBarriers_index)
+        {
+            GetTable().AddResourceToUser(commandBuffer, pBufferMemoryBarriers_ptr[pBufferMemoryBarriers_index].buffer);
+        }
+    }
+
+    assert(pImageMemoryBarriers != nullptr);
+
+    if (!pImageMemoryBarriers->IsNull() && (pImageMemoryBarriers->HasData()))
+    {
+        auto pImageMemoryBarriers_ptr = pImageMemoryBarriers->GetMetaStructPointer();
+        size_t pImageMemoryBarriers_count = pImageMemoryBarriers->GetLength();
+        for (size_t pImageMemoryBarriers_index = 0; pImageMemoryBarriers_index < pImageMemoryBarriers_count; ++pImageMemoryBarriers_index)
+        {
+            GetTable().AddResourceToUser(commandBuffer, pImageMemoryBarriers_ptr[pImageMemoryBarriers_index].image);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdCopyQueryPoolResults(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            queryPool,
+    uint32_t                                    firstQuery,
+    uint32_t                                    queryCount,
+    format::HandleId                            dstBuffer,
+    VkDeviceSize                                dstOffset,
+    VkDeviceSize                                stride,
+    VkQueryResultFlags                          flags)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(queryPool);
+    GFXRECON_UNREFERENCED_PARAMETER(firstQuery);
+    GFXRECON_UNREFERENCED_PARAMETER(queryCount);
+    GFXRECON_UNREFERENCED_PARAMETER(dstOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(stride);
+    GFXRECON_UNREFERENCED_PARAMETER(flags);
+
+    GetTable().AddResourceToUser(commandBuffer, dstBuffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdBeginRenderPass(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
+    VkSubpassContents                           contents)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(contents);
+
+    assert(pRenderPassBegin != nullptr);
+
+    if (!pRenderPassBegin->IsNull() && (pRenderPassBegin->HasData()))
+    {
+        auto pRenderPassBegin_ptr = pRenderPassBegin->GetMetaStructPointer();
+        const VkBaseInStructure* pnext_header = nullptr;
+        if (pRenderPassBegin_ptr->pNext != nullptr)
+        {
+            pnext_header = reinterpret_cast<const VkBaseInStructure*>(pRenderPassBegin_ptr->pNext->GetPointer());
+        }
+        while (pnext_header)
+        {
+            switch (pnext_header->sType)
+            {
+                default:
+                    break;
+                case VK_STRUCTURE_TYPE_RENDER_PASS_ATTACHMENT_BEGIN_INFO:
+                {
+                    auto pnext_value = reinterpret_cast<const Decoded_VkRenderPassAttachmentBeginInfo*>(pRenderPassBegin_ptr->pNext->GetPointer());
+                    if (!pnext_value->pAttachments.IsNull() && (pnext_value->pAttachments.HasData()))
+                    {
+                        auto pAttachments_ptr = pnext_value->pAttachments.GetPointer();
+                        size_t pAttachments_count = pnext_value->pAttachments.GetLength();
+                        for (size_t pAttachments_index = 0; pAttachments_index < pAttachments_count; ++pAttachments_index)
+                        {
+                            GetTable().AddResourceToUser(commandBuffer, pAttachments_ptr[pAttachments_index]);
+                        }
+                    }
+                    break;
+                }
+            }
+            pnext_header = pnext_header->pNext;
+        }
+        GetTable().AddResourceToUser(commandBuffer, pRenderPassBegin_ptr->framebuffer);
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdExecuteCommands(
+    format::HandleId                            commandBuffer,
+    uint32_t                                    commandBufferCount,
+    HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(commandBufferCount);
+
+    assert(pCommandBuffers != nullptr);
+
+    if (!pCommandBuffers->IsNull() && (pCommandBuffers->HasData()))
+    {
+        auto pCommandBuffers_ptr = pCommandBuffers->GetPointer();
+        size_t pCommandBuffers_count = pCommandBuffers->GetLength();
+        for (size_t pCommandBuffers_index = 0; pCommandBuffers_index < pCommandBuffers_count; ++pCommandBuffers_index)
+        {
+            GetTable().AddUserToUser(commandBuffer, pCommandBuffers_ptr[pCommandBuffers_index]);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndirectCount(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    format::HandleId                            countBuffer,
+    VkDeviceSize                                countBufferOffset,
+    uint32_t                                    maxDrawCount,
+    uint32_t                                    stride)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(offset);
+    GFXRECON_UNREFERENCED_PARAMETER(countBufferOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(maxDrawCount);
+    GFXRECON_UNREFERENCED_PARAMETER(stride);
+
+    GetTable().AddResourceToUser(commandBuffer, buffer);
+    GetTable().AddResourceToUser(commandBuffer, countBuffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndexedIndirectCount(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    format::HandleId                            countBuffer,
+    VkDeviceSize                                countBufferOffset,
+    uint32_t                                    maxDrawCount,
+    uint32_t                                    stride)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(offset);
+    GFXRECON_UNREFERENCED_PARAMETER(countBufferOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(maxDrawCount);
+    GFXRECON_UNREFERENCED_PARAMETER(stride);
+
+    GetTable().AddResourceToUser(commandBuffer, buffer);
+    GetTable().AddResourceToUser(commandBuffer, countBuffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdBeginRenderPass2(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
+    StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(pSubpassBeginInfo);
+
+    assert(pRenderPassBegin != nullptr);
+
+    if (!pRenderPassBegin->IsNull() && (pRenderPassBegin->HasData()))
+    {
+        auto pRenderPassBegin_ptr = pRenderPassBegin->GetMetaStructPointer();
+        const VkBaseInStructure* pnext_header = nullptr;
+        if (pRenderPassBegin_ptr->pNext != nullptr)
+        {
+            pnext_header = reinterpret_cast<const VkBaseInStructure*>(pRenderPassBegin_ptr->pNext->GetPointer());
+        }
+        while (pnext_header)
+        {
+            switch (pnext_header->sType)
+            {
+                default:
+                    break;
+                case VK_STRUCTURE_TYPE_RENDER_PASS_ATTACHMENT_BEGIN_INFO:
+                {
+                    auto pnext_value = reinterpret_cast<const Decoded_VkRenderPassAttachmentBeginInfo*>(pRenderPassBegin_ptr->pNext->GetPointer());
+                    if (!pnext_value->pAttachments.IsNull() && (pnext_value->pAttachments.HasData()))
+                    {
+                        auto pAttachments_ptr = pnext_value->pAttachments.GetPointer();
+                        size_t pAttachments_count = pnext_value->pAttachments.GetLength();
+                        for (size_t pAttachments_index = 0; pAttachments_index < pAttachments_count; ++pAttachments_index)
+                        {
+                            GetTable().AddResourceToUser(commandBuffer, pAttachments_ptr[pAttachments_index]);
+                        }
+                    }
+                    break;
+                }
+            }
+            pnext_header = pnext_header->pNext;
+        }
+        GetTable().AddResourceToUser(commandBuffer, pRenderPassBegin_ptr->framebuffer);
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdPushDescriptorSetKHR(
+    format::HandleId                            commandBuffer,
+    VkPipelineBindPoint                         pipelineBindPoint,
+    format::HandleId                            layout,
+    uint32_t                                    set,
+    uint32_t                                    descriptorWriteCount,
+    StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(pipelineBindPoint);
+    GFXRECON_UNREFERENCED_PARAMETER(layout);
+    GFXRECON_UNREFERENCED_PARAMETER(set);
+    GFXRECON_UNREFERENCED_PARAMETER(descriptorWriteCount);
+
+    assert(pDescriptorWrites != nullptr);
+
+    if (!pDescriptorWrites->IsNull() && (pDescriptorWrites->HasData()))
+    {
+        auto pDescriptorWrites_ptr = pDescriptorWrites->GetMetaStructPointer();
+        size_t pDescriptorWrites_count = pDescriptorWrites->GetLength();
+        for (size_t pDescriptorWrites_index = 0; pDescriptorWrites_index < pDescriptorWrites_count; ++pDescriptorWrites_index)
+        {
+            GetTable().AddContainerToUser(commandBuffer, pDescriptorWrites_ptr[pDescriptorWrites_index].dstSet);
+
+            if (!pDescriptorWrites_ptr[pDescriptorWrites_index].pImageInfo->IsNull() && (pDescriptorWrites_ptr[pDescriptorWrites_index].pImageInfo->HasData()))
+            {
+                auto pImageInfo_ptr = pDescriptorWrites_ptr[pDescriptorWrites_index].pImageInfo->GetMetaStructPointer();
+                size_t pImageInfo_count = pDescriptorWrites_ptr[pDescriptorWrites_index].pImageInfo->GetLength();
+                for (size_t pImageInfo_index = 0; pImageInfo_index < pImageInfo_count; ++pImageInfo_index)
+                {
+                    GetTable().AddResourceToUser(commandBuffer, pImageInfo_ptr[pImageInfo_index].imageView);
+                }
+            }
+
+            if (!pDescriptorWrites_ptr[pDescriptorWrites_index].pBufferInfo->IsNull() && (pDescriptorWrites_ptr[pDescriptorWrites_index].pBufferInfo->HasData()))
+            {
+                auto pBufferInfo_ptr = pDescriptorWrites_ptr[pDescriptorWrites_index].pBufferInfo->GetMetaStructPointer();
+                size_t pBufferInfo_count = pDescriptorWrites_ptr[pDescriptorWrites_index].pBufferInfo->GetLength();
+                for (size_t pBufferInfo_index = 0; pBufferInfo_index < pBufferInfo_count; ++pBufferInfo_index)
+                {
+                    GetTable().AddResourceToUser(commandBuffer, pBufferInfo_ptr[pBufferInfo_index].buffer);
+                }
+            }
+
+            if (!pDescriptorWrites_ptr[pDescriptorWrites_index].pTexelBufferView.IsNull() && (pDescriptorWrites_ptr[pDescriptorWrites_index].pTexelBufferView.HasData()))
+            {
+                auto pTexelBufferView_ptr = pDescriptorWrites_ptr[pDescriptorWrites_index].pTexelBufferView.GetPointer();
+                size_t pTexelBufferView_count = pDescriptorWrites_ptr[pDescriptorWrites_index].pTexelBufferView.GetLength();
+                for (size_t pTexelBufferView_index = 0; pTexelBufferView_index < pTexelBufferView_count; ++pTexelBufferView_index)
+                {
+                    GetTable().AddResourceToUser(commandBuffer, pTexelBufferView_ptr[pTexelBufferView_index]);
+                }
+            }
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdBeginRenderPass2KHR(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
+    StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(pSubpassBeginInfo);
+
+    assert(pRenderPassBegin != nullptr);
+
+    if (!pRenderPassBegin->IsNull() && (pRenderPassBegin->HasData()))
+    {
+        auto pRenderPassBegin_ptr = pRenderPassBegin->GetMetaStructPointer();
+        const VkBaseInStructure* pnext_header = nullptr;
+        if (pRenderPassBegin_ptr->pNext != nullptr)
+        {
+            pnext_header = reinterpret_cast<const VkBaseInStructure*>(pRenderPassBegin_ptr->pNext->GetPointer());
+        }
+        while (pnext_header)
+        {
+            switch (pnext_header->sType)
+            {
+                default:
+                    break;
+                case VK_STRUCTURE_TYPE_RENDER_PASS_ATTACHMENT_BEGIN_INFO:
+                {
+                    auto pnext_value = reinterpret_cast<const Decoded_VkRenderPassAttachmentBeginInfo*>(pRenderPassBegin_ptr->pNext->GetPointer());
+                    if (!pnext_value->pAttachments.IsNull() && (pnext_value->pAttachments.HasData()))
+                    {
+                        auto pAttachments_ptr = pnext_value->pAttachments.GetPointer();
+                        size_t pAttachments_count = pnext_value->pAttachments.GetLength();
+                        for (size_t pAttachments_index = 0; pAttachments_index < pAttachments_count; ++pAttachments_index)
+                        {
+                            GetTable().AddResourceToUser(commandBuffer, pAttachments_ptr[pAttachments_index]);
+                        }
+                    }
+                    break;
+                }
+            }
+            pnext_header = pnext_header->pNext;
+        }
+        GetTable().AddResourceToUser(commandBuffer, pRenderPassBegin_ptr->framebuffer);
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndirectCountKHR(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    format::HandleId                            countBuffer,
+    VkDeviceSize                                countBufferOffset,
+    uint32_t                                    maxDrawCount,
+    uint32_t                                    stride)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(offset);
+    GFXRECON_UNREFERENCED_PARAMETER(countBufferOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(maxDrawCount);
+    GFXRECON_UNREFERENCED_PARAMETER(stride);
+
+    GetTable().AddResourceToUser(commandBuffer, buffer);
+    GetTable().AddResourceToUser(commandBuffer, countBuffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndexedIndirectCountKHR(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    format::HandleId                            countBuffer,
+    VkDeviceSize                                countBufferOffset,
+    uint32_t                                    maxDrawCount,
+    uint32_t                                    stride)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(offset);
+    GFXRECON_UNREFERENCED_PARAMETER(countBufferOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(maxDrawCount);
+    GFXRECON_UNREFERENCED_PARAMETER(stride);
+
+    GetTable().AddResourceToUser(commandBuffer, buffer);
+    GetTable().AddResourceToUser(commandBuffer, countBuffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdBindTransformFeedbackBuffersEXT(
+    format::HandleId                            commandBuffer,
+    uint32_t                                    firstBinding,
+    uint32_t                                    bindingCount,
+    HandlePointerDecoder<VkBuffer>*             pBuffers,
+    PointerDecoder<VkDeviceSize>*               pOffsets,
+    PointerDecoder<VkDeviceSize>*               pSizes)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(firstBinding);
+    GFXRECON_UNREFERENCED_PARAMETER(bindingCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pOffsets);
+    GFXRECON_UNREFERENCED_PARAMETER(pSizes);
+
+    assert(pBuffers != nullptr);
+
+    if (!pBuffers->IsNull() && (pBuffers->HasData()))
+    {
+        auto pBuffers_ptr = pBuffers->GetPointer();
+        size_t pBuffers_count = pBuffers->GetLength();
+        for (size_t pBuffers_index = 0; pBuffers_index < pBuffers_count; ++pBuffers_index)
+        {
+            GetTable().AddResourceToUser(commandBuffer, pBuffers_ptr[pBuffers_index]);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdBeginTransformFeedbackEXT(
+    format::HandleId                            commandBuffer,
+    uint32_t                                    firstCounterBuffer,
+    uint32_t                                    counterBufferCount,
+    HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
+    PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(firstCounterBuffer);
+    GFXRECON_UNREFERENCED_PARAMETER(counterBufferCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pCounterBufferOffsets);
+
+    assert(pCounterBuffers != nullptr);
+
+    if (!pCounterBuffers->IsNull() && (pCounterBuffers->HasData()))
+    {
+        auto pCounterBuffers_ptr = pCounterBuffers->GetPointer();
+        size_t pCounterBuffers_count = pCounterBuffers->GetLength();
+        for (size_t pCounterBuffers_index = 0; pCounterBuffers_index < pCounterBuffers_count; ++pCounterBuffers_index)
+        {
+            GetTable().AddResourceToUser(commandBuffer, pCounterBuffers_ptr[pCounterBuffers_index]);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdEndTransformFeedbackEXT(
+    format::HandleId                            commandBuffer,
+    uint32_t                                    firstCounterBuffer,
+    uint32_t                                    counterBufferCount,
+    HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
+    PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(firstCounterBuffer);
+    GFXRECON_UNREFERENCED_PARAMETER(counterBufferCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pCounterBufferOffsets);
+
+    assert(pCounterBuffers != nullptr);
+
+    if (!pCounterBuffers->IsNull() && (pCounterBuffers->HasData()))
+    {
+        auto pCounterBuffers_ptr = pCounterBuffers->GetPointer();
+        size_t pCounterBuffers_count = pCounterBuffers->GetLength();
+        for (size_t pCounterBuffers_index = 0; pCounterBuffers_index < pCounterBuffers_count; ++pCounterBuffers_index)
+        {
+            GetTable().AddResourceToUser(commandBuffer, pCounterBuffers_ptr[pCounterBuffers_index]);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndirectByteCountEXT(
+    format::HandleId                            commandBuffer,
+    uint32_t                                    instanceCount,
+    uint32_t                                    firstInstance,
+    format::HandleId                            counterBuffer,
+    VkDeviceSize                                counterBufferOffset,
+    uint32_t                                    counterOffset,
+    uint32_t                                    vertexStride)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(instanceCount);
+    GFXRECON_UNREFERENCED_PARAMETER(firstInstance);
+    GFXRECON_UNREFERENCED_PARAMETER(counterBufferOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(counterOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(vertexStride);
+
+    GetTable().AddResourceToUser(commandBuffer, counterBuffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndirectCountAMD(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    format::HandleId                            countBuffer,
+    VkDeviceSize                                countBufferOffset,
+    uint32_t                                    maxDrawCount,
+    uint32_t                                    stride)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(offset);
+    GFXRECON_UNREFERENCED_PARAMETER(countBufferOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(maxDrawCount);
+    GFXRECON_UNREFERENCED_PARAMETER(stride);
+
+    GetTable().AddResourceToUser(commandBuffer, buffer);
+    GetTable().AddResourceToUser(commandBuffer, countBuffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndexedIndirectCountAMD(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    format::HandleId                            countBuffer,
+    VkDeviceSize                                countBufferOffset,
+    uint32_t                                    maxDrawCount,
+    uint32_t                                    stride)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(offset);
+    GFXRECON_UNREFERENCED_PARAMETER(countBufferOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(maxDrawCount);
+    GFXRECON_UNREFERENCED_PARAMETER(stride);
+
+    GetTable().AddResourceToUser(commandBuffer, buffer);
+    GetTable().AddResourceToUser(commandBuffer, countBuffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdBeginConditionalRenderingEXT(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>* pConditionalRenderingBegin)
+{
+    assert(pConditionalRenderingBegin != nullptr);
+
+    if (!pConditionalRenderingBegin->IsNull() && (pConditionalRenderingBegin->HasData()))
+    {
+        auto pConditionalRenderingBegin_ptr = pConditionalRenderingBegin->GetMetaStructPointer();
+        GetTable().AddResourceToUser(commandBuffer, pConditionalRenderingBegin_ptr->buffer);
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdBindShadingRateImageNV(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            imageView,
+    VkImageLayout                               imageLayout)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(imageLayout);
+
+    GetTable().AddResourceToUser(commandBuffer, imageView);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdBuildAccelerationStructureNV(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>* pInfo,
+    format::HandleId                            instanceData,
+    VkDeviceSize                                instanceOffset,
+    VkBool32                                    update,
+    format::HandleId                            dst,
+    format::HandleId                            src,
+    format::HandleId                            scratch,
+    VkDeviceSize                                scratchOffset)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(instanceOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(update);
+    GFXRECON_UNREFERENCED_PARAMETER(dst);
+    GFXRECON_UNREFERENCED_PARAMETER(src);
+    GFXRECON_UNREFERENCED_PARAMETER(scratchOffset);
+
+    assert(pInfo != nullptr);
+
+    if (!pInfo->IsNull() && (pInfo->HasData()))
+    {
+        auto pInfo_ptr = pInfo->GetMetaStructPointer();
+        if (!pInfo_ptr->pGeometries->IsNull() && (pInfo_ptr->pGeometries->HasData()))
+        {
+            auto pGeometries_ptr = pInfo_ptr->pGeometries->GetMetaStructPointer();
+            size_t pGeometries_count = pInfo_ptr->pGeometries->GetLength();
+            for (size_t pGeometries_index = 0; pGeometries_index < pGeometries_count; ++pGeometries_index)
+            {
+                GetTable().AddResourceToUser(commandBuffer, pGeometries_ptr[pGeometries_index].geometry->triangles->vertexData);
+                GetTable().AddResourceToUser(commandBuffer, pGeometries_ptr[pGeometries_index].geometry->triangles->indexData);
+                GetTable().AddResourceToUser(commandBuffer, pGeometries_ptr[pGeometries_index].geometry->triangles->transformData);
+                GetTable().AddResourceToUser(commandBuffer, pGeometries_ptr[pGeometries_index].geometry->aabbs->aabbData);
+            }
+        }
+    }
+    GetTable().AddResourceToUser(commandBuffer, instanceData);
+    GetTable().AddResourceToUser(commandBuffer, scratch);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdTraceRaysNV(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            raygenShaderBindingTableBuffer,
+    VkDeviceSize                                raygenShaderBindingOffset,
+    format::HandleId                            missShaderBindingTableBuffer,
+    VkDeviceSize                                missShaderBindingOffset,
+    VkDeviceSize                                missShaderBindingStride,
+    format::HandleId                            hitShaderBindingTableBuffer,
+    VkDeviceSize                                hitShaderBindingOffset,
+    VkDeviceSize                                hitShaderBindingStride,
+    format::HandleId                            callableShaderBindingTableBuffer,
+    VkDeviceSize                                callableShaderBindingOffset,
+    VkDeviceSize                                callableShaderBindingStride,
+    uint32_t                                    width,
+    uint32_t                                    height,
+    uint32_t                                    depth)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(raygenShaderBindingOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(missShaderBindingOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(missShaderBindingStride);
+    GFXRECON_UNREFERENCED_PARAMETER(hitShaderBindingOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(hitShaderBindingStride);
+    GFXRECON_UNREFERENCED_PARAMETER(callableShaderBindingOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(callableShaderBindingStride);
+    GFXRECON_UNREFERENCED_PARAMETER(width);
+    GFXRECON_UNREFERENCED_PARAMETER(height);
+    GFXRECON_UNREFERENCED_PARAMETER(depth);
+
+    GetTable().AddResourceToUser(commandBuffer, raygenShaderBindingTableBuffer);
+    GetTable().AddResourceToUser(commandBuffer, missShaderBindingTableBuffer);
+    GetTable().AddResourceToUser(commandBuffer, hitShaderBindingTableBuffer);
+    GetTable().AddResourceToUser(commandBuffer, callableShaderBindingTableBuffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdWriteBufferMarkerAMD(
+    format::HandleId                            commandBuffer,
+    VkPipelineStageFlagBits                     pipelineStage,
+    format::HandleId                            dstBuffer,
+    VkDeviceSize                                dstOffset,
+    uint32_t                                    marker)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(pipelineStage);
+    GFXRECON_UNREFERENCED_PARAMETER(dstOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(marker);
+
+    GetTable().AddResourceToUser(commandBuffer, dstBuffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdDrawMeshTasksIndirectNV(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    uint32_t                                    drawCount,
+    uint32_t                                    stride)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(offset);
+    GFXRECON_UNREFERENCED_PARAMETER(drawCount);
+    GFXRECON_UNREFERENCED_PARAMETER(stride);
+
+    GetTable().AddResourceToUser(commandBuffer, buffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdDrawMeshTasksIndirectCountNV(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    format::HandleId                            countBuffer,
+    VkDeviceSize                                countBufferOffset,
+    uint32_t                                    maxDrawCount,
+    uint32_t                                    stride)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(offset);
+    GFXRECON_UNREFERENCED_PARAMETER(countBufferOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(maxDrawCount);
+    GFXRECON_UNREFERENCED_PARAMETER(stride);
+
+    GetTable().AddResourceToUser(commandBuffer, buffer);
+    GetTable().AddResourceToUser(commandBuffer, countBuffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdBindVertexBuffers2EXT(
+    format::HandleId                            commandBuffer,
+    uint32_t                                    firstBinding,
+    uint32_t                                    bindingCount,
+    HandlePointerDecoder<VkBuffer>*             pBuffers,
+    PointerDecoder<VkDeviceSize>*               pOffsets,
+    PointerDecoder<VkDeviceSize>*               pSizes,
+    PointerDecoder<VkDeviceSize>*               pStrides)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(firstBinding);
+    GFXRECON_UNREFERENCED_PARAMETER(bindingCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pOffsets);
+    GFXRECON_UNREFERENCED_PARAMETER(pSizes);
+    GFXRECON_UNREFERENCED_PARAMETER(pStrides);
+
+    assert(pBuffers != nullptr);
+
+    if (!pBuffers->IsNull() && (pBuffers->HasData()))
+    {
+        auto pBuffers_ptr = pBuffers->GetPointer();
+        size_t pBuffers_count = pBuffers->GetLength();
+        for (size_t pBuffers_index = 0; pBuffers_index < pBuffers_count; ++pBuffers_index)
+        {
+            GetTable().AddResourceToUser(commandBuffer, pBuffers_ptr[pBuffers_index]);
+        }
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdPreprocessGeneratedCommandsNV(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo)
+{
+    assert(pGeneratedCommandsInfo != nullptr);
+
+    if (!pGeneratedCommandsInfo->IsNull() && (pGeneratedCommandsInfo->HasData()))
+    {
+        auto pGeneratedCommandsInfo_ptr = pGeneratedCommandsInfo->GetMetaStructPointer();
+        if (!pGeneratedCommandsInfo_ptr->pStreams->IsNull() && (pGeneratedCommandsInfo_ptr->pStreams->HasData()))
+        {
+            auto pStreams_ptr = pGeneratedCommandsInfo_ptr->pStreams->GetMetaStructPointer();
+            size_t pStreams_count = pGeneratedCommandsInfo_ptr->pStreams->GetLength();
+            for (size_t pStreams_index = 0; pStreams_index < pStreams_count; ++pStreams_index)
+            {
+                GetTable().AddResourceToUser(commandBuffer, pStreams_ptr[pStreams_index].buffer);
+            }
+        }
+        GetTable().AddResourceToUser(commandBuffer, pGeneratedCommandsInfo_ptr->preprocessBuffer);
+        GetTable().AddResourceToUser(commandBuffer, pGeneratedCommandsInfo_ptr->sequencesCountBuffer);
+        GetTable().AddResourceToUser(commandBuffer, pGeneratedCommandsInfo_ptr->sequencesIndexBuffer);
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdExecuteGeneratedCommandsNV(
+    format::HandleId                            commandBuffer,
+    VkBool32                                    isPreprocessed,
+    StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(isPreprocessed);
+
+    assert(pGeneratedCommandsInfo != nullptr);
+
+    if (!pGeneratedCommandsInfo->IsNull() && (pGeneratedCommandsInfo->HasData()))
+    {
+        auto pGeneratedCommandsInfo_ptr = pGeneratedCommandsInfo->GetMetaStructPointer();
+        if (!pGeneratedCommandsInfo_ptr->pStreams->IsNull() && (pGeneratedCommandsInfo_ptr->pStreams->HasData()))
+        {
+            auto pStreams_ptr = pGeneratedCommandsInfo_ptr->pStreams->GetMetaStructPointer();
+            size_t pStreams_count = pGeneratedCommandsInfo_ptr->pStreams->GetLength();
+            for (size_t pStreams_index = 0; pStreams_index < pStreams_count; ++pStreams_index)
+            {
+                GetTable().AddResourceToUser(commandBuffer, pStreams_ptr[pStreams_index].buffer);
+            }
+        }
+        GetTable().AddResourceToUser(commandBuffer, pGeneratedCommandsInfo_ptr->preprocessBuffer);
+        GetTable().AddResourceToUser(commandBuffer, pGeneratedCommandsInfo_ptr->sequencesCountBuffer);
+        GetTable().AddResourceToUser(commandBuffer, pGeneratedCommandsInfo_ptr->sequencesIndexBuffer);
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdBuildAccelerationStructureIndirectKHR(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfo,
+    format::HandleId                            indirectBuffer,
+    VkDeviceSize                                indirectOffset,
+    uint32_t                                    indirectStride)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(indirectOffset);
+    GFXRECON_UNREFERENCED_PARAMETER(indirectStride);
+
+    assert(pInfo != nullptr);
+
+    if (!pInfo->IsNull() && (pInfo->HasData()))
+    {
+        auto pInfo_ptr = pInfo->GetMetaStructPointer();
+    }
+    GetTable().AddResourceToUser(commandBuffer, indirectBuffer);
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdCopyAccelerationStructureKHR(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo)
+{
+    assert(pInfo != nullptr);
+
+    if (!pInfo->IsNull() && (pInfo->HasData()))
+    {
+        auto pInfo_ptr = pInfo->GetMetaStructPointer();
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdCopyAccelerationStructureToMemoryKHR(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkCopyAccelerationStructureToMemoryInfoKHR>* pInfo)
+{
+    assert(pInfo != nullptr);
+
+    if (!pInfo->IsNull() && (pInfo->HasData()))
+    {
+        auto pInfo_ptr = pInfo->GetMetaStructPointer();
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdCopyMemoryToAccelerationStructureKHR(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkCopyMemoryToAccelerationStructureInfoKHR>* pInfo)
+{
+    assert(pInfo != nullptr);
+
+    if (!pInfo->IsNull() && (pInfo->HasData()))
+    {
+        auto pInfo_ptr = pInfo->GetMetaStructPointer();
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdTraceRaysKHR(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pRaygenShaderBindingTable,
+    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pMissShaderBindingTable,
+    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pHitShaderBindingTable,
+    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pCallableShaderBindingTable,
+    uint32_t                                    width,
+    uint32_t                                    height,
+    uint32_t                                    depth)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(width);
+    GFXRECON_UNREFERENCED_PARAMETER(height);
+    GFXRECON_UNREFERENCED_PARAMETER(depth);
+
+    assert(pRaygenShaderBindingTable != nullptr);
+
+    if (!pRaygenShaderBindingTable->IsNull() && (pRaygenShaderBindingTable->HasData()))
+    {
+        auto pRaygenShaderBindingTable_ptr = pRaygenShaderBindingTable->GetMetaStructPointer();
+        GetTable().AddResourceToUser(commandBuffer, pRaygenShaderBindingTable_ptr->buffer);
+    }
+
+    assert(pMissShaderBindingTable != nullptr);
+
+    if (!pMissShaderBindingTable->IsNull() && (pMissShaderBindingTable->HasData()))
+    {
+        auto pMissShaderBindingTable_ptr = pMissShaderBindingTable->GetMetaStructPointer();
+        GetTable().AddResourceToUser(commandBuffer, pMissShaderBindingTable_ptr->buffer);
+    }
+
+    assert(pHitShaderBindingTable != nullptr);
+
+    if (!pHitShaderBindingTable->IsNull() && (pHitShaderBindingTable->HasData()))
+    {
+        auto pHitShaderBindingTable_ptr = pHitShaderBindingTable->GetMetaStructPointer();
+        GetTable().AddResourceToUser(commandBuffer, pHitShaderBindingTable_ptr->buffer);
+    }
+
+    assert(pCallableShaderBindingTable != nullptr);
+
+    if (!pCallableShaderBindingTable->IsNull() && (pCallableShaderBindingTable->HasData()))
+    {
+        auto pCallableShaderBindingTable_ptr = pCallableShaderBindingTable->GetMetaStructPointer();
+        GetTable().AddResourceToUser(commandBuffer, pCallableShaderBindingTable_ptr->buffer);
+    }
+}
+
+void VulkanReferencedResourceConsumer::Process_vkCmdTraceRaysIndirectKHR(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pRaygenShaderBindingTable,
+    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pMissShaderBindingTable,
+    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pHitShaderBindingTable,
+    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pCallableShaderBindingTable,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(offset);
+
+    assert(pRaygenShaderBindingTable != nullptr);
+
+    if (!pRaygenShaderBindingTable->IsNull() && (pRaygenShaderBindingTable->HasData()))
+    {
+        auto pRaygenShaderBindingTable_ptr = pRaygenShaderBindingTable->GetMetaStructPointer();
+        GetTable().AddResourceToUser(commandBuffer, pRaygenShaderBindingTable_ptr->buffer);
+    }
+
+    assert(pMissShaderBindingTable != nullptr);
+
+    if (!pMissShaderBindingTable->IsNull() && (pMissShaderBindingTable->HasData()))
+    {
+        auto pMissShaderBindingTable_ptr = pMissShaderBindingTable->GetMetaStructPointer();
+        GetTable().AddResourceToUser(commandBuffer, pMissShaderBindingTable_ptr->buffer);
+    }
+
+    assert(pHitShaderBindingTable != nullptr);
+
+    if (!pHitShaderBindingTable->IsNull() && (pHitShaderBindingTable->HasData()))
+    {
+        auto pHitShaderBindingTable_ptr = pHitShaderBindingTable->GetMetaStructPointer();
+        GetTable().AddResourceToUser(commandBuffer, pHitShaderBindingTable_ptr->buffer);
+    }
+
+    assert(pCallableShaderBindingTable != nullptr);
+
+    if (!pCallableShaderBindingTable->IsNull() && (pCallableShaderBindingTable->HasData()))
+    {
+        auto pCallableShaderBindingTable_ptr = pCallableShaderBindingTable->GetMetaStructPointer();
+        GetTable().AddResourceToUser(commandBuffer, pCallableShaderBindingTable_ptr->buffer);
+    }
+    GetTable().AddResourceToUser(commandBuffer, buffer);
+}
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/generated_vulkan_referenced_resource_consumer.h
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.h
@@ -1,0 +1,483 @@
+/*
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+/*
+** This file is generated from the Khronos Vulkan XML API Registry.
+**
+*/
+
+#include "decode/vulkan_referenced_resource_consumer_base.h"
+#include "util/defines.h"
+
+#include "vulkan/vulkan.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumerBase
+{
+  public:
+    VulkanReferencedResourceConsumer() { }
+
+    virtual ~VulkanReferencedResourceConsumer() override { }
+
+void Process_vkBeginCommandBuffer(
+    VkResult                                    returnValue,
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo);
+
+
+void Process_vkCmdBindDescriptorSets(
+    format::HandleId                            commandBuffer,
+    VkPipelineBindPoint                         pipelineBindPoint,
+    format::HandleId                            layout,
+    uint32_t                                    firstSet,
+    uint32_t                                    descriptorSetCount,
+    HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets,
+    uint32_t                                    dynamicOffsetCount,
+    PointerDecoder<uint32_t>*                   pDynamicOffsets);
+
+
+void Process_vkCmdBindIndexBuffer(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    VkIndexType                                 indexType);
+
+
+void Process_vkCmdBindVertexBuffers(
+    format::HandleId                            commandBuffer,
+    uint32_t                                    firstBinding,
+    uint32_t                                    bindingCount,
+    HandlePointerDecoder<VkBuffer>*             pBuffers,
+    PointerDecoder<VkDeviceSize>*               pOffsets);
+
+
+void Process_vkCmdDrawIndirect(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    uint32_t                                    drawCount,
+    uint32_t                                    stride);
+
+
+void Process_vkCmdDrawIndexedIndirect(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    uint32_t                                    drawCount,
+    uint32_t                                    stride);
+
+
+void Process_vkCmdDispatchIndirect(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset);
+
+
+void Process_vkCmdCopyBuffer(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            srcBuffer,
+    format::HandleId                            dstBuffer,
+    uint32_t                                    regionCount,
+    StructPointerDecoder<Decoded_VkBufferCopy>* pRegions);
+
+
+void Process_vkCmdCopyImage(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            srcImage,
+    VkImageLayout                               srcImageLayout,
+    format::HandleId                            dstImage,
+    VkImageLayout                               dstImageLayout,
+    uint32_t                                    regionCount,
+    StructPointerDecoder<Decoded_VkImageCopy>*  pRegions);
+
+
+void Process_vkCmdBlitImage(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            srcImage,
+    VkImageLayout                               srcImageLayout,
+    format::HandleId                            dstImage,
+    VkImageLayout                               dstImageLayout,
+    uint32_t                                    regionCount,
+    StructPointerDecoder<Decoded_VkImageBlit>*  pRegions,
+    VkFilter                                    filter);
+
+
+void Process_vkCmdCopyBufferToImage(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            srcBuffer,
+    format::HandleId                            dstImage,
+    VkImageLayout                               dstImageLayout,
+    uint32_t                                    regionCount,
+    StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions);
+
+
+void Process_vkCmdCopyImageToBuffer(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            srcImage,
+    VkImageLayout                               srcImageLayout,
+    format::HandleId                            dstBuffer,
+    uint32_t                                    regionCount,
+    StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions);
+
+
+void Process_vkCmdUpdateBuffer(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            dstBuffer,
+    VkDeviceSize                                dstOffset,
+    VkDeviceSize                                dataSize,
+    PointerDecoder<uint8_t>*                    pData);
+
+
+void Process_vkCmdFillBuffer(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            dstBuffer,
+    VkDeviceSize                                dstOffset,
+    VkDeviceSize                                size,
+    uint32_t                                    data);
+
+
+void Process_vkCmdClearColorImage(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            image,
+    VkImageLayout                               imageLayout,
+    StructPointerDecoder<Decoded_VkClearColorValue>* pColor,
+    uint32_t                                    rangeCount,
+    StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges);
+
+
+void Process_vkCmdClearDepthStencilImage(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            image,
+    VkImageLayout                               imageLayout,
+    StructPointerDecoder<Decoded_VkClearDepthStencilValue>* pDepthStencil,
+    uint32_t                                    rangeCount,
+    StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges);
+
+
+void Process_vkCmdResolveImage(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            srcImage,
+    VkImageLayout                               srcImageLayout,
+    format::HandleId                            dstImage,
+    VkImageLayout                               dstImageLayout,
+    uint32_t                                    regionCount,
+    StructPointerDecoder<Decoded_VkImageResolve>* pRegions);
+
+
+void Process_vkCmdWaitEvents(
+    format::HandleId                            commandBuffer,
+    uint32_t                                    eventCount,
+    HandlePointerDecoder<VkEvent>*              pEvents,
+    VkPipelineStageFlags                        srcStageMask,
+    VkPipelineStageFlags                        dstStageMask,
+    uint32_t                                    memoryBarrierCount,
+    StructPointerDecoder<Decoded_VkMemoryBarrier>* pMemoryBarriers,
+    uint32_t                                    bufferMemoryBarrierCount,
+    StructPointerDecoder<Decoded_VkBufferMemoryBarrier>* pBufferMemoryBarriers,
+    uint32_t                                    imageMemoryBarrierCount,
+    StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers);
+
+
+void Process_vkCmdPipelineBarrier(
+    format::HandleId                            commandBuffer,
+    VkPipelineStageFlags                        srcStageMask,
+    VkPipelineStageFlags                        dstStageMask,
+    VkDependencyFlags                           dependencyFlags,
+    uint32_t                                    memoryBarrierCount,
+    StructPointerDecoder<Decoded_VkMemoryBarrier>* pMemoryBarriers,
+    uint32_t                                    bufferMemoryBarrierCount,
+    StructPointerDecoder<Decoded_VkBufferMemoryBarrier>* pBufferMemoryBarriers,
+    uint32_t                                    imageMemoryBarrierCount,
+    StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers);
+
+
+void Process_vkCmdCopyQueryPoolResults(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            queryPool,
+    uint32_t                                    firstQuery,
+    uint32_t                                    queryCount,
+    format::HandleId                            dstBuffer,
+    VkDeviceSize                                dstOffset,
+    VkDeviceSize                                stride,
+    VkQueryResultFlags                          flags);
+
+
+void Process_vkCmdBeginRenderPass(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
+    VkSubpassContents                           contents);
+
+
+void Process_vkCmdExecuteCommands(
+    format::HandleId                            commandBuffer,
+    uint32_t                                    commandBufferCount,
+    HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers);
+
+
+void Process_vkCmdDrawIndirectCount(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    format::HandleId                            countBuffer,
+    VkDeviceSize                                countBufferOffset,
+    uint32_t                                    maxDrawCount,
+    uint32_t                                    stride);
+
+
+void Process_vkCmdDrawIndexedIndirectCount(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    format::HandleId                            countBuffer,
+    VkDeviceSize                                countBufferOffset,
+    uint32_t                                    maxDrawCount,
+    uint32_t                                    stride);
+
+
+void Process_vkCmdBeginRenderPass2(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
+    StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo);
+
+
+void Process_vkCmdPushDescriptorSetKHR(
+    format::HandleId                            commandBuffer,
+    VkPipelineBindPoint                         pipelineBindPoint,
+    format::HandleId                            layout,
+    uint32_t                                    set,
+    uint32_t                                    descriptorWriteCount,
+    StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites);
+
+
+void Process_vkCmdBeginRenderPass2KHR(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
+    StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo);
+
+
+void Process_vkCmdDrawIndirectCountKHR(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    format::HandleId                            countBuffer,
+    VkDeviceSize                                countBufferOffset,
+    uint32_t                                    maxDrawCount,
+    uint32_t                                    stride);
+
+
+void Process_vkCmdDrawIndexedIndirectCountKHR(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    format::HandleId                            countBuffer,
+    VkDeviceSize                                countBufferOffset,
+    uint32_t                                    maxDrawCount,
+    uint32_t                                    stride);
+
+
+void Process_vkCmdBindTransformFeedbackBuffersEXT(
+    format::HandleId                            commandBuffer,
+    uint32_t                                    firstBinding,
+    uint32_t                                    bindingCount,
+    HandlePointerDecoder<VkBuffer>*             pBuffers,
+    PointerDecoder<VkDeviceSize>*               pOffsets,
+    PointerDecoder<VkDeviceSize>*               pSizes);
+
+
+void Process_vkCmdBeginTransformFeedbackEXT(
+    format::HandleId                            commandBuffer,
+    uint32_t                                    firstCounterBuffer,
+    uint32_t                                    counterBufferCount,
+    HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
+    PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets);
+
+
+void Process_vkCmdEndTransformFeedbackEXT(
+    format::HandleId                            commandBuffer,
+    uint32_t                                    firstCounterBuffer,
+    uint32_t                                    counterBufferCount,
+    HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
+    PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets);
+
+
+void Process_vkCmdDrawIndirectByteCountEXT(
+    format::HandleId                            commandBuffer,
+    uint32_t                                    instanceCount,
+    uint32_t                                    firstInstance,
+    format::HandleId                            counterBuffer,
+    VkDeviceSize                                counterBufferOffset,
+    uint32_t                                    counterOffset,
+    uint32_t                                    vertexStride);
+
+
+void Process_vkCmdDrawIndirectCountAMD(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    format::HandleId                            countBuffer,
+    VkDeviceSize                                countBufferOffset,
+    uint32_t                                    maxDrawCount,
+    uint32_t                                    stride);
+
+
+void Process_vkCmdDrawIndexedIndirectCountAMD(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    format::HandleId                            countBuffer,
+    VkDeviceSize                                countBufferOffset,
+    uint32_t                                    maxDrawCount,
+    uint32_t                                    stride);
+
+
+void Process_vkCmdBeginConditionalRenderingEXT(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>* pConditionalRenderingBegin);
+
+
+void Process_vkCmdBindShadingRateImageNV(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            imageView,
+    VkImageLayout                               imageLayout);
+
+
+void Process_vkCmdBuildAccelerationStructureNV(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>* pInfo,
+    format::HandleId                            instanceData,
+    VkDeviceSize                                instanceOffset,
+    VkBool32                                    update,
+    format::HandleId                            dst,
+    format::HandleId                            src,
+    format::HandleId                            scratch,
+    VkDeviceSize                                scratchOffset);
+
+
+void Process_vkCmdTraceRaysNV(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            raygenShaderBindingTableBuffer,
+    VkDeviceSize                                raygenShaderBindingOffset,
+    format::HandleId                            missShaderBindingTableBuffer,
+    VkDeviceSize                                missShaderBindingOffset,
+    VkDeviceSize                                missShaderBindingStride,
+    format::HandleId                            hitShaderBindingTableBuffer,
+    VkDeviceSize                                hitShaderBindingOffset,
+    VkDeviceSize                                hitShaderBindingStride,
+    format::HandleId                            callableShaderBindingTableBuffer,
+    VkDeviceSize                                callableShaderBindingOffset,
+    VkDeviceSize                                callableShaderBindingStride,
+    uint32_t                                    width,
+    uint32_t                                    height,
+    uint32_t                                    depth);
+
+
+void Process_vkCmdWriteBufferMarkerAMD(
+    format::HandleId                            commandBuffer,
+    VkPipelineStageFlagBits                     pipelineStage,
+    format::HandleId                            dstBuffer,
+    VkDeviceSize                                dstOffset,
+    uint32_t                                    marker);
+
+
+void Process_vkCmdDrawMeshTasksIndirectNV(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    uint32_t                                    drawCount,
+    uint32_t                                    stride);
+
+
+void Process_vkCmdDrawMeshTasksIndirectCountNV(
+    format::HandleId                            commandBuffer,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset,
+    format::HandleId                            countBuffer,
+    VkDeviceSize                                countBufferOffset,
+    uint32_t                                    maxDrawCount,
+    uint32_t                                    stride);
+
+
+void Process_vkCmdBindVertexBuffers2EXT(
+    format::HandleId                            commandBuffer,
+    uint32_t                                    firstBinding,
+    uint32_t                                    bindingCount,
+    HandlePointerDecoder<VkBuffer>*             pBuffers,
+    PointerDecoder<VkDeviceSize>*               pOffsets,
+    PointerDecoder<VkDeviceSize>*               pSizes,
+    PointerDecoder<VkDeviceSize>*               pStrides);
+
+
+void Process_vkCmdPreprocessGeneratedCommandsNV(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo);
+
+
+void Process_vkCmdExecuteGeneratedCommandsNV(
+    format::HandleId                            commandBuffer,
+    VkBool32                                    isPreprocessed,
+    StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo);
+
+
+void Process_vkCmdBuildAccelerationStructureIndirectKHR(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfo,
+    format::HandleId                            indirectBuffer,
+    VkDeviceSize                                indirectOffset,
+    uint32_t                                    indirectStride);
+
+
+void Process_vkCmdCopyAccelerationStructureKHR(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo);
+
+
+void Process_vkCmdCopyAccelerationStructureToMemoryKHR(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkCopyAccelerationStructureToMemoryInfoKHR>* pInfo);
+
+
+void Process_vkCmdCopyMemoryToAccelerationStructureKHR(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkCopyMemoryToAccelerationStructureInfoKHR>* pInfo);
+
+
+void Process_vkCmdTraceRaysKHR(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pRaygenShaderBindingTable,
+    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pMissShaderBindingTable,
+    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pHitShaderBindingTable,
+    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pCallableShaderBindingTable,
+    uint32_t                                    width,
+    uint32_t                                    height,
+    uint32_t                                    depth);
+
+
+void Process_vkCmdTraceRaysIndirectKHR(
+    format::HandleId                            commandBuffer,
+    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pRaygenShaderBindingTable,
+    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pMissShaderBindingTable,
+    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pHitShaderBindingTable,
+    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pCallableShaderBindingTable,
+    format::HandleId                            buffer,
+    VkDeviceSize                                offset);
+
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/vulkan_generators/codegen.pyproj
+++ b/framework/generated/vulkan_generators/codegen.pyproj
@@ -30,6 +30,8 @@
     <Compile Include="vulkan_api_call_encoders_body_generator.py" />
     <Compile Include="vulkan_api_call_encoders_header_generator.py" />
     <Compile Include="vulkan_dispatch_table_generator.py" />
+    <Compile Include="vulkan_referenced_resource_consumer_body_generator.py" />
+    <Compile Include="vulkan_referenced_resource_consumer_header_generator.py" />
     <Compile Include="vulkan_replay_consumer_body_generator.py" />
     <Compile Include="base_generator.py" />
     <Compile Include="vulkan_struct_decoders_header_generator.py" />

--- a/framework/generated/vulkan_generators/gencode.py
+++ b/framework/generated/vulkan_generators/gencode.py
@@ -34,6 +34,8 @@ from decode_pnext_struct_generator import DecodePNextStructGenerator,DecodePNext
 from vulkan_consumer_header_generator import VulkanConsumerHeaderGenerator,VulkanConsumerHeaderGeneratorOptions
 from vulkan_ascii_consumer_body_generator import VulkanAsciiConsumerBodyGenerator,VulkanAsciiConsumerBodyGeneratorOptions
 from vulkan_replay_consumer_body_generator import VulkanReplayConsumerBodyGenerator,VulkanReplayConsumerBodyGeneratorOptions
+from vulkan_referenced_resource_consumer_header_generator import VulkanReferencedResourceHeaderGenerator,VulkanReferencedResourceHeaderGeneratorOptions
+from vulkan_referenced_resource_consumer_body_generator import VulkanReferencedResourceBodyGenerator,VulkanReferencedResourceBodyGeneratorOptions
 from vulkan_struct_handle_mappers_header_generator import VulkanStructHandleMappersHeaderGenerator,VulkanStructHandleMappersHeaderGeneratorOptions
 from vulkan_struct_handle_mappers_body_generator import VulkanStructHandleMappersBodyGenerator,VulkanStructHandleMappersBodyGeneratorOptions
 
@@ -227,6 +229,18 @@ def makeGenOpts(args):
         protectFeature    = False)
     ]
 
+    genOpts['generated_vulkan_referenced_resource_consumer.h'] = [
+        VulkanReferencedResourceHeaderGenerator,
+        VulkanReferencedResourceHeaderGeneratorOptions(
+        filename          = 'generated_vulkan_referenced_resource_consumer.h',
+        directory         = directory,
+        blacklists        = blacklists,
+        platformTypes     = platformTypes,
+        prefixText        = prefixStrings + vkPrefixStrings,
+        protectFile       = False,
+        protectFeature    = False)
+    ]
+
     genOpts['generated_vulkan_replay_consumer.h'] = [
         VulkanConsumerHeaderGenerator,
         VulkanConsumerHeaderGeneratorOptions(
@@ -262,6 +276,18 @@ def makeGenOpts(args):
         directory         = directory,
         blacklists        = blacklists,
         replayOverrides   = replayOverrides,
+        platformTypes     = platformTypes,
+        prefixText        = prefixStrings + vkPrefixStrings,
+        protectFile       = False,
+        protectFeature    = False)
+    ]
+
+    genOpts['generated_vulkan_referenced_resource_consumer.cpp'] = [
+        VulkanReferencedResourceBodyGenerator,
+        VulkanReferencedResourceBodyGeneratorOptions(
+        filename          = 'generated_vulkan_referenced_resource_consumer.cpp',
+        directory         = directory,
+        blacklists        = blacklists,
         platformTypes     = platformTypes,
         prefixText        = prefixStrings + vkPrefixStrings,
         protectFile       = False,

--- a/framework/generated/vulkan_generators/vulkan_referenced_resource_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_referenced_resource_consumer_body_generator.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2018-2019 Valve Corporation
-# Copyright (c) 2018-2019 LunarG, Inc.
+# Copyright (c) 2020 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +17,8 @@
 import os,re,sys
 from base_generator import *
 
-class VulkanCommandBufferUtilBodyGeneratorOptions(BaseGeneratorOptions):
-    """Options for generating a C++ class for Vulkan capture file replay"""
+class VulkanReferencedResourceBodyGeneratorOptions(BaseGeneratorOptions):
+    """Options for generating a C++ class for detecting unreferenced resource handles in a capture file"""
     def __init__(self,
                  blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
                  platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
@@ -32,11 +31,20 @@ class VulkanCommandBufferUtilBodyGeneratorOptions(BaseGeneratorOptions):
                                       filename, directory, prefixText,
                                       protectFile, protectFeature)
 
-# VulkanCommandBufferUtilBodyGenerator - subclass of BaseGenerator.
-# Generates C++ member definitions for the VulkanReplayConsumer class responsible for
-# replaying decoded Vulkan API call parameter data.
-class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
-    """Generate a C++ class for Vulkan capture file replay"""
+# VulkanReferencedResourceBodyGenerator - subclass of BaseGenerator.
+# Generates C++ member definitions for the VulkanReferencedResource class responsible for
+# determining which resource handles are used or unused in a capture file.
+class VulkanReferencedResourceBodyGenerator(BaseGenerator):
+    """Generate a C++ class for detecting unreferenced resource handles in a capture file"""
+    # All resource and resource associated handle types to be processed.
+    RESOURCE_HANDLE_TYPES = ['VkBuffer', 'VkImage', 'VkBufferView', 'VkImageView', 'VkFramebuffer', 'VkDescriptorSet', 'VkCommandBuffer']
+
+    # Handle types that contain resource and child resource handle types.
+    CONTAINER_HANDLE_TYPES = ['VkDescriptorSet']
+
+    # Handle types that use resource and child resource handle types.
+    USER_HANDLE_TYPES = ['VkCommandBuffer']
+
     def __init__(self,
                  errFile = sys.stderr,
                  warnFile = sys.stderr,
@@ -44,50 +52,63 @@ class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
         BaseGenerator.__init__(self,
                                processCmds=True, processStructs=True, featureBreak=False,
                                errFile=errFile, warnFile=warnFile, diagFile=diagFile)
-
         # Map of Vulkan structs containing handles to a list values for handle members or struct members
         # that contain handles (eg. VkGraphicsPipelineCreateInfo contains a VkPipelineShaderStageCreateInfo
         # member that contains handles).
         self.structsWithHandles = dict()
         self.pNextStructs = dict()    # Map of Vulkan structure types to sType value for structs that can be part of a pNext chain.
         self.commandInfo = dict()     # Map of Vulkan commands to parameter info
+        self.restrictHandles = True   # Determines if the 'isHandle' override limits the handle test to only the values conained by RESOURCE_HANDLE_TYPES.
 
     # Method override
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
 
-        write('#include "generated/generated_vulkan_command_buffer_util.h"', file=self.outFile)
+        write('#include "generated/generated_vulkan_referenced_resource_consumer.h"', file=self.outFile)
         self.newline()
-        write('#include "encode/vulkan_handle_wrapper_util.h"', file=self.outFile)
-        write('#include "encode/vulkan_state_info.h"', file=self.outFile)
+        write('#include <cassert>', file=self.outFile)
         self.newline()
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
-        write('GFXRECON_BEGIN_NAMESPACE(encode)', file=self.outFile)
+        write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)
 
     # Method override
     def endFile(self):
         for cmd, info in self.commandInfo.items():
+            returnType = info[0]
             params = info[2]
             if params and params[0].baseType == 'VkCommandBuffer':
-                # Check for parameters with handle types, ignoring the first VkCommandBuffer parameter.
+                # Check for parameters with resource handle types.
                 handles = self.getParamListHandles(params[1:])
 
                 if (handles):
-                    # Generate a function to build a list of handle types and values.
+                    # Generate a function to add handles to the command buffer's referenced handle list.
                     cmddef = '\n'
-                    cmddef += 'void Track{}Handles(CommandBufferWrapper* wrapper, {})\n'.format(cmd[2:], self.getArgList(handles))
+
+                    # Temporarily remove resource only matching restriction from isHandle() when generating the function signature.
+                    self.restrictHandles = False
+                    cmddef += self.makeConsumerFuncDecl(returnType, 'VulkanReferencedResourceConsumer::Process_' + cmd, params) + '\n'
+                    self.restrictHandles = True
+
                     cmddef += '{\n'
                     indent = self.INDENT_SIZE * ' '
-                    cmddef += indent + 'assert(wrapper != nullptr);\n'
-                    cmddef += '\n'
+
+                    # Add unreferenced parameter macros.
+                    unrefCount = 0
+                    for param in params[1:]:
+                        if not param in handles:
+                            cmddef += indent + 'GFXRECON_UNREFERENCED_PARAMETER({});\n'.format(param.name)
+                            unrefCount += 1
+                    if unrefCount > 0:
+                        cmddef += '\n'
+
                     for index, handle in enumerate(handles):
-                        cmddef += self.insertCommandHandle(index, handle, indent=indent)
+                        cmddef += self.trackCommandHandle(index, params[0].name, handle, indent=indent)
                     cmddef += '}'
 
                     write(cmddef, file=self.outFile)
 
         self.newline()
-        write('GFXRECON_END_NAMESPACE(encode)', file=self.outFile)
+        write('GFXRECON_END_NAMESPACE(decode)', file=self.outFile)
         write('GFXRECON_END_NAMESPACE(gfxrecon)', file=self.outFile)
 
         # Finish processing in superclass
@@ -122,6 +143,16 @@ class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
             self.commandInfo[cmd] = self.featureCmdParams[cmd]
 
     #
+    # Override method to check for handle type, only matching resource handle types.
+    def isHandle(self, baseType):
+        if self.restrictHandles:
+            if baseType in self.RESOURCE_HANDLE_TYPES:
+                return True
+            return False
+        else:
+            return BaseGenerator.isHandle(self, baseType)
+
+    #
     # Create list of parameters that have handle types or are structs that contain handles.
     def getParamListHandles(self, values):
         handles = []
@@ -134,58 +165,85 @@ class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
 
     #
     #
-    def getArgList(self, values):
-        args = []
-        for value in values:
-            if value.arrayLength:
-                args.append('uint32_t {}'.format(value.arrayLength))
-            args.append('{} {}'.format(value.fullType, value.name))
-        return ', '.join(args)
-
-    #
-    #
-    def insertCommandHandle(self, index, value, valuePrefix='', indent=''):
+    def trackCommandHandle(self, index, commandParamName, value, valuePrefix='', indent=''):
         body = ''
         tail = ''
         indexName = None
+        countName = None
+        valueName = valuePrefix + value.name
+        isHandle = self.isHandle(value.baseType)
+
         if (value.isPointer or value.isArray) and value.name != 'pnext_value':
             if index > 0:
                 body += '\n'
-            body += indent + 'if ({}{} != nullptr)\n'.format(valuePrefix, value.name)
+
+            accessOperator = '->'
+            if not valuePrefix:
+                # If there is no prefix, this is the pointer parameter received by the function, which should never be null.
+                body += indent + 'assert({} != nullptr);\n'.format(value.name)
+                body += '\n'
+            else:
+                # If there is a prefix, this is a struct member.  We need to determine the type of access operator to use
+                # for the member of a 'decoded' struct type, where handle member types will be HandlePointerDecoder, but
+                # struct member types will be unique_ptr<StructPointerDecoder>.
+                if isHandle:
+                    accessOperator = '.'
+
+            # Add IsNull and HasData checks for the pointer decoder, before accessing its data.
+            # Note that this does not handle the decoded struct member cases for static arrays, which would need to use '.' instead of '->'.
+            body += indent + 'if (!{prefix}{name}{op}IsNull() && ({prefix}{name}{op}HasData()))\n'.format(prefix=valuePrefix, name=value.name, op=accessOperator)
             body += indent + '{\n'
             tail = indent + '}\n' + tail
             indent += ' ' * self.INDENT_SIZE
 
+            # Get the pointer from the pointer decoder object.
+            valueName = '{}_ptr'.format(value.name)
+            if isHandle:
+                body += indent + 'auto {} = {}{}{}GetPointer();\n'.format(valueName, valuePrefix, value.name, accessOperator)
+            else:
+                body += indent + 'auto {} = {}{}{}GetMetaStructPointer();\n'.format(valueName, valuePrefix, value.name, accessOperator)
+
+            # Add a for loop for an array of values.
             if value.isArray:
                 indexName = '{}_index'.format(value.name)
-                body += indent + 'for (uint32_t {i} = 0; {i} < {}{}; ++{i})\n'.format(valuePrefix, value.arrayLength, i=indexName)
+                countName = '{}_count'.format(value.name)
+                body += indent + 'size_t {} = {}{}{}GetLength();\n'.format(countName, valuePrefix, value.name, accessOperator)
+                body += indent + 'for (size_t {i} = 0; {i} < {}; ++{i})\n'.format(countName, i=indexName)
                 body += indent + '{\n'
                 tail = indent + '}\n' + tail
                 indent += ' ' * self.INDENT_SIZE
 
-        if self.isHandle(value.baseType):
-            typeEnumValue = '{}Handle'.format(value.baseType[2:])
-            valueName = valuePrefix + value.name
+        # Insert commands to add handles to a container, or to process struct members that contain handles.
+        if isHandle:
             if value.isArray:
                 valueName = '{}[{}]'.format(valueName, indexName)
             elif value.isPointer:
                 valueName = '(*{})'.format(valueName)
 
-            body += indent + 'wrapper->command_handles[CommandHandleType::{}].insert(GetWrappedId({}));\n'.format(typeEnumValue, valueName)
+            if value.baseType in self.CONTAINER_HANDLE_TYPES:
+                body += indent + 'GetTable().AddContainerToUser({}, {});\n'.format(commandParamName, valueName)
+            elif value.baseType in self.USER_HANDLE_TYPES:
+                body += indent + 'GetTable().AddUserToUser({}, {});\n'.format(commandParamName, valueName)
+            else:
+                body += indent + 'GetTable().AddResourceToUser({}, {});\n'.format(commandParamName, valueName)
 
         elif self.isStruct(value.baseType) and (value.baseType in self.structsWithHandles):
             if value.isArray:
                 accessOperator = '[{}].'.format(indexName)
-            elif value.isPointer:
-                accessOperator = '->'
             else:
-                accessOperator = '.'
+                accessOperator = '->'
 
             for index, entry in enumerate(self.structsWithHandles[value.baseType]):
                 if entry.name == 'pNext':
                     extStructsWithHandles = [extStruct for extStruct in self.registry.validextensionstructs[value.baseType] if extStruct in self.structsWithHandles]
                     if extStructsWithHandles:
-                        body += indent + 'auto pnext_header = reinterpret_cast<const VkBaseInStructure*>({}{}->pNext);\n'.format(valuePrefix, value.name)
+                        body += indent + 'const VkBaseInStructure* pnext_header = nullptr;\n'
+                        body += indent + 'if ({name}->pNext != nullptr)\n'.format(name=valueName)
+                        body += indent + '{\n'
+                        indent += ' ' * self.INDENT_SIZE
+                        body += indent + 'pnext_header = reinterpret_cast<const VkBaseInStructure*>({}->pNext->GetPointer());\n'.format(valueName)
+                        indent = indent[:-self.INDENT_SIZE]
+                        body += indent + '}\n'
                         body += indent + 'while (pnext_header)\n'
                         body += indent + '{\n'
                         indent += ' ' * self.INDENT_SIZE
@@ -200,8 +258,8 @@ class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
                             body += indent + 'case {}:\n'.format(self.pNextStructs[extStruct])
                             body += indent + '{\n'
                             indent += ' ' * self.INDENT_SIZE
-                            body += indent + 'auto pnext_value = reinterpret_cast<const {}*>(pnext_header);\n'.format(extStruct)
-                            body += self.insertCommandHandle(index, ValueInfo('pnext_value', extStruct, 'const {} *'.format(extStruct), 1), '', indent=indent)
+                            body += indent + 'auto pnext_value = reinterpret_cast<const Decoded_{}*>({}->pNext->GetPointer());\n'.format(extStruct, valueName)
+                            body += self.trackCommandHandle(index, commandParamName, ValueInfo('pnext_value', extStruct, 'const {} *'.format(extStruct), 1), '', indent=indent)
                             body += indent + 'break;\n'
                             indent = indent[:-self.INDENT_SIZE]
                             body += indent + '}\n'
@@ -211,6 +269,6 @@ class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
                         indent = indent[:-self.INDENT_SIZE]
                         body += indent + '}\n'
                 else:
-                    body += self.insertCommandHandle(index, entry, valuePrefix + value.name + accessOperator, indent)
+                    body += self.trackCommandHandle(index, commandParamName, entry, valueName + accessOperator, indent)
 
         return body + tail

--- a/framework/generated/vulkan_generators/vulkan_referenced_resource_consumer_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_referenced_resource_consumer_header_generator.py
@@ -1,0 +1,144 @@
+#!/usr/bin/python3 -i
+#
+# Copyright (c) 2020 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os,re,sys
+from base_generator import *
+
+class VulkanReferencedResourceHeaderGeneratorOptions(BaseGeneratorOptions):
+    """Options for generating the header to a C++ class for detecting unreferenced resource handles in a capture file"""
+    def __init__(self,
+                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
+                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+                 filename = None,
+                 directory = '.',
+                 prefixText = '',
+                 protectFile = False,
+                 protectFeature = True):
+        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
+                                      filename, directory, prefixText,
+                                      protectFile, protectFeature)
+
+# VulkanReferencedResourceHeaderGenerator - subclass of BaseGenerator.
+# Generates C++ member definitions for the VulkanReferencedResource class responsible for
+# determining which resource handles are used or unused in a capture file.
+class VulkanReferencedResourceHeaderGenerator(BaseGenerator):
+    """Generate the header to a C++ class for detecting unreferenced resource handles in a capture file"""
+    # All resource and resource associated handle types to be processed.
+    RESOURCE_HANDLE_TYPES = ['VkBuffer', 'VkImage', 'VkBufferView', 'VkImageView', 'VkFramebuffer', 'VkDescriptorSet', 'VkCommandBuffer']
+
+    def __init__(self,
+                 errFile = sys.stderr,
+                 warnFile = sys.stderr,
+                 diagFile = sys.stdout):
+        BaseGenerator.__init__(self,
+                               processCmds=True, processStructs=True, featureBreak=False,
+                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+        # Map of Vulkan structs containing handles to a list values for handle members or struct members
+        # that contain handles (eg. VkGraphicsPipelineCreateInfo contains a VkPipelineShaderStageCreateInfo
+        # member that contains handles).
+        self.structsWithHandles = dict()
+        self.commandInfo = dict()     # Map of Vulkan commands to parameter info
+        self.restrictHandles = True   # Determines if the 'isHandle' override limits the handle test to only the values conained by RESOURCE_HANDLE_TYPES.
+
+    # Method override
+    def beginFile(self, genOpts):
+        BaseGenerator.beginFile(self, genOpts)
+
+        className = 'VulkanReferencedResourceConsumer'
+
+        write('#include "decode/vulkan_referenced_resource_consumer_base.h"', file=self.outFile)
+        write('#include "util/defines.h"', file=self.outFile)
+        self.newline()
+        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.newline()
+        write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
+        write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)
+        self.newline()
+        write('class {name} : public {name}Base'.format(name=className), file=self.outFile)
+        write('{', file=self.outFile)
+        write('  public:', file=self.outFile)
+        write('    {}() {{ }}\n'.format(className), file=self.outFile)
+        write('    virtual ~{}() override {{ }}'.format(className), file=self.outFile)
+
+    # Method override
+    def endFile(self):
+        for cmd, info in self.commandInfo.items():
+            returnType = info[0]
+            params = info[2]
+            if params and params[0].baseType == 'VkCommandBuffer':
+                # Check for parameters with resource handle types.
+                handles = self.getParamListHandles(params[1:])
+
+                if (handles):
+                    # Generate a function to build a list of handle types and values.
+                    cmddef = '\n'
+
+                    # Temporarily remove resource only matching restriction from isHandle() when generating the function signature.
+                    self.restrictHandles = False
+                    cmddef += self.makeConsumerFuncDecl(returnType, 'Process_' + cmd, params) + ';\n'
+                    self.restrictHandles = True
+
+                    write(cmddef, file=self.outFile)
+
+        write('};', file=self.outFile)
+        self.newline()
+        write('GFXRECON_END_NAMESPACE(decode)', file=self.outFile)
+        write('GFXRECON_END_NAMESPACE(gfxrecon)', file=self.outFile)
+
+        # Finish processing in superclass
+        BaseGenerator.endFile(self)
+
+    #
+    # Method override
+    def genStruct(self, typeinfo, typename, alias):
+        BaseGenerator.genStruct(self, typeinfo, typename, alias)
+
+        if not alias:
+            self.checkStructMemberHandles(typename, self.structsWithHandles)
+
+    #
+    # Indicates that the current feature has C++ code to generate.
+    def needFeatureGeneration(self):
+        if self.featureCmdParams:
+            return True
+        return False
+
+    #
+    # Performs C++ code generation for the feature.
+    def generateFeature(self):
+        for cmd in self.getFilteredCmdNames():
+            self.commandInfo[cmd] = self.featureCmdParams[cmd]
+
+    #
+    # Override method to check for handle type, only matching resource handle types.
+    def isHandle(self, baseType):
+        if self.restrictHandles:
+            if baseType in self.RESOURCE_HANDLE_TYPES:
+                return True
+            return False
+        else:
+            return BaseGenerator.isHandle(self, baseType)
+
+    #
+    # Create list of parameters that have handle types or are structs that contain handles.
+    def getParamListHandles(self, values):
+        handles = []
+        for value in values:
+            if self.isHandle(value.baseType):
+                handles.append(value)
+            elif self.isStruct(value.baseType) and (value.baseType in self.structsWithHandles):
+                handles.append(value)
+        return handles

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -3,6 +3,6 @@ add_subdirectory(toascii)
 add_subdirectory(compress)
 add_subdirectory(info)
 add_subdirectory(extract)
+add_subdirectory(optimize)
 add_subdirectory(capture)
 add_subdirectory(gfxrecon)
-

--- a/tools/optimize/CMakeLists.txt
+++ b/tools/optimize/CMakeLists.txt
@@ -1,0 +1,37 @@
+###############################################################################
+# Copyright (c) 2020 LunarG, Inc.
+# All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: LunarG Team
+# Author: AMD Developer Tools Team
+# Description: CMake script for framework util target
+###############################################################################
+
+add_executable(gfxrecon-optimize "")
+
+target_sources(gfxrecon-optimize
+               PRIVATE
+                   ${CMAKE_CURRENT_LIST_DIR}/main.cpp
+                   ${CMAKE_CURRENT_LIST_DIR}/optimizing_file_processor.h
+                   ${CMAKE_CURRENT_LIST_DIR}/optimizing_file_processor.cpp
+              )
+
+target_include_directories(gfxrecon-optimize PUBLIC ${CMAKE_BINARY_DIR})
+
+target_link_libraries(gfxrecon-optimize gfxrecon_decode gfxrecon_format gfxrecon_util platform_specific)
+
+common_build_directives(gfxrecon-optimize)
+
+install(TARGETS gfxrecon-optimize RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/tools/optimize/main.cpp
+++ b/tools/optimize/main.cpp
@@ -1,0 +1,236 @@
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include "project_version.h"
+#include "optimizing_file_processor.h"
+
+#include "decode/file_processor.h"
+#include "format/format.h"
+#include "format/format_util.h"
+#include "generated/generated_vulkan_decoder.h"
+#include "generated/generated_vulkan_referenced_resource_consumer.h"
+#include "util/argument_parser.h"
+#include "util/logging.h"
+
+#include "vulkan/vulkan.h"
+
+#include <cassert>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+const char kHelpShortOption[] = "-h";
+const char kHelpLongOption[]  = "--help";
+const char kVersionOption[]   = "--version";
+const char kNoDebugPopup[]    = "--no-debug-popup";
+
+const char kOptions[] = "-h|--help,--version,--no-debug-popup";
+
+static void PrintUsage(const char* exe_name)
+{
+    std::string app_name     = exe_name;
+    size_t      dir_location = app_name.find_last_of("/\\");
+    if (dir_location >= 0)
+    {
+        app_name.replace(0, dir_location + 1, "");
+    }
+    GFXRECON_WRITE_CONSOLE(
+        "\n%s - Remove unused resource initialization data from trimmed GFXReconstruct capture files.\n",
+        app_name.c_str());
+    GFXRECON_WRITE_CONSOLE("Usage:");
+    GFXRECON_WRITE_CONSOLE("  %s [-h | --help] [--version] <input-file> <output-file>\n", app_name.c_str());
+    GFXRECON_WRITE_CONSOLE("Required arguments:");
+    GFXRECON_WRITE_CONSOLE("  <input-file>\t\tThe trimmed GFXReconstruct capture file to be processed.");
+    GFXRECON_WRITE_CONSOLE("  <output-file>\t\tThe name of the new GFXReconstruct capture file to be created.");
+    GFXRECON_WRITE_CONSOLE("\nOptional arguments:");
+    GFXRECON_WRITE_CONSOLE("  -h\t\t\tPrint usage information and exit (same as --help).");
+    GFXRECON_WRITE_CONSOLE("  --version\t\tPrint version information and exit.");
+#if defined(WIN32) && defined(_DEBUG)
+    GFXRECON_WRITE_CONSOLE("  --no-debug-popup\tDisable the 'Abort, Retry, Ignore' message box");
+    GFXRECON_WRITE_CONSOLE("        \t\tdisplayed when abort() is called (Windows debug only).");
+#endif
+}
+
+static bool CheckOptionPrintUsage(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
+{
+    if (arg_parser.IsOptionSet(kHelpShortOption) || arg_parser.IsOptionSet(kHelpLongOption))
+    {
+        PrintUsage(exe_name);
+        return true;
+    }
+
+    return false;
+}
+
+static bool CheckOptionPrintVersion(const char* exe_name, const gfxrecon::util::ArgumentParser& arg_parser)
+{
+    if (arg_parser.IsOptionSet(kVersionOption))
+    {
+        std::string app_name     = exe_name;
+        size_t      dir_location = app_name.find_last_of("/\\");
+
+        if (dir_location >= 0)
+        {
+            app_name.replace(0, dir_location + 1, "");
+        }
+
+        GFXRECON_WRITE_CONSOLE("%s version info:", app_name.c_str());
+        GFXRECON_WRITE_CONSOLE("  GFXReconstruct Version %s", GFXRECON_PROJECT_VERSION_STRING);
+        GFXRECON_WRITE_CONSOLE("  Vulkan Header Version %u.%u.%u",
+                               VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE),
+                               VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE),
+                               VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
+
+        return true;
+    }
+
+    return false;
+}
+
+static std::string GetVersionString(uint32_t api_version)
+{
+    uint32_t major = api_version >> 22;
+    uint32_t minor = (api_version >> 12) & 0x3ff;
+    uint32_t patch = api_version & 0xfff;
+
+    return std::to_string(major) + "." + std::to_string(minor) + "." + std::to_string(patch);
+}
+
+void GetUnreferencedResources(const std::string&                              input_filename,
+                              std::unordered_set<gfxrecon::format::HandleId>* unreferenced_ids)
+{
+    assert(unreferenced_ids != nullptr);
+
+    gfxrecon::decode::FileProcessor file_processor;
+    if (file_processor.Initialize(input_filename))
+    {
+        gfxrecon::decode::VulkanDecoder                    decoder;
+        gfxrecon::decode::VulkanReferencedResourceConsumer resref_consumer;
+
+        decoder.AddConsumer(&resref_consumer);
+
+        file_processor.AddDecoder(&decoder);
+        file_processor.ProcessAllFrames();
+
+        if ((file_processor.GetCurrentFrameNumber() > 0) &&
+            (file_processor.GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone))
+        {
+            // Get the list of resources that were included in a command buffer submission during replay.
+            resref_consumer.GetReferencedResourceIds(nullptr, unreferenced_ids);
+        }
+        else if (file_processor.GetErrorState() != gfxrecon::decode::FileProcessor::kErrorNone)
+        {
+            GFXRECON_WRITE_CONSOLE("A failure has occurred during file processing");
+            gfxrecon::util::Log::Release();
+            exit(-1);
+        }
+        else
+        {
+            GFXRECON_WRITE_CONSOLE("File did not contain any frames");
+            gfxrecon::util::Log::Release();
+            exit(0);
+        }
+    }
+}
+
+void FilterUnreferencedResources(const std::string&                               input_filename,
+                                 const std::string&                               output_filename,
+                                 std::unordered_set<gfxrecon::format::HandleId>&& unreferenced_ids)
+{
+    gfxrecon::OptimizingFileProcessor file_processor(std::move(unreferenced_ids));
+    if (file_processor.Initialize(input_filename, output_filename))
+    {
+        file_processor.Process();
+
+        if (file_processor.GetErrorState() != gfxrecon::OptimizingFileProcessor::kErrorNone)
+        {
+            GFXRECON_WRITE_CONSOLE("A failure has occurred during file processing");
+            gfxrecon::util::Log::Release();
+            exit(-1);
+        }
+
+        GFXRECON_WRITE_CONSOLE("Resource filtering complete.");
+        GFXRECON_WRITE_CONSOLE("\tOriginal file size: %" PRIu64 " bytes", file_processor.GetNumBytesRead());
+        GFXRECON_WRITE_CONSOLE("\tOptimized file size: %" PRIu64 " bytes", file_processor.GetNumBytesWritten());
+    }
+}
+
+int main(int argc, const char** argv)
+{
+    gfxrecon::util::Log::Init();
+
+    gfxrecon::util::ArgumentParser arg_parser(argc, argv, kOptions, "");
+
+    if (CheckOptionPrintUsage(argv[0], arg_parser) || CheckOptionPrintVersion(argv[0], arg_parser))
+    {
+        gfxrecon::util::Log::Release();
+        exit(0);
+    }
+    else if (arg_parser.IsInvalid() || (arg_parser.GetPositionalArgumentsCount() != 2))
+    {
+        PrintUsage(argv[0]);
+        gfxrecon::util::Log::Release();
+        exit(-1);
+    }
+    else
+    {
+#if defined(WIN32) && defined(_DEBUG)
+        if (arg_parser.IsOptionSet(kNoDebugPopup))
+        {
+            _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+        }
+#endif
+    }
+
+    try
+    {
+        const std::vector<std::string>& positional_arguments = arg_parser.GetPositionalArguments();
+        std::string                     input_filename       = positional_arguments[0];
+        std::string                     output_filename      = positional_arguments[1];
+
+        GFXRECON_WRITE_CONSOLE("Scanning %s for unreferenced resources.", input_filename.c_str());
+        std::unordered_set<gfxrecon::format::HandleId> unreferenced_ids;
+        GetUnreferencedResources(input_filename, &unreferenced_ids);
+
+        if (!unreferenced_ids.empty())
+        {
+            // Filter unreferenced ids.
+            GFXRECON_WRITE_CONSOLE("Writing optimized file, removing initialization data for %" PRIu64
+                                   " unused resources.",
+                                   unreferenced_ids.size());
+            FilterUnreferencedResources(input_filename, output_filename, std::move(unreferenced_ids));
+        }
+        else
+        {
+            GFXRECON_WRITE_CONSOLE("No unused resources detected.  A new file will not be created.",
+                                   input_filename.c_str());
+        }
+    }
+    catch (std::runtime_error error)
+    {
+        GFXRECON_WRITE_CONSOLE("File processing has encountered a fatal error and cannot continue: %s", error.what());
+        return -1;
+    }
+    catch (...)
+    {
+        GFXRECON_WRITE_CONSOLE("File processing failed due to an unhandled exception");
+        return -1;
+    }
+
+    gfxrecon::util::Log::Release();
+    return 0;
+}

--- a/tools/optimize/optimizing_file_processor.cpp
+++ b/tools/optimize/optimizing_file_processor.cpp
@@ -1,0 +1,613 @@
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include "optimizing_file_processor.h"
+
+#include "format/format_util.h"
+#include "util/logging.h"
+#include "util/platform.h"
+
+#include <cassert>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+
+OptimizingFileProcessor::OptimizingFileProcessor(const std::unordered_set<format::HandleId>& unreferenced_ids) :
+    unreferenced_ids_(unreferenced_ids), file_header_{}, input_file_(nullptr), output_file_(nullptr), bytes_read_(0),
+    bytes_written_(0), error_state_(kErrorInvalidFileDescriptor), loading_state_(false)
+{}
+
+OptimizingFileProcessor::OptimizingFileProcessor(std::unordered_set<format::HandleId>&& unreferenced_ids) :
+    unreferenced_ids_(std::move(unreferenced_ids)), file_header_{}, input_file_(nullptr), output_file_(nullptr),
+    bytes_read_(0), bytes_written_(0), error_state_(kErrorInvalidFileDescriptor), loading_state_(false)
+{}
+
+OptimizingFileProcessor::~OptimizingFileProcessor()
+{
+    if (input_file_ != nullptr)
+    {
+        fclose(input_file_);
+    }
+
+    if (output_file_ != nullptr)
+    {
+        fclose(output_file_);
+    }
+}
+
+bool OptimizingFileProcessor::Initialize(const std::string& input_filename, const std::string& output_filename)
+{
+    bool success = false;
+
+    int32_t result = util::platform::FileOpen(&input_file_, input_filename.c_str(), "rb");
+
+    if ((result == 0) && (input_file_ != nullptr))
+    {
+        result = util::platform::FileOpen(&output_file_, output_filename.c_str(), "wb");
+
+        if ((result == 0) && (output_file_ != nullptr))
+        {
+            success = ProcessFileHeader();
+
+            if (success)
+            {
+                error_state_ = kErrorNone;
+            }
+            else
+            {
+                fclose(input_file_);
+                fclose(output_file_);
+                input_file_  = nullptr;
+                output_file_ = nullptr;
+            }
+        }
+        else
+        {
+            GFXRECON_LOG_ERROR("Failed to open output file %s", output_filename.c_str());
+            error_state_ = kErrorOpeningFile;
+        }
+    }
+    else
+    {
+        GFXRECON_LOG_ERROR("Failed to open input file %s", input_filename.c_str());
+        error_state_ = kErrorOpeningFile;
+    }
+
+    return success;
+}
+
+// Returns false if processing failed.  Use GetErrorState() to determine error condition for failure case.
+bool OptimizingFileProcessor::Process()
+{
+    bool success = true;
+
+    while (success)
+    {
+        success = ProcessNextBlock();
+    }
+
+    if (!success)
+    {
+        // If not EOF, determine reason for invalid state.
+        if ((input_file_ == nullptr) || (output_file_ == nullptr))
+        {
+            error_state_ = kErrorInvalidFileDescriptor;
+        }
+        else if (ferror(input_file_))
+        {
+            error_state_ = kErrorReadingFile;
+        }
+        else if (ferror(output_file_))
+        {
+            error_state_ = kErrorWritingFile;
+        }
+    }
+
+    return (error_state_ == kErrorNone);
+}
+
+bool OptimizingFileProcessor::ProcessFileHeader()
+{
+    bool success = false;
+
+    if (ReadBytes(&file_header_, sizeof(file_header_)))
+    {
+        success = format::ValidateFileHeader(file_header_);
+
+        if (success)
+        {
+            file_options_.resize(file_header_.num_options);
+
+            size_t option_data_size = file_header_.num_options * sizeof(format::FileOptionPair);
+
+            success = ReadBytes(file_options_.data(), option_data_size);
+
+            if (success)
+            {
+                for (const auto& option : file_options_)
+                {
+                    switch (option.key)
+                    {
+                        case format::FileOption::kCompressionType:
+                            enabled_options_.compression_type = static_cast<format::CompressionType>(option.value);
+                            break;
+                        default:
+                            GFXRECON_LOG_WARNING("Ignoring unrecognized file header option %u", option.key);
+                            break;
+                    }
+                }
+
+                compressor_ =
+                    std::unique_ptr<util::Compressor>(format::CreateCompressor(enabled_options_.compression_type));
+
+                if ((compressor_ == nullptr) && (enabled_options_.compression_type != format::CompressionType::kNone))
+                {
+                    GFXRECON_LOG_ERROR("Failed to initialized file compression module (type = %u); processing of "
+                                       "compressed data will not be possible",
+                                       enabled_options_.compression_type);
+                    success      = false;
+                    error_state_ = kErrorUnsupportedCompressionType;
+                }
+            }
+
+            if (success)
+            {
+                // Write header to output file.
+                success = WriteBytes(&file_header_, sizeof(file_header_));
+                success = success && WriteBytes(file_options_.data(), option_data_size);
+
+                if (!success)
+                {
+                    GFXRECON_LOG_ERROR("Failed to write file header");
+                    error_state_ = kErrorWritingFileHeader;
+                }
+            }
+        }
+        else
+        {
+            GFXRECON_LOG_ERROR("File header contains invalid four character code");
+            error_state_ = kErrorInvalidFourCC;
+        }
+    }
+    else
+    {
+        GFXRECON_LOG_ERROR("Failed to read file header");
+        error_state_ = kErrorReadingFileHeader;
+    }
+
+    return success;
+}
+
+bool OptimizingFileProcessor::ProcessNextBlock()
+{
+    format::BlockHeader block_header;
+    bool                success = true;
+
+    success = ReadBlockHeader(&block_header);
+
+    if (success)
+    {
+        if (format::RemoveCompressedBlockBit(block_header.type) == format::BlockType::kFunctionCallBlock)
+        {
+            format::ApiCallId api_call_id = format::ApiCallId::ApiCall_Unknown;
+
+            success = ReadBytes(&api_call_id, sizeof(api_call_id));
+
+            if (success)
+            {
+                success = ProcessFunctionCall(block_header, api_call_id);
+            }
+            else
+            {
+                HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read function call block header");
+            }
+        }
+        else if (format::RemoveCompressedBlockBit(block_header.type) == format::BlockType::kMetaDataBlock)
+        {
+            format::MetaDataType meta_type = format::MetaDataType::kUnknownMetaDataType;
+
+            success = ReadBytes(&meta_type, sizeof(meta_type));
+
+            if (success)
+            {
+                success = ProcessMetaData(block_header, meta_type);
+            }
+            else
+            {
+                HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read meta-data block header");
+            }
+        }
+        else if (block_header.type == format::BlockType::kStateMarkerBlock)
+        {
+            format::MarkerType marker_type  = format::MarkerType::kUnknownMarker;
+            uint64_t           frame_number = 0;
+
+            success = ReadBytes(&marker_type, sizeof(marker_type));
+
+            if (success)
+            {
+                success = ProcessStateMarker(block_header, marker_type);
+            }
+            else
+            {
+                HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read state marker header");
+            }
+        }
+        else
+        {
+            // Copy the block to the output file.
+            success = WriteBlockHeader(block_header);
+
+            if (success)
+            {
+                success = CopyBytes(block_header.size);
+
+                if (!success)
+                {
+                    GFXRECON_LOG_ERROR("Failed to write block data");
+                    error_state_ = kErrorWritingBlockData;
+                }
+            }
+        }
+    }
+    else
+    {
+        if (!feof(input_file_))
+        {
+            // If we have not hit a normal EOF condition, report an error reading the block header.
+            GFXRECON_LOG_ERROR("Failed to read block header");
+            error_state_ = kErrorReadingBlockHeader;
+        }
+    }
+
+    return success;
+}
+
+bool OptimizingFileProcessor::ReadBlockHeader(format::BlockHeader* block_header)
+{
+    assert(block_header != nullptr);
+
+    if (ReadBytes(block_header, sizeof(*block_header)))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+bool OptimizingFileProcessor::WriteBlockHeader(const format::BlockHeader& block_header)
+{
+    if (!WriteBytes(&block_header, sizeof(block_header)))
+    {
+        GFXRECON_LOG_ERROR("Failed to write block header");
+        error_state_ = kErrorWritingBlockHeader;
+        return false;
+    }
+
+    return true;
+}
+
+bool OptimizingFileProcessor::ReadParameterBuffer(size_t buffer_size)
+{
+    if (buffer_size > parameter_buffer_.size())
+    {
+        parameter_buffer_.resize(buffer_size);
+    }
+
+    return ReadBytes(parameter_buffer_.data(), buffer_size);
+}
+
+bool OptimizingFileProcessor::ReadCompressedParameterBuffer(size_t  compressed_buffer_size,
+                                                            size_t  expected_uncompressed_size,
+                                                            size_t* uncompressed_buffer_size)
+{
+    // This should only be null if initialization failed.
+    assert(compressor_ != nullptr);
+
+    if (compressed_buffer_size > compressed_parameter_buffer_.size())
+    {
+        compressed_parameter_buffer_.resize(compressed_buffer_size);
+    }
+
+    if (ReadBytes(compressed_parameter_buffer_.data(), compressed_buffer_size))
+    {
+        if (parameter_buffer_.size() < expected_uncompressed_size)
+        {
+            parameter_buffer_.resize(expected_uncompressed_size);
+        }
+
+        size_t uncompressed_size = compressor_->Decompress(
+            compressed_buffer_size, compressed_parameter_buffer_, expected_uncompressed_size, &parameter_buffer_);
+        if ((0 < uncompressed_size) && (uncompressed_size == expected_uncompressed_size))
+        {
+            *uncompressed_buffer_size = uncompressed_size;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool OptimizingFileProcessor::ReadBytes(void* buffer, size_t buffer_size)
+{
+    size_t bytes_read = util::platform::FileRead(buffer, 1, buffer_size, input_file_);
+    bytes_read_ += bytes_read;
+    return (bytes_read == buffer_size);
+}
+
+bool OptimizingFileProcessor::WriteBytes(const void* buffer, size_t buffer_size)
+{
+    size_t bytes_written = util::platform::FileWrite(buffer, 1, buffer_size, output_file_);
+    bytes_written_ += bytes_written;
+    return (bytes_written == buffer_size);
+}
+
+bool OptimizingFileProcessor::SkipBytes(uint64_t skip_size)
+{
+    bool success = util::platform::FileSeek(input_file_, skip_size, util::platform::FileSeekCurrent);
+
+    if (success)
+    {
+        // These technically count as bytes read/processed.
+        bytes_read_ += skip_size;
+    }
+
+    return success;
+}
+
+bool OptimizingFileProcessor::CopyBytes(uint64_t copy_size)
+{
+    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, copy_size);
+    if (ReadParameterBuffer(static_cast<size_t>(copy_size)))
+    {
+        if (WriteBytes(parameter_buffer_.data(), static_cast<size_t>(copy_size)))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void OptimizingFileProcessor::HandleBlockReadError(Error error_code, const char* error_message)
+{
+    // Report incomplete block at end of file as a warning, other I/O errors as an error.
+    if (feof(input_file_) && !ferror(input_file_))
+    {
+        GFXRECON_LOG_WARNING("Incomplete block at end of file");
+    }
+    else
+    {
+        GFXRECON_LOG_ERROR("%s", error_message);
+        error_state_ = error_code;
+    }
+}
+
+bool OptimizingFileProcessor::ProcessFunctionCall(const format::BlockHeader& block_header, format::ApiCallId call_id)
+{
+    // This is currently only copying the API call data from the old to the new file.
+    if (!WriteBlockHeader(block_header))
+    {
+        return false;
+    }
+
+    if (!WriteBytes(&call_id, sizeof(call_id)))
+    {
+        GFXRECON_LOG_ERROR("Failed to write function call block header");
+        error_state_ = kErrorWritingBlockHeader;
+        return false;
+    }
+
+    if (!CopyBytes(block_header.size - sizeof(call_id)))
+    {
+        GFXRECON_LOG_ERROR("Failed to copy function call block data");
+        error_state_ = kErrorWritingBlockData;
+        return false;
+    }
+
+    return true;
+}
+
+bool OptimizingFileProcessor::ProcessMetaData(const format::BlockHeader& block_header, format::MetaDataType meta_type)
+{
+    if (meta_type == format::MetaDataType::kInitBufferCommand)
+    {
+        return FilterInitBufferMetaData(block_header, meta_type);
+    }
+    else if (meta_type == format::MetaDataType::kInitImageCommand)
+    {
+        return FilterInitImageMetaData(block_header, meta_type);
+    }
+    else
+    {
+        // Copy the meta data block, if it was not filtered.
+        if (!WriteBlockHeader(block_header))
+        {
+            return false;
+        }
+
+        if (!WriteBytes(&meta_type, sizeof(meta_type)))
+        {
+            GFXRECON_LOG_ERROR("Failed to write meta-data block header");
+            error_state_ = kErrorWritingBlockHeader;
+            return false;
+        }
+
+        if (!CopyBytes(block_header.size - sizeof(meta_type)))
+        {
+            GFXRECON_LOG_ERROR("Failed to copy meta-data block data");
+            error_state_ = kErrorWritingBlockData;
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool OptimizingFileProcessor::ProcessStateMarker(const format::BlockHeader& block_header,
+                                                 format::MarkerType         marker_type)
+{
+    uint64_t frame_number = 0;
+
+    if (ReadBytes(&frame_number, sizeof(frame_number)))
+    {
+        if (marker_type == format::kBeginMarker)
+        {
+            loading_state_ = true;
+        }
+        else if (marker_type == format::kEndMarker)
+        {
+            loading_state_ = false;
+        }
+
+        format::Marker marker;
+        marker.header       = block_header;
+        marker.marker_type  = marker_type;
+        marker.frame_number = frame_number;
+
+        if (!WriteBytes(&marker, sizeof(marker)))
+        {
+            GFXRECON_LOG_ERROR("Failed to write state marker data");
+            error_state_ = kErrorWritingBlockData;
+            return false;
+        }
+    }
+    else
+    {
+        GFXRECON_LOG_ERROR("Failed to read state marker data");
+        error_state_ = kErrorReadingBlockData;
+        return false;
+    }
+
+    return true;
+}
+
+bool OptimizingFileProcessor::FilterInitBufferMetaData(const format::BlockHeader& block_header,
+                                                       format::MetaDataType       meta_type)
+{
+    assert(meta_type == format::MetaDataType::kInitBufferCommand);
+
+    format::InitBufferCommandHeader header;
+
+    bool success = ReadBytes(&header.thread_id, sizeof(header.thread_id));
+    success      = success && ReadBytes(&header.device_id, sizeof(header.device_id));
+    success      = success && ReadBytes(&header.buffer_id, sizeof(header.buffer_id));
+    success      = success && ReadBytes(&header.data_size, sizeof(header.data_size));
+
+    if (success)
+    {
+        // Total number of bytes remaining to be read for the current block.
+        uint64_t unread_bytes = block_header.size - (sizeof(header) - sizeof(block_header));
+
+        // If the buffer is in the unused list, omit its initialization data from the file.
+        if (unreferenced_ids_.find(header.buffer_id) != unreferenced_ids_.end())
+        {
+            if (!SkipBytes(unread_bytes))
+            {
+                GFXRECON_LOG_ERROR("Failed to skip init buffer data meta-data block data");
+                return false;
+            }
+        }
+        else
+        {
+            // Copy the block from the input file to the output file.
+            header.meta_header.block_header   = block_header;
+            header.meta_header.meta_data_type = meta_type;
+
+            if (!WriteBytes(&header, sizeof(header)))
+            {
+                GFXRECON_LOG_ERROR("Failed to write init buffer data meta-data block header");
+                error_state_ = kErrorReadingBlockHeader;
+                return false;
+            }
+
+            if (!CopyBytes(unread_bytes))
+            {
+                GFXRECON_LOG_ERROR("Failed to copy init buffer data meta-data block data");
+                error_state_ = kErrorWritingBlockData;
+                return false;
+            }
+        }
+    }
+    else
+    {
+        HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read init buffer data meta-data block header");
+        return false;
+    }
+
+    return true;
+}
+
+bool OptimizingFileProcessor::FilterInitImageMetaData(const format::BlockHeader& block_header,
+                                                      format::MetaDataType       meta_type)
+{
+    assert(meta_type == format::MetaDataType::kInitImageCommand);
+
+    format::InitImageCommandHeader header;
+    std::vector<uint64_t>          level_sizes;
+
+    bool success = ReadBytes(&header.thread_id, sizeof(header.thread_id));
+    success      = success && ReadBytes(&header.device_id, sizeof(header.device_id));
+    success      = success && ReadBytes(&header.image_id, sizeof(header.image_id));
+    success      = success && ReadBytes(&header.data_size, sizeof(header.data_size));
+    success      = success && ReadBytes(&header.aspect, sizeof(header.aspect));
+    success      = success && ReadBytes(&header.layout, sizeof(header.layout));
+    success      = success && ReadBytes(&header.level_count, sizeof(header.level_count));
+
+    if (success)
+    {
+        // Total number of bytes remaining to be read for the current block.
+        uint64_t unread_bytes = block_header.size - (sizeof(header) - sizeof(block_header));
+
+        // If the image is in the unused list, omit its initialization data from the file.
+        if (unreferenced_ids_.find(header.image_id) != unreferenced_ids_.end())
+        {
+            if (!SkipBytes(unread_bytes))
+            {
+                GFXRECON_LOG_ERROR("Failed to skip init image data meta-data block data");
+                return false;
+            }
+        }
+        else
+        {
+            // Copy the block from the input file to the output file.
+            header.meta_header.block_header   = block_header;
+            header.meta_header.meta_data_type = meta_type;
+
+            if (!WriteBytes(&header, sizeof(header)))
+            {
+                GFXRECON_LOG_ERROR("Failed to write init image data meta-data block header");
+                error_state_ = kErrorReadingBlockHeader;
+                return false;
+            }
+
+            if (!CopyBytes(unread_bytes))
+            {
+                GFXRECON_LOG_ERROR("Failed to copy init image data meta-data block data");
+                error_state_ = kErrorWritingBlockData;
+                return false;
+            }
+        }
+    }
+    else
+    {
+        HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read init image data meta-data block header");
+        return false;
+    }
+
+    return true;
+}
+
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/tools/optimize/optimizing_file_processor.h
+++ b/tools/optimize/optimizing_file_processor.h
@@ -1,0 +1,130 @@
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef GFXRECON_OPTIMIZING_FILE_PPROCESSOR_H
+#define GFXRECON_OPTIMIZING_FILE_PPROCESSOR_H
+
+#include "format/format.h"
+#include "util/compressor.h"
+
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+
+class OptimizingFileProcessor
+{
+  public:
+    enum Error : int32_t
+    {
+        kErrorNone                         = 0,
+        kErrorInvalidFileDescriptor        = -1,
+        kErrorOpeningFile                  = -2,
+        kErrorReadingFile                  = -3,
+        kErrorReadingFileHeader            = -4,
+        kErrorReadingBlockHeader           = -5,
+        kErrorReadingCompressedBlockHeader = -6,
+        kErrorReadingBlockData             = -7,
+        kErrorReadingCompressedBlockData   = -8,
+        kErrorInvalidFourCC                = -9,
+        kErrorUnsupportedCompressionType   = -10,
+        kErrorWritingFile                  = -11,
+        kErrorWritingFileHeader            = -12,
+        kErrorWritingBlockHeader           = -13,
+        kErrorWritingCompressedBlockHeader = -14,
+        kErrorWritingBlockData             = -15,
+        kErrorWritingCompressedBlockData   = -16
+    };
+
+  public:
+    OptimizingFileProcessor(const std::unordered_set<format::HandleId>& unreferenced_ids);
+
+    OptimizingFileProcessor(std::unordered_set<format::HandleId>&& unreferenced_ids);
+
+    ~OptimizingFileProcessor();
+
+    bool Initialize(const std::string& input_filename, const std::string& output_filename);
+
+    // Returns false if processing failed.  Use GetErrorState() to determine error condition for failure case.
+    bool Process();
+
+    uint64_t GetNumBytesRead() const { return bytes_read_; }
+
+    uint64_t GetNumBytesWritten() const { return bytes_written_; }
+
+    Error GetErrorState() const { return error_state_; }
+
+  private:
+    bool ProcessFileHeader();
+
+    bool ProcessNextBlock();
+
+    bool ReadBlockHeader(format::BlockHeader* block_header);
+
+    bool WriteBlockHeader(const format::BlockHeader& block_header);
+
+    bool ReadParameterBuffer(size_t buffer_size);
+
+    bool ReadCompressedParameterBuffer(size_t  compressed_buffer_size,
+                                       size_t  expected_uncompressed_size,
+                                       size_t* uncompressed_buffer_size);
+
+    bool ReadBytes(void* buffer, size_t buffer_size);
+
+    bool WriteBytes(const void* buffer, size_t buffer_size);
+
+    bool SkipBytes(uint64_t skip_size);
+
+    bool CopyBytes(uint64_t copy_size);
+
+    void HandleBlockReadError(Error error_code, const char* error_message);
+
+    bool ProcessFunctionCall(const format::BlockHeader& block_header, format::ApiCallId call_id);
+
+    bool ProcessMetaData(const format::BlockHeader& block_header, format::MetaDataType meta_type);
+
+    bool ProcessStateMarker(const format::BlockHeader& block_header, format::MarkerType marker_type);
+
+    bool FilterInitBufferMetaData(const format::BlockHeader& block_header, format::MetaDataType meta_type);
+
+    bool FilterInitImageMetaData(const format::BlockHeader& block_header, format::MetaDataType meta_type);
+
+    bool IsFileHeaderValid() const { return (file_header_.fourcc == GFXRECON_FOURCC); }
+
+    bool IsFileValid(FILE* fd) const { return ((fd != nullptr) && !feof(fd) && !ferror(fd)); }
+
+  private:
+    std::unordered_set<format::HandleId> unreferenced_ids_;
+    FILE*                                input_file_;
+    FILE*                                output_file_;
+    format::FileHeader                   file_header_;
+    std::vector<format::FileOptionPair>  file_options_;
+    format::EnabledOptions               enabled_options_;
+    uint64_t                             bytes_read_;
+    uint64_t                             bytes_written_;
+    Error                                error_state_;
+    bool                                 loading_state_;
+    std::vector<uint8_t>                 parameter_buffer_;
+    std::vector<uint8_t>                 compressed_parameter_buffer_;
+    std::unique_ptr<util::Compressor>    compressor_;
+};
+
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_OPTIMIZING_FILE_PPROCESSOR_H


### PR DESCRIPTION
Adds a new command line utility, gfxrecon-optimize, to remove unused buffer and image initialization data from trimmed capture files.  

For trimmed capture files, a snapshot of the Vulkan API state is written at the start of the file.  This state snapshot includes the data for all buffers and images that were live at the time that capture started.  Some of the buffer and image objects captured in the state snapshot may go unreferenced by the captured frames and their data can be removed from the capture file.

The new file optimization utility will process trimmed files to identify buffer and image objects that were initialized in the state snapshot, but were not used by any of the captured frames, and generate a new capture file that omits the data for these unused buffer and image objects.

Example usage:
```
> gfxrecon-optimize.exe test_frames_778_through_1009.gfxr test_opt.gfxr
Scanning test_frames_778_through_1009.gfxr for unreferenced resources.
Writing optimized file, removing initialization data for 4061 unused resources.
Resource filtering complete.
        Original file size: 409444600 bytes
        Optimized file size: 361701021 bytes
```

Closes: #425