### PR TITLE
Update replay surface management

### DIFF
--- a/framework/application/android_window.cpp
+++ b/framework/application/android_window.cpp
@@ -110,11 +110,24 @@ VkResult AndroidWindow::CreateSurface(const encode::InstanceTable* table,
                                       VkFlags                      flags,
                                       VkSurfaceKHR*                pSurface)
 {
-    VkAndroidSurfaceCreateInfoKHR create_info{
-        VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR, nullptr, flags, window_
-    };
+    if (table != nullptr)
+    {
+        VkAndroidSurfaceCreateInfoKHR create_info{
+            VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR, nullptr, flags, window_
+        };
 
-    return table->CreateAndroidSurfaceKHR(instance, &create_info, nullptr, pSurface);
+        return table->CreateAndroidSurfaceKHR(instance, &create_info, nullptr, pSurface);
+    }
+
+    return VK_ERROR_INITIALIZATION_FAILED;
+}
+
+void AndroidWindow::DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+{
+    if (table != nullptr)
+    {
+        table->DestroySurfaceKHR(instance, surface, nullptr);
+    }
 }
 
 AndroidWindowFactory::AndroidWindowFactory(AndroidApplication* application) : android_application_(application)

--- a/framework/application/android_window.h
+++ b/framework/application/android_window.h
@@ -62,6 +62,8 @@ class AndroidWindow : public decode::Window
                                    VkFlags                      flags,
                                    VkSurfaceKHR*                pSurface) override;
 
+    virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+
   private:
     AndroidApplication* android_application_;
     ANativeWindow*      window_;

--- a/framework/application/wayland_window.cpp
+++ b/framework/application/wayland_window.cpp
@@ -169,11 +169,26 @@ VkResult WaylandWindow::CreateSurface(const encode::InstanceTable* table,
                                       VkFlags                      flags,
                                       VkSurfaceKHR*                pSurface)
 {
-    VkWaylandSurfaceCreateInfoKHR create_info{
-        VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR, nullptr, flags, wayland_application_->GetDisplay(), surface_
-    };
+    if (table != nullptr)
+    {
+        VkWaylandSurfaceCreateInfoKHR create_info{ VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR,
+                                                   nullptr,
+                                                   flags,
+                                                   wayland_application_->GetDisplay(),
+                                                   surface_ };
 
-    return table->CreateWaylandSurfaceKHR(instance, &create_info, nullptr, pSurface);
+        return table->CreateWaylandSurfaceKHR(instance, &create_info, nullptr, pSurface);
+    }
+
+    return VK_ERROR_INITIALIZATION_FAILED;
+}
+
+void WaylandWindow::DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+{
+    if (table != nullptr)
+    {
+        table->DestroySurfaceKHR(instance, surface, nullptr);
+    }
 }
 
 void WaylandWindow::UpdateWindowSize()

--- a/framework/application/wayland_window.h
+++ b/framework/application/wayland_window.h
@@ -66,6 +66,8 @@ class WaylandWindow : public decode::Window
                                    VkFlags                      flags,
                                    VkSurfaceKHR*                pSurface) override;
 
+    virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+
   private:
     static void HandleSurfaceEnter(void* data, struct wl_surface* surface, struct wl_output* output);
     static void HandleSurfaceLeave(void* data, struct wl_surface* surface, struct wl_output* output);

--- a/framework/application/win32_window.cpp
+++ b/framework/application/win32_window.cpp
@@ -258,11 +258,24 @@ VkResult Win32Window::CreateSurface(const encode::InstanceTable* table,
                                     VkFlags                      flags,
                                     VkSurfaceKHR*                pSurface)
 {
-    VkWin32SurfaceCreateInfoKHR create_info{
-        VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR, nullptr, flags, hinstance_, hwnd_
-    };
+    if (table != nullptr)
+    {
+        VkWin32SurfaceCreateInfoKHR create_info{
+            VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR, nullptr, flags, hinstance_, hwnd_
+        };
 
-    return table->CreateWin32SurfaceKHR(instance, &create_info, nullptr, pSurface);
+        return table->CreateWin32SurfaceKHR(instance, &create_info, nullptr, pSurface);
+    }
+
+    return VK_ERROR_INITIALIZATION_FAILED;
+}
+
+void Win32Window::DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+{
+    if (table != nullptr)
+    {
+        table->DestroySurfaceKHR(instance, surface, nullptr);
+    }
 }
 
 Win32WindowFactory::Win32WindowFactory(Win32Application* application) : win32_application_(application)

--- a/framework/application/win32_window.h
+++ b/framework/application/win32_window.h
@@ -63,6 +63,8 @@ class Win32Window : public decode::Window
                                    VkFlags                      flags,
                                    VkSurfaceKHR*                pSurface) override;
 
+    virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+
   private:
     HWND              hwnd_;
     Win32Application* win32_application_;

--- a/framework/application/xcb_window.cpp
+++ b/framework/application/xcb_window.cpp
@@ -396,11 +396,24 @@ bool XcbWindow::GetNativeHandle(HandleType type, void** handle)
 VkResult
 XcbWindow::CreateSurface(const encode::InstanceTable* table, VkInstance instance, VkFlags flags, VkSurfaceKHR* pSurface)
 {
-    VkXcbSurfaceCreateInfoKHR create_info{
-        VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR, nullptr, flags, xcb_application_->GetConnection(), window_
-    };
+    if (table != nullptr)
+    {
+        VkXcbSurfaceCreateInfoKHR create_info{
+            VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR, nullptr, flags, xcb_application_->GetConnection(), window_
+        };
 
-    return table->CreateXcbSurfaceKHR(instance, &create_info, nullptr, pSurface);
+        return table->CreateXcbSurfaceKHR(instance, &create_info, nullptr, pSurface);
+    }
+
+    return VK_ERROR_INITIALIZATION_FAILED;
+}
+
+void XcbWindow::DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+{
+    if (table != nullptr)
+    {
+        table->DestroySurfaceKHR(instance, surface, nullptr);
+    }
 }
 
 xcb_intern_atom_cookie_t

--- a/framework/application/xcb_window.h
+++ b/framework/application/xcb_window.h
@@ -81,6 +81,8 @@ class XcbWindow : public decode::Window
                                    VkFlags                      flags,
                                    VkSurfaceKHR*                pSurface) override;
 
+    virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+
   private:
     void SetFullscreen(bool fullscreen);
 

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -192,9 +192,9 @@ struct InstanceInfo : public VulkanObjectInfo<VkInstance>
 
     std::unordered_map<VkPhysicalDevice, ReplayDeviceInfo> replay_device_info;
 
-    // Ensure swapchains and surfaces are cleaned up on exit to avoid issues encountered when calling xcb_disconnect
-    // with active xcb surfaces.
-    std::unordered_map<VkSurfaceKHR, Window*> active_surfaces;
+    // Ensure surfaces are cleaned up on exit to avoid issues encountered when calling xcb_disconnect with active xcb
+    // surfaces.
+    std::unordered_set<format::HandleId> active_surfaces;
 };
 
 struct PhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
@@ -228,9 +228,9 @@ struct DeviceInfo : public VulkanObjectInfo<VkDevice>
     std::vector<std::string>                   extensions;
     std::unique_ptr<VulkanResourceInitializer> resource_initializer;
 
-    // Ensure swapchains and surfaces are cleaned up on exit to avoid issues encountered when calling xcb_disconnect
-    // with active xcb surfaces.
-    std::unordered_set<VkSwapchainKHR> active_swapchains;
+    // Ensure swapchains are cleaned up on exit to avoid issues encountered when calling xcb_disconnect with active xcb
+    // surfaces.
+    std::unordered_set<format::HandleId> active_swapchains;
 };
 
 struct QueueInfo : public VulkanObjectInfo<VkQueue>

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -194,7 +194,7 @@ struct InstanceInfo : public VulkanObjectInfo<VkInstance>
 
     // Ensure swapchains and surfaces are cleaned up on exit to avoid issues encountered when calling xcb_disconnect
     // with active xcb surfaces.
-    std::unordered_set<VkSurfaceKHR> active_surfaces;
+    std::unordered_map<VkSurfaceKHR, Window*> active_surfaces;
 };
 
 struct PhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>

--- a/framework/decode/window.h
+++ b/framework/decode/window.h
@@ -73,14 +73,16 @@ class Window
 
     virtual VkResult
     CreateSurface(const encode::InstanceTable* table, VkInstance instance, VkFlags flags, VkSurfaceKHR* pSurface) = 0;
+
+    virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) = 0;
 };
 
 class WindowFactory
 {
   public:
-    WindowFactory(){};
+    WindowFactory() {}
 
-    virtual ~WindowFactory(){};
+    virtual ~WindowFactory() {}
 
     virtual const char* GetSurfaceExtensionName() const = 0;
 


### PR DESCRIPTION
* Make the window that creates the surface responsible for destroying the surface.
* Track surfaces with capture ID instead of replay handle.