### PR TITLE
Remove alternate --sync option

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -284,7 +284,7 @@ The `gfxrecon.py replay` command has the following usage:
 
 ```text
 usage: gfxrecon.py replay [-h] [-p local-file] [--version] [--pause-frame N]
-                          [--paused] [--sfa] [--opcd] [-s] [-m <mode>]
+                          [--paused] [--sfa] [--opcd] [--sync] [-m <mode>]
                           [file]
 
 positional arguments:
@@ -308,7 +308,7 @@ optional arguments:
   --opcd, --omit-pipeline-cache-data
                         Omit pipeline cache data from calls to
                         vkCreatePipelineCache (forwarded to replay tool)
-  -s, --sync            Synchronize after each queue submission with
+  --sync                Synchronize after each queue submission with
                         vkQueueWaitIdle (forwarded to replay tool)
   -m <mode>, --memory-translation <mode>
                         Enable memory translation for replay on GPUs with

--- a/USAGE_desktop.md
+++ b/USAGE_desktop.md
@@ -328,7 +328,7 @@ arguments:
 
 ```text
 gfxrecon-replay         [-h | --help] [--version] [--gpu <index>]
-                        [--pause-frame <N>] [--paused] [-s | --sync]
+                        [--pause-frame <N>] [--paused] [--sync]
                         [--sfa | --skip-failed-allocations] [--replace-shaders <dir>]
                         [--opcd | --omit-pipeline-cache-data] [--wsi <platform>]
                         [-m <mode> | --memory-translation <mode>] <file>
@@ -358,8 +358,7 @@ Optional arguments:
                         vkCreatePipelineCache (same as --omit-pipeline-cache-data).
   --wsi <platform>      Force replay to use the specified wsi platform.
                         Available platforms are: auto,win32,xcb,wayland
-  -s                    Synchronize after each queue submission with vkQueueWaitIdle
-                        (same as --sync).
+  --sync                Synchronize after each queue submission with vkQueueWaitIdle.
   -m <mode>             Enable memory translation for replay on GPUs with memory
                         types that are not compatible with the capture GPU's
                         memory types.  Available modes are:

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -64,7 +64,7 @@ def CreateReplayParser():
     parser.add_argument('--paused', action='store_true', default=False, help='Pause after replaying the first frame (same as "--pause-frame 1"; forwarded to replay tool)')
     parser.add_argument('--sfa', '--skip-failed-allocations', action='store_true', default=False, help='Skip vkAllocateMemory, vkAllocateCommandBuffers, and vkAllocateDescriptorSets calls that failed during capture (forwarded to replay tool)')
     parser.add_argument('--opcd', '--omit-pipeline-cache-data', action='store_true', default=False, help='Omit pipeline cache data from calls to vkCreatePipelineCache (forwarded to replay tool)')
-    parser.add_argument('-s', '--sync', action='store_true', default=False, help='Synchronize after each queue submission with vkQueueWaitIdle (forwarded to replay tool)')
+    parser.add_argument('--sync', action='store_true', default=False, help='Synchronize after each queue submission with vkQueueWaitIdle (forwarded to replay tool)')
     parser.add_argument('-m', '--memory-translation', metavar='<mode>', choices=['none', 'remap', 'realign', 'rebind'], help='Enable memory translation for replay on GPUs with memory types that are not compatible with the capture GPU\'s memory types.  Available modes are: none, remap, realign, rebind (forwarded to replay tool)')
     parser.add_argument('file', nargs='?', help='File on device to play (forwarded to replay tool)')
     return parser

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -54,11 +54,10 @@ const char kOmitPipelineCacheDataLongOption[]  = "--omit-pipeline-cache-data";
 const char kWsiArgument[]                      = "--wsi";
 const char kMemoryPortabilityShortOption[]     = "-m";
 const char kMemoryPortabilityLongOption[]      = "--memory-translation";
-const char kSyncShortOption[]                  = "-s";
-const char kSyncLongOption[]                   = "--sync";
+const char kSyncOption[]                       = "--sync";
 const char kShaderReplaceArgument[]            = "--replace-shaders";
 
-const char kOptions[] = "-h|--help,--version,--no-debug-popup,--paused,-s|--sync,--sfa|--skip-failed-allocations,--"
+const char kOptions[] = "-h|--help,--version,--no-debug-popup,--paused,--sync,--sfa|--skip-failed-allocations,--"
                         "opcd|--omit-pipeline-cache-data";
 const char kArguments[] = "--gpu,--pause-frame,--wsi,-m|--memory-translation,--replace-shaders";
 
@@ -304,7 +303,7 @@ GetReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parser,
         replay_options.override_gpu_index = std::stoi(override_gpu);
     }
 
-    if (arg_parser.IsOptionSet(kSyncLongOption) || arg_parser.IsOptionSet(kSyncShortOption))
+    if (arg_parser.IsOptionSet(kSyncOption))
     {
         replay_options.sync_queue_submissions = true;
     }
@@ -366,7 +365,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\n%s - A tool to replay GFXReconstruct capture files.\n", app_name.c_str());
     GFXRECON_WRITE_CONSOLE("Usage:");
     GFXRECON_WRITE_CONSOLE("  %s\t[-h | --help] [--version] [--gpu <index>]", app_name.c_str());
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--pause-frame <N>] [--paused] [-s | --sync]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--pause-frame <N>] [--paused] [--sync]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--sfa | --skip-failed-allocations] [--replace-shaders <dir>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--opcd | --omit-pipeline-cache-data] [--wsi <platform>]");
 #if defined(WIN32) && defined(_DEBUG)
@@ -401,8 +400,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("  --no-debug-popup\tDisable the 'Abort, Retry, Ignore' message box");
     GFXRECON_WRITE_CONSOLE("       \t\t\tdisplayed when abort() is called (Windows debug only).");
 #endif
-    GFXRECON_WRITE_CONSOLE("  -s\t\t\tSynchronize after each queue submission with vkQueueWaitIdle");
-    GFXRECON_WRITE_CONSOLE("    \t\t\t(same as --sync).");
+    GFXRECON_WRITE_CONSOLE("  --sync\t\tSynchronize after each queue submission with vkQueueWaitIdle.");
     GFXRECON_WRITE_CONSOLE("  -m <mode>\t\tEnable memory translation for replay on GPUs with memory");
     GFXRECON_WRITE_CONSOLE("          \t\ttypes that are not compatible with the capture GPU's");
     GFXRECON_WRITE_CONSOLE("          \t\tmemory types.  Available modes are:");


### PR DESCRIPTION
Change to remove the -s option before creating a stable release from the dev branch.  The --sync option was recently added to dev, with -s as an alternative.  The -s option will be used for selecting swapchain modes in the future.
