### PR TITLE
Fix VulkanReferencedResourceConsumer virtual function override declarations

### DIFF
--- a/framework/generated/generated_vulkan_referenced_resource_consumer.h
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.h
@@ -35,478 +35,421 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
 
     virtual ~VulkanReferencedResourceConsumer() override { }
 
-void Process_vkBeginCommandBuffer(
-    VkResult                                    returnValue,
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo);
-
-
-void Process_vkCmdBindDescriptorSets(
-    format::HandleId                            commandBuffer,
-    VkPipelineBindPoint                         pipelineBindPoint,
-    format::HandleId                            layout,
-    uint32_t                                    firstSet,
-    uint32_t                                    descriptorSetCount,
-    HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets,
-    uint32_t                                    dynamicOffsetCount,
-    PointerDecoder<uint32_t>*                   pDynamicOffsets);
-
-
-void Process_vkCmdBindIndexBuffer(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            buffer,
-    VkDeviceSize                                offset,
-    VkIndexType                                 indexType);
-
-
-void Process_vkCmdBindVertexBuffers(
-    format::HandleId                            commandBuffer,
-    uint32_t                                    firstBinding,
-    uint32_t                                    bindingCount,
-    HandlePointerDecoder<VkBuffer>*             pBuffers,
-    PointerDecoder<VkDeviceSize>*               pOffsets);
-
-
-void Process_vkCmdDrawIndirect(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            buffer,
-    VkDeviceSize                                offset,
-    uint32_t                                    drawCount,
-    uint32_t                                    stride);
-
-
-void Process_vkCmdDrawIndexedIndirect(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            buffer,
-    VkDeviceSize                                offset,
-    uint32_t                                    drawCount,
-    uint32_t                                    stride);
-
-
-void Process_vkCmdDispatchIndirect(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            buffer,
-    VkDeviceSize                                offset);
-
-
-void Process_vkCmdCopyBuffer(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            srcBuffer,
-    format::HandleId                            dstBuffer,
-    uint32_t                                    regionCount,
-    StructPointerDecoder<Decoded_VkBufferCopy>* pRegions);
-
-
-void Process_vkCmdCopyImage(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            srcImage,
-    VkImageLayout                               srcImageLayout,
-    format::HandleId                            dstImage,
-    VkImageLayout                               dstImageLayout,
-    uint32_t                                    regionCount,
-    StructPointerDecoder<Decoded_VkImageCopy>*  pRegions);
-
-
-void Process_vkCmdBlitImage(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            srcImage,
-    VkImageLayout                               srcImageLayout,
-    format::HandleId                            dstImage,
-    VkImageLayout                               dstImageLayout,
-    uint32_t                                    regionCount,
-    StructPointerDecoder<Decoded_VkImageBlit>*  pRegions,
-    VkFilter                                    filter);
-
-
-void Process_vkCmdCopyBufferToImage(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            srcBuffer,
-    format::HandleId                            dstImage,
-    VkImageLayout                               dstImageLayout,
-    uint32_t                                    regionCount,
-    StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions);
-
-
-void Process_vkCmdCopyImageToBuffer(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            srcImage,
-    VkImageLayout                               srcImageLayout,
-    format::HandleId                            dstBuffer,
-    uint32_t                                    regionCount,
-    StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions);
-
-
-void Process_vkCmdUpdateBuffer(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            dstBuffer,
-    VkDeviceSize                                dstOffset,
-    VkDeviceSize                                dataSize,
-    PointerDecoder<uint8_t>*                    pData);
-
-
-void Process_vkCmdFillBuffer(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            dstBuffer,
-    VkDeviceSize                                dstOffset,
-    VkDeviceSize                                size,
-    uint32_t                                    data);
-
-
-void Process_vkCmdClearColorImage(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            image,
-    VkImageLayout                               imageLayout,
-    StructPointerDecoder<Decoded_VkClearColorValue>* pColor,
-    uint32_t                                    rangeCount,
-    StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges);
-
-
-void Process_vkCmdClearDepthStencilImage(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            image,
-    VkImageLayout                               imageLayout,
-    StructPointerDecoder<Decoded_VkClearDepthStencilValue>* pDepthStencil,
-    uint32_t                                    rangeCount,
-    StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges);
-
-
-void Process_vkCmdResolveImage(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            srcImage,
-    VkImageLayout                               srcImageLayout,
-    format::HandleId                            dstImage,
-    VkImageLayout                               dstImageLayout,
-    uint32_t                                    regionCount,
-    StructPointerDecoder<Decoded_VkImageResolve>* pRegions);
-
-
-void Process_vkCmdWaitEvents(
-    format::HandleId                            commandBuffer,
-    uint32_t                                    eventCount,
-    HandlePointerDecoder<VkEvent>*              pEvents,
-    VkPipelineStageFlags                        srcStageMask,
-    VkPipelineStageFlags                        dstStageMask,
-    uint32_t                                    memoryBarrierCount,
-    StructPointerDecoder<Decoded_VkMemoryBarrier>* pMemoryBarriers,
-    uint32_t                                    bufferMemoryBarrierCount,
-    StructPointerDecoder<Decoded_VkBufferMemoryBarrier>* pBufferMemoryBarriers,
-    uint32_t                                    imageMemoryBarrierCount,
-    StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers);
-
-
-void Process_vkCmdPipelineBarrier(
-    format::HandleId                            commandBuffer,
-    VkPipelineStageFlags                        srcStageMask,
-    VkPipelineStageFlags                        dstStageMask,
-    VkDependencyFlags                           dependencyFlags,
-    uint32_t                                    memoryBarrierCount,
-    StructPointerDecoder<Decoded_VkMemoryBarrier>* pMemoryBarriers,
-    uint32_t                                    bufferMemoryBarrierCount,
-    StructPointerDecoder<Decoded_VkBufferMemoryBarrier>* pBufferMemoryBarriers,
-    uint32_t                                    imageMemoryBarrierCount,
-    StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers);
-
-
-void Process_vkCmdCopyQueryPoolResults(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            queryPool,
-    uint32_t                                    firstQuery,
-    uint32_t                                    queryCount,
-    format::HandleId                            dstBuffer,
-    VkDeviceSize                                dstOffset,
-    VkDeviceSize                                stride,
-    VkQueryResultFlags                          flags);
-
-
-void Process_vkCmdBeginRenderPass(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
-    VkSubpassContents                           contents);
-
-
-void Process_vkCmdExecuteCommands(
-    format::HandleId                            commandBuffer,
-    uint32_t                                    commandBufferCount,
-    HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers);
-
-
-void Process_vkCmdDrawIndirectCount(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            buffer,
-    VkDeviceSize                                offset,
-    format::HandleId                            countBuffer,
-    VkDeviceSize                                countBufferOffset,
-    uint32_t                                    maxDrawCount,
-    uint32_t                                    stride);
-
-
-void Process_vkCmdDrawIndexedIndirectCount(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            buffer,
-    VkDeviceSize                                offset,
-    format::HandleId                            countBuffer,
-    VkDeviceSize                                countBufferOffset,
-    uint32_t                                    maxDrawCount,
-    uint32_t                                    stride);
-
-
-void Process_vkCmdBeginRenderPass2(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
-    StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo);
-
-
-void Process_vkCmdPushDescriptorSetKHR(
-    format::HandleId                            commandBuffer,
-    VkPipelineBindPoint                         pipelineBindPoint,
-    format::HandleId                            layout,
-    uint32_t                                    set,
-    uint32_t                                    descriptorWriteCount,
-    StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites);
-
-
-void Process_vkCmdBeginRenderPass2KHR(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
-    StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo);
-
-
-void Process_vkCmdDrawIndirectCountKHR(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            buffer,
-    VkDeviceSize                                offset,
-    format::HandleId                            countBuffer,
-    VkDeviceSize                                countBufferOffset,
-    uint32_t                                    maxDrawCount,
-    uint32_t                                    stride);
-
-
-void Process_vkCmdDrawIndexedIndirectCountKHR(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            buffer,
-    VkDeviceSize                                offset,
-    format::HandleId                            countBuffer,
-    VkDeviceSize                                countBufferOffset,
-    uint32_t                                    maxDrawCount,
-    uint32_t                                    stride);
-
-
-void Process_vkCmdCopyBuffer2KHR(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkCopyBufferInfo2KHR>* pCopyBufferInfo);
-
-
-void Process_vkCmdCopyImage2KHR(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkCopyImageInfo2KHR>* pCopyImageInfo);
-
-
-void Process_vkCmdCopyBufferToImage2KHR(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2KHR>* pCopyBufferToImageInfo);
-
-
-void Process_vkCmdCopyImageToBuffer2KHR(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2KHR>* pCopyImageToBufferInfo);
-
-
-void Process_vkCmdBlitImage2KHR(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkBlitImageInfo2KHR>* pBlitImageInfo);
-
-
-void Process_vkCmdResolveImage2KHR(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkResolveImageInfo2KHR>* pResolveImageInfo);
-
-
-void Process_vkCmdBindTransformFeedbackBuffersEXT(
-    format::HandleId                            commandBuffer,
-    uint32_t                                    firstBinding,
-    uint32_t                                    bindingCount,
-    HandlePointerDecoder<VkBuffer>*             pBuffers,
-    PointerDecoder<VkDeviceSize>*               pOffsets,
-    PointerDecoder<VkDeviceSize>*               pSizes);
-
-
-void Process_vkCmdBeginTransformFeedbackEXT(
-    format::HandleId                            commandBuffer,
-    uint32_t                                    firstCounterBuffer,
-    uint32_t                                    counterBufferCount,
-    HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
-    PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets);
-
-
-void Process_vkCmdEndTransformFeedbackEXT(
-    format::HandleId                            commandBuffer,
-    uint32_t                                    firstCounterBuffer,
-    uint32_t                                    counterBufferCount,
-    HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
-    PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets);
-
-
-void Process_vkCmdDrawIndirectByteCountEXT(
-    format::HandleId                            commandBuffer,
-    uint32_t                                    instanceCount,
-    uint32_t                                    firstInstance,
-    format::HandleId                            counterBuffer,
-    VkDeviceSize                                counterBufferOffset,
-    uint32_t                                    counterOffset,
-    uint32_t                                    vertexStride);
-
-
-void Process_vkCmdDrawIndirectCountAMD(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            buffer,
-    VkDeviceSize                                offset,
-    format::HandleId                            countBuffer,
-    VkDeviceSize                                countBufferOffset,
-    uint32_t                                    maxDrawCount,
-    uint32_t                                    stride);
-
-
-void Process_vkCmdDrawIndexedIndirectCountAMD(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            buffer,
-    VkDeviceSize                                offset,
-    format::HandleId                            countBuffer,
-    VkDeviceSize                                countBufferOffset,
-    uint32_t                                    maxDrawCount,
-    uint32_t                                    stride);
-
-
-void Process_vkCmdBeginConditionalRenderingEXT(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>* pConditionalRenderingBegin);
-
-
-void Process_vkCmdBindShadingRateImageNV(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            imageView,
-    VkImageLayout                               imageLayout);
-
-
-void Process_vkCmdBuildAccelerationStructureNV(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>* pInfo,
-    format::HandleId                            instanceData,
-    VkDeviceSize                                instanceOffset,
-    VkBool32                                    update,
-    format::HandleId                            dst,
-    format::HandleId                            src,
-    format::HandleId                            scratch,
-    VkDeviceSize                                scratchOffset);
-
-
-void Process_vkCmdTraceRaysNV(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            raygenShaderBindingTableBuffer,
-    VkDeviceSize                                raygenShaderBindingOffset,
-    format::HandleId                            missShaderBindingTableBuffer,
-    VkDeviceSize                                missShaderBindingOffset,
-    VkDeviceSize                                missShaderBindingStride,
-    format::HandleId                            hitShaderBindingTableBuffer,
-    VkDeviceSize                                hitShaderBindingOffset,
-    VkDeviceSize                                hitShaderBindingStride,
-    format::HandleId                            callableShaderBindingTableBuffer,
-    VkDeviceSize                                callableShaderBindingOffset,
-    VkDeviceSize                                callableShaderBindingStride,
-    uint32_t                                    width,
-    uint32_t                                    height,
-    uint32_t                                    depth);
-
-
-void Process_vkCmdWriteBufferMarkerAMD(
-    format::HandleId                            commandBuffer,
-    VkPipelineStageFlagBits                     pipelineStage,
-    format::HandleId                            dstBuffer,
-    VkDeviceSize                                dstOffset,
-    uint32_t                                    marker);
-
-
-void Process_vkCmdDrawMeshTasksIndirectNV(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            buffer,
-    VkDeviceSize                                offset,
-    uint32_t                                    drawCount,
-    uint32_t                                    stride);
-
-
-void Process_vkCmdDrawMeshTasksIndirectCountNV(
-    format::HandleId                            commandBuffer,
-    format::HandleId                            buffer,
-    VkDeviceSize                                offset,
-    format::HandleId                            countBuffer,
-    VkDeviceSize                                countBufferOffset,
-    uint32_t                                    maxDrawCount,
-    uint32_t                                    stride);
-
-
-void Process_vkCmdBindVertexBuffers2EXT(
-    format::HandleId                            commandBuffer,
-    uint32_t                                    firstBinding,
-    uint32_t                                    bindingCount,
-    HandlePointerDecoder<VkBuffer>*             pBuffers,
-    PointerDecoder<VkDeviceSize>*               pOffsets,
-    PointerDecoder<VkDeviceSize>*               pSizes,
-    PointerDecoder<VkDeviceSize>*               pStrides);
-
-
-void Process_vkCmdPreprocessGeneratedCommandsNV(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo);
-
-
-void Process_vkCmdExecuteGeneratedCommandsNV(
-    format::HandleId                            commandBuffer,
-    VkBool32                                    isPreprocessed,
-    StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo);
-
-
-void Process_vkCmdBuildAccelerationStructureIndirectKHR(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfo,
-    format::HandleId                            indirectBuffer,
-    VkDeviceSize                                indirectOffset,
-    uint32_t                                    indirectStride);
-
-
-void Process_vkCmdCopyAccelerationStructureKHR(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo);
-
-
-void Process_vkCmdCopyAccelerationStructureToMemoryKHR(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkCopyAccelerationStructureToMemoryInfoKHR>* pInfo);
-
-
-void Process_vkCmdCopyMemoryToAccelerationStructureKHR(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkCopyMemoryToAccelerationStructureInfoKHR>* pInfo);
-
-
-void Process_vkCmdTraceRaysKHR(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pRaygenShaderBindingTable,
-    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pMissShaderBindingTable,
-    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pHitShaderBindingTable,
-    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pCallableShaderBindingTable,
-    uint32_t                                    width,
-    uint32_t                                    height,
-    uint32_t                                    depth);
-
-
-void Process_vkCmdTraceRaysIndirectKHR(
-    format::HandleId                            commandBuffer,
-    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pRaygenShaderBindingTable,
-    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pMissShaderBindingTable,
-    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pHitShaderBindingTable,
-    StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pCallableShaderBindingTable,
-    format::HandleId                            buffer,
-    VkDeviceSize                                offset);
-
+    virtual void Process_vkBeginCommandBuffer(
+        VkResult                                    returnValue,
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo) override;
+
+    virtual void Process_vkCmdBindDescriptorSets(
+        format::HandleId                            commandBuffer,
+        VkPipelineBindPoint                         pipelineBindPoint,
+        format::HandleId                            layout,
+        uint32_t                                    firstSet,
+        uint32_t                                    descriptorSetCount,
+        HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets,
+        uint32_t                                    dynamicOffsetCount,
+        PointerDecoder<uint32_t>*                   pDynamicOffsets) override;
+
+    virtual void Process_vkCmdBindIndexBuffer(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            buffer,
+        VkDeviceSize                                offset,
+        VkIndexType                                 indexType) override;
+
+    virtual void Process_vkCmdBindVertexBuffers(
+        format::HandleId                            commandBuffer,
+        uint32_t                                    firstBinding,
+        uint32_t                                    bindingCount,
+        HandlePointerDecoder<VkBuffer>*             pBuffers,
+        PointerDecoder<VkDeviceSize>*               pOffsets) override;
+
+    virtual void Process_vkCmdDrawIndirect(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            buffer,
+        VkDeviceSize                                offset,
+        uint32_t                                    drawCount,
+        uint32_t                                    stride) override;
+
+    virtual void Process_vkCmdDrawIndexedIndirect(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            buffer,
+        VkDeviceSize                                offset,
+        uint32_t                                    drawCount,
+        uint32_t                                    stride) override;
+
+    virtual void Process_vkCmdDispatchIndirect(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            buffer,
+        VkDeviceSize                                offset) override;
+
+    virtual void Process_vkCmdCopyBuffer(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            srcBuffer,
+        format::HandleId                            dstBuffer,
+        uint32_t                                    regionCount,
+        StructPointerDecoder<Decoded_VkBufferCopy>* pRegions) override;
+
+    virtual void Process_vkCmdCopyImage(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            srcImage,
+        VkImageLayout                               srcImageLayout,
+        format::HandleId                            dstImage,
+        VkImageLayout                               dstImageLayout,
+        uint32_t                                    regionCount,
+        StructPointerDecoder<Decoded_VkImageCopy>*  pRegions) override;
+
+    virtual void Process_vkCmdBlitImage(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            srcImage,
+        VkImageLayout                               srcImageLayout,
+        format::HandleId                            dstImage,
+        VkImageLayout                               dstImageLayout,
+        uint32_t                                    regionCount,
+        StructPointerDecoder<Decoded_VkImageBlit>*  pRegions,
+        VkFilter                                    filter) override;
+
+    virtual void Process_vkCmdCopyBufferToImage(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            srcBuffer,
+        format::HandleId                            dstImage,
+        VkImageLayout                               dstImageLayout,
+        uint32_t                                    regionCount,
+        StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions) override;
+
+    virtual void Process_vkCmdCopyImageToBuffer(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            srcImage,
+        VkImageLayout                               srcImageLayout,
+        format::HandleId                            dstBuffer,
+        uint32_t                                    regionCount,
+        StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions) override;
+
+    virtual void Process_vkCmdUpdateBuffer(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            dstBuffer,
+        VkDeviceSize                                dstOffset,
+        VkDeviceSize                                dataSize,
+        PointerDecoder<uint8_t>*                    pData) override;
+
+    virtual void Process_vkCmdFillBuffer(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            dstBuffer,
+        VkDeviceSize                                dstOffset,
+        VkDeviceSize                                size,
+        uint32_t                                    data) override;
+
+    virtual void Process_vkCmdClearColorImage(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            image,
+        VkImageLayout                               imageLayout,
+        StructPointerDecoder<Decoded_VkClearColorValue>* pColor,
+        uint32_t                                    rangeCount,
+        StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges) override;
+
+    virtual void Process_vkCmdClearDepthStencilImage(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            image,
+        VkImageLayout                               imageLayout,
+        StructPointerDecoder<Decoded_VkClearDepthStencilValue>* pDepthStencil,
+        uint32_t                                    rangeCount,
+        StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges) override;
+
+    virtual void Process_vkCmdResolveImage(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            srcImage,
+        VkImageLayout                               srcImageLayout,
+        format::HandleId                            dstImage,
+        VkImageLayout                               dstImageLayout,
+        uint32_t                                    regionCount,
+        StructPointerDecoder<Decoded_VkImageResolve>* pRegions) override;
+
+    virtual void Process_vkCmdWaitEvents(
+        format::HandleId                            commandBuffer,
+        uint32_t                                    eventCount,
+        HandlePointerDecoder<VkEvent>*              pEvents,
+        VkPipelineStageFlags                        srcStageMask,
+        VkPipelineStageFlags                        dstStageMask,
+        uint32_t                                    memoryBarrierCount,
+        StructPointerDecoder<Decoded_VkMemoryBarrier>* pMemoryBarriers,
+        uint32_t                                    bufferMemoryBarrierCount,
+        StructPointerDecoder<Decoded_VkBufferMemoryBarrier>* pBufferMemoryBarriers,
+        uint32_t                                    imageMemoryBarrierCount,
+        StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers) override;
+
+    virtual void Process_vkCmdPipelineBarrier(
+        format::HandleId                            commandBuffer,
+        VkPipelineStageFlags                        srcStageMask,
+        VkPipelineStageFlags                        dstStageMask,
+        VkDependencyFlags                           dependencyFlags,
+        uint32_t                                    memoryBarrierCount,
+        StructPointerDecoder<Decoded_VkMemoryBarrier>* pMemoryBarriers,
+        uint32_t                                    bufferMemoryBarrierCount,
+        StructPointerDecoder<Decoded_VkBufferMemoryBarrier>* pBufferMemoryBarriers,
+        uint32_t                                    imageMemoryBarrierCount,
+        StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers) override;
+
+    virtual void Process_vkCmdCopyQueryPoolResults(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            queryPool,
+        uint32_t                                    firstQuery,
+        uint32_t                                    queryCount,
+        format::HandleId                            dstBuffer,
+        VkDeviceSize                                dstOffset,
+        VkDeviceSize                                stride,
+        VkQueryResultFlags                          flags) override;
+
+    virtual void Process_vkCmdBeginRenderPass(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
+        VkSubpassContents                           contents) override;
+
+    virtual void Process_vkCmdExecuteCommands(
+        format::HandleId                            commandBuffer,
+        uint32_t                                    commandBufferCount,
+        HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) override;
+
+    virtual void Process_vkCmdDrawIndirectCount(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            buffer,
+        VkDeviceSize                                offset,
+        format::HandleId                            countBuffer,
+        VkDeviceSize                                countBufferOffset,
+        uint32_t                                    maxDrawCount,
+        uint32_t                                    stride) override;
+
+    virtual void Process_vkCmdDrawIndexedIndirectCount(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            buffer,
+        VkDeviceSize                                offset,
+        format::HandleId                            countBuffer,
+        VkDeviceSize                                countBufferOffset,
+        uint32_t                                    maxDrawCount,
+        uint32_t                                    stride) override;
+
+    virtual void Process_vkCmdBeginRenderPass2(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
+        StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo) override;
+
+    virtual void Process_vkCmdPushDescriptorSetKHR(
+        format::HandleId                            commandBuffer,
+        VkPipelineBindPoint                         pipelineBindPoint,
+        format::HandleId                            layout,
+        uint32_t                                    set,
+        uint32_t                                    descriptorWriteCount,
+        StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites) override;
+
+    virtual void Process_vkCmdBeginRenderPass2KHR(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
+        StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo) override;
+
+    virtual void Process_vkCmdDrawIndirectCountKHR(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            buffer,
+        VkDeviceSize                                offset,
+        format::HandleId                            countBuffer,
+        VkDeviceSize                                countBufferOffset,
+        uint32_t                                    maxDrawCount,
+        uint32_t                                    stride) override;
+
+    virtual void Process_vkCmdDrawIndexedIndirectCountKHR(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            buffer,
+        VkDeviceSize                                offset,
+        format::HandleId                            countBuffer,
+        VkDeviceSize                                countBufferOffset,
+        uint32_t                                    maxDrawCount,
+        uint32_t                                    stride) override;
+
+    virtual void Process_vkCmdCopyBuffer2KHR(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkCopyBufferInfo2KHR>* pCopyBufferInfo) override;
+
+    virtual void Process_vkCmdCopyImage2KHR(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkCopyImageInfo2KHR>* pCopyImageInfo) override;
+
+    virtual void Process_vkCmdCopyBufferToImage2KHR(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2KHR>* pCopyBufferToImageInfo) override;
+
+    virtual void Process_vkCmdCopyImageToBuffer2KHR(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2KHR>* pCopyImageToBufferInfo) override;
+
+    virtual void Process_vkCmdBlitImage2KHR(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkBlitImageInfo2KHR>* pBlitImageInfo) override;
+
+    virtual void Process_vkCmdResolveImage2KHR(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkResolveImageInfo2KHR>* pResolveImageInfo) override;
+
+    virtual void Process_vkCmdBindTransformFeedbackBuffersEXT(
+        format::HandleId                            commandBuffer,
+        uint32_t                                    firstBinding,
+        uint32_t                                    bindingCount,
+        HandlePointerDecoder<VkBuffer>*             pBuffers,
+        PointerDecoder<VkDeviceSize>*               pOffsets,
+        PointerDecoder<VkDeviceSize>*               pSizes) override;
+
+    virtual void Process_vkCmdBeginTransformFeedbackEXT(
+        format::HandleId                            commandBuffer,
+        uint32_t                                    firstCounterBuffer,
+        uint32_t                                    counterBufferCount,
+        HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
+        PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets) override;
+
+    virtual void Process_vkCmdEndTransformFeedbackEXT(
+        format::HandleId                            commandBuffer,
+        uint32_t                                    firstCounterBuffer,
+        uint32_t                                    counterBufferCount,
+        HandlePointerDecoder<VkBuffer>*             pCounterBuffers,
+        PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets) override;
+
+    virtual void Process_vkCmdDrawIndirectByteCountEXT(
+        format::HandleId                            commandBuffer,
+        uint32_t                                    instanceCount,
+        uint32_t                                    firstInstance,
+        format::HandleId                            counterBuffer,
+        VkDeviceSize                                counterBufferOffset,
+        uint32_t                                    counterOffset,
+        uint32_t                                    vertexStride) override;
+
+    virtual void Process_vkCmdDrawIndirectCountAMD(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            buffer,
+        VkDeviceSize                                offset,
+        format::HandleId                            countBuffer,
+        VkDeviceSize                                countBufferOffset,
+        uint32_t                                    maxDrawCount,
+        uint32_t                                    stride) override;
+
+    virtual void Process_vkCmdDrawIndexedIndirectCountAMD(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            buffer,
+        VkDeviceSize                                offset,
+        format::HandleId                            countBuffer,
+        VkDeviceSize                                countBufferOffset,
+        uint32_t                                    maxDrawCount,
+        uint32_t                                    stride) override;
+
+    virtual void Process_vkCmdBeginConditionalRenderingEXT(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>* pConditionalRenderingBegin) override;
+
+    virtual void Process_vkCmdBindShadingRateImageNV(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            imageView,
+        VkImageLayout                               imageLayout) override;
+
+    virtual void Process_vkCmdBuildAccelerationStructureNV(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>* pInfo,
+        format::HandleId                            instanceData,
+        VkDeviceSize                                instanceOffset,
+        VkBool32                                    update,
+        format::HandleId                            dst,
+        format::HandleId                            src,
+        format::HandleId                            scratch,
+        VkDeviceSize                                scratchOffset) override;
+
+    virtual void Process_vkCmdTraceRaysNV(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            raygenShaderBindingTableBuffer,
+        VkDeviceSize                                raygenShaderBindingOffset,
+        format::HandleId                            missShaderBindingTableBuffer,
+        VkDeviceSize                                missShaderBindingOffset,
+        VkDeviceSize                                missShaderBindingStride,
+        format::HandleId                            hitShaderBindingTableBuffer,
+        VkDeviceSize                                hitShaderBindingOffset,
+        VkDeviceSize                                hitShaderBindingStride,
+        format::HandleId                            callableShaderBindingTableBuffer,
+        VkDeviceSize                                callableShaderBindingOffset,
+        VkDeviceSize                                callableShaderBindingStride,
+        uint32_t                                    width,
+        uint32_t                                    height,
+        uint32_t                                    depth) override;
+
+    virtual void Process_vkCmdWriteBufferMarkerAMD(
+        format::HandleId                            commandBuffer,
+        VkPipelineStageFlagBits                     pipelineStage,
+        format::HandleId                            dstBuffer,
+        VkDeviceSize                                dstOffset,
+        uint32_t                                    marker) override;
+
+    virtual void Process_vkCmdDrawMeshTasksIndirectNV(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            buffer,
+        VkDeviceSize                                offset,
+        uint32_t                                    drawCount,
+        uint32_t                                    stride) override;
+
+    virtual void Process_vkCmdDrawMeshTasksIndirectCountNV(
+        format::HandleId                            commandBuffer,
+        format::HandleId                            buffer,
+        VkDeviceSize                                offset,
+        format::HandleId                            countBuffer,
+        VkDeviceSize                                countBufferOffset,
+        uint32_t                                    maxDrawCount,
+        uint32_t                                    stride) override;
+
+    virtual void Process_vkCmdBindVertexBuffers2EXT(
+        format::HandleId                            commandBuffer,
+        uint32_t                                    firstBinding,
+        uint32_t                                    bindingCount,
+        HandlePointerDecoder<VkBuffer>*             pBuffers,
+        PointerDecoder<VkDeviceSize>*               pOffsets,
+        PointerDecoder<VkDeviceSize>*               pSizes,
+        PointerDecoder<VkDeviceSize>*               pStrides) override;
+
+    virtual void Process_vkCmdPreprocessGeneratedCommandsNV(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo) override;
+
+    virtual void Process_vkCmdExecuteGeneratedCommandsNV(
+        format::HandleId                            commandBuffer,
+        VkBool32                                    isPreprocessed,
+        StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo) override;
+
+    virtual void Process_vkCmdBuildAccelerationStructureIndirectKHR(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfo,
+        format::HandleId                            indirectBuffer,
+        VkDeviceSize                                indirectOffset,
+        uint32_t                                    indirectStride) override;
+
+    virtual void Process_vkCmdCopyAccelerationStructureKHR(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo) override;
+
+    virtual void Process_vkCmdCopyAccelerationStructureToMemoryKHR(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkCopyAccelerationStructureToMemoryInfoKHR>* pInfo) override;
+
+    virtual void Process_vkCmdCopyMemoryToAccelerationStructureKHR(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkCopyMemoryToAccelerationStructureInfoKHR>* pInfo) override;
+
+    virtual void Process_vkCmdTraceRaysKHR(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pRaygenShaderBindingTable,
+        StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pMissShaderBindingTable,
+        StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pHitShaderBindingTable,
+        StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pCallableShaderBindingTable,
+        uint32_t                                    width,
+        uint32_t                                    height,
+        uint32_t                                    depth) override;
+
+    virtual void Process_vkCmdTraceRaysIndirectKHR(
+        format::HandleId                            commandBuffer,
+        StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pRaygenShaderBindingTable,
+        StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pMissShaderBindingTable,
+        StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pHitShaderBindingTable,
+        StructPointerDecoder<Decoded_VkStridedBufferRegionKHR>* pCallableShaderBindingTable,
+        format::HandleId                            buffer,
+        VkDeviceSize                                offset) override;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/vulkan_generators/vulkan_referenced_resource_consumer_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_referenced_resource_consumer_header_generator.py
@@ -88,7 +88,8 @@ class VulkanReferencedResourceHeaderGenerator(BaseGenerator):
 
                     # Temporarily remove resource only matching restriction from isHandle() when generating the function signature.
                     self.restrictHandles = False
-                    cmddef += self.makeConsumerFuncDecl(returnType, 'Process_' + cmd, params) + ';\n'
+                    decl = self.makeConsumerFuncDecl(returnType, 'Process_' + cmd, params)
+                    cmddef += self.indent('virtual ' + decl + ' override;', self.INDENT_SIZE)
                     self.restrictHandles = True
 
                     write(cmddef, file=self.outFile)


### PR DESCRIPTION
Updates to the generated VulkanReferencedResourceConsumer code for consistency with other consumer classes:
- Add the override keyword to the VulkanReferencedResourceConsumer virtual function overrides.
- Add the virtual keyword to the VulkanReferencedResourceConsumer virtual function overrides.
- Fix indentation of VulkanReferencedResourceConsumer method declarations.
