### PR TITLE
Destroy Live Vulkan Objects on Replay Exit

### DIFF
--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -42,6 +42,8 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_default_allocator.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_enum_util.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_handle_mapping_util.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_object_cleanup_util.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_object_cleanup_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_object_info.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_object_info_table.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_realign_allocator.h

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -64,6 +64,8 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_default_allocator.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_enum_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_mapping_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_object_cleanup_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_object_cleanup_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_object_info.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_object_info_table.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_realign_allocator.h
@@ -107,7 +109,8 @@ target_sources(gfxrecon_decode
 if (MSVC AND (MSVC_VERSION LESS 1910))
     # This file fails to compile with VS2015, requiring the default section limit of 2^16 to be increased.
     set_source_files_properties(${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_replay_consumer.cpp PROPERTIES COMPILE_FLAGS /bigobj)
-    set_source_files_properties(vulkan_replay_consumer_base.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+    set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/vulkan_object_cleanup_util.cpp PROPERTIES COMPILE_FLAGS /bigobj)
+    set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/vulkan_replay_consumer_base.cpp PROPERTIES COMPILE_FLAGS /bigobj)
 endif()
 
 target_include_directories(gfxrecon_decode

--- a/framework/decode/vulkan_handle_mapping_util.h
+++ b/framework/decode/vulkan_handle_mapping_util.h
@@ -80,7 +80,8 @@ static typename T::HandleType* MapHandleArray(HandlePointerDecoder<typename T::H
 }
 
 template <typename T>
-static void AddHandle(const format::HandleId       id,
+static void AddHandle(format::HandleId             parent_id,
+                      format::HandleId             id,
                       const typename T::HandleType handle,
                       T&&                          initial_info,
                       VulkanObjectInfoTable*       object_info_table,
@@ -90,11 +91,13 @@ static void AddHandle(const format::HandleId       id,
 
     initial_info.handle     = handle;
     initial_info.capture_id = id;
+    initial_info.parent_id  = parent_id;
     (object_info_table->*AddFunc)(std::forward<T>(initial_info));
 }
 
 template <typename T>
-static void AddHandle(format::HandleId       id,
+static void AddHandle(format::HandleId       parent_id,
+                      format::HandleId       id,
                       typename T::HandleType handle,
                       VulkanObjectInfoTable* object_info_table,
                       void (VulkanObjectInfoTable::*AddFunc)(T&&))
@@ -104,11 +107,13 @@ static void AddHandle(format::HandleId       id,
     T info;
     info.handle     = handle;
     info.capture_id = id;
+    info.parent_id  = parent_id;
     (object_info_table->*AddFunc)(std::move(info));
 }
 
 template <typename T>
-static void AddHandleArray(const format::HandleId*       ids,
+static void AddHandleArray(format::HandleId              parent_id,
+                           const format::HandleId*       ids,
                            size_t                        ids_len,
                            const typename T::HandleType* handles,
                            size_t                        handles_len,
@@ -129,13 +134,15 @@ static void AddHandleArray(const format::HandleId*       ids,
             auto info_iter        = std::next(initial_infos.begin(), i);
             info_iter->handle     = handles[i];
             info_iter->capture_id = ids[i];
+            info_iter->parent_id  = parent_id;
             (object_info_table->*AddFunc)(std::move(*info_iter));
         }
     }
 }
 
 template <typename T>
-static void AddHandleArray(const format::HandleId*       ids,
+static void AddHandleArray(format::HandleId              parent_id,
+                           const format::HandleId*       ids,
                            size_t                        ids_len,
                            const typename T::HandleType* handles,
                            size_t                        handles_len,
@@ -152,6 +159,7 @@ static void AddHandleArray(const format::HandleId*       ids,
             T info;
             info.handle     = handles[i];
             info.capture_id = ids[i];
+            info.parent_id  = parent_id;
             (object_info_table->*AddFunc)(std::move(info));
         }
     }

--- a/framework/decode/vulkan_handle_mapping_util.h
+++ b/framework/decode/vulkan_handle_mapping_util.h
@@ -19,6 +19,7 @@
 
 #include "decode/vulkan_object_info_table.h"
 #include "format/format.h"
+#include "generated/generated_vulkan_struct_decoders.h"
 
 #include "vulkan/vulkan.h"
 
@@ -45,22 +46,22 @@ static typename T::HandleType MapHandle(format::HandleId             id,
 }
 
 template <typename T>
-static typename T::HandleType* MapHandleArray(HandlePointerDecoder<typename T::HandleType>* handle_pointer,
+static typename T::HandleType* MapHandleArray(HandlePointerDecoder<typename T::HandleType>* handles_pointer,
                                               const VulkanObjectInfoTable&                  object_info_table,
                                               const T* (VulkanObjectInfoTable::*MapFunc)(format::HandleId) const)
 {
-    assert(handle_pointer != nullptr);
+    assert(handles_pointer != nullptr);
 
     typename T::HandleType* handles = nullptr;
 
-    if (!handle_pointer->IsNull())
+    if (!handles_pointer->IsNull())
     {
-        size_t                  len = handle_pointer->GetLength();
-        const format::HandleId* ids = handle_pointer->GetPointer();
+        size_t                  len = handles_pointer->GetLength();
+        const format::HandleId* ids = handles_pointer->GetPointer();
 
-        handle_pointer->SetHandleLength(len);
+        handles_pointer->SetHandleLength(len);
 
-        handles = handle_pointer->GetHandlePointer();
+        handles = handles_pointer->GetHandlePointer();
 
         for (size_t i = 0; i < len; ++i)
         {
@@ -163,6 +164,171 @@ static void AddHandleArray(format::HandleId              parent_id,
             (object_info_table->*AddFunc)(std::move(info));
         }
     }
+}
+
+template <typename S, typename T>
+static void AddHandleArray(format::HandleId              parent_id,
+                           format::HandleId              pool_id,
+                           const format::HandleId*       ids,
+                           size_t                        ids_len,
+                           const typename T::HandleType* handles,
+                           size_t                        handles_len,
+                           std::vector<T>&&              initial_infos,
+                           VulkanObjectInfoTable*        object_info_table,
+                           S* (VulkanObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
+                           void (VulkanObjectInfoTable::*AddFunc)(T&&))
+{
+    assert(object_info_table != nullptr);
+
+    if ((ids != nullptr) && (handles != nullptr))
+    {
+        auto pool_info = (object_info_table->*GetPoolInfoFunc)(pool_id);
+
+        size_t len = std::min(ids_len, handles_len);
+
+        assert(len <= initial_infos.size());
+
+        for (size_t i = 0; i < len; ++i)
+        {
+            if (ids[i] != format::kNullHandleId)
+            {
+                if (pool_info != nullptr)
+                {
+                    pool_info->child_ids.insert(ids[i]);
+                }
+
+                auto info_iter        = std::next(initial_infos.begin(), i);
+                info_iter->handle     = handles[i];
+                info_iter->capture_id = ids[i];
+                info_iter->parent_id  = parent_id;
+                info_iter->pool_id    = pool_id;
+                (object_info_table->*AddFunc)(std::move(*info_iter));
+            }
+        }
+    }
+}
+
+template <typename S, typename T>
+static void AddHandleArray(format::HandleId              parent_id,
+                           format::HandleId              pool_id,
+                           const format::HandleId*       ids,
+                           size_t                        ids_len,
+                           const typename T::HandleType* handles,
+                           size_t                        handles_len,
+                           VulkanObjectInfoTable*        object_info_table,
+                           S* (VulkanObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
+                           void (VulkanObjectInfoTable::*AddFunc)(T&&))
+{
+    assert(object_info_table != nullptr);
+
+    if ((ids != nullptr) && (handles != nullptr))
+    {
+        auto pool_info = (object_info_table->*GetPoolInfoFunc)(pool_id);
+
+        size_t len = std::min(ids_len, handles_len);
+        for (size_t i = 0; i < len; ++i)
+        {
+            if (ids[i] != format::kNullHandleId)
+            {
+                if (pool_info != nullptr)
+                {
+                    pool_info->child_ids.insert(ids[i]);
+                }
+
+                T info;
+                info.handle     = handles[i];
+                info.capture_id = ids[i];
+                info.parent_id  = parent_id;
+                info.pool_id    = pool_id;
+                (object_info_table->*AddFunc)(std::move(info));
+            }
+        }
+    }
+}
+
+inline void RemoveHandle(format::HandleId       id,
+                         VulkanObjectInfoTable* object_info_table,
+                         void (VulkanObjectInfoTable::*RemoveFunc)(format::HandleId))
+{
+    assert(object_info_table != nullptr);
+
+    if (id != format::kNullHandleId)
+    {
+        (object_info_table->*RemoveFunc)(id);
+    }
+}
+
+// Special case removal of pool objects, which require removal of objects allocated from the pool.
+template <typename T>
+void RemovePoolHandle(format::HandleId       id,
+                      VulkanObjectInfoTable* object_info_table,
+                      T* (VulkanObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
+                      void (VulkanObjectInfoTable::*RemovePoolFunc)(format::HandleId),
+                      void (VulkanObjectInfoTable::*RemoveObjectFunc)(format::HandleId))
+{
+    assert(object_info_table != nullptr);
+
+    const auto pool_info = (object_info_table->*GetPoolInfoFunc)(id);
+
+    if (pool_info != nullptr)
+    {
+        for (auto child_id : pool_info->child_ids)
+        {
+            (object_info_table->*RemoveObjectFunc)(child_id);
+        }
+
+        (object_info_table->*RemovePoolFunc)(id);
+    }
+}
+
+template <typename S, typename T>
+void RemoveHandleArray(format::HandleId                                    pool_id,
+                       const HandlePointerDecoder<typename T::HandleType>* handles_pointer,
+                       VulkanObjectInfoTable*                              object_info_table,
+                       S* (VulkanObjectInfoTable::*GetPoolInfoFunc)(format::HandleId),
+                       void (VulkanObjectInfoTable::*RemoveFunc)(format::HandleId))
+{
+    assert((handles_pointer != nullptr) && (object_info_table != nullptr));
+
+    if (!handles_pointer->IsNull() && (handles_pointer->GetLength() > 0))
+    {
+        size_t                  len       = handles_pointer->GetLength();
+        const format::HandleId* ids       = handles_pointer->GetPointer();
+        auto                    pool_info = (object_info_table->*GetPoolInfoFunc)(pool_id);
+
+        for (size_t i = 0; i < len; ++i)
+        {
+            if (ids[i] != format::kNullHandleId)
+            {
+                (object_info_table->*RemoveFunc)(ids[i]);
+
+                if (pool_info != nullptr)
+                {
+                    pool_info->child_ids.erase(ids[i]);
+                }
+            }
+        }
+    }
+}
+
+inline format::HandleId GetPoolId(const Decoded_VkCommandBufferAllocateInfo* info)
+{
+    if (info != nullptr)
+    {
+        return info->commandPool;
+    }
+
+    return format::kNullHandleId;
+}
+
+inline format::HandleId GetPoolId(const Decoded_VkDescriptorSetAllocateInfo* info)
+{
+    if (info != nullptr)
+    {
+        return info->descriptorPool;
+    }
+
+    return format::kNullHandleId;
 }
 
 GFXRECON_END_NAMESPACE(handle_mapping)

--- a/framework/decode/vulkan_object_cleanup_util.cpp
+++ b/framework/decode/vulkan_object_cleanup_util.cpp
@@ -1,0 +1,685 @@
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include "decode/vulkan_object_cleanup_util.h"
+
+#include "format/format.h"
+#include "util/logging.h"
+
+#include "vulkan/vulkan.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+GFXRECON_BEGIN_NAMESPACE(object_cleanup)
+
+template <typename T>
+void AddChildObject(std::unordered_map<format::HandleId, std::unordered_map<typename T::HandleType, const T*>>* objects,
+                    const T*                                                                                    info)
+{
+    assert(objects != nullptr);
+    (*objects)[info->parent_id].insert(std::make_pair(info->handle, info));
+}
+
+// ImageInfo specialization to filter swapchain images from the list of VkImage objects to destroy.
+template <>
+void AddChildObject<ImageInfo>(
+    std::unordered_map<format::HandleId, std::unordered_map<VkImage, const ImageInfo*>>* objects, const ImageInfo* info)
+{
+    assert(objects != nullptr);
+
+    if (!info->is_swapchain_image)
+    {
+        (*objects)[info->parent_id].insert(std::make_pair(info->handle, info));
+    }
+}
+
+template <typename S, typename T>
+void FreeChildObjects(VulkanObjectInfoTable* table,
+                      const std::string&     parent_type_name,
+                      const std::string&     object_type_name,
+                      bool                   remove_entries,
+                      bool                   report_leaks,
+                      S* (VulkanObjectInfoTable::*GetParentInfoFunc)(format::HandleId),
+                      void (VulkanObjectInfoTable::*VisitFunc)(std::function<void(const T*)>) const,
+                      void (VulkanObjectInfoTable::*RemoveFunc)(format::HandleId),
+                      std::function<void(const S*, const T*)> destroy_func)
+{
+    assert(table != nullptr);
+
+    // Visit all table entries and sort them by parent ID.  Using unordered_map to filter duplicate handles.
+    std::unordered_map<format::HandleId, std::unordered_map<typename T::HandleType, const T*>> objects;
+
+    (table->*VisitFunc)([&](const T* info) { AddChildObject(&objects, info); });
+
+    for (const auto& entry : objects)
+    {
+        auto parent_info = (table->*GetParentInfoFunc)(entry.first);
+
+        if (parent_info != nullptr)
+        {
+            // Free resources.
+            for (const auto& object_info : entry.second)
+            {
+                if (object_info.second != nullptr)
+                {
+                    destroy_func(parent_info, object_info.second);
+                    if (remove_entries)
+                    {
+                        (table->*RemoveFunc)(object_info.second->capture_id);
+                    }
+                }
+            }
+        }
+        else if (report_leaks)
+        {
+            GFXRECON_LOG_WARNING("Leaked %" PRIuPTR " %s objects allocated from %s ID %" PRIu64 " on exit",
+                                 entry.second.size(),
+                                 object_type_name.c_str(),
+                                 parent_type_name.c_str(),
+                                 entry.first);
+        }
+    }
+}
+
+template <typename T>
+void FreeParentObjects(VulkanObjectInfoTable* table,
+                       bool                   remove_entries,
+                       void (VulkanObjectInfoTable::*VisitFunc)(std::function<void(const T*)>) const,
+                       void (VulkanObjectInfoTable::*RemoveFunc)(format::HandleId),
+                       std::function<void(const T*)> destroy_func)
+{
+    assert(table != nullptr);
+
+    std::unordered_map<typename T::HandleType, const T*> objects;
+
+    (table->*VisitFunc)([&](const T* info) { objects.insert(std::make_pair(info->handle, info)); });
+
+    for (const auto& entry : objects)
+    {
+        if (entry.second != nullptr)
+        {
+            destroy_func(entry.second);
+            if (remove_entries)
+            {
+                (table->*RemoveFunc)(entry.second->capture_id);
+            }
+        }
+    }
+}
+
+template <typename T>
+void ClearObjects(VulkanObjectInfoTable* table,
+                  void (VulkanObjectInfoTable::*VisitFunc)(std::function<void(const T*)>) const,
+                  void (VulkanObjectInfoTable::*RemoveFunc)(format::HandleId))
+{
+    assert(table != nullptr);
+
+    std::vector<const T*> objects;
+
+    (table->*VisitFunc)([&](const T* info) { objects.push_back(info); });
+
+    for (const auto entry : objects)
+    {
+        if (entry != nullptr)
+        {
+            (table->*RemoveFunc)(entry->capture_id);
+        }
+    }
+}
+
+void FreeAllLiveObjects(VulkanObjectInfoTable*                                   table,
+                        bool                                                     remove_entries,
+                        bool                                                     report_leaks,
+                        std::function<const encode::InstanceTable*(const void*)> get_instance_table,
+                        std::function<const encode::DeviceTable*(const void*)>   get_device_table)
+{
+    FreeChildObjects<DeviceInfo, EventInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkEvent),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitEventInfo,
+        &VulkanObjectInfoTable::RemoveEventInfo,
+        [&](const DeviceInfo* parent_info, const EventInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)->DestroyEvent(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, FenceInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkFence),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitFenceInfo,
+        &VulkanObjectInfoTable::RemoveFenceInfo,
+        [&](const DeviceInfo* parent_info, const FenceInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)->DestroyFence(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, SemaphoreInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkSemaphore),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitSemaphoreInfo,
+        &VulkanObjectInfoTable::RemoveSemaphoreInfo,
+        [&](const DeviceInfo* parent_info, const SemaphoreInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)->DestroySemaphore(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, QueryPoolInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkQueryPool),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitQueryPoolInfo,
+        &VulkanObjectInfoTable::RemoveQueryPoolInfo,
+        [&](const DeviceInfo* parent_info, const QueryPoolInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)->DestroyQueryPool(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, RenderPassInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkRenderPass),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitRenderPassInfo,
+        &VulkanObjectInfoTable::RemoveRenderPassInfo,
+        [&](const DeviceInfo* parent_info, const RenderPassInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)->DestroyRenderPass(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, SamplerInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkSampler),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitSamplerInfo,
+        &VulkanObjectInfoTable::RemoveSamplerInfo,
+        [&](const DeviceInfo* parent_info, const SamplerInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)->DestroySampler(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, SamplerYcbcrConversionInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkSamplerYcbcrConversion),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitSamplerYcbcrConversionInfo,
+        &VulkanObjectInfoTable::RemoveSamplerYcbcrConversionInfo,
+        [&](const DeviceInfo* parent_info, const SamplerYcbcrConversionInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroySamplerYcbcrConversion(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, FramebufferInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkFramebuffer),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitFramebufferInfo,
+        &VulkanObjectInfoTable::RemoveFramebufferInfo,
+        [&](const DeviceInfo* parent_info, const FramebufferInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroyFramebuffer(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, ImageViewInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkImageView),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitImageViewInfo,
+        &VulkanObjectInfoTable::RemoveImageViewInfo,
+        [&](const DeviceInfo* parent_info, const ImageViewInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)->DestroyImageView(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, ImageInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkImage),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitImageInfo,
+        &VulkanObjectInfoTable::RemoveImageInfo,
+        [&](const DeviceInfo* parent_info, const ImageInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)->DestroyImage(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, BufferViewInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkBufferView),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitBufferViewInfo,
+        &VulkanObjectInfoTable::RemoveBufferViewInfo,
+        [&](const DeviceInfo* parent_info, const BufferViewInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)->DestroyBufferView(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, BufferInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkBuffer),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitBufferInfo,
+        &VulkanObjectInfoTable::RemoveBufferInfo,
+        [&](const DeviceInfo* parent_info, const BufferInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)->DestroyBuffer(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, DeviceMemoryInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkDeviceMemory),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitDeviceMemoryInfo,
+        &VulkanObjectInfoTable::RemoveDeviceMemoryInfo,
+        [&](const DeviceInfo* parent_info, const DeviceMemoryInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)->FreeMemory(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, PipelineCacheInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkPipelineCache),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitPipelineCacheInfo,
+        &VulkanObjectInfoTable::RemovePipelineCacheInfo,
+        [&](const DeviceInfo* parent_info, const PipelineCacheInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroyPipelineCache(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, PipelineInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkPipeline),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitPipelineInfo,
+        &VulkanObjectInfoTable::RemovePipelineInfo,
+        [&](const DeviceInfo* parent_info, const PipelineInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)->DestroyPipeline(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, PipelineLayoutInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkPipelineLayout),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitPipelineLayoutInfo,
+        &VulkanObjectInfoTable::RemovePipelineLayoutInfo,
+        [&](const DeviceInfo* parent_info, const PipelineLayoutInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroyPipelineLayout(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, ShaderModuleInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkShaderModule),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitShaderModuleInfo,
+        &VulkanObjectInfoTable::RemoveShaderModuleInfo,
+        [&](const DeviceInfo* parent_info, const ShaderModuleInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroyShaderModule(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, DescriptorSetLayoutInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkDescriptorSetLayout),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitDescriptorSetLayoutInfo,
+        &VulkanObjectInfoTable::RemoveDescriptorSetLayoutInfo,
+        [&](const DeviceInfo* parent_info, const DescriptorSetLayoutInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroyDescriptorSetLayout(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, DescriptorUpdateTemplateInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkDescriptorUpdateTemplate),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitDescriptorUpdateTemplateInfo,
+        &VulkanObjectInfoTable::RemoveDescriptorUpdateTemplateInfo,
+        [&](const DeviceInfo* parent_info, const DescriptorUpdateTemplateInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroyDescriptorUpdateTemplate(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, DescriptorPoolInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkDescriptorPool),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitDescriptorPoolInfo,
+        &VulkanObjectInfoTable::RemoveDescriptorPoolInfo,
+        [&](const DeviceInfo* parent_info, const DescriptorPoolInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroyDescriptorPool(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, CommandPoolInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkCommandPool),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitCommandPoolInfo,
+        &VulkanObjectInfoTable::RemoveCommandPoolInfo,
+        [&](const DeviceInfo* parent_info, const CommandPoolInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroyCommandPool(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, IndirectCommandsLayoutNVInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkIndirectCommandsLayoutNV),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitIndirectCommandsLayoutNVInfo,
+        &VulkanObjectInfoTable::RemoveIndirectCommandsLayoutNVInfo,
+        [&](const DeviceInfo* parent_info, const IndirectCommandsLayoutNVInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroyIndirectCommandsLayoutNV(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, ValidationCacheEXTInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkValidationCacheEXT),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitValidationCacheEXTInfo,
+        &VulkanObjectInfoTable::RemoveValidationCacheEXTInfo,
+        [&](const DeviceInfo* parent_info, const ValidationCacheEXTInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroyValidationCacheEXT(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, AccelerationStructureKHRInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkAccelerationStructureKHR),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitAccelerationStructureKHRInfo,
+        &VulkanObjectInfoTable::RemoveAccelerationStructureKHRInfo,
+        [&](const DeviceInfo* parent_info, const AccelerationStructureKHRInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroyAccelerationStructureKHR(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, AccelerationStructureNVInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkAccelerationStructureNV),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitAccelerationStructureNVInfo,
+        &VulkanObjectInfoTable::RemoveAccelerationStructureNVInfo,
+        [&](const DeviceInfo* parent_info, const AccelerationStructureNVInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroyAccelerationStructureNV(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, PerformanceConfigurationINTELInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkPerformanceConfigurationINTEL),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitPerformanceConfigurationINTELInfo,
+        &VulkanObjectInfoTable::RemovePerformanceConfigurationINTELInfo,
+        [&](const DeviceInfo* parent_info, const PerformanceConfigurationINTELInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->ReleasePerformanceConfigurationINTEL(parent_info->handle, object_info->handle);
+        });
+
+    FreeChildObjects<DeviceInfo, DeferredOperationKHRInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkDeferredOperationKHR),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitDeferredOperationKHRInfo,
+        &VulkanObjectInfoTable::RemoveDeferredOperationKHRInfo,
+        [&](const DeviceInfo* parent_info, const DeferredOperationKHRInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroyDeferredOperationKHR(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, PrivateDataSlotEXTInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkPrivateDataSlotEXT),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitPrivateDataSlotEXTInfo,
+        &VulkanObjectInfoTable::RemovePrivateDataSlotEXTInfo,
+        [&](const DeviceInfo* parent_info, const PrivateDataSlotEXTInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroyPrivateDataSlotEXT(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<DeviceInfo, SwapchainKHRInfo>(
+        table,
+        GFXRECON_STR(VkDevice),
+        GFXRECON_STR(VkSwapchainKHR),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetDeviceInfo,
+        &VulkanObjectInfoTable::VisitSwapchainKHRInfo,
+        &VulkanObjectInfoTable::RemoveSwapchainKHRInfo,
+        [&](const DeviceInfo* parent_info, const SwapchainKHRInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_device_table(parent_info->handle)
+                ->DestroySwapchainKHR(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<InstanceInfo, DebugReportCallbackEXTInfo>(
+        table,
+        GFXRECON_STR(VkInstance),
+        GFXRECON_STR(VkDebugReportCallbackEXT),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetInstanceInfo,
+        &VulkanObjectInfoTable::VisitDebugReportCallbackEXTInfo,
+        &VulkanObjectInfoTable::RemoveDebugReportCallbackEXTInfo,
+        [&](const InstanceInfo* parent_info, const DebugReportCallbackEXTInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_instance_table(parent_info->handle)
+                ->DestroyDebugReportCallbackEXT(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    FreeChildObjects<InstanceInfo, DebugUtilsMessengerEXTInfo>(
+        table,
+        GFXRECON_STR(VkInstance),
+        GFXRECON_STR(VkDebugUtilsMessengerEXT),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetInstanceInfo,
+        &VulkanObjectInfoTable::VisitDebugUtilsMessengerEXTInfo,
+        &VulkanObjectInfoTable::RemoveDebugUtilsMessengerEXTInfo,
+        [&](const InstanceInfo* parent_info, const DebugUtilsMessengerEXTInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            get_instance_table(parent_info->handle)
+                ->DestroyDebugUtilsMessengerEXT(parent_info->handle, object_info->handle, nullptr);
+        });
+
+    // VkSurfaceKHR objects have a special destroy function to destroy the object through the Window object that
+    // initially created it.
+    FreeChildObjects<InstanceInfo, SurfaceKHRInfo>(
+        table,
+        GFXRECON_STR(VkInstance),
+        GFXRECON_STR(VkSurfaceKHR),
+        remove_entries,
+        report_leaks,
+        &VulkanObjectInfoTable::GetInstanceInfo,
+        &VulkanObjectInfoTable::VisitSurfaceKHRInfo,
+        &VulkanObjectInfoTable::RemoveSurfaceKHRInfo,
+        [&](const InstanceInfo* parent_info, const SurfaceKHRInfo* object_info) {
+            assert((parent_info != nullptr) && (object_info != nullptr));
+            auto table  = get_instance_table(parent_info->handle);
+            auto window = object_info->window;
+            if (window != nullptr)
+            {
+                window->DestroySurface(table, parent_info->handle, object_info->handle);
+            }
+            else
+            {
+                table->DestroySurfaceKHR(parent_info->handle, object_info->handle, nullptr);
+            }
+        });
+
+    FreeParentObjects<DeviceInfo>(table,
+                                  remove_entries,
+                                  &VulkanObjectInfoTable::VisitDeviceInfo,
+                                  &VulkanObjectInfoTable::RemoveDeviceInfo,
+                                  [&](const DeviceInfo* object_info) {
+                                      assert(object_info != nullptr);
+                                      auto table = get_device_table(object_info->handle);
+                                      table->DestroyDevice(object_info->handle, nullptr);
+                                  });
+
+    FreeParentObjects<InstanceInfo>(table,
+                                    remove_entries,
+                                    &VulkanObjectInfoTable::VisitInstanceInfo,
+                                    &VulkanObjectInfoTable::RemoveInstanceInfo,
+                                    [&](const InstanceInfo* object_info) {
+                                        assert(object_info != nullptr);
+                                        auto table = get_instance_table(object_info->handle);
+                                        table->DestroyInstance(object_info->handle, nullptr);
+                                    });
+
+    // Remove the objects that are not destroyed from the table.
+    if (remove_entries)
+    {
+        // The following object types are not processed because they are retrieved handles without destroy functions.
+        //   VkPhysicalDevice
+        //   VkQueue
+        //   VkDisplayKHR
+        //   VkDisplayModeKHR
+        //
+        // The following object types are not processed because they are implicitly freed when their pool/parent is
+        // destroyed.
+        //   VkCommandBuffer
+        //   VkDescriptorSet
+        //   VkImage objects that were retrieved from a VkSwapchainKHR object
+
+        ClearObjects<PhysicalDeviceInfo>(
+            table, &VulkanObjectInfoTable::VisitPhysicalDeviceInfo, &VulkanObjectInfoTable::RemovePhysicalDeviceInfo);
+        ClearObjects<QueueInfo>(table, &VulkanObjectInfoTable::VisitQueueInfo, &VulkanObjectInfoTable::RemoveQueueInfo);
+        ClearObjects<DisplayKHRInfo>(
+            table, &VulkanObjectInfoTable::VisitDisplayKHRInfo, &VulkanObjectInfoTable::RemoveDisplayKHRInfo);
+        ClearObjects<DisplayModeKHRInfo>(
+            table, &VulkanObjectInfoTable::VisitDisplayModeKHRInfo, &VulkanObjectInfoTable::RemoveDisplayModeKHRInfo);
+        ClearObjects<CommandBufferInfo>(
+            table, &VulkanObjectInfoTable::VisitCommandBufferInfo, &VulkanObjectInfoTable::RemoveCommandBufferInfo);
+        ClearObjects<DescriptorSetInfo>(
+            table, &VulkanObjectInfoTable::VisitDescriptorSetInfo, &VulkanObjectInfoTable::RemoveDescriptorSetInfo);
+
+        // Clear the remaining swap chain images.
+        ClearObjects<ImageInfo>(table, &VulkanObjectInfoTable::VisitImageInfo, &VulkanObjectInfoTable::RemoveImageInfo);
+    }
+}
+
+GFXRECON_END_NAMESPACE(object_cleanup)
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_object_cleanup_util.h
+++ b/framework/decode/vulkan_object_cleanup_util.h
@@ -1,0 +1,40 @@
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef GFXRECON_DECODE_VULKAN_OBJECT_CLEANUP_UTIL_H
+#define GFXRECON_DECODE_VULKAN_OBJECT_CLEANUP_UTIL_H
+
+#include "decode/vulkan_object_info_table.h"
+#include "generated/generated_vulkan_dispatch_table.h"
+#include "util/defines.h"
+
+#include <functional>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+GFXRECON_BEGIN_NAMESPACE(object_cleanup)
+
+void FreeAllLiveObjects(VulkanObjectInfoTable*                                   table,
+                        bool                                                     remove_entries,
+                        bool                                                     report_leaks,
+                        std::function<const encode::InstanceTable*(const void*)> get_instance_table,
+                        std::function<const encode::DeviceTable*(const void*)>   get_device_table);
+
+GFXRECON_END_NAMESPACE(object_cleanup)
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_VULKAN_OBJECT_CLEANUP_UTIL_H

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -144,6 +144,7 @@ struct VulkanObjectInfo
     // Standard info stored for all Vulkan objects.
     HandleType       handle{ VK_NULL_HANDLE };            // Handle created for the object during replay.
     format::HandleId capture_id{ format::kNullHandleId }; // ID assigned to the object at capture.
+    format::HandleId parent_id{ format::kNullHandleId };  // ID of the object's parent instance/device object.
 };
 
 //
@@ -200,7 +201,6 @@ struct InstanceInfo : public VulkanObjectInfo<VkInstance>
 struct PhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
 {
     VkInstance                           parent{ VK_NULL_HANDLE };
-    format::HandleId                     parent_id{ format::kNullHandleId };
     uint32_t                             parent_api_version{ 0 };
     std::unordered_map<uint32_t, size_t> array_counts;
 

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -147,11 +147,25 @@ struct VulkanObjectInfo
     format::HandleId parent_id{ format::kNullHandleId };  // ID of the object's parent instance/device object.
 };
 
+// Info for a pool object which other objects will be allocated from.
+template <typename T>
+struct VulkanPoolInfo : public VulkanObjectInfo<T>
+{
+    std::unordered_set<format::HandleId> child_ids; // IDs of objects allocated from the pool.
+};
+
+// Info for objects that are allocated from pools.
+template <typename T>
+struct VulkanPoolObjectInfo : public VulkanObjectInfo<T>
+{
+    format::HandleId pool_id{ format::kNullHandleId }; // ID of the pool that the object was allocated from.
+};
+
 //
 // Declarations for Vulkan objects without additional replay state info.
 //
 
-typedef VulkanObjectInfo<VkCommandBuffer>                 CommandBufferInfo;
+typedef VulkanPoolObjectInfo<VkCommandBuffer>             CommandBufferInfo;
 typedef VulkanObjectInfo<VkFence>                         FenceInfo;
 typedef VulkanObjectInfo<VkEvent>                         EventInfo;
 typedef VulkanObjectInfo<VkQueryPool>                     QueryPoolInfo;
@@ -162,10 +176,10 @@ typedef VulkanObjectInfo<VkPipelineLayout>                PipelineLayoutInfo;
 typedef VulkanObjectInfo<VkRenderPass>                    RenderPassInfo;
 typedef VulkanObjectInfo<VkDescriptorSetLayout>           DescriptorSetLayoutInfo;
 typedef VulkanObjectInfo<VkSampler>                       SamplerInfo;
-typedef VulkanObjectInfo<VkDescriptorPool>                DescriptorPoolInfo;
-typedef VulkanObjectInfo<VkDescriptorSet>                 DescriptorSetInfo;
+typedef VulkanPoolInfo<VkDescriptorPool>                  DescriptorPoolInfo;
+typedef VulkanPoolObjectInfo<VkDescriptorSet>             DescriptorSetInfo;
 typedef VulkanObjectInfo<VkFramebuffer>                   FramebufferInfo;
-typedef VulkanObjectInfo<VkCommandPool>                   CommandPoolInfo;
+typedef VulkanPoolInfo<VkCommandPool>                     CommandPoolInfo;
 typedef VulkanObjectInfo<VkSamplerYcbcrConversion>        SamplerYcbcrConversionInfo;
 typedef VulkanObjectInfo<VkDisplayModeKHR>                DisplayModeKHRInfo;
 typedef VulkanObjectInfo<VkDebugReportCallbackEXT>        DebugReportCallbackEXTInfo;

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -206,10 +206,6 @@ struct InstanceInfo : public VulkanObjectInfo<VkInstance>
     std::vector<VkPhysicalDevice> replay_devices;
 
     std::unordered_map<VkPhysicalDevice, ReplayDeviceInfo> replay_device_info;
-
-    // Ensure surfaces are cleaned up on exit to avoid issues encountered when calling xcb_disconnect with active xcb
-    // surfaces.
-    std::unordered_set<format::HandleId> active_surfaces;
 };
 
 struct PhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
@@ -241,10 +237,6 @@ struct DeviceInfo : public VulkanObjectInfo<VkDevice>
     // The following values are only used when loading the initial state for trimmed files.
     std::vector<std::string>                   extensions;
     std::unique_ptr<VulkanResourceInitializer> resource_initializer;
-
-    // Ensure swapchains are cleaned up on exit to avoid issues encountered when calling xcb_disconnect with active xcb
-    // surfaces.
-    std::unordered_set<format::HandleId> active_swapchains;
 };
 
 struct QueueInfo : public VulkanObjectInfo<VkQueue>
@@ -280,6 +272,8 @@ struct BufferInfo : public VulkanObjectInfo<VkBuffer>
 struct ImageInfo : public VulkanObjectInfo<VkImage>
 {
     std::unordered_map<uint32_t, size_t> array_counts;
+
+    bool is_swapchain_image{ false };
 
     // The following values are only used for memory portability.
     VulkanResourceAllocator::ResourceData allocator_data{ 0 };

--- a/framework/decode/vulkan_object_info_table.h
+++ b/framework/decode/vulkan_object_info_table.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2018-2019 Valve Corporation
-** Copyright (c) 2018-2019 LunarG, Inc.
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -76,6 +76,48 @@ class VulkanObjectInfoTable
     void AddPerformanceConfigurationINTELInfo(PerformanceConfigurationINTELInfo&& info) { AddObjectInfo(std::move(info), &performance_configuration_intel_map_); }
     void AddDeferredOperationKHRInfo(DeferredOperationKHRInfo&& info)                   { AddObjectInfo(std::move(info), &deferred_operation_khr_map_); }
     void AddPrivateDataSlotEXTInfo(PrivateDataSlotEXTInfo&& info)                       { AddObjectInfo(std::move(info), &private_data_slot_ext_map_); }
+
+    void RemoveInstanceInfo(format::HandleId id)                      { instance_map_.erase(id); }
+    void RemovePhysicalDeviceInfo(format::HandleId id)                { physical_device_map_.erase(id); }
+    void RemoveDeviceInfo(format::HandleId id)                        { device_map_.erase(id); }
+    void RemoveQueueInfo(format::HandleId id)                         { queue_map_.erase(id); }
+    void RemoveSemaphoreInfo(format::HandleId id)                     { semaphore_map_.erase(id); }
+    void RemoveCommandBufferInfo(format::HandleId id)                 { command_buffer_map_.erase(id); }
+    void RemoveFenceInfo(format::HandleId id)                         { fence_map_.erase(id); }
+    void RemoveDeviceMemoryInfo(format::HandleId id)                  { device_memory_map_.erase(id); }
+    void RemoveBufferInfo(format::HandleId id)                        { buffer_map_.erase(id); }
+    void RemoveImageInfo(format::HandleId id)                         { image_map_.erase(id); }
+    void RemoveEventInfo(format::HandleId id)                         { event_map_.erase(id); }
+    void RemoveQueryPoolInfo(format::HandleId id)                     { query_pool_map_.erase(id); }
+    void RemoveBufferViewInfo(format::HandleId id)                    { buffer_view_map_.erase(id); }
+    void RemoveImageViewInfo(format::HandleId id)                     { image_view_map_.erase(id); }
+    void RemoveShaderModuleInfo(format::HandleId id)                  { shader_module_map_.erase(id); }
+    void RemovePipelineCacheInfo(format::HandleId id)                 { pipeline_cache_map_.erase(id); }
+    void RemovePipelineLayoutInfo(format::HandleId id)                { pipeline_layout_map_.erase(id); }
+    void RemoveRenderPassInfo(format::HandleId id)                    { render_pass_map_.erase(id); }
+    void RemovePipelineInfo(format::HandleId id)                      { pipeline_map_.erase(id); }
+    void RemoveDescriptorSetLayoutInfo(format::HandleId id)           { descriptor_set_layout_map_.erase(id); }
+    void RemoveSamplerInfo(format::HandleId id)                       { sampler_map_.erase(id); }
+    void RemoveDescriptorPoolInfo(format::HandleId id)                { descriptor_pool_map_.erase(id); }
+    void RemoveDescriptorSetInfo(format::HandleId id)                 { descriptor_set_map_.erase(id); }
+    void RemoveFramebufferInfo(format::HandleId id)                   { framebuffer_map_.erase(id); }
+    void RemoveCommandPoolInfo(format::HandleId id)                   { command_pool_map_.erase(id); }
+    void RemoveSamplerYcbcrConversionInfo(format::HandleId id)        { sampler_ycbcr_conversion_map_.erase(id); }
+    void RemoveDescriptorUpdateTemplateInfo(format::HandleId id)      { descriptor_update_template_map_.erase(id); }
+    void RemoveSurfaceKHRInfo(format::HandleId id)                    { surface_khr_map_.erase(id); }
+    void RemoveSwapchainKHRInfo(format::HandleId id)                  { swapchain_khr_map_.erase(id); }
+    void RemoveDisplayKHRInfo(format::HandleId id)                    { display_khr_map_.erase(id); }
+    void RemoveDisplayModeKHRInfo(format::HandleId id)                { display_mode_khr_map_.erase(id); }
+    void RemoveSamplerYcbcrConversionKHRInfo(format::HandleId id)     { sampler_ycbcr_conversion_khr_map_.erase(id); }
+    void RemoveDebugReportCallbackEXTInfo(format::HandleId id)        { debug_report_callback_ext_map_.erase(id); }
+    void RemoveIndirectCommandsLayoutNVInfo(format::HandleId id)      { indirect_commands_layout_nv_map_.erase(id); }
+    void RemoveDebugUtilsMessengerEXTInfo(format::HandleId id)        { debug_utils_messenger_ext_map_.erase(id); }
+    void RemoveValidationCacheEXTInfo(format::HandleId id)            { validation_cache_ext_map_.erase(id); }
+    void RemoveAccelerationStructureKHRInfo(format::HandleId id)      { acceleration_structure_khr_map_.erase(id); }
+    void RemoveAccelerationStructureNVInfo(format::HandleId id)       { acceleration_structure_nv_map_.erase(id); }
+    void RemovePerformanceConfigurationINTELInfo(format::HandleId id) { performance_configuration_intel_map_.erase(id); }
+    void RemoveDeferredOperationKHRInfo(format::HandleId id)          { deferred_operation_khr_map_.erase(id); }
+    void RemovePrivateDataSlotEXTInfo(format::HandleId id)            { private_data_slot_ext_map_.erase(id); }
 
     const InstanceInfo*                      GetInstanceInfo(format::HandleId id) const                       { return GetObjectInfo<InstanceInfo>(id, &instance_map_); }
     const PhysicalDeviceInfo*                GetPhysicalDeviceInfo(format::HandleId id) const                 { return GetObjectInfo<PhysicalDeviceInfo>(id, &physical_device_map_); }

--- a/framework/decode/vulkan_object_info_table.h
+++ b/framework/decode/vulkan_object_info_table.h
@@ -21,7 +21,6 @@
 #include "decode/vulkan_object_info.h"
 #include "format/format.h"
 #include "util/defines.h"
-#include "util/logging.h"
 
 #include "vulkan/vulkan.h"
 
@@ -272,10 +271,6 @@ class VulkanObjectInfoTable
             {
                 object_info = &entry->second;
             }
-            else
-            {
-                GFXRECON_LOG_WARNING("Failed to map handle for object id %" PRIu64, id);
-            }
         }
 
         return object_info;
@@ -295,10 +290,6 @@ class VulkanObjectInfoTable
             if (entry != map->end())
             {
                 object_info = &entry->second;
-            }
-            else
-            {
-                GFXRECON_LOG_WARNING("Failed to map handle for object id %" PRIu64, id);
             }
         }
 

--- a/framework/decode/vulkan_object_info_table.h
+++ b/framework/decode/vulkan_object_info_table.h
@@ -25,6 +25,7 @@
 #include "vulkan/vulkan.h"
 
 #include <cassert>
+#include <functional>
 #include <unordered_map>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
@@ -201,6 +202,47 @@ class VulkanObjectInfoTable
     PerformanceConfigurationINTELInfo* GetPerformanceConfigurationINTELInfo(format::HandleId id)  { return GetObjectInfo<PerformanceConfigurationINTELInfo>(id, &performance_configuration_intel_map_); }
     DeferredOperationKHRInfo*          GetDeferredOperationKHRInfo(format::HandleId id)           { return GetObjectInfo<DeferredOperationKHRInfo>(id, &deferred_operation_khr_map_); }
     PrivateDataSlotEXTInfo*            GetPrivateDataSlotEXTInfo(format::HandleId id)             { return GetObjectInfo<PrivateDataSlotEXTInfo>(id, &private_data_slot_ext_map_); }
+
+    void VisitInstanceInfo(std::function<void(const InstanceInfo*)> visitor) const                                           { for (const auto& entry : instance_map_) { visitor(&entry.second); } }
+    void VisitPhysicalDeviceInfo(std::function<void(const PhysicalDeviceInfo*)> visitor) const                               { for (const auto& entry : physical_device_map_) { visitor(&entry.second); } }
+    void VisitDeviceInfo(std::function<void(const DeviceInfo*)> visitor) const                                               { for (const auto& entry : device_map_) { visitor(&entry.second); } }
+    void VisitQueueInfo(std::function<void(const QueueInfo*)> visitor) const                                                 { for (const auto& entry : queue_map_) { visitor(&entry.second); } }
+    void VisitSemaphoreInfo(std::function<void(const SemaphoreInfo*)> visitor) const                                         { for (const auto& entry : semaphore_map_) { visitor(&entry.second); } }
+    void VisitCommandBufferInfo(std::function<void(const CommandBufferInfo*)> visitor) const                                 { for (const auto& entry : command_buffer_map_) { visitor(&entry.second); } }
+    void VisitFenceInfo(std::function<void(const FenceInfo*)> visitor) const                                                 { for (const auto& entry : fence_map_) { visitor(&entry.second); } }
+    void VisitDeviceMemoryInfo(std::function<void(const DeviceMemoryInfo*)> visitor) const                                   { for (const auto& entry : device_memory_map_) { visitor(&entry.second); } }
+    void VisitBufferInfo(std::function<void(const BufferInfo*)> visitor) const                                               { for (const auto& entry : buffer_map_) { visitor(&entry.second); } }
+    void VisitImageInfo(std::function<void(const ImageInfo*)> visitor) const                                                 { for (const auto& entry : image_map_) { visitor(&entry.second); } }
+    void VisitEventInfo(std::function<void(const EventInfo*)> visitor) const                                                 { for (const auto& entry : event_map_) { visitor(&entry.second); } }
+    void VisitQueryPoolInfo(std::function<void(const QueryPoolInfo*)> visitor) const                                         { for (const auto& entry : query_pool_map_) { visitor(&entry.second); } }
+    void VisitBufferViewInfo(std::function<void(const BufferViewInfo*)> visitor) const                                       { for (const auto& entry : buffer_view_map_) { visitor(&entry.second); } }
+    void VisitImageViewInfo(std::function<void(const ImageViewInfo*)> visitor) const                                         { for (const auto& entry : image_view_map_) { visitor(&entry.second); } }
+    void VisitShaderModuleInfo(std::function<void(const ShaderModuleInfo*)> visitor) const                                   { for (const auto& entry : shader_module_map_) { visitor(&entry.second); } }
+    void VisitPipelineCacheInfo(std::function<void(const PipelineCacheInfo*)> visitor) const                                 { for (const auto& entry : pipeline_cache_map_) { visitor(&entry.second); } }
+    void VisitPipelineLayoutInfo(std::function<void(const PipelineLayoutInfo*)> visitor) const                               { for (const auto& entry : pipeline_layout_map_) { visitor(&entry.second); } }
+    void VisitRenderPassInfo(std::function<void(const RenderPassInfo*)> visitor) const                                       { for (const auto& entry : render_pass_map_) { visitor(&entry.second); } }
+    void VisitPipelineInfo(std::function<void(const PipelineInfo*)> visitor) const                                           { for (const auto& entry : pipeline_map_) { visitor(&entry.second); } }
+    void VisitDescriptorSetLayoutInfo(std::function<void(const DescriptorSetLayoutInfo*)> visitor) const                     { for (const auto& entry : descriptor_set_layout_map_) { visitor(&entry.second); } }
+    void VisitSamplerInfo(std::function<void(const SamplerInfo*)> visitor) const                                             { for (const auto& entry : sampler_map_) { visitor(&entry.second); } }
+    void VisitDescriptorPoolInfo(std::function<void(const DescriptorPoolInfo*)> visitor) const                               { for (const auto& entry : descriptor_pool_map_) { visitor(&entry.second); } }
+    void VisitDescriptorSetInfo(std::function<void(const DescriptorSetInfo*)> visitor) const                                 { for (const auto& entry : descriptor_set_map_) { visitor(&entry.second); } }
+    void VisitFramebufferInfo(std::function<void(const FramebufferInfo*)> visitor) const                                     { for (const auto& entry : framebuffer_map_) { visitor(&entry.second); } }
+    void VisitCommandPoolInfo(std::function<void(const CommandPoolInfo*)> visitor) const                                     { for (const auto& entry : command_pool_map_) { visitor(&entry.second); } }
+    void VisitSamplerYcbcrConversionInfo(std::function<void(const SamplerYcbcrConversionInfo*)> visitor) const               { for (const auto& entry : sampler_ycbcr_conversion_map_) { visitor(&entry.second); } }
+    void VisitDescriptorUpdateTemplateInfo(std::function<void(const DescriptorUpdateTemplateInfo*)> visitor) const           { for (const auto& entry : descriptor_update_template_map_) { visitor(&entry.second); } }
+    void VisitSurfaceKHRInfo(std::function<void(const SurfaceKHRInfo*)> visitor) const                                       { for (const auto& entry : surface_khr_map_) { visitor(&entry.second); } }
+    void VisitSwapchainKHRInfo(std::function<void(const SwapchainKHRInfo*)> visitor) const                                   { for (const auto& entry : swapchain_khr_map_) { visitor(&entry.second); } }
+    void VisitDisplayKHRInfo(std::function<void(const DisplayKHRInfo*)> visitor) const                                       { for (const auto& entry : display_khr_map_) { visitor(&entry.second); } }
+    void VisitDisplayModeKHRInfo(std::function<void(const DisplayModeKHRInfo*)> visitor) const                               { for (const auto& entry : display_mode_khr_map_) { visitor(&entry.second); } }
+    void VisitDebugReportCallbackEXTInfo(std::function<void(const DebugReportCallbackEXTInfo*)> visitor) const               { for (const auto& entry : debug_report_callback_ext_map_) { visitor(&entry.second); } }
+    void VisitIndirectCommandsLayoutNVInfo(std::function<void(const IndirectCommandsLayoutNVInfo*)> visitor) const           { for (const auto& entry : indirect_commands_layout_nv_map_) { visitor(&entry.second); } }
+    void VisitDebugUtilsMessengerEXTInfo(std::function<void(const DebugUtilsMessengerEXTInfo*)> visitor) const               { for (const auto& entry : debug_utils_messenger_ext_map_) { visitor(&entry.second); } }
+    void VisitValidationCacheEXTInfo(std::function<void(const ValidationCacheEXTInfo*)> visitor) const                       { for (const auto& entry : validation_cache_ext_map_) { visitor(&entry.second); } }
+    void VisitAccelerationStructureKHRInfo(std::function<void(const AccelerationStructureKHRInfo*)> visitor) const           { for (const auto& entry : acceleration_structure_khr_map_) { visitor(&entry.second); } }
+    void VisitAccelerationStructureNVInfo(std::function<void(const AccelerationStructureNVInfo*)> visitor) const             { for (const auto& entry : acceleration_structure_nv_map_) { visitor(&entry.second); } }
+    void VisitPerformanceConfigurationINTELInfo(std::function<void(const PerformanceConfigurationINTELInfo*)> visitor) const { for (const auto& entry : performance_configuration_intel_map_) { visitor(&entry.second); } }
+    void VisitDeferredOperationKHRInfo(std::function<void(const DeferredOperationKHRInfo*)> visitor) const                   { for (const auto& entry : deferred_operation_khr_map_) { visitor(&entry.second); } }
+    void VisitPrivateDataSlotEXTInfo(std::function<void(const PrivateDataSlotEXTInfo*)> visitor) const                       { for (const auto& entry : private_data_slot_ext_map_) { visitor(&entry.second); } }
     // clang-format on
 
     void ReplaceSemaphore(VkSemaphore target, VkSemaphore replacement)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1670,7 +1670,7 @@ void VulkanReplayConsumerBase::SetPhysicalDeviceMemoryProperties(
 
 void VulkanReplayConsumerBase::SelectPhysicalDevice(PhysicalDeviceInfo* physical_device_info)
 {
-    assert((physical_device_info != nullptr) && (physical_device_info->parent_id != 0));
+    assert((physical_device_info != nullptr) && (physical_device_info->parent_id != format::kNullHandleId));
 
     InstanceInfo* instance_info = object_info_table_.GetInstanceInfo(physical_device_info->parent_id);
 
@@ -2479,7 +2479,6 @@ VulkanReplayConsumerBase::OverrideEnumeratePhysicalDevices(PFN_vkEnumeratePhysic
             assert(physical_device_info != nullptr);
 
             physical_device_info->parent             = instance;
-            physical_device_info->parent_id          = instance_info->capture_id;
             physical_device_info->parent_api_version = instance_info->api_version;
             physical_device_info->replay_device_info = &instance_info->replay_device_info[replay_devices[i]];
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -197,30 +197,34 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     }
 
     template <typename T>
-    void AddHandle(const format::HandleId*       id,
+    void AddHandle(format::HandleId              parent_id,
+                   const format::HandleId*       id,
                    const typename T::HandleType* handle,
                    T&&                           initial_info,
                    void (VulkanObjectInfoTable::*AddFunc)(T&&))
     {
         if ((id != nullptr) && (handle != nullptr))
         {
-            handle_mapping::AddHandle(*id, *handle, std::forward<T>(initial_info), &object_info_table_, AddFunc);
+            handle_mapping::AddHandle(
+                parent_id, *id, *handle, std::forward<T>(initial_info), &object_info_table_, AddFunc);
         }
     }
 
     template <typename T>
-    void AddHandle(const format::HandleId*       id,
+    void AddHandle(format::HandleId              parent_id,
+                   const format::HandleId*       id,
                    const typename T::HandleType* handle,
                    void (VulkanObjectInfoTable::*AddFunc)(T&&))
     {
         if ((id != nullptr) && (handle != nullptr))
         {
-            handle_mapping::AddHandle(*id, *handle, &object_info_table_, AddFunc);
+            handle_mapping::AddHandle(parent_id, *id, *handle, &object_info_table_, AddFunc);
         }
     }
 
     template <typename T>
-    void AddHandles(const format::HandleId*       ids,
+    void AddHandles(format::HandleId              parent_id,
+                    const format::HandleId*       ids,
                     size_t                        ids_len,
                     const typename T::HandleType* handles,
                     size_t                        handles_len,
@@ -228,17 +232,18 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                     void (VulkanObjectInfoTable::*AddFunc)(T&&))
     {
         handle_mapping::AddHandleArray(
-            ids, ids_len, handles, handles_len, std::move(initial_infos), &object_info_table_, AddFunc);
+            parent_id, ids, ids_len, handles, handles_len, std::move(initial_infos), &object_info_table_, AddFunc);
     }
 
     template <typename T>
-    void AddHandles(const format::HandleId*       ids,
+    void AddHandles(format::HandleId              parent_id,
+                    const format::HandleId*       ids,
                     size_t                        ids_len,
                     const typename T::HandleType* handles,
                     size_t                        handles_len,
                     void (VulkanObjectInfoTable::*AddFunc)(T&&))
     {
-        handle_mapping::AddHandleArray(ids, ids_len, handles, handles_len, &object_info_table_, AddFunc);
+        handle_mapping::AddHandleArray(parent_id, ids, ids_len, handles, handles_len, &object_info_table_, AddFunc);
     }
 
     template <typename HandleInfoT>

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -381,10 +381,6 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                     const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                     HandlePointerDecoder<VkInstance>*                          pInstance);
 
-    void OverrideDestroyInstance(PFN_vkDestroyInstance                                      func,
-                                 const InstanceInfo*                                        instance_info,
-                                 const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
-
     VkResult OverrideCreateDevice(VkResult                                                   original_result,
                                   PhysicalDeviceInfo*                                        physical_device_info,
                                   const StructPointerDecoder<Decoded_VkDeviceCreateInfo>*    pCreateInfo,
@@ -863,8 +859,6 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     SwapchainImageTracker                                            swapchain_image_tracker_;
     HardwareBufferMap                                                hardware_buffers_;
     HardwareBufferMemoryMap                                          hardware_buffer_memory_info_;
-    std::unordered_set<format::HandleId>                             active_instance_ids_;
-    std::unordered_set<format::HandleId>                             active_device_ids_;
     std::unique_ptr<ScreenshotHandler>                               screenshot_handler_;
     std::string                                                      screenshot_file_prefix_;
 };

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -43,7 +43,7 @@ void VulkanReplayConsumer::Process_vkCreateInstance(
     VkResult replay_result = OverrideCreateInstance(returnValue, pCreateInfo, pAllocator, pInstance);
     CheckResult("vkCreateInstance", returnValue, replay_result);
 
-    AddHandle<InstanceInfo>(pInstance->GetPointer(), pInstance->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddInstanceInfo);
+    AddHandle<InstanceInfo>(format::kNullHandleId, pInstance->GetPointer(), pInstance->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddInstanceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyInstance(
@@ -71,7 +71,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDevices(
     CheckResult("vkEnumeratePhysicalDevices", returnValue, replay_result);
 
     if (pPhysicalDevices->IsNull()) { SetOutputArrayCount<InstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDevices, *pPhysicalDeviceCount->GetOutputPointer(), &VulkanObjectInfoTable::GetInstanceInfo); }
-    AddHandles<PhysicalDeviceInfo>(pPhysicalDevices->GetPointer(), pPhysicalDevices->GetLength(), pPhysicalDevices->GetHandlePointer(), *pPhysicalDeviceCount->GetOutputPointer(), std::move(handle_info), &VulkanObjectInfoTable::AddPhysicalDeviceInfo);
+    AddHandles<PhysicalDeviceInfo>(instance, pPhysicalDevices->GetPointer(), pPhysicalDevices->GetLength(), pPhysicalDevices->GetHandlePointer(), *pPhysicalDeviceCount->GetOutputPointer(), std::move(handle_info), &VulkanObjectInfoTable::AddPhysicalDeviceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFeatures(
@@ -163,7 +163,7 @@ void VulkanReplayConsumer::Process_vkCreateDevice(
     VkResult replay_result = OverrideCreateDevice(returnValue, in_physicalDevice, pCreateInfo, pAllocator, pDevice);
     CheckResult("vkCreateDevice", returnValue, replay_result);
 
-    AddHandle<DeviceInfo>(pDevice->GetPointer(), pDevice->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDeviceInfo);
+    AddHandle<DeviceInfo>(physicalDevice, pDevice->GetPointer(), pDevice->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDeviceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDevice(
@@ -187,7 +187,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceQueue(
 
     GetDeviceTable(in_device)->GetDeviceQueue(in_device, queueFamilyIndex, queueIndex, out_pQueue);
 
-    AddHandle<QueueInfo>(pQueue->GetPointer(), out_pQueue, &VulkanObjectInfoTable::AddQueueInfo);
+    AddHandle<QueueInfo>(device, pQueue->GetPointer(), out_pQueue, &VulkanObjectInfoTable::AddQueueInfo);
 }
 
 void VulkanReplayConsumer::Process_vkQueueSubmit(
@@ -243,7 +243,7 @@ void VulkanReplayConsumer::Process_vkAllocateMemory(
     VkResult replay_result = OverrideAllocateMemory(GetDeviceTable(in_device->handle)->AllocateMemory, returnValue, in_device, pAllocateInfo, pAllocator, pMemory);
     CheckResult("vkAllocateMemory", returnValue, replay_result);
 
-    AddHandle<DeviceMemoryInfo>(pMemory->GetPointer(), pMemory->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDeviceMemoryInfo);
+    AddHandle<DeviceMemoryInfo>(device, pMemory->GetPointer(), pMemory->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDeviceMemoryInfo);
 }
 
 void VulkanReplayConsumer::Process_vkFreeMemory(
@@ -447,7 +447,7 @@ void VulkanReplayConsumer::Process_vkCreateFence(
     VkResult replay_result = GetDeviceTable(in_device)->CreateFence(in_device, in_pCreateInfo, in_pAllocator, out_pFence);
     CheckResult("vkCreateFence", returnValue, replay_result);
 
-    AddHandle<FenceInfo>(pFence->GetPointer(), out_pFence, &VulkanObjectInfoTable::AddFenceInfo);
+    AddHandle<FenceInfo>(device, pFence->GetPointer(), out_pFence, &VulkanObjectInfoTable::AddFenceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyFence(
@@ -518,7 +518,7 @@ void VulkanReplayConsumer::Process_vkCreateSemaphore(
     VkResult replay_result = GetDeviceTable(in_device)->CreateSemaphore(in_device, in_pCreateInfo, in_pAllocator, out_pSemaphore);
     CheckResult("vkCreateSemaphore", returnValue, replay_result);
 
-    AddHandle<SemaphoreInfo>(pSemaphore->GetPointer(), out_pSemaphore, &VulkanObjectInfoTable::AddSemaphoreInfo);
+    AddHandle<SemaphoreInfo>(device, pSemaphore->GetPointer(), out_pSemaphore, &VulkanObjectInfoTable::AddSemaphoreInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroySemaphore(
@@ -549,7 +549,7 @@ void VulkanReplayConsumer::Process_vkCreateEvent(
     VkResult replay_result = GetDeviceTable(in_device)->CreateEvent(in_device, in_pCreateInfo, in_pAllocator, out_pEvent);
     CheckResult("vkCreateEvent", returnValue, replay_result);
 
-    AddHandle<EventInfo>(pEvent->GetPointer(), out_pEvent, &VulkanObjectInfoTable::AddEventInfo);
+    AddHandle<EventInfo>(device, pEvent->GetPointer(), out_pEvent, &VulkanObjectInfoTable::AddEventInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyEvent(
@@ -616,7 +616,7 @@ void VulkanReplayConsumer::Process_vkCreateQueryPool(
     VkResult replay_result = GetDeviceTable(in_device)->CreateQueryPool(in_device, in_pCreateInfo, in_pAllocator, out_pQueryPool);
     CheckResult("vkCreateQueryPool", returnValue, replay_result);
 
-    AddHandle<QueryPoolInfo>(pQueryPool->GetPointer(), out_pQueryPool, &VulkanObjectInfoTable::AddQueryPoolInfo);
+    AddHandle<QueryPoolInfo>(device, pQueryPool->GetPointer(), out_pQueryPool, &VulkanObjectInfoTable::AddQueryPoolInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyQueryPool(
@@ -665,7 +665,7 @@ void VulkanReplayConsumer::Process_vkCreateBuffer(
     VkResult replay_result = OverrideCreateBuffer(GetDeviceTable(in_device->handle)->CreateBuffer, returnValue, in_device, pCreateInfo, pAllocator, pBuffer);
     CheckResult("vkCreateBuffer", returnValue, replay_result);
 
-    AddHandle<BufferInfo>(pBuffer->GetPointer(), pBuffer->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddBufferInfo);
+    AddHandle<BufferInfo>(device, pBuffer->GetPointer(), pBuffer->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddBufferInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyBuffer(
@@ -696,7 +696,7 @@ void VulkanReplayConsumer::Process_vkCreateBufferView(
     VkResult replay_result = GetDeviceTable(in_device)->CreateBufferView(in_device, in_pCreateInfo, in_pAllocator, out_pView);
     CheckResult("vkCreateBufferView", returnValue, replay_result);
 
-    AddHandle<BufferViewInfo>(pView->GetPointer(), out_pView, &VulkanObjectInfoTable::AddBufferViewInfo);
+    AddHandle<BufferViewInfo>(device, pView->GetPointer(), out_pView, &VulkanObjectInfoTable::AddBufferViewInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyBufferView(
@@ -728,7 +728,7 @@ void VulkanReplayConsumer::Process_vkCreateImage(
     VkResult replay_result = OverrideCreateImage(GetDeviceTable(in_device->handle)->CreateImage, returnValue, in_device, pCreateInfo, pAllocator, pImage);
     CheckResult("vkCreateImage", returnValue, replay_result);
 
-    AddHandle<ImageInfo>(pImage->GetPointer(), pImage->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddImageInfo);
+    AddHandle<ImageInfo>(device, pImage->GetPointer(), pImage->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddImageInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyImage(
@@ -772,7 +772,7 @@ void VulkanReplayConsumer::Process_vkCreateImageView(
     VkResult replay_result = GetDeviceTable(in_device)->CreateImageView(in_device, in_pCreateInfo, in_pAllocator, out_pView);
     CheckResult("vkCreateImageView", returnValue, replay_result);
 
-    AddHandle<ImageViewInfo>(pView->GetPointer(), out_pView, &VulkanObjectInfoTable::AddImageViewInfo);
+    AddHandle<ImageViewInfo>(device, pView->GetPointer(), out_pView, &VulkanObjectInfoTable::AddImageViewInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyImageView(
@@ -804,7 +804,7 @@ void VulkanReplayConsumer::Process_vkCreateShaderModule(
     VkResult replay_result = OverrideCreateShaderModule(GetDeviceTable(in_device->handle)->CreateShaderModule, returnValue, in_device, pCreateInfo, pAllocator, pShaderModule);
     CheckResult("vkCreateShaderModule", returnValue, replay_result);
 
-    AddHandle<ShaderModuleInfo>(pShaderModule->GetPointer(), pShaderModule->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddShaderModuleInfo);
+    AddHandle<ShaderModuleInfo>(device, pShaderModule->GetPointer(), pShaderModule->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddShaderModuleInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyShaderModule(
@@ -834,7 +834,7 @@ void VulkanReplayConsumer::Process_vkCreatePipelineCache(
     VkResult replay_result = OverrideCreatePipelineCache(GetDeviceTable(in_device->handle)->CreatePipelineCache, returnValue, in_device, pCreateInfo, pAllocator, pPipelineCache);
     CheckResult("vkCreatePipelineCache", returnValue, replay_result);
 
-    AddHandle<PipelineCacheInfo>(pPipelineCache->GetPointer(), pPipelineCache->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddPipelineCacheInfo);
+    AddHandle<PipelineCacheInfo>(device, pPipelineCache->GetPointer(), pPipelineCache->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddPipelineCacheInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyPipelineCache(
@@ -902,7 +902,7 @@ void VulkanReplayConsumer::Process_vkCreateGraphicsPipelines(
     VkResult replay_result = GetDeviceTable(in_device)->CreateGraphicsPipelines(in_device, in_pipelineCache, createInfoCount, in_pCreateInfos, in_pAllocator, out_pPipelines);
     CheckResult("vkCreateGraphicsPipelines", returnValue, replay_result);
 
-    AddHandles<PipelineInfo>(pPipelines->GetPointer(), pPipelines->GetLength(), out_pPipelines, createInfoCount, &VulkanObjectInfoTable::AddPipelineInfo);
+    AddHandles<PipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), out_pPipelines, createInfoCount, &VulkanObjectInfoTable::AddPipelineInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateComputePipelines(
@@ -925,7 +925,7 @@ void VulkanReplayConsumer::Process_vkCreateComputePipelines(
     VkResult replay_result = GetDeviceTable(in_device)->CreateComputePipelines(in_device, in_pipelineCache, createInfoCount, in_pCreateInfos, in_pAllocator, out_pPipelines);
     CheckResult("vkCreateComputePipelines", returnValue, replay_result);
 
-    AddHandles<PipelineInfo>(pPipelines->GetPointer(), pPipelines->GetLength(), out_pPipelines, createInfoCount, &VulkanObjectInfoTable::AddPipelineInfo);
+    AddHandles<PipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), out_pPipelines, createInfoCount, &VulkanObjectInfoTable::AddPipelineInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyPipeline(
@@ -957,7 +957,7 @@ void VulkanReplayConsumer::Process_vkCreatePipelineLayout(
     VkResult replay_result = GetDeviceTable(in_device)->CreatePipelineLayout(in_device, in_pCreateInfo, in_pAllocator, out_pPipelineLayout);
     CheckResult("vkCreatePipelineLayout", returnValue, replay_result);
 
-    AddHandle<PipelineLayoutInfo>(pPipelineLayout->GetPointer(), out_pPipelineLayout, &VulkanObjectInfoTable::AddPipelineLayoutInfo);
+    AddHandle<PipelineLayoutInfo>(device, pPipelineLayout->GetPointer(), out_pPipelineLayout, &VulkanObjectInfoTable::AddPipelineLayoutInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyPipelineLayout(
@@ -989,7 +989,7 @@ void VulkanReplayConsumer::Process_vkCreateSampler(
     VkResult replay_result = GetDeviceTable(in_device)->CreateSampler(in_device, in_pCreateInfo, in_pAllocator, out_pSampler);
     CheckResult("vkCreateSampler", returnValue, replay_result);
 
-    AddHandle<SamplerInfo>(pSampler->GetPointer(), out_pSampler, &VulkanObjectInfoTable::AddSamplerInfo);
+    AddHandle<SamplerInfo>(device, pSampler->GetPointer(), out_pSampler, &VulkanObjectInfoTable::AddSamplerInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroySampler(
@@ -1021,7 +1021,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorSetLayout(
     VkResult replay_result = GetDeviceTable(in_device)->CreateDescriptorSetLayout(in_device, in_pCreateInfo, in_pAllocator, out_pSetLayout);
     CheckResult("vkCreateDescriptorSetLayout", returnValue, replay_result);
 
-    AddHandle<DescriptorSetLayoutInfo>(pSetLayout->GetPointer(), out_pSetLayout, &VulkanObjectInfoTable::AddDescriptorSetLayoutInfo);
+    AddHandle<DescriptorSetLayoutInfo>(device, pSetLayout->GetPointer(), out_pSetLayout, &VulkanObjectInfoTable::AddDescriptorSetLayoutInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDescriptorSetLayout(
@@ -1052,7 +1052,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorPool(
     VkResult replay_result = GetDeviceTable(in_device)->CreateDescriptorPool(in_device, in_pCreateInfo, in_pAllocator, out_pDescriptorPool);
     CheckResult("vkCreateDescriptorPool", returnValue, replay_result);
 
-    AddHandle<DescriptorPoolInfo>(pDescriptorPool->GetPointer(), out_pDescriptorPool, &VulkanObjectInfoTable::AddDescriptorPoolInfo);
+    AddHandle<DescriptorPoolInfo>(device, pDescriptorPool->GetPointer(), out_pDescriptorPool, &VulkanObjectInfoTable::AddDescriptorPoolInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDescriptorPool(
@@ -1096,7 +1096,7 @@ void VulkanReplayConsumer::Process_vkAllocateDescriptorSets(
     VkResult replay_result = OverrideAllocateDescriptorSets(GetDeviceTable(in_device->handle)->AllocateDescriptorSets, returnValue, in_device, pAllocateInfo, pDescriptorSets);
     CheckResult("vkAllocateDescriptorSets", returnValue, replay_result);
 
-    AddHandles<DescriptorSetInfo>(pDescriptorSets->GetPointer(), pDescriptorSets->GetLength(), pDescriptorSets->GetHandlePointer(), pAllocateInfo->GetPointer()->descriptorSetCount, std::move(handle_info), &VulkanObjectInfoTable::AddDescriptorSetInfo);
+    AddHandles<DescriptorSetInfo>(device, pDescriptorSets->GetPointer(), pDescriptorSets->GetLength(), pDescriptorSets->GetHandlePointer(), pAllocateInfo->GetPointer()->descriptorSetCount, std::move(handle_info), &VulkanObjectInfoTable::AddDescriptorSetInfo);
 }
 
 void VulkanReplayConsumer::Process_vkFreeDescriptorSets(
@@ -1147,7 +1147,7 @@ void VulkanReplayConsumer::Process_vkCreateFramebuffer(
     VkResult replay_result = GetDeviceTable(in_device)->CreateFramebuffer(in_device, in_pCreateInfo, in_pAllocator, out_pFramebuffer);
     CheckResult("vkCreateFramebuffer", returnValue, replay_result);
 
-    AddHandle<FramebufferInfo>(pFramebuffer->GetPointer(), out_pFramebuffer, &VulkanObjectInfoTable::AddFramebufferInfo);
+    AddHandle<FramebufferInfo>(device, pFramebuffer->GetPointer(), out_pFramebuffer, &VulkanObjectInfoTable::AddFramebufferInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyFramebuffer(
@@ -1178,7 +1178,7 @@ void VulkanReplayConsumer::Process_vkCreateRenderPass(
     VkResult replay_result = GetDeviceTable(in_device)->CreateRenderPass(in_device, in_pCreateInfo, in_pAllocator, out_pRenderPass);
     CheckResult("vkCreateRenderPass", returnValue, replay_result);
 
-    AddHandle<RenderPassInfo>(pRenderPass->GetPointer(), out_pRenderPass, &VulkanObjectInfoTable::AddRenderPassInfo);
+    AddHandle<RenderPassInfo>(device, pRenderPass->GetPointer(), out_pRenderPass, &VulkanObjectInfoTable::AddRenderPassInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyRenderPass(
@@ -1221,7 +1221,7 @@ void VulkanReplayConsumer::Process_vkCreateCommandPool(
     VkResult replay_result = GetDeviceTable(in_device)->CreateCommandPool(in_device, in_pCreateInfo, in_pAllocator, out_pCommandPool);
     CheckResult("vkCreateCommandPool", returnValue, replay_result);
 
-    AddHandle<CommandPoolInfo>(pCommandPool->GetPointer(), out_pCommandPool, &VulkanObjectInfoTable::AddCommandPoolInfo);
+    AddHandle<CommandPoolInfo>(device, pCommandPool->GetPointer(), out_pCommandPool, &VulkanObjectInfoTable::AddCommandPoolInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyCommandPool(
@@ -1265,7 +1265,7 @@ void VulkanReplayConsumer::Process_vkAllocateCommandBuffers(
     VkResult replay_result = OverrideAllocateCommandBuffers(GetDeviceTable(in_device->handle)->AllocateCommandBuffers, returnValue, in_device, pAllocateInfo, pCommandBuffers);
     CheckResult("vkAllocateCommandBuffers", returnValue, replay_result);
 
-    AddHandles<CommandBufferInfo>(pCommandBuffers->GetPointer(), pCommandBuffers->GetLength(), pCommandBuffers->GetHandlePointer(), pAllocateInfo->GetPointer()->commandBufferCount, std::move(handle_info), &VulkanObjectInfoTable::AddCommandBufferInfo);
+    AddHandles<CommandBufferInfo>(device, pCommandBuffers->GetPointer(), pCommandBuffers->GetLength(), pCommandBuffers->GetHandlePointer(), pAllocateInfo->GetPointer()->commandBufferCount, std::move(handle_info), &VulkanObjectInfoTable::AddCommandBufferInfo);
 }
 
 void VulkanReplayConsumer::Process_vkFreeCommandBuffers(
@@ -1975,7 +1975,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroups(
     CheckResult("vkEnumeratePhysicalDeviceGroups", returnValue, replay_result);
 
     if (pPhysicalDeviceGroupProperties->IsNull()) { SetOutputArrayCount<InstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDeviceGroups, *out_pPhysicalDeviceGroupCount, &VulkanObjectInfoTable::GetInstanceInfo); }
-    AddStructArrayHandles<Decoded_VkPhysicalDeviceGroupProperties>(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), out_pPhysicalDeviceGroupProperties, *out_pPhysicalDeviceGroupCount, &GetObjectInfoTable());
+    AddStructArrayHandles<Decoded_VkPhysicalDeviceGroupProperties>(instance, pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), out_pPhysicalDeviceGroupProperties, *out_pPhysicalDeviceGroupCount, &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkGetImageMemoryRequirements2(
@@ -2129,7 +2129,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceQueue2(
 
     GetDeviceTable(in_device)->GetDeviceQueue2(in_device, in_pQueueInfo, out_pQueue);
 
-    AddHandle<QueueInfo>(pQueue->GetPointer(), out_pQueue, &VulkanObjectInfoTable::AddQueueInfo);
+    AddHandle<QueueInfo>(device, pQueue->GetPointer(), out_pQueue, &VulkanObjectInfoTable::AddQueueInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversion(
@@ -2148,7 +2148,7 @@ void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversion(
     VkResult replay_result = GetDeviceTable(in_device)->CreateSamplerYcbcrConversion(in_device, in_pCreateInfo, in_pAllocator, out_pYcbcrConversion);
     CheckResult("vkCreateSamplerYcbcrConversion", returnValue, replay_result);
 
-    AddHandle<SamplerYcbcrConversionInfo>(pYcbcrConversion->GetPointer(), out_pYcbcrConversion, &VulkanObjectInfoTable::AddSamplerYcbcrConversionInfo);
+    AddHandle<SamplerYcbcrConversionInfo>(device, pYcbcrConversion->GetPointer(), out_pYcbcrConversion, &VulkanObjectInfoTable::AddSamplerYcbcrConversionInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroySamplerYcbcrConversion(
@@ -2180,7 +2180,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorUpdateTemplate(
     VkResult replay_result = OverrideCreateDescriptorUpdateTemplate(GetDeviceTable(in_device->handle)->CreateDescriptorUpdateTemplate, returnValue, in_device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
     CheckResult("vkCreateDescriptorUpdateTemplate", returnValue, replay_result);
 
-    AddHandle<DescriptorUpdateTemplateInfo>(pDescriptorUpdateTemplate->GetPointer(), pDescriptorUpdateTemplate->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDescriptorUpdateTemplateInfo);
+    AddHandle<DescriptorUpdateTemplateInfo>(device, pDescriptorUpdateTemplate->GetPointer(), pDescriptorUpdateTemplate->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDescriptorUpdateTemplateInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDescriptorUpdateTemplate(
@@ -2291,7 +2291,7 @@ void VulkanReplayConsumer::Process_vkCreateRenderPass2(
     VkResult replay_result = GetDeviceTable(in_device)->CreateRenderPass2(in_device, in_pCreateInfo, in_pAllocator, out_pRenderPass);
     CheckResult("vkCreateRenderPass2", returnValue, replay_result);
 
-    AddHandle<RenderPassInfo>(pRenderPass->GetPointer(), out_pRenderPass, &VulkanObjectInfoTable::AddRenderPassInfo);
+    AddHandle<RenderPassInfo>(device, pRenderPass->GetPointer(), out_pRenderPass, &VulkanObjectInfoTable::AddRenderPassInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginRenderPass2(
@@ -2511,7 +2511,7 @@ void VulkanReplayConsumer::Process_vkCreateSwapchainKHR(
     VkResult replay_result = OverrideCreateSwapchainKHR(GetDeviceTable(in_device->handle)->CreateSwapchainKHR, returnValue, in_device, pCreateInfo, pAllocator, pSwapchain);
     CheckResult("vkCreateSwapchainKHR", returnValue, replay_result);
 
-    AddHandle<SwapchainKHRInfo>(pSwapchain->GetPointer(), pSwapchain->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSwapchainKHRInfo);
+    AddHandle<SwapchainKHRInfo>(device, pSwapchain->GetPointer(), pSwapchain->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSwapchainKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroySwapchainKHR(
@@ -2543,7 +2543,7 @@ void VulkanReplayConsumer::Process_vkGetSwapchainImagesKHR(
     CheckResult("vkGetSwapchainImagesKHR", returnValue, replay_result);
 
     if (pSwapchainImages->IsNull()) { SetOutputArrayCount<SwapchainKHRInfo>(swapchain, kSwapchainKHRArrayGetSwapchainImagesKHR, *pSwapchainImageCount->GetOutputPointer(), &VulkanObjectInfoTable::GetSwapchainKHRInfo); }
-    AddHandles<ImageInfo>(pSwapchainImages->GetPointer(), pSwapchainImages->GetLength(), pSwapchainImages->GetHandlePointer(), *pSwapchainImageCount->GetOutputPointer(), std::move(handle_info), &VulkanObjectInfoTable::AddImageInfo);
+    AddHandles<ImageInfo>(device, pSwapchainImages->GetPointer(), pSwapchainImages->GetLength(), pSwapchainImages->GetHandlePointer(), *pSwapchainImageCount->GetOutputPointer(), std::move(handle_info), &VulkanObjectInfoTable::AddImageInfo);
 }
 
 void VulkanReplayConsumer::Process_vkAcquireNextImageKHR(
@@ -2651,7 +2651,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
     CheckResult("vkGetPhysicalDeviceDisplayPropertiesKHR", returnValue, replay_result);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
-    AddStructArrayHandles<Decoded_VkDisplayPropertiesKHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
+    AddStructArrayHandles<Decoded_VkDisplayPropertiesKHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
@@ -2668,7 +2668,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
     CheckResult("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", returnValue, replay_result);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlanePropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
-    AddStructArrayHandles<Decoded_VkDisplayPlanePropertiesKHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
+    AddStructArrayHandles<Decoded_VkDisplayPlanePropertiesKHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
@@ -2687,7 +2687,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
     CheckResult("vkGetDisplayPlaneSupportedDisplaysKHR", returnValue, replay_result);
 
     if (pDisplays->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetDisplayPlaneSupportedDisplaysKHR, *out_pDisplayCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
-    AddHandles<DisplayKHRInfo>(pDisplays->GetPointer(), pDisplays->GetLength(), out_pDisplays, *out_pDisplayCount, &VulkanObjectInfoTable::AddDisplayKHRInfo);
+    AddHandles<DisplayKHRInfo>(physicalDevice, pDisplays->GetPointer(), pDisplays->GetLength(), out_pDisplays, *out_pDisplayCount, &VulkanObjectInfoTable::AddDisplayKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetDisplayModePropertiesKHR(
@@ -2706,7 +2706,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayModePropertiesKHR(
     CheckResult("vkGetDisplayModePropertiesKHR", returnValue, replay_result);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<DisplayKHRInfo>(display, kDisplayKHRArrayGetDisplayModePropertiesKHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetDisplayKHRInfo); }
-    AddStructArrayHandles<Decoded_VkDisplayModePropertiesKHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
+    AddStructArrayHandles<Decoded_VkDisplayModePropertiesKHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkCreateDisplayModeKHR(
@@ -2727,7 +2727,7 @@ void VulkanReplayConsumer::Process_vkCreateDisplayModeKHR(
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->CreateDisplayModeKHR(in_physicalDevice, in_display, in_pCreateInfo, in_pAllocator, out_pMode);
     CheckResult("vkCreateDisplayModeKHR", returnValue, replay_result);
 
-    AddHandle<DisplayModeKHRInfo>(pMode->GetPointer(), out_pMode, &VulkanObjectInfoTable::AddDisplayModeKHRInfo);
+    AddHandle<DisplayModeKHRInfo>(physicalDevice, pMode->GetPointer(), out_pMode, &VulkanObjectInfoTable::AddDisplayModeKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetDisplayPlaneCapabilitiesKHR(
@@ -2762,7 +2762,7 @@ void VulkanReplayConsumer::Process_vkCreateDisplayPlaneSurfaceKHR(
     VkResult replay_result = GetInstanceTable(in_instance)->CreateDisplayPlaneSurfaceKHR(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
     CheckResult("vkCreateDisplayPlaneSurfaceKHR", returnValue, replay_result);
 
-    AddHandle<SurfaceKHRInfo>(pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
+    AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateSharedSwapchainsKHR(
@@ -2783,7 +2783,7 @@ void VulkanReplayConsumer::Process_vkCreateSharedSwapchainsKHR(
     VkResult replay_result = GetDeviceTable(in_device)->CreateSharedSwapchainsKHR(in_device, swapchainCount, in_pCreateInfos, in_pAllocator, out_pSwapchains);
     CheckResult("vkCreateSharedSwapchainsKHR", returnValue, replay_result);
 
-    AddHandles<SwapchainKHRInfo>(pSwapchains->GetPointer(), pSwapchains->GetLength(), out_pSwapchains, swapchainCount, &VulkanObjectInfoTable::AddSwapchainKHRInfo);
+    AddHandles<SwapchainKHRInfo>(device, pSwapchains->GetPointer(), pSwapchains->GetLength(), out_pSwapchains, swapchainCount, &VulkanObjectInfoTable::AddSwapchainKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateXlibSurfaceKHR(
@@ -2801,7 +2801,7 @@ void VulkanReplayConsumer::Process_vkCreateXlibSurfaceKHR(
     VkResult replay_result = OverrideCreateXlibSurfaceKHR(GetInstanceTable(in_instance->handle)->CreateXlibSurfaceKHR, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
     CheckResult("vkCreateXlibSurfaceKHR", returnValue, replay_result);
 
-    AddHandle<SurfaceKHRInfo>(pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSurfaceKHRInfo);
+    AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
@@ -2832,7 +2832,7 @@ void VulkanReplayConsumer::Process_vkCreateXcbSurfaceKHR(
     VkResult replay_result = OverrideCreateXcbSurfaceKHR(GetInstanceTable(in_instance->handle)->CreateXcbSurfaceKHR, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
     CheckResult("vkCreateXcbSurfaceKHR", returnValue, replay_result);
 
-    AddHandle<SurfaceKHRInfo>(pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSurfaceKHRInfo);
+    AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
@@ -2863,7 +2863,7 @@ void VulkanReplayConsumer::Process_vkCreateWaylandSurfaceKHR(
     VkResult replay_result = OverrideCreateWaylandSurfaceKHR(GetInstanceTable(in_instance->handle)->CreateWaylandSurfaceKHR, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
     CheckResult("vkCreateWaylandSurfaceKHR", returnValue, replay_result);
 
-    AddHandle<SurfaceKHRInfo>(pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSurfaceKHRInfo);
+    AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceWaylandPresentationSupportKHR(
@@ -2893,7 +2893,7 @@ void VulkanReplayConsumer::Process_vkCreateAndroidSurfaceKHR(
     VkResult replay_result = OverrideCreateAndroidSurfaceKHR(GetInstanceTable(in_instance->handle)->CreateAndroidSurfaceKHR, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
     CheckResult("vkCreateAndroidSurfaceKHR", returnValue, replay_result);
 
-    AddHandle<SurfaceKHRInfo>(pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSurfaceKHRInfo);
+    AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateWin32SurfaceKHR(
@@ -2911,7 +2911,7 @@ void VulkanReplayConsumer::Process_vkCreateWin32SurfaceKHR(
     VkResult replay_result = OverrideCreateWin32SurfaceKHR(GetInstanceTable(in_instance->handle)->CreateWin32SurfaceKHR, returnValue, in_instance, pCreateInfo, pAllocator, pSurface);
     CheckResult("vkCreateWin32SurfaceKHR", returnValue, replay_result);
 
-    AddHandle<SurfaceKHRInfo>(pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSurfaceKHRInfo);
+    AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), pSurface->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceWin32PresentationSupportKHR(
@@ -3071,7 +3071,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
     CheckResult("vkEnumeratePhysicalDeviceGroupsKHR", returnValue, replay_result);
 
     if (pPhysicalDeviceGroupProperties->IsNull()) { SetOutputArrayCount<InstanceInfo>(instance, kInstanceArrayEnumeratePhysicalDeviceGroupsKHR, *out_pPhysicalDeviceGroupCount, &VulkanObjectInfoTable::GetInstanceInfo); }
-    AddStructArrayHandles<Decoded_VkPhysicalDeviceGroupProperties>(pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), out_pPhysicalDeviceGroupProperties, *out_pPhysicalDeviceGroupCount, &GetObjectInfoTable());
+    AddStructArrayHandles<Decoded_VkPhysicalDeviceGroupProperties>(instance, pPhysicalDeviceGroupProperties->GetMetaStructPointer(), pPhysicalDeviceGroupProperties->GetLength(), out_pPhysicalDeviceGroupProperties, *out_pPhysicalDeviceGroupCount, &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR(
@@ -3250,7 +3250,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorUpdateTemplateKHR(
     VkResult replay_result = OverrideCreateDescriptorUpdateTemplate(GetDeviceTable(in_device->handle)->CreateDescriptorUpdateTemplateKHR, returnValue, in_device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate);
     CheckResult("vkCreateDescriptorUpdateTemplateKHR", returnValue, replay_result);
 
-    AddHandle<DescriptorUpdateTemplateInfo>(pDescriptorUpdateTemplate->GetPointer(), pDescriptorUpdateTemplate->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDescriptorUpdateTemplateInfo);
+    AddHandle<DescriptorUpdateTemplateInfo>(device, pDescriptorUpdateTemplate->GetPointer(), pDescriptorUpdateTemplate->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDescriptorUpdateTemplateInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDescriptorUpdateTemplateKHR(
@@ -3280,7 +3280,7 @@ void VulkanReplayConsumer::Process_vkCreateRenderPass2KHR(
     VkResult replay_result = GetDeviceTable(in_device)->CreateRenderPass2KHR(in_device, in_pCreateInfo, in_pAllocator, out_pRenderPass);
     CheckResult("vkCreateRenderPass2KHR", returnValue, replay_result);
 
-    AddHandle<RenderPassInfo>(pRenderPass->GetPointer(), out_pRenderPass, &VulkanObjectInfoTable::AddRenderPassInfo);
+    AddHandle<RenderPassInfo>(device, pRenderPass->GetPointer(), out_pRenderPass, &VulkanObjectInfoTable::AddRenderPassInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginRenderPass2KHR(
@@ -3500,7 +3500,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
     CheckResult("vkGetPhysicalDeviceDisplayProperties2KHR", returnValue, replay_result);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
-    AddStructArrayHandles<Decoded_VkDisplayProperties2KHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
+    AddStructArrayHandles<Decoded_VkDisplayProperties2KHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(
@@ -3517,7 +3517,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR
     CheckResult("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", returnValue, replay_result);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<PhysicalDeviceInfo>(physicalDevice, kPhysicalDeviceArrayGetPhysicalDeviceDisplayPlaneProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetPhysicalDeviceInfo); }
-    AddStructArrayHandles<Decoded_VkDisplayPlaneProperties2KHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
+    AddStructArrayHandles<Decoded_VkDisplayPlaneProperties2KHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkGetDisplayModeProperties2KHR(
@@ -3536,7 +3536,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayModeProperties2KHR(
     CheckResult("vkGetDisplayModeProperties2KHR", returnValue, replay_result);
 
     if (pProperties->IsNull()) { SetOutputArrayCount<DisplayKHRInfo>(display, kDisplayKHRArrayGetDisplayModeProperties2KHR, *out_pPropertyCount, &VulkanObjectInfoTable::GetDisplayKHRInfo); }
-    AddStructArrayHandles<Decoded_VkDisplayModeProperties2KHR>(pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
+    AddStructArrayHandles<Decoded_VkDisplayModeProperties2KHR>(physicalDevice, pProperties->GetMetaStructPointer(), pProperties->GetLength(), out_pProperties, *out_pPropertyCount, &GetObjectInfoTable());
 }
 
 void VulkanReplayConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(
@@ -3613,7 +3613,7 @@ void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
     VkResult replay_result = GetDeviceTable(in_device)->CreateSamplerYcbcrConversionKHR(in_device, in_pCreateInfo, in_pAllocator, out_pYcbcrConversion);
     CheckResult("vkCreateSamplerYcbcrConversionKHR", returnValue, replay_result);
 
-    AddHandle<SamplerYcbcrConversionInfo>(pYcbcrConversion->GetPointer(), out_pYcbcrConversion, &VulkanObjectInfoTable::AddSamplerYcbcrConversionInfo);
+    AddHandle<SamplerYcbcrConversionInfo>(device, pYcbcrConversion->GetPointer(), out_pYcbcrConversion, &VulkanObjectInfoTable::AddSamplerYcbcrConversionInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroySamplerYcbcrConversionKHR(
@@ -3792,7 +3792,7 @@ void VulkanReplayConsumer::Process_vkCreateDeferredOperationKHR(
     VkResult replay_result = GetDeviceTable(in_device)->CreateDeferredOperationKHR(in_device, in_pAllocator, out_pDeferredOperation);
     CheckResult("vkCreateDeferredOperationKHR", returnValue, replay_result);
 
-    AddHandle<DeferredOperationKHRInfo>(pDeferredOperation->GetPointer(), out_pDeferredOperation, &VulkanObjectInfoTable::AddDeferredOperationKHRInfo);
+    AddHandle<DeferredOperationKHRInfo>(device, pDeferredOperation->GetPointer(), out_pDeferredOperation, &VulkanObjectInfoTable::AddDeferredOperationKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDeferredOperationKHR(
@@ -3980,7 +3980,7 @@ void VulkanReplayConsumer::Process_vkCreateDebugReportCallbackEXT(
     VkResult replay_result = OverrideCreateDebugReportCallbackEXT(GetInstanceTable(in_instance->handle)->CreateDebugReportCallbackEXT, returnValue, in_instance, pCreateInfo, pAllocator, pCallback);
     CheckResult("vkCreateDebugReportCallbackEXT", returnValue, replay_result);
 
-    AddHandle<DebugReportCallbackEXTInfo>(pCallback->GetPointer(), pCallback->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDebugReportCallbackEXTInfo);
+    AddHandle<DebugReportCallbackEXTInfo>(instance, pCallback->GetPointer(), pCallback->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDebugReportCallbackEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDebugReportCallbackEXT(
@@ -4242,7 +4242,7 @@ void VulkanReplayConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
     VkResult replay_result = GetInstanceTable(in_instance)->CreateStreamDescriptorSurfaceGGP(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
     CheckResult("vkCreateStreamDescriptorSurfaceGGP", returnValue, replay_result);
 
-    AddHandle<SurfaceKHRInfo>(pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
+    AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(
@@ -4296,7 +4296,7 @@ void VulkanReplayConsumer::Process_vkCreateViSurfaceNN(
     VkResult replay_result = GetInstanceTable(in_instance)->CreateViSurfaceNN(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
     CheckResult("vkCreateViSurfaceNN", returnValue, replay_result);
 
-    AddHandle<SurfaceKHRInfo>(pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
+    AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginConditionalRenderingEXT(
@@ -4371,7 +4371,7 @@ void VulkanReplayConsumer::Process_vkGetRandROutputDisplayEXT(
     VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetRandROutputDisplayEXT(in_physicalDevice, in_dpy, rrOutput, out_pDisplay);
     CheckResult("vkGetRandROutputDisplayEXT", returnValue, replay_result);
 
-    AddHandle<DisplayKHRInfo>(pDisplay->GetPointer(), out_pDisplay, &VulkanObjectInfoTable::AddDisplayKHRInfo);
+    AddHandle<DisplayKHRInfo>(physicalDevice, pDisplay->GetPointer(), out_pDisplay, &VulkanObjectInfoTable::AddDisplayKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
@@ -4418,7 +4418,7 @@ void VulkanReplayConsumer::Process_vkRegisterDeviceEventEXT(
     VkResult replay_result = GetDeviceTable(in_device)->RegisterDeviceEventEXT(in_device, in_pDeviceEventInfo, in_pAllocator, out_pFence);
     CheckResult("vkRegisterDeviceEventEXT", returnValue, replay_result);
 
-    AddHandle<FenceInfo>(pFence->GetPointer(), out_pFence, &VulkanObjectInfoTable::AddFenceInfo);
+    AddHandle<FenceInfo>(device, pFence->GetPointer(), out_pFence, &VulkanObjectInfoTable::AddFenceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkRegisterDisplayEventEXT(
@@ -4439,7 +4439,7 @@ void VulkanReplayConsumer::Process_vkRegisterDisplayEventEXT(
     VkResult replay_result = GetDeviceTable(in_device)->RegisterDisplayEventEXT(in_device, in_display, in_pDisplayEventInfo, in_pAllocator, out_pFence);
     CheckResult("vkRegisterDisplayEventEXT", returnValue, replay_result);
 
-    AddHandle<FenceInfo>(pFence->GetPointer(), out_pFence, &VulkanObjectInfoTable::AddFenceInfo);
+    AddHandle<FenceInfo>(device, pFence->GetPointer(), out_pFence, &VulkanObjectInfoTable::AddFenceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetSwapchainCounterEXT(
@@ -4530,7 +4530,7 @@ void VulkanReplayConsumer::Process_vkCreateIOSSurfaceMVK(
     VkResult replay_result = GetInstanceTable(in_instance)->CreateIOSSurfaceMVK(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
     CheckResult("vkCreateIOSSurfaceMVK", returnValue, replay_result);
 
-    AddHandle<SurfaceKHRInfo>(pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
+    AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateMacOSSurfaceMVK(
@@ -4549,7 +4549,7 @@ void VulkanReplayConsumer::Process_vkCreateMacOSSurfaceMVK(
     VkResult replay_result = GetInstanceTable(in_instance)->CreateMacOSSurfaceMVK(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
     CheckResult("vkCreateMacOSSurfaceMVK", returnValue, replay_result);
 
-    AddHandle<SurfaceKHRInfo>(pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
+    AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectNameEXT(
@@ -4647,7 +4647,7 @@ void VulkanReplayConsumer::Process_vkCreateDebugUtilsMessengerEXT(
     VkResult replay_result = OverrideCreateDebugUtilsMessengerEXT(GetInstanceTable(in_instance->handle)->CreateDebugUtilsMessengerEXT, returnValue, in_instance, pCreateInfo, pAllocator, pMessenger);
     CheckResult("vkCreateDebugUtilsMessengerEXT", returnValue, replay_result);
 
-    AddHandle<DebugUtilsMessengerEXTInfo>(pMessenger->GetPointer(), pMessenger->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDebugUtilsMessengerEXTInfo);
+    AddHandle<DebugUtilsMessengerEXTInfo>(instance, pMessenger->GetPointer(), pMessenger->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDebugUtilsMessengerEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDebugUtilsMessengerEXT(
@@ -4756,7 +4756,7 @@ void VulkanReplayConsumer::Process_vkCreateValidationCacheEXT(
     VkResult replay_result = GetDeviceTable(in_device)->CreateValidationCacheEXT(in_device, in_pCreateInfo, in_pAllocator, out_pValidationCache);
     CheckResult("vkCreateValidationCacheEXT", returnValue, replay_result);
 
-    AddHandle<ValidationCacheEXTInfo>(pValidationCache->GetPointer(), out_pValidationCache, &VulkanObjectInfoTable::AddValidationCacheEXTInfo);
+    AddHandle<ValidationCacheEXTInfo>(device, pValidationCache->GetPointer(), out_pValidationCache, &VulkanObjectInfoTable::AddValidationCacheEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyValidationCacheEXT(
@@ -4856,7 +4856,7 @@ void VulkanReplayConsumer::Process_vkCreateAccelerationStructureNV(
     VkResult replay_result = GetDeviceTable(in_device)->CreateAccelerationStructureNV(in_device, in_pCreateInfo, in_pAllocator, out_pAccelerationStructure);
     CheckResult("vkCreateAccelerationStructureNV", returnValue, replay_result);
 
-    AddHandle<AccelerationStructureNVInfo>(pAccelerationStructure->GetPointer(), out_pAccelerationStructure, &VulkanObjectInfoTable::AddAccelerationStructureNVInfo);
+    AddHandle<AccelerationStructureNVInfo>(device, pAccelerationStructure->GetPointer(), out_pAccelerationStructure, &VulkanObjectInfoTable::AddAccelerationStructureNVInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyAccelerationStructureKHR(
@@ -5005,7 +5005,7 @@ void VulkanReplayConsumer::Process_vkCreateRayTracingPipelinesNV(
     VkResult replay_result = GetDeviceTable(in_device)->CreateRayTracingPipelinesNV(in_device, in_pipelineCache, createInfoCount, in_pCreateInfos, in_pAllocator, out_pPipelines);
     CheckResult("vkCreateRayTracingPipelinesNV", returnValue, replay_result);
 
-    AddHandles<PipelineInfo>(pPipelines->GetPointer(), pPipelines->GetLength(), out_pPipelines, createInfoCount, &VulkanObjectInfoTable::AddPipelineInfo);
+    AddHandles<PipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), out_pPipelines, createInfoCount, &VulkanObjectInfoTable::AddPipelineInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetRayTracingShaderGroupHandlesKHR(
@@ -5306,7 +5306,7 @@ void VulkanReplayConsumer::Process_vkAcquirePerformanceConfigurationINTEL(
     VkResult replay_result = GetDeviceTable(in_device)->AcquirePerformanceConfigurationINTEL(in_device, in_pAcquireInfo, out_pConfiguration);
     CheckResult("vkAcquirePerformanceConfigurationINTEL", returnValue, replay_result);
 
-    AddHandle<PerformanceConfigurationINTELInfo>(pConfiguration->GetPointer(), out_pConfiguration, &VulkanObjectInfoTable::AddPerformanceConfigurationINTELInfo);
+    AddHandle<PerformanceConfigurationINTELInfo>(device, pConfiguration->GetPointer(), out_pConfiguration, &VulkanObjectInfoTable::AddPerformanceConfigurationINTELInfo);
 }
 
 void VulkanReplayConsumer::Process_vkReleasePerformanceConfigurationINTEL(
@@ -5373,7 +5373,7 @@ void VulkanReplayConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
     VkResult replay_result = GetInstanceTable(in_instance)->CreateImagePipeSurfaceFUCHSIA(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
     CheckResult("vkCreateImagePipeSurfaceFUCHSIA", returnValue, replay_result);
 
-    AddHandle<SurfaceKHRInfo>(pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
+    AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateMetalSurfaceEXT(
@@ -5392,7 +5392,7 @@ void VulkanReplayConsumer::Process_vkCreateMetalSurfaceEXT(
     VkResult replay_result = GetInstanceTable(in_instance)->CreateMetalSurfaceEXT(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
     CheckResult("vkCreateMetalSurfaceEXT", returnValue, replay_result);
 
-    AddHandle<SurfaceKHRInfo>(pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
+    AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferDeviceAddressEXT(
@@ -5529,7 +5529,7 @@ void VulkanReplayConsumer::Process_vkCreateHeadlessSurfaceEXT(
     VkResult replay_result = GetInstanceTable(in_instance)->CreateHeadlessSurfaceEXT(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
     CheckResult("vkCreateHeadlessSurfaceEXT", returnValue, replay_result);
 
-    AddHandle<SurfaceKHRInfo>(pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
+    AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetLineStippleEXT(
@@ -5744,7 +5744,7 @@ void VulkanReplayConsumer::Process_vkCreateIndirectCommandsLayoutNV(
     VkResult replay_result = GetDeviceTable(in_device)->CreateIndirectCommandsLayoutNV(in_device, in_pCreateInfo, in_pAllocator, out_pIndirectCommandsLayout);
     CheckResult("vkCreateIndirectCommandsLayoutNV", returnValue, replay_result);
 
-    AddHandle<IndirectCommandsLayoutNVInfo>(pIndirectCommandsLayout->GetPointer(), out_pIndirectCommandsLayout, &VulkanObjectInfoTable::AddIndirectCommandsLayoutNVInfo);
+    AddHandle<IndirectCommandsLayoutNVInfo>(device, pIndirectCommandsLayout->GetPointer(), out_pIndirectCommandsLayout, &VulkanObjectInfoTable::AddIndirectCommandsLayoutNVInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyIndirectCommandsLayoutNV(
@@ -5775,7 +5775,7 @@ void VulkanReplayConsumer::Process_vkCreatePrivateDataSlotEXT(
     VkResult replay_result = GetDeviceTable(in_device)->CreatePrivateDataSlotEXT(in_device, in_pCreateInfo, in_pAllocator, out_pPrivateDataSlot);
     CheckResult("vkCreatePrivateDataSlotEXT", returnValue, replay_result);
 
-    AddHandle<PrivateDataSlotEXTInfo>(pPrivateDataSlot->GetPointer(), out_pPrivateDataSlot, &VulkanObjectInfoTable::AddPrivateDataSlotEXTInfo);
+    AddHandle<PrivateDataSlotEXTInfo>(device, pPrivateDataSlot->GetPointer(), out_pPrivateDataSlot, &VulkanObjectInfoTable::AddPrivateDataSlotEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyPrivateDataSlotEXT(
@@ -5835,7 +5835,7 @@ void VulkanReplayConsumer::Process_vkCreateDirectFBSurfaceEXT(
     VkResult replay_result = GetInstanceTable(in_instance)->CreateDirectFBSurfaceEXT(in_instance, in_pCreateInfo, in_pAllocator, out_pSurface);
     CheckResult("vkCreateDirectFBSurfaceEXT", returnValue, replay_result);
 
-    AddHandle<SurfaceKHRInfo>(pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
+    AddHandle<SurfaceKHRInfo>(instance, pSurface->GetPointer(), out_pSurface, &VulkanObjectInfoTable::AddSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDirectFBPresentationSupportEXT(
@@ -5866,7 +5866,7 @@ void VulkanReplayConsumer::Process_vkCreateAccelerationStructureKHR(
     VkResult replay_result = GetDeviceTable(in_device)->CreateAccelerationStructureKHR(in_device, in_pCreateInfo, in_pAllocator, out_pAccelerationStructure);
     CheckResult("vkCreateAccelerationStructureKHR", returnValue, replay_result);
 
-    AddHandle<AccelerationStructureKHRInfo>(pAccelerationStructure->GetPointer(), out_pAccelerationStructure, &VulkanObjectInfoTable::AddAccelerationStructureKHRInfo);
+    AddHandle<AccelerationStructureKHRInfo>(device, pAccelerationStructure->GetPointer(), out_pAccelerationStructure, &VulkanObjectInfoTable::AddAccelerationStructureKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetAccelerationStructureMemoryRequirementsKHR(
@@ -6030,7 +6030,7 @@ void VulkanReplayConsumer::Process_vkCreateRayTracingPipelinesKHR(
     VkResult replay_result = GetDeviceTable(in_device)->CreateRayTracingPipelinesKHR(in_device, in_pipelineCache, createInfoCount, in_pCreateInfos, in_pAllocator, out_pPipelines);
     CheckResult("vkCreateRayTracingPipelinesKHR", returnValue, replay_result);
 
-    AddHandles<PipelineInfo>(pPipelines->GetPointer(), pPipelines->GetLength(), out_pPipelines, createInfoCount, &VulkanObjectInfoTable::AddPipelineInfo);
+    AddHandles<PipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), out_pPipelines, createInfoCount, &VulkanObjectInfoTable::AddPipelineInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetAccelerationStructureDeviceAddressKHR(

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -51,9 +51,10 @@ void VulkanReplayConsumer::Process_vkDestroyInstance(
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
-    auto in_instance = GetObjectInfoTable().GetInstanceInfo(instance);
+    VkInstance in_instance = MapHandle<InstanceInfo>(instance, &VulkanObjectInfoTable::GetInstanceInfo);
+    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
-    OverrideDestroyInstance(GetInstanceTable(in_instance->handle)->DestroyInstance, in_instance, pAllocator);
+    GetInstanceTable(in_instance)->DestroyInstance(in_instance, in_pAllocator);
     RemoveHandle(instance, &VulkanObjectInfoTable::RemoveInstanceInfo);
 }
 

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -23,6 +23,7 @@
 #include "generated/generated_vulkan_replay_consumer.h"
 
 #include "decode/custom_vulkan_struct_handle_mappers.h"
+#include "decode/vulkan_handle_mapping_util.h"
 #include "generated/generated_vulkan_dispatch_table.h"
 #include "generated/generated_vulkan_struct_handle_mappers.h"
 #include "util/defines.h"
@@ -53,6 +54,7 @@ void VulkanReplayConsumer::Process_vkDestroyInstance(
     auto in_instance = GetObjectInfoTable().GetInstanceInfo(instance);
 
     OverrideDestroyInstance(GetInstanceTable(in_instance->handle)->DestroyInstance, in_instance, pAllocator);
+    RemoveHandle(instance, &VulkanObjectInfoTable::RemoveInstanceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkEnumeratePhysicalDevices(
@@ -173,6 +175,7 @@ void VulkanReplayConsumer::Process_vkDestroyDevice(
     auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
 
     OverrideDestroyDevice(GetDeviceTable(in_device->handle)->DestroyDevice, in_device, pAllocator);
+    RemoveHandle(device, &VulkanObjectInfoTable::RemoveDeviceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceQueue(
@@ -255,6 +258,7 @@ void VulkanReplayConsumer::Process_vkFreeMemory(
     auto in_memory = GetObjectInfoTable().GetDeviceMemoryInfo(memory);
 
     OverrideFreeMemory(GetDeviceTable(in_device->handle)->FreeMemory, in_device, in_memory, pAllocator);
+    RemoveHandle(memory, &VulkanObjectInfoTable::RemoveDeviceMemoryInfo);
 }
 
 void VulkanReplayConsumer::Process_vkMapMemory(
@@ -460,6 +464,7 @@ void VulkanReplayConsumer::Process_vkDestroyFence(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyFence(in_device, in_fence, in_pAllocator);
+    RemoveHandle(fence, &VulkanObjectInfoTable::RemoveFenceInfo);
 }
 
 void VulkanReplayConsumer::Process_vkResetFences(
@@ -531,6 +536,7 @@ void VulkanReplayConsumer::Process_vkDestroySemaphore(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroySemaphore(in_device, in_semaphore, in_pAllocator);
+    RemoveHandle(semaphore, &VulkanObjectInfoTable::RemoveSemaphoreInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateEvent(
@@ -562,6 +568,7 @@ void VulkanReplayConsumer::Process_vkDestroyEvent(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyEvent(in_device, in_event, in_pAllocator);
+    RemoveHandle(event, &VulkanObjectInfoTable::RemoveEventInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetEventStatus(
@@ -629,6 +636,7 @@ void VulkanReplayConsumer::Process_vkDestroyQueryPool(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyQueryPool(in_device, in_queryPool, in_pAllocator);
+    RemoveHandle(queryPool, &VulkanObjectInfoTable::RemoveQueryPoolInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetQueryPoolResults(
@@ -677,6 +685,7 @@ void VulkanReplayConsumer::Process_vkDestroyBuffer(
     auto in_buffer = GetObjectInfoTable().GetBufferInfo(buffer);
 
     OverrideDestroyBuffer(GetDeviceTable(in_device->handle)->DestroyBuffer, in_device, in_buffer, pAllocator);
+    RemoveHandle(buffer, &VulkanObjectInfoTable::RemoveBufferInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateBufferView(
@@ -709,6 +718,7 @@ void VulkanReplayConsumer::Process_vkDestroyBufferView(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyBufferView(in_device, in_bufferView, in_pAllocator);
+    RemoveHandle(bufferView, &VulkanObjectInfoTable::RemoveBufferViewInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateImage(
@@ -740,6 +750,7 @@ void VulkanReplayConsumer::Process_vkDestroyImage(
     auto in_image = GetObjectInfoTable().GetImageInfo(image);
 
     OverrideDestroyImage(GetDeviceTable(in_device->handle)->DestroyImage, in_device, in_image, pAllocator);
+    RemoveHandle(image, &VulkanObjectInfoTable::RemoveImageInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetImageSubresourceLayout(
@@ -785,6 +796,7 @@ void VulkanReplayConsumer::Process_vkDestroyImageView(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyImageView(in_device, in_imageView, in_pAllocator);
+    RemoveHandle(imageView, &VulkanObjectInfoTable::RemoveImageViewInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateShaderModule(
@@ -817,6 +829,7 @@ void VulkanReplayConsumer::Process_vkDestroyShaderModule(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyShaderModule(in_device, in_shaderModule, in_pAllocator);
+    RemoveHandle(shaderModule, &VulkanObjectInfoTable::RemoveShaderModuleInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreatePipelineCache(
@@ -847,6 +860,7 @@ void VulkanReplayConsumer::Process_vkDestroyPipelineCache(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyPipelineCache(in_device, in_pipelineCache, in_pAllocator);
+    RemoveHandle(pipelineCache, &VulkanObjectInfoTable::RemovePipelineCacheInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPipelineCacheData(
@@ -938,6 +952,7 @@ void VulkanReplayConsumer::Process_vkDestroyPipeline(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyPipeline(in_device, in_pipeline, in_pAllocator);
+    RemoveHandle(pipeline, &VulkanObjectInfoTable::RemovePipelineInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreatePipelineLayout(
@@ -970,6 +985,7 @@ void VulkanReplayConsumer::Process_vkDestroyPipelineLayout(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyPipelineLayout(in_device, in_pipelineLayout, in_pAllocator);
+    RemoveHandle(pipelineLayout, &VulkanObjectInfoTable::RemovePipelineLayoutInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateSampler(
@@ -1002,6 +1018,7 @@ void VulkanReplayConsumer::Process_vkDestroySampler(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroySampler(in_device, in_sampler, in_pAllocator);
+    RemoveHandle(sampler, &VulkanObjectInfoTable::RemoveSamplerInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateDescriptorSetLayout(
@@ -1034,6 +1051,7 @@ void VulkanReplayConsumer::Process_vkDestroyDescriptorSetLayout(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyDescriptorSetLayout(in_device, in_descriptorSetLayout, in_pAllocator);
+    RemoveHandle(descriptorSetLayout, &VulkanObjectInfoTable::RemoveDescriptorSetLayoutInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateDescriptorPool(
@@ -1065,6 +1083,7 @@ void VulkanReplayConsumer::Process_vkDestroyDescriptorPool(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyDescriptorPool(in_device, in_descriptorPool, in_pAllocator);
+    RemovePoolHandle<DescriptorPoolInfo>(descriptorPool, &VulkanObjectInfoTable::GetDescriptorPoolInfo, &VulkanObjectInfoTable::RemoveDescriptorPoolInfo, &VulkanObjectInfoTable::RemoveDescriptorSetInfo);
 }
 
 void VulkanReplayConsumer::Process_vkResetDescriptorPool(
@@ -1073,10 +1092,10 @@ void VulkanReplayConsumer::Process_vkResetDescriptorPool(
     format::HandleId                            descriptorPool,
     VkDescriptorPoolResetFlags                  flags)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkDescriptorPool in_descriptorPool = MapHandle<DescriptorPoolInfo>(descriptorPool, &VulkanObjectInfoTable::GetDescriptorPoolInfo);
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
+    auto in_descriptorPool = GetObjectInfoTable().GetDescriptorPoolInfo(descriptorPool);
 
-    VkResult replay_result = GetDeviceTable(in_device)->ResetDescriptorPool(in_device, in_descriptorPool, flags);
+    VkResult replay_result = OverrideResetDescriptorPool(GetDeviceTable(in_device->handle)->ResetDescriptorPool, returnValue, in_device, in_descriptorPool, flags);
     CheckResult("vkResetDescriptorPool", returnValue, replay_result);
 }
 
@@ -1096,7 +1115,7 @@ void VulkanReplayConsumer::Process_vkAllocateDescriptorSets(
     VkResult replay_result = OverrideAllocateDescriptorSets(GetDeviceTable(in_device->handle)->AllocateDescriptorSets, returnValue, in_device, pAllocateInfo, pDescriptorSets);
     CheckResult("vkAllocateDescriptorSets", returnValue, replay_result);
 
-    AddHandles<DescriptorSetInfo>(device, pDescriptorSets->GetPointer(), pDescriptorSets->GetLength(), pDescriptorSets->GetHandlePointer(), pAllocateInfo->GetPointer()->descriptorSetCount, std::move(handle_info), &VulkanObjectInfoTable::AddDescriptorSetInfo);
+    AddPoolHandles<DescriptorPoolInfo, DescriptorSetInfo>(device, handle_mapping::GetPoolId(pAllocateInfo->GetMetaStructPointer()), pDescriptorSets->GetPointer(), pDescriptorSets->GetLength(), pDescriptorSets->GetHandlePointer(), pAllocateInfo->GetPointer()->descriptorSetCount, std::move(handle_info), &VulkanObjectInfoTable::GetDescriptorPoolInfo, &VulkanObjectInfoTable::AddDescriptorSetInfo);
 }
 
 void VulkanReplayConsumer::Process_vkFreeDescriptorSets(
@@ -1112,6 +1131,7 @@ void VulkanReplayConsumer::Process_vkFreeDescriptorSets(
 
     VkResult replay_result = GetDeviceTable(in_device)->FreeDescriptorSets(in_device, in_descriptorPool, descriptorSetCount, in_pDescriptorSets);
     CheckResult("vkFreeDescriptorSets", returnValue, replay_result);
+    RemovePoolHandles<DescriptorPoolInfo, DescriptorSetInfo>(descriptorPool, pDescriptorSets, descriptorSetCount, &VulkanObjectInfoTable::GetDescriptorPoolInfo, &VulkanObjectInfoTable::RemoveDescriptorSetInfo);
 }
 
 void VulkanReplayConsumer::Process_vkUpdateDescriptorSets(
@@ -1160,6 +1180,7 @@ void VulkanReplayConsumer::Process_vkDestroyFramebuffer(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyFramebuffer(in_device, in_framebuffer, in_pAllocator);
+    RemoveHandle(framebuffer, &VulkanObjectInfoTable::RemoveFramebufferInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateRenderPass(
@@ -1191,6 +1212,7 @@ void VulkanReplayConsumer::Process_vkDestroyRenderPass(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyRenderPass(in_device, in_renderPass, in_pAllocator);
+    RemoveHandle(renderPass, &VulkanObjectInfoTable::RemoveRenderPassInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetRenderAreaGranularity(
@@ -1234,6 +1256,7 @@ void VulkanReplayConsumer::Process_vkDestroyCommandPool(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyCommandPool(in_device, in_commandPool, in_pAllocator);
+    RemovePoolHandle<CommandPoolInfo>(commandPool, &VulkanObjectInfoTable::GetCommandPoolInfo, &VulkanObjectInfoTable::RemoveCommandPoolInfo, &VulkanObjectInfoTable::RemoveCommandBufferInfo);
 }
 
 void VulkanReplayConsumer::Process_vkResetCommandPool(
@@ -1265,7 +1288,7 @@ void VulkanReplayConsumer::Process_vkAllocateCommandBuffers(
     VkResult replay_result = OverrideAllocateCommandBuffers(GetDeviceTable(in_device->handle)->AllocateCommandBuffers, returnValue, in_device, pAllocateInfo, pCommandBuffers);
     CheckResult("vkAllocateCommandBuffers", returnValue, replay_result);
 
-    AddHandles<CommandBufferInfo>(device, pCommandBuffers->GetPointer(), pCommandBuffers->GetLength(), pCommandBuffers->GetHandlePointer(), pAllocateInfo->GetPointer()->commandBufferCount, std::move(handle_info), &VulkanObjectInfoTable::AddCommandBufferInfo);
+    AddPoolHandles<CommandPoolInfo, CommandBufferInfo>(device, handle_mapping::GetPoolId(pAllocateInfo->GetMetaStructPointer()), pCommandBuffers->GetPointer(), pCommandBuffers->GetLength(), pCommandBuffers->GetHandlePointer(), pAllocateInfo->GetPointer()->commandBufferCount, std::move(handle_info), &VulkanObjectInfoTable::GetCommandPoolInfo, &VulkanObjectInfoTable::AddCommandBufferInfo);
 }
 
 void VulkanReplayConsumer::Process_vkFreeCommandBuffers(
@@ -1279,6 +1302,7 @@ void VulkanReplayConsumer::Process_vkFreeCommandBuffers(
     const VkCommandBuffer* in_pCommandBuffers = MapHandles<CommandBufferInfo>(pCommandBuffers, commandBufferCount, &VulkanObjectInfoTable::GetCommandBufferInfo);
 
     GetDeviceTable(in_device)->FreeCommandBuffers(in_device, in_commandPool, commandBufferCount, in_pCommandBuffers);
+    RemovePoolHandles<CommandPoolInfo, CommandBufferInfo>(commandPool, pCommandBuffers, commandBufferCount, &VulkanObjectInfoTable::GetCommandPoolInfo, &VulkanObjectInfoTable::RemoveCommandBufferInfo);
 }
 
 void VulkanReplayConsumer::Process_vkBeginCommandBuffer(
@@ -2161,6 +2185,7 @@ void VulkanReplayConsumer::Process_vkDestroySamplerYcbcrConversion(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroySamplerYcbcrConversion(in_device, in_ycbcrConversion, in_pAllocator);
+    RemoveHandle(ycbcrConversion, &VulkanObjectInfoTable::RemoveSamplerYcbcrConversionInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateDescriptorUpdateTemplate(
@@ -2192,6 +2217,7 @@ void VulkanReplayConsumer::Process_vkDestroyDescriptorUpdateTemplate(
     auto in_descriptorUpdateTemplate = GetObjectInfoTable().GetDescriptorUpdateTemplateInfo(descriptorUpdateTemplate);
 
     OverrideDestroyDescriptorUpdateTemplate(GetDeviceTable(in_device->handle)->DestroyDescriptorUpdateTemplate, in_device, in_descriptorUpdateTemplate, pAllocator);
+    RemoveHandle(descriptorUpdateTemplate, &VulkanObjectInfoTable::RemoveDescriptorUpdateTemplateInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalBufferProperties(
@@ -2427,6 +2453,7 @@ void VulkanReplayConsumer::Process_vkDestroySurfaceKHR(
     auto in_surface = GetObjectInfoTable().GetSurfaceKHRInfo(surface);
 
     OverrideDestroySurfaceKHR(GetInstanceTable(in_instance->handle)->DestroySurfaceKHR, in_instance, in_surface, pAllocator);
+    RemoveHandle(surface, &VulkanObjectInfoTable::RemoveSurfaceKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceSupportKHR(
@@ -2523,6 +2550,7 @@ void VulkanReplayConsumer::Process_vkDestroySwapchainKHR(
     auto in_swapchain = GetObjectInfoTable().GetSwapchainKHRInfo(swapchain);
 
     OverrideDestroySwapchainKHR(GetDeviceTable(in_device->handle)->DestroySwapchainKHR, in_device, in_swapchain, pAllocator);
+    RemoveHandle(swapchain, &VulkanObjectInfoTable::RemoveSwapchainKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetSwapchainImagesKHR(
@@ -3262,6 +3290,7 @@ void VulkanReplayConsumer::Process_vkDestroyDescriptorUpdateTemplateKHR(
     auto in_descriptorUpdateTemplate = GetObjectInfoTable().GetDescriptorUpdateTemplateInfo(descriptorUpdateTemplate);
 
     OverrideDestroyDescriptorUpdateTemplate(GetDeviceTable(in_device->handle)->DestroyDescriptorUpdateTemplateKHR, in_device, in_descriptorUpdateTemplate, pAllocator);
+    RemoveHandle(descriptorUpdateTemplate, &VulkanObjectInfoTable::RemoveDescriptorUpdateTemplateInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreateRenderPass2KHR(
@@ -3626,6 +3655,7 @@ void VulkanReplayConsumer::Process_vkDestroySamplerYcbcrConversionKHR(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroySamplerYcbcrConversionKHR(in_device, in_ycbcrConversion, in_pAllocator);
+    RemoveHandle(ycbcrConversion, &VulkanObjectInfoTable::RemoveSamplerYcbcrConversionInfo);
 }
 
 void VulkanReplayConsumer::Process_vkBindBufferMemory2KHR(
@@ -3805,6 +3835,7 @@ void VulkanReplayConsumer::Process_vkDestroyDeferredOperationKHR(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyDeferredOperationKHR(in_device, in_operation, in_pAllocator);
+    RemoveHandle(operation, &VulkanObjectInfoTable::RemoveDeferredOperationKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetDeferredOperationMaxConcurrencyKHR(
@@ -3993,6 +4024,7 @@ void VulkanReplayConsumer::Process_vkDestroyDebugReportCallbackEXT(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetInstanceTable(in_instance)->DestroyDebugReportCallbackEXT(in_instance, in_callback, in_pAllocator);
+    RemoveHandle(callback, &VulkanObjectInfoTable::RemoveDebugReportCallbackEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDebugReportMessageEXT(
@@ -4660,6 +4692,7 @@ void VulkanReplayConsumer::Process_vkDestroyDebugUtilsMessengerEXT(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetInstanceTable(in_instance)->DestroyDebugUtilsMessengerEXT(in_instance, in_messenger, in_pAllocator);
+    RemoveHandle(messenger, &VulkanObjectInfoTable::RemoveDebugUtilsMessengerEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkSubmitDebugUtilsMessageEXT(
@@ -4769,6 +4802,7 @@ void VulkanReplayConsumer::Process_vkDestroyValidationCacheEXT(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyValidationCacheEXT(in_device, in_validationCache, in_pAllocator);
+    RemoveHandle(validationCache, &VulkanObjectInfoTable::RemoveValidationCacheEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkMergeValidationCachesEXT(
@@ -4869,6 +4903,7 @@ void VulkanReplayConsumer::Process_vkDestroyAccelerationStructureKHR(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyAccelerationStructureKHR(in_device, in_accelerationStructure, in_pAllocator);
+    RemoveHandle(accelerationStructure, &VulkanObjectInfoTable::RemoveAccelerationStructureKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyAccelerationStructureNV(
@@ -4881,6 +4916,7 @@ void VulkanReplayConsumer::Process_vkDestroyAccelerationStructureNV(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyAccelerationStructureNV(in_device, in_accelerationStructure, in_pAllocator);
+    RemoveHandle(accelerationStructure, &VulkanObjectInfoTable::RemoveAccelerationStructureKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetAccelerationStructureMemoryRequirementsNV(
@@ -5757,6 +5793,7 @@ void VulkanReplayConsumer::Process_vkDestroyIndirectCommandsLayoutNV(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyIndirectCommandsLayoutNV(in_device, in_indirectCommandsLayout, in_pAllocator);
+    RemoveHandle(indirectCommandsLayout, &VulkanObjectInfoTable::RemoveIndirectCommandsLayoutNVInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCreatePrivateDataSlotEXT(
@@ -5788,6 +5825,7 @@ void VulkanReplayConsumer::Process_vkDestroyPrivateDataSlotEXT(
     const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
 
     GetDeviceTable(in_device)->DestroyPrivateDataSlotEXT(in_device, in_privateDataSlot, in_pAllocator);
+    RemoveHandle(privateDataSlot, &VulkanObjectInfoTable::RemovePrivateDataSlotEXTInfo);
 }
 
 void VulkanReplayConsumer::Process_vkSetPrivateDataEXT(

--- a/framework/generated/generated_vulkan_struct_handle_mappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.cpp
@@ -1331,59 +1331,59 @@ void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectI
     }
 }
 
-void AddStructHandles(const Decoded_VkPhysicalDeviceGroupProperties* id_wrapper, const VkPhysicalDeviceGroupProperties* handle_struct, VulkanObjectInfoTable* object_info_table)
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkPhysicalDeviceGroupProperties* id_wrapper, const VkPhysicalDeviceGroupProperties* handle_struct, VulkanObjectInfoTable* object_info_table)
 {
     if (id_wrapper != nullptr)
     {
-        handle_mapping::AddHandleArray<PhysicalDeviceInfo>(id_wrapper->physicalDevices.GetPointer(), id_wrapper->physicalDevices.GetLength(), handle_struct->physicalDevices, handle_struct->physicalDeviceCount, object_info_table, &VulkanObjectInfoTable::AddPhysicalDeviceInfo);
+        handle_mapping::AddHandleArray<PhysicalDeviceInfo>(parent_id, id_wrapper->physicalDevices.GetPointer(), id_wrapper->physicalDevices.GetLength(), handle_struct->physicalDevices, handle_struct->physicalDeviceCount, object_info_table, &VulkanObjectInfoTable::AddPhysicalDeviceInfo);
     }
 }
 
-void AddStructHandles(const Decoded_VkDisplayPropertiesKHR* id_wrapper, const VkDisplayPropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table)
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPropertiesKHR* id_wrapper, const VkDisplayPropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table)
 {
     if (id_wrapper != nullptr)
     {
-        handle_mapping::AddHandle<DisplayKHRInfo>(id_wrapper->display, handle_struct->display, object_info_table, &VulkanObjectInfoTable::AddDisplayKHRInfo);
+        handle_mapping::AddHandle<DisplayKHRInfo>(parent_id, id_wrapper->display, handle_struct->display, object_info_table, &VulkanObjectInfoTable::AddDisplayKHRInfo);
     }
 }
 
-void AddStructHandles(const Decoded_VkDisplayPlanePropertiesKHR* id_wrapper, const VkDisplayPlanePropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table)
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPlanePropertiesKHR* id_wrapper, const VkDisplayPlanePropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table)
 {
     if (id_wrapper != nullptr)
     {
-        handle_mapping::AddHandle<DisplayKHRInfo>(id_wrapper->currentDisplay, handle_struct->currentDisplay, object_info_table, &VulkanObjectInfoTable::AddDisplayKHRInfo);
+        handle_mapping::AddHandle<DisplayKHRInfo>(parent_id, id_wrapper->currentDisplay, handle_struct->currentDisplay, object_info_table, &VulkanObjectInfoTable::AddDisplayKHRInfo);
     }
 }
 
-void AddStructHandles(const Decoded_VkDisplayModePropertiesKHR* id_wrapper, const VkDisplayModePropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table)
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayModePropertiesKHR* id_wrapper, const VkDisplayModePropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table)
 {
     if (id_wrapper != nullptr)
     {
-        handle_mapping::AddHandle<DisplayModeKHRInfo>(id_wrapper->displayMode, handle_struct->displayMode, object_info_table, &VulkanObjectInfoTable::AddDisplayModeKHRInfo);
+        handle_mapping::AddHandle<DisplayModeKHRInfo>(parent_id, id_wrapper->displayMode, handle_struct->displayMode, object_info_table, &VulkanObjectInfoTable::AddDisplayModeKHRInfo);
     }
 }
 
-void AddStructHandles(const Decoded_VkDisplayProperties2KHR* id_wrapper, const VkDisplayProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table)
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayProperties2KHR* id_wrapper, const VkDisplayProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table)
 {
     if (id_wrapper != nullptr)
     {
-        AddStructHandles(id_wrapper->displayProperties.get(), &handle_struct->displayProperties, object_info_table);
+        AddStructHandles(parent_id, id_wrapper->displayProperties.get(), &handle_struct->displayProperties, object_info_table);
     }
 }
 
-void AddStructHandles(const Decoded_VkDisplayPlaneProperties2KHR* id_wrapper, const VkDisplayPlaneProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table)
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPlaneProperties2KHR* id_wrapper, const VkDisplayPlaneProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table)
 {
     if (id_wrapper != nullptr)
     {
-        AddStructHandles(id_wrapper->displayPlaneProperties.get(), &handle_struct->displayPlaneProperties, object_info_table);
+        AddStructHandles(parent_id, id_wrapper->displayPlaneProperties.get(), &handle_struct->displayPlaneProperties, object_info_table);
     }
 }
 
-void AddStructHandles(const Decoded_VkDisplayModeProperties2KHR* id_wrapper, const VkDisplayModeProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table)
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayModeProperties2KHR* id_wrapper, const VkDisplayModeProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table)
 {
     if (id_wrapper != nullptr)
     {
-        AddStructHandles(id_wrapper->displayModeProperties.get(), &handle_struct->displayModeProperties, object_info_table);
+        AddStructHandles(parent_id, id_wrapper->displayModeProperties.get(), &handle_struct->displayModeProperties, object_info_table);
     }
 }
 

--- a/framework/generated/generated_vulkan_struct_handle_mappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.h
@@ -270,22 +270,22 @@ void MapStructArrayHandles(T* structs, size_t len, const VulkanObjectInfoTable& 
     }
 }
 
-void AddStructHandles(const Decoded_VkPhysicalDeviceGroupProperties* id_wrapper, const VkPhysicalDeviceGroupProperties* handle_struct, VulkanObjectInfoTable* object_info_table);
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkPhysicalDeviceGroupProperties* id_wrapper, const VkPhysicalDeviceGroupProperties* handle_struct, VulkanObjectInfoTable* object_info_table);
 
-void AddStructHandles(const Decoded_VkDisplayPropertiesKHR* id_wrapper, const VkDisplayPropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table);
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPropertiesKHR* id_wrapper, const VkDisplayPropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table);
 
-void AddStructHandles(const Decoded_VkDisplayPlanePropertiesKHR* id_wrapper, const VkDisplayPlanePropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table);
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPlanePropertiesKHR* id_wrapper, const VkDisplayPlanePropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table);
 
-void AddStructHandles(const Decoded_VkDisplayModePropertiesKHR* id_wrapper, const VkDisplayModePropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table);
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayModePropertiesKHR* id_wrapper, const VkDisplayModePropertiesKHR* handle_struct, VulkanObjectInfoTable* object_info_table);
 
-void AddStructHandles(const Decoded_VkDisplayProperties2KHR* id_wrapper, const VkDisplayProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table);
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayProperties2KHR* id_wrapper, const VkDisplayProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table);
 
-void AddStructHandles(const Decoded_VkDisplayPlaneProperties2KHR* id_wrapper, const VkDisplayPlaneProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table);
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPlaneProperties2KHR* id_wrapper, const VkDisplayPlaneProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table);
 
-void AddStructHandles(const Decoded_VkDisplayModeProperties2KHR* id_wrapper, const VkDisplayModeProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table);
+void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayModeProperties2KHR* id_wrapper, const VkDisplayModeProperties2KHR* handle_struct, VulkanObjectInfoTable* object_info_table);
 
 template <typename T>
-void AddStructArrayHandles(const T* id_wrappers, size_t id_len, const typename T::struct_type* handle_structs, size_t handle_len, VulkanObjectInfoTable* object_info_table)
+void AddStructArrayHandles(format::HandleId parent_id, const T* id_wrappers, size_t id_len, const typename T::struct_type* handle_structs, size_t handle_len, VulkanObjectInfoTable* object_info_table)
 {
     if (id_wrappers != nullptr && handle_structs != nullptr)
     {
@@ -293,7 +293,7 @@ void AddStructArrayHandles(const T* id_wrappers, size_t id_len, const typename T
         size_t len = std::min(id_len, handle_len);
         for (size_t i = 0; i < len; ++i)
         {
-            AddStructHandles(&id_wrappers[i], &handle_structs[i], object_info_table);
+            AddStructHandles(parent_id, &id_wrappers[i], &handle_structs[i], object_info_table);
         }
     }
 }

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -38,6 +38,7 @@
     "vkGetImageSubresourceLayout" : "OverrideGetImageSubresourceLayout",
     "vkCreateShaderModule": "OverrideCreateShaderModule",
     "vkCreatePipelineCache": "OverrideCreatePipelineCache",
+    "vkResetDescriptorPool": "OverrideResetDescriptorPool",
     "vkCreateDescriptorUpdateTemplate": "OverrideCreateDescriptorUpdateTemplate",
     "vkCreateDescriptorUpdateTemplateKHR": "OverrideCreateDescriptorUpdateTemplate",
     "vkDestroyDescriptorUpdateTemplate": "OverrideDestroyDescriptorUpdateTemplate",

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -1,7 +1,6 @@
 {
   "functions": {
     "vkCreateInstance": "OverrideCreateInstance",
-    "vkDestroyInstance" : "OverrideDestroyInstance",
     "vkCreateDevice": "OverrideCreateDevice",
     "vkDestroyDevice" : "OverrideDestroyDevice",
     "vkEnumeratePhysicalDevices": "OverrideEnumeratePhysicalDevices",

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
@@ -87,11 +87,11 @@ class VulkanStructHandleMappersHeaderGenerator(BaseGenerator):
         self.newline()
 
         for struct in self.outputStructsWithHandles:
-            write('void AddStructHandles(const Decoded_{type}* id_wrapper, const {type}* handle_struct, VulkanObjectInfoTable* object_info_table);'.format(type=struct), file=self.outFile)
+            write('void AddStructHandles(format::HandleId parent_id, const Decoded_{type}* id_wrapper, const {type}* handle_struct, VulkanObjectInfoTable* object_info_table);'.format(type=struct), file=self.outFile)
             self.newline()
 
         write('template <typename T>', file=self.outFile)
-        write('void AddStructArrayHandles(const T* id_wrappers, size_t id_len, const typename T::struct_type* handle_structs, size_t handle_len, VulkanObjectInfoTable* object_info_table)', file=self.outFile)
+        write('void AddStructArrayHandles(format::HandleId parent_id, const T* id_wrappers, size_t id_len, const typename T::struct_type* handle_structs, size_t handle_len, VulkanObjectInfoTable* object_info_table)', file=self.outFile)
         write('{', file=self.outFile)
         write('    if (id_wrappers != nullptr && handle_structs != nullptr)', file=self.outFile)
         write('    {', file=self.outFile)
@@ -99,7 +99,7 @@ class VulkanStructHandleMappersHeaderGenerator(BaseGenerator):
         write('        size_t len = std::min(id_len, handle_len);', file=self.outFile)
         write('        for (size_t i = 0; i < len; ++i)', file=self.outFile)
         write('        {', file=self.outFile)
-        write('            AddStructHandles(&id_wrappers[i], &handle_structs[i], object_info_table);', file=self.outFile)
+        write('            AddStructHandles(parent_id, &id_wrappers[i], &handle_structs[i], object_info_table);', file=self.outFile)
         write('        }', file=self.outFile)
         write('    }', file=self.outFile)
         write('}', file=self.outFile)


### PR DESCRIPTION
If instance or device objects are still live at replay exit, replay will now destroy them and any objects that may have been created from them.  If no instance or device objects were live at replay exit, but other Vulkan objects are live, replay will report the total number of Vulkan objects of each type that were leaked.

This change is primarily targeted at trimmed files, which may not have recorded the API calls to destroy objects.  For Android, leaked resource can be an issue as the replay Activity starts and stops, but the process does not always exit, so consecutive replays either leak resources until the process runs out of memory or start with layers in the state from the previous replay because a VkInstance object was not destroyed and the layer libraries remained loaded by the process.