### PR TITLE
Add a replay option to disable unsupported extensions and device features

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -287,7 +287,8 @@ usage: gfxrecon.py replay [-h] [-p LOCAL_FILE] [--version] [--pause-frame N]
                           [--paused] [--screenshot-all] [--screenshots RANGES]
                           [--screenshot-format FORMAT] [--screenshot-dir DIR]
                           [--screenshot-prefix PREFIX] [--sfa] [--opcd]
-                          [--surface-index N] [--sync] [-m MODE]
+                          [--surface-index N] [--sync] [--remove-unsupported]
+                          [-m MODE]
                           [file]
 
 Launch the replay tool.
@@ -341,6 +342,9 @@ optional arguments:
                         replay tool)
   --sync                Synchronize after each queue submission with
                         vkQueueWaitIdle (forwarded to replay tool)
+  --remove-unsupported  Remove unsupported extensions and features from
+                        instance and device creation parameters (forwarded to
+                        replay tool)
   -m MODE, --memory-translation MODE
                         Enable memory translation for replay on GPUs with
                         memory types that are not compatible with the capture

--- a/USAGE_desktop.md
+++ b/USAGE_desktop.md
@@ -334,7 +334,9 @@ gfxrecon-replay         [-h | --help] [--version] [--gpu <index>]
                         [--screenshot-dir <dir>] [--screenshot-prefix <file-prefix>]
                         [--sfa | --skip-failed-allocations] [--replace-shaders <dir>]
                         [--opcd | --omit-pipeline-cache-data] [--wsi <platform>]
-                        [--surface-index <N>] [-m <mode> | --memory-translation <mode>]<file>
+                        [--surface-index <N>] [--remove-unsupported]
+                        [-m <mode> | --memory-translation <mode>]
+                        <file>
 
 Required arguments:
   <file>                Path to the capture file to replay.
@@ -391,6 +393,8 @@ Optional arguments:
                         Used with captures that include multiple surfaces.  Default
                         is -1 (render to all surfaces).
   --sync                Synchronize after each queue submission with vkQueueWaitIdle.
+  --remove-unsupported  Remove unsupported extensions and features from instance
+                        and device creation parameters.
   -m <mode>             Enable memory translation for replay on GPUs with memory
                         types that are not compatible with the capture GPU's
                         memory types.  Available modes are:

--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -74,6 +74,7 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_consumer.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_decoder.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_feature_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_referenced_resource_consumer.h
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/generated/generated_vulkan_replay_consumer.h

--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -41,6 +41,8 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_default_allocator.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_default_allocator.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_enum_util.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_feature_util.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_feature_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_handle_mapping_util.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_object_cleanup_util.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_object_cleanup_util.cpp

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2018-2019 LunarG, Inc.
+# Copyright (c) 2018-2020 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -71,6 +71,7 @@ def CreateReplayParser():
     parser.add_argument('--opcd', '--omit-pipeline-cache-data', action='store_true', default=False, help='Omit pipeline cache data from calls to vkCreatePipelineCache and skip calls to vkGetPipelineCacheData (forwarded to replay tool)')
     parser.add_argument('--surface-index', metavar='N', help='Restrict rendering to the Nth surface object created.  Used with captures that include multiple surfaces.  Default is -1 (render to all surfaces; forwarded to replay tool)')
     parser.add_argument('--sync', action='store_true', default=False, help='Synchronize after each queue submission with vkQueueWaitIdle (forwarded to replay tool)')
+    parser.add_argument('--remove-unsupported', action='store_true', default=False, help='Remove unsupported extensions and features from instance and device creation parameters (forwarded to replay tool)')
     parser.add_argument('-m', '--memory-translation', metavar='MODE', choices=['none', 'remap', 'realign', 'rebind'], help='Enable memory translation for replay on GPUs with memory types that are not compatible with the capture GPU\'s memory types.  Available modes are: none, remap, realign, rebind (forwarded to replay tool)')
     parser.add_argument('file', nargs='?', help='File on device to play (forwarded to replay tool)')
     return parser
@@ -118,6 +119,9 @@ def MakeExtrasString(args):
 
     if args.sync:
         arg_list.append('--sync')
+
+    if args.remove_unsupported:
+        arg_list.append('--remove-unsupported')
 
     if args.memory_translation:
         arg_list.append('-m')

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -96,6 +96,7 @@ target_sources(gfxrecon_decode
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_consumer.h
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_decoder.h
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_decoder.cpp
+                    ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_feature_util.cpp
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_referenced_resource_consumer.h
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_replay_consumer.h

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -63,6 +63,8 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_default_allocator.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_default_allocator.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_enum_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_feature_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_feature_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_mapping_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_object_cleanup_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_object_cleanup_util.cpp

--- a/framework/decode/vulkan_feature_util.cpp
+++ b/framework/decode/vulkan_feature_util.cpp
@@ -1,0 +1,104 @@
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include "decode/vulkan_feature_util.h"
+#include "util/logging.h"
+
+#include <cassert>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+GFXRECON_BEGIN_NAMESPACE(feature_util)
+
+VkResult GetInstanceExtensions(PFN_vkEnumerateInstanceExtensionProperties instance_extension_proc,
+                               std::vector<VkExtensionProperties>*        properties)
+{
+    assert(properties != nullptr);
+
+    VkResult result = VK_ERROR_INITIALIZATION_FAILED;
+
+    if (instance_extension_proc != nullptr)
+    {
+        uint32_t count = 0;
+        result         = instance_extension_proc(nullptr, &count, nullptr);
+
+        if ((result == VK_SUCCESS) && (count > 0))
+        {
+            properties->resize(count);
+            result = instance_extension_proc(nullptr, &count, properties->data());
+        }
+    }
+
+    return result;
+}
+
+VkResult GetDeviceExtensions(VkPhysicalDevice                         physical_device,
+                             PFN_vkEnumerateDeviceExtensionProperties device_extension_proc,
+                             std::vector<VkExtensionProperties>*      properties)
+{
+    assert(properties != nullptr);
+
+    VkResult result = VK_ERROR_INITIALIZATION_FAILED;
+
+    if ((physical_device != VK_NULL_HANDLE) && (device_extension_proc != nullptr))
+    {
+        uint32_t count = 0;
+        result         = device_extension_proc(physical_device, nullptr, &count, nullptr);
+
+        if ((result == VK_SUCCESS) && (count > 0))
+        {
+            properties->resize(count);
+            result = device_extension_proc(physical_device, nullptr, &count, properties->data());
+        }
+    }
+
+    return result;
+}
+
+void RemoveUnsupportedExtensions(const std::vector<VkExtensionProperties>& properties,
+                                 std::vector<const char*>*                 extensions)
+{
+    assert(extensions != nullptr);
+
+    auto extensionIter = extensions->begin();
+    while (extensionIter != extensions->end())
+    {
+        bool found = false;
+        for (const auto& property : properties)
+        {
+            if (strcmp(property.extensionName, *extensionIter) == 0)
+            {
+                found = true;
+                break;
+            }
+        }
+
+        if (found == false)
+        {
+            GFXRECON_LOG_WARNING("Extension %s, which is not supported by the replay device, will not be enabled",
+                                 *extensionIter);
+            extensionIter = extensions->erase(extensionIter);
+        }
+        else
+        {
+            ++extensionIter;
+        }
+    }
+}
+
+GFXRECON_END_NAMESPACE(feature_util)
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_feature_util.h
+++ b/framework/decode/vulkan_feature_util.h
@@ -1,0 +1,44 @@
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef GFXRECON_DECODE_VULKAN_FEATURE_FILTER_UTIL_H
+#define GFXRECON_DECODE_VULKAN_FEATURE_FILTER_UTIL_H
+
+#include "util/defines.h"
+
+#include "vulkan/vulkan.h"
+
+#include <vector>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+GFXRECON_BEGIN_NAMESPACE(feature_util)
+
+VkResult GetInstanceExtensions(PFN_vkEnumerateInstanceExtensionProperties instance_extension_proc,
+                               std::vector<VkExtensionProperties>*        properties);
+
+VkResult GetDeviceExtensions(VkPhysicalDevice                         physical_device,
+                             PFN_vkEnumerateDeviceExtensionProperties device_extension_proc,
+                             std::vector<VkExtensionProperties>*      properties);
+
+void RemoveUnsupportedExtensions(const std::vector<VkExtensionProperties>& properties,
+                                 std::vector<const char*>*                 extensions);
+
+GFXRECON_END_NAMESPACE(feature_util)
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_VULKAN_FEATURE_FILTER_UTIL_H

--- a/framework/decode/vulkan_feature_util.h
+++ b/framework/decode/vulkan_feature_util.h
@@ -37,6 +37,13 @@ VkResult GetDeviceExtensions(VkPhysicalDevice                         physical_d
 void RemoveUnsupportedExtensions(const std::vector<VkExtensionProperties>& properties,
                                  std::vector<const char*>*                 extensions);
 
+// This is a declaration for a generated function.
+void RemoveUnsupportedFeatures(VkPhysicalDevice                 physicalDevice,
+                               PFN_vkGetPhysicalDeviceFeatures  get_device_features_proc,
+                               PFN_vkGetPhysicalDeviceFeatures2 get_device_features2_proc,
+                               const void*                      pNext,
+                               const VkPhysicalDeviceFeatures*  pEnabledFeatures);
+
 GFXRECON_END_NAMESPACE(feature_util)
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2377,6 +2377,13 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult            original_resu
             {
                 feature_util::RemoveUnsupportedExtensions(properties, &modified_extensions);
             }
+
+            // Remove enabled features that are not available from the replay device.
+            feature_util::RemoveUnsupportedFeatures(physical_device,
+                                                    table->GetPhysicalDeviceFeatures,
+                                                    table->GetPhysicalDeviceFeatures2,
+                                                    modified_create_info.pNext,
+                                                    modified_create_info.pEnabledFeatures);
         }
 
         modified_create_info.enabledExtensionCount   = static_cast<uint32_t>(modified_extensions.size());

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -21,6 +21,7 @@
 #include "decode/descriptor_update_template_decoder.h"
 #include "decode/resource_util.h"
 #include "decode/vulkan_enum_util.h"
+#include "decode/vulkan_feature_util.h"
 #include "decode/vulkan_object_cleanup_util.h"
 #include "format/format_util.h"
 #include "generated/generated_vulkan_struct_handle_mappers.h"
@@ -2241,6 +2242,7 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
     {
         if (replay_create_info->ppEnabledExtensionNames)
         {
+            // Swap the surface extension supported by platform the replay is running on if different from trace
             for (uint32_t i = 0; i < replay_create_info->enabledExtensionCount; ++i)
             {
                 const char* current_extension = replay_create_info->ppEnabledExtensionNames[i];
@@ -2251,6 +2253,21 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
                 else
                 {
                     filtered_extensions.push_back(current_extension);
+                }
+            }
+
+            if (options_.remove_unsupported_features)
+            {
+                // Remove enabled extensions that are not available from the replay instance.
+                // Proc addresses that can't be used in layers so are not generated into shared dispatch table, but are
+                // needed in the replay application.
+                PFN_vkEnumerateInstanceExtensionProperties instance_extension_proc =
+                    reinterpret_cast<PFN_vkEnumerateInstanceExtensionProperties>(
+                        get_instance_proc_addr_(nullptr, "vkEnumerateInstanceExtensionProperties"));
+                std::vector<VkExtensionProperties> properties;
+                if (feature_util::GetInstanceExtensions(instance_extension_proc, &properties) == VK_SUCCESS)
+                {
+                    feature_util::RemoveUnsupportedExtensions(properties, &filtered_extensions);
                 }
             }
         }
@@ -2321,49 +2338,52 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult            original_resu
     {
         auto replay_create_info = pCreateInfo->GetPointer();
         auto replay_device      = pDevice->GetHandlePointer();
+        assert(replay_create_info != nullptr);
+        VkDeviceCreateInfo modified_create_info = (*replay_create_info);
 
+        // Make copy so list can be modified without effecting original.
+        std::vector<const char*> modified_extensions;
+        if (replay_create_info->ppEnabledExtensionNames)
+        {
+            modified_extensions.insert(
+                modified_extensions.begin(),
+                replay_create_info->ppEnabledExtensionNames,
+                std::next(replay_create_info->ppEnabledExtensionNames, replay_create_info->enabledExtensionCount));
+        }
+
+        // Enable extensions used for loading resources during initial state setup for trimmed files.
         std::vector<std::string> extensions;
         if (loading_trim_state_ && CheckTrimDeviceExtensions(physical_device, &extensions))
         {
-            std::vector<const char*> modified_extensions;
-            VkDeviceCreateInfo       modified_create_info{};
-
-            if (replay_create_info != nullptr)
+            for (const auto& extension : extensions)
             {
-                if (replay_create_info->ppEnabledExtensionNames)
+                if (std::find(modified_extensions.begin(), modified_extensions.end(), extension) ==
+                    modified_extensions.end())
                 {
-                    modified_extensions.insert(
-                        modified_extensions.begin(),
-                        replay_create_info->ppEnabledExtensionNames,
-                        (replay_create_info->ppEnabledExtensionNames + replay_create_info->enabledExtensionCount));
+                    modified_extensions.push_back(extension.c_str());
                 }
-
-                for (const auto& extension : extensions)
-                {
-                    if (std::find(modified_extensions.begin(), modified_extensions.end(), extension) ==
-                        modified_extensions.end())
-                    {
-                        modified_extensions.push_back(extension.c_str());
-                    }
-                }
-
-                modified_create_info                         = (*replay_create_info);
-                modified_create_info.enabledExtensionCount   = static_cast<uint32_t>(modified_extensions.size());
-                modified_create_info.ppEnabledExtensionNames = modified_extensions.data();
             }
-            else
-            {
-                GFXRECON_LOG_WARNING("The vkCreateDevice parameter pCreateInfo is NULL.");
-            }
-
-            result = create_device_proc(
-                physical_device, &modified_create_info, GetAllocationCallbacks(pAllocator), replay_device);
         }
-        else
+
+        if (options_.remove_unsupported_features && (physical_device != VK_NULL_HANDLE))
         {
-            result = create_device_proc(
-                physical_device, replay_create_info, GetAllocationCallbacks(pAllocator), replay_device);
+            // Remove enabled extensions that are not available from the replay device.
+            auto table = GetInstanceTable(physical_device);
+            assert(table != nullptr);
+
+            std::vector<VkExtensionProperties> properties;
+            if (feature_util::GetDeviceExtensions(
+                    physical_device, table->EnumerateDeviceExtensionProperties, &properties) == VK_SUCCESS)
+            {
+                feature_util::RemoveUnsupportedExtensions(properties, &modified_extensions);
+            }
         }
+
+        modified_create_info.enabledExtensionCount   = static_cast<uint32_t>(modified_extensions.size());
+        modified_create_info.ppEnabledExtensionNames = modified_extensions.data();
+
+        result = create_device_proc(
+            physical_device, &modified_create_info, GetAllocationCallbacks(pAllocator), replay_device);
 
         if ((replay_device != nullptr) && (result == VK_SUCCESS))
         {

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -48,6 +48,7 @@ struct ReplayOptions
     bool                         sync_queue_submissions{ false };
     bool                         skip_failed_allocations{ false };
     bool                         omit_pipeline_cache_data{ false };
+    bool                         remove_unsupported_features{ false };
     int32_t                      override_gpu_index{ -1 };
     int32_t                      surface_index{ -1 };
     CreateResourceAllocator      create_resource_allocator;

--- a/framework/generated/generate_vulkan.py
+++ b/framework/generated/generate_vulkan.py
@@ -52,7 +52,8 @@ generate_targets = [
     'generated_vulkan_referenced_resource_consumer.h',
     'generated_vulkan_referenced_resource_consumer.cpp',
     'generated_vulkan_struct_handle_mappers.h',
-    'generated_vulkan_struct_handle_mappers.cpp'
+    'generated_vulkan_struct_handle_mappers.cpp',
+    'generated_vulkan_feature_util.cpp'
 ]
 
 if __name__ == '__main__':

--- a/framework/generated/generated_vulkan_feature_util.cpp
+++ b/framework/generated/generated_vulkan_feature_util.cpp
@@ -1,0 +1,1985 @@
+/*
+** Copyright (c) 2018-2020 Valve Corporation
+** Copyright (c) 2018-2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+/*
+** This file is generated from the Khronos Vulkan XML API Registry.
+**
+*/
+
+#include "decode/vulkan_feature_util.h"
+
+#include "util/logging.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+GFXRECON_BEGIN_NAMESPACE(feature_util)
+
+void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysicalDeviceFeatures GetPhysicalDeviceFeatures, PFN_vkGetPhysicalDeviceFeatures2 GetPhysicalDeviceFeatures2, const void* pNext, const VkPhysicalDeviceFeatures* pEnabledFeatures)
+{
+    // If the pNext chain includes a VkPhysicalDeviceFeatures2 structure, then pEnabledFeatures must be NULL
+    const VkPhysicalDeviceFeatures* physicalDeviceFeatures = nullptr;
+    if (pEnabledFeatures != nullptr)
+    {
+        physicalDeviceFeatures = pEnabledFeatures;
+    }
+
+    if (GetPhysicalDeviceFeatures2 != nullptr)
+    {
+        VkPhysicalDeviceFeatures2 physicalDeviceFeatures2 = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, nullptr };
+        const VkDeviceCreateInfo* next = reinterpret_cast<const VkDeviceCreateInfo*>(pNext);
+        while (next != nullptr)
+        {
+            switch (next->sType)
+            {
+            // Special case to set VkPhysicalDeviceFeatures if passed in pNext
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2:
+                physicalDeviceFeatures = &reinterpret_cast<const VkPhysicalDeviceFeatures2*>(next)->features;
+                break;
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES:
+            {
+                const VkPhysicalDevice16BitStorageFeatures* currentNext = reinterpret_cast<const VkPhysicalDevice16BitStorageFeatures*>(next);
+                VkPhysicalDevice16BitStorageFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->storageBuffer16BitAccess == VK_TRUE) && (query.storageBuffer16BitAccess == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature storageBuffer16BitAccess, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevice16BitStorageFeatures*>(currentNext)->storageBuffer16BitAccess = VK_FALSE;
+                }
+                if ((currentNext->uniformAndStorageBuffer16BitAccess == VK_TRUE) && (query.uniformAndStorageBuffer16BitAccess == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature uniformAndStorageBuffer16BitAccess, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevice16BitStorageFeatures*>(currentNext)->uniformAndStorageBuffer16BitAccess = VK_FALSE;
+                }
+                if ((currentNext->storagePushConstant16 == VK_TRUE) && (query.storagePushConstant16 == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature storagePushConstant16, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevice16BitStorageFeatures*>(currentNext)->storagePushConstant16 = VK_FALSE;
+                }
+                if ((currentNext->storageInputOutput16 == VK_TRUE) && (query.storageInputOutput16 == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature storageInputOutput16, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevice16BitStorageFeatures*>(currentNext)->storageInputOutput16 = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES:
+            {
+                const VkPhysicalDeviceMultiviewFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures*>(next);
+                VkPhysicalDeviceMultiviewFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->multiview == VK_TRUE) && (query.multiview == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature multiview, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceMultiviewFeatures*>(currentNext)->multiview = VK_FALSE;
+                }
+                if ((currentNext->multiviewGeometryShader == VK_TRUE) && (query.multiviewGeometryShader == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature multiviewGeometryShader, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceMultiviewFeatures*>(currentNext)->multiviewGeometryShader = VK_FALSE;
+                }
+                if ((currentNext->multiviewTessellationShader == VK_TRUE) && (query.multiviewTessellationShader == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature multiviewTessellationShader, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceMultiviewFeatures*>(currentNext)->multiviewTessellationShader = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES:
+            {
+                const VkPhysicalDeviceVariablePointersFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures*>(next);
+                VkPhysicalDeviceVariablePointersFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->variablePointersStorageBuffer == VK_TRUE) && (query.variablePointersStorageBuffer == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature variablePointersStorageBuffer, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVariablePointersFeatures*>(currentNext)->variablePointersStorageBuffer = VK_FALSE;
+                }
+                if ((currentNext->variablePointers == VK_TRUE) && (query.variablePointers == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature variablePointers, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVariablePointersFeatures*>(currentNext)->variablePointers = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES:
+            {
+                const VkPhysicalDeviceProtectedMemoryFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures*>(next);
+                VkPhysicalDeviceProtectedMemoryFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->protectedMemory == VK_TRUE) && (query.protectedMemory == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature protectedMemory, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceProtectedMemoryFeatures*>(currentNext)->protectedMemory = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES:
+            {
+                const VkPhysicalDeviceSamplerYcbcrConversionFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(next);
+                VkPhysicalDeviceSamplerYcbcrConversionFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->samplerYcbcrConversion == VK_TRUE) && (query.samplerYcbcrConversion == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature samplerYcbcrConversion, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(currentNext)->samplerYcbcrConversion = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES:
+            {
+                const VkPhysicalDeviceShaderDrawParametersFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures*>(next);
+                VkPhysicalDeviceShaderDrawParametersFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->shaderDrawParameters == VK_TRUE) && (query.shaderDrawParameters == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderDrawParameters, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderDrawParametersFeatures*>(currentNext)->shaderDrawParameters = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES:
+            {
+                const VkPhysicalDeviceVulkan11Features* currentNext = reinterpret_cast<const VkPhysicalDeviceVulkan11Features*>(next);
+                VkPhysicalDeviceVulkan11Features query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->storageBuffer16BitAccess == VK_TRUE) && (query.storageBuffer16BitAccess == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature storageBuffer16BitAccess, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->storageBuffer16BitAccess = VK_FALSE;
+                }
+                if ((currentNext->uniformAndStorageBuffer16BitAccess == VK_TRUE) && (query.uniformAndStorageBuffer16BitAccess == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature uniformAndStorageBuffer16BitAccess, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->uniformAndStorageBuffer16BitAccess = VK_FALSE;
+                }
+                if ((currentNext->storagePushConstant16 == VK_TRUE) && (query.storagePushConstant16 == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature storagePushConstant16, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->storagePushConstant16 = VK_FALSE;
+                }
+                if ((currentNext->storageInputOutput16 == VK_TRUE) && (query.storageInputOutput16 == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature storageInputOutput16, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->storageInputOutput16 = VK_FALSE;
+                }
+                if ((currentNext->multiview == VK_TRUE) && (query.multiview == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature multiview, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->multiview = VK_FALSE;
+                }
+                if ((currentNext->multiviewGeometryShader == VK_TRUE) && (query.multiviewGeometryShader == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature multiviewGeometryShader, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->multiviewGeometryShader = VK_FALSE;
+                }
+                if ((currentNext->multiviewTessellationShader == VK_TRUE) && (query.multiviewTessellationShader == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature multiviewTessellationShader, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->multiviewTessellationShader = VK_FALSE;
+                }
+                if ((currentNext->variablePointersStorageBuffer == VK_TRUE) && (query.variablePointersStorageBuffer == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature variablePointersStorageBuffer, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->variablePointersStorageBuffer = VK_FALSE;
+                }
+                if ((currentNext->variablePointers == VK_TRUE) && (query.variablePointers == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature variablePointers, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->variablePointers = VK_FALSE;
+                }
+                if ((currentNext->protectedMemory == VK_TRUE) && (query.protectedMemory == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature protectedMemory, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->protectedMemory = VK_FALSE;
+                }
+                if ((currentNext->samplerYcbcrConversion == VK_TRUE) && (query.samplerYcbcrConversion == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature samplerYcbcrConversion, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->samplerYcbcrConversion = VK_FALSE;
+                }
+                if ((currentNext->shaderDrawParameters == VK_TRUE) && (query.shaderDrawParameters == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderDrawParameters, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan11Features*>(currentNext)->shaderDrawParameters = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES:
+            {
+                const VkPhysicalDeviceVulkan12Features* currentNext = reinterpret_cast<const VkPhysicalDeviceVulkan12Features*>(next);
+                VkPhysicalDeviceVulkan12Features query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->samplerMirrorClampToEdge == VK_TRUE) && (query.samplerMirrorClampToEdge == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature samplerMirrorClampToEdge, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->samplerMirrorClampToEdge = VK_FALSE;
+                }
+                if ((currentNext->drawIndirectCount == VK_TRUE) && (query.drawIndirectCount == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature drawIndirectCount, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->drawIndirectCount = VK_FALSE;
+                }
+                if ((currentNext->storageBuffer8BitAccess == VK_TRUE) && (query.storageBuffer8BitAccess == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature storageBuffer8BitAccess, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->storageBuffer8BitAccess = VK_FALSE;
+                }
+                if ((currentNext->uniformAndStorageBuffer8BitAccess == VK_TRUE) && (query.uniformAndStorageBuffer8BitAccess == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature uniformAndStorageBuffer8BitAccess, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->uniformAndStorageBuffer8BitAccess = VK_FALSE;
+                }
+                if ((currentNext->storagePushConstant8 == VK_TRUE) && (query.storagePushConstant8 == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature storagePushConstant8, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->storagePushConstant8 = VK_FALSE;
+                }
+                if ((currentNext->shaderBufferInt64Atomics == VK_TRUE) && (query.shaderBufferInt64Atomics == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderBufferInt64Atomics, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderBufferInt64Atomics = VK_FALSE;
+                }
+                if ((currentNext->shaderSharedInt64Atomics == VK_TRUE) && (query.shaderSharedInt64Atomics == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderSharedInt64Atomics, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderSharedInt64Atomics = VK_FALSE;
+                }
+                if ((currentNext->shaderFloat16 == VK_TRUE) && (query.shaderFloat16 == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderFloat16, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderFloat16 = VK_FALSE;
+                }
+                if ((currentNext->shaderInt8 == VK_TRUE) && (query.shaderInt8 == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderInt8, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderInt8 = VK_FALSE;
+                }
+                if ((currentNext->descriptorIndexing == VK_TRUE) && (query.descriptorIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderInputAttachmentArrayDynamicIndexing == VK_TRUE) && (query.shaderInputAttachmentArrayDynamicIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderInputAttachmentArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderInputAttachmentArrayDynamicIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderUniformTexelBufferArrayDynamicIndexing == VK_TRUE) && (query.shaderUniformTexelBufferArrayDynamicIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderUniformTexelBufferArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderUniformTexelBufferArrayDynamicIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderStorageTexelBufferArrayDynamicIndexing == VK_TRUE) && (query.shaderStorageTexelBufferArrayDynamicIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderStorageTexelBufferArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderStorageTexelBufferArrayDynamicIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderUniformBufferArrayNonUniformIndexing == VK_TRUE) && (query.shaderUniformBufferArrayNonUniformIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderUniformBufferArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderUniformBufferArrayNonUniformIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderSampledImageArrayNonUniformIndexing == VK_TRUE) && (query.shaderSampledImageArrayNonUniformIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderSampledImageArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderSampledImageArrayNonUniformIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderStorageBufferArrayNonUniformIndexing == VK_TRUE) && (query.shaderStorageBufferArrayNonUniformIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderStorageBufferArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderStorageBufferArrayNonUniformIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderStorageImageArrayNonUniformIndexing == VK_TRUE) && (query.shaderStorageImageArrayNonUniformIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderStorageImageArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderStorageImageArrayNonUniformIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderInputAttachmentArrayNonUniformIndexing == VK_TRUE) && (query.shaderInputAttachmentArrayNonUniformIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderInputAttachmentArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderInputAttachmentArrayNonUniformIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderUniformTexelBufferArrayNonUniformIndexing == VK_TRUE) && (query.shaderUniformTexelBufferArrayNonUniformIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderUniformTexelBufferArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderUniformTexelBufferArrayNonUniformIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderStorageTexelBufferArrayNonUniformIndexing == VK_TRUE) && (query.shaderStorageTexelBufferArrayNonUniformIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderStorageTexelBufferArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderStorageTexelBufferArrayNonUniformIndexing = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingUniformBufferUpdateAfterBind == VK_TRUE) && (query.descriptorBindingUniformBufferUpdateAfterBind == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingUniformBufferUpdateAfterBind, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingUniformBufferUpdateAfterBind = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingSampledImageUpdateAfterBind == VK_TRUE) && (query.descriptorBindingSampledImageUpdateAfterBind == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingSampledImageUpdateAfterBind, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingSampledImageUpdateAfterBind = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingStorageImageUpdateAfterBind == VK_TRUE) && (query.descriptorBindingStorageImageUpdateAfterBind == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageImageUpdateAfterBind, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingStorageImageUpdateAfterBind = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingStorageBufferUpdateAfterBind == VK_TRUE) && (query.descriptorBindingStorageBufferUpdateAfterBind == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageBufferUpdateAfterBind, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingStorageBufferUpdateAfterBind = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingUniformTexelBufferUpdateAfterBind == VK_TRUE) && (query.descriptorBindingUniformTexelBufferUpdateAfterBind == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingUniformTexelBufferUpdateAfterBind, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingUniformTexelBufferUpdateAfterBind = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingStorageTexelBufferUpdateAfterBind == VK_TRUE) && (query.descriptorBindingStorageTexelBufferUpdateAfterBind == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageTexelBufferUpdateAfterBind, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingStorageTexelBufferUpdateAfterBind = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingUpdateUnusedWhilePending == VK_TRUE) && (query.descriptorBindingUpdateUnusedWhilePending == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingUpdateUnusedWhilePending, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingUpdateUnusedWhilePending = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingPartiallyBound == VK_TRUE) && (query.descriptorBindingPartiallyBound == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingPartiallyBound, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingPartiallyBound = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingVariableDescriptorCount == VK_TRUE) && (query.descriptorBindingVariableDescriptorCount == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingVariableDescriptorCount, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->descriptorBindingVariableDescriptorCount = VK_FALSE;
+                }
+                if ((currentNext->runtimeDescriptorArray == VK_TRUE) && (query.runtimeDescriptorArray == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature runtimeDescriptorArray, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->runtimeDescriptorArray = VK_FALSE;
+                }
+                if ((currentNext->samplerFilterMinmax == VK_TRUE) && (query.samplerFilterMinmax == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature samplerFilterMinmax, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->samplerFilterMinmax = VK_FALSE;
+                }
+                if ((currentNext->scalarBlockLayout == VK_TRUE) && (query.scalarBlockLayout == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature scalarBlockLayout, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->scalarBlockLayout = VK_FALSE;
+                }
+                if ((currentNext->imagelessFramebuffer == VK_TRUE) && (query.imagelessFramebuffer == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature imagelessFramebuffer, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->imagelessFramebuffer = VK_FALSE;
+                }
+                if ((currentNext->uniformBufferStandardLayout == VK_TRUE) && (query.uniformBufferStandardLayout == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature uniformBufferStandardLayout, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->uniformBufferStandardLayout = VK_FALSE;
+                }
+                if ((currentNext->shaderSubgroupExtendedTypes == VK_TRUE) && (query.shaderSubgroupExtendedTypes == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderSubgroupExtendedTypes, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderSubgroupExtendedTypes = VK_FALSE;
+                }
+                if ((currentNext->separateDepthStencilLayouts == VK_TRUE) && (query.separateDepthStencilLayouts == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature separateDepthStencilLayouts, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->separateDepthStencilLayouts = VK_FALSE;
+                }
+                if ((currentNext->hostQueryReset == VK_TRUE) && (query.hostQueryReset == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature hostQueryReset, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->hostQueryReset = VK_FALSE;
+                }
+                if ((currentNext->timelineSemaphore == VK_TRUE) && (query.timelineSemaphore == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature timelineSemaphore, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->timelineSemaphore = VK_FALSE;
+                }
+                if ((currentNext->bufferDeviceAddress == VK_TRUE) && (query.bufferDeviceAddress == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddress, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->bufferDeviceAddress = VK_FALSE;
+                }
+                if ((currentNext->bufferDeviceAddressCaptureReplay == VK_TRUE) && (query.bufferDeviceAddressCaptureReplay == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressCaptureReplay, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->bufferDeviceAddressCaptureReplay = VK_FALSE;
+                }
+                if ((currentNext->bufferDeviceAddressMultiDevice == VK_TRUE) && (query.bufferDeviceAddressMultiDevice == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressMultiDevice, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->bufferDeviceAddressMultiDevice = VK_FALSE;
+                }
+                if ((currentNext->vulkanMemoryModel == VK_TRUE) && (query.vulkanMemoryModel == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModel, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->vulkanMemoryModel = VK_FALSE;
+                }
+                if ((currentNext->vulkanMemoryModelDeviceScope == VK_TRUE) && (query.vulkanMemoryModelDeviceScope == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModelDeviceScope, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->vulkanMemoryModelDeviceScope = VK_FALSE;
+                }
+                if ((currentNext->vulkanMemoryModelAvailabilityVisibilityChains == VK_TRUE) && (query.vulkanMemoryModelAvailabilityVisibilityChains == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModelAvailabilityVisibilityChains, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->vulkanMemoryModelAvailabilityVisibilityChains = VK_FALSE;
+                }
+                if ((currentNext->shaderOutputViewportIndex == VK_TRUE) && (query.shaderOutputViewportIndex == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderOutputViewportIndex, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderOutputViewportIndex = VK_FALSE;
+                }
+                if ((currentNext->shaderOutputLayer == VK_TRUE) && (query.shaderOutputLayer == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderOutputLayer, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->shaderOutputLayer = VK_FALSE;
+                }
+                if ((currentNext->subgroupBroadcastDynamicId == VK_TRUE) && (query.subgroupBroadcastDynamicId == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature subgroupBroadcastDynamicId, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkan12Features*>(currentNext)->subgroupBroadcastDynamicId = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES:
+            {
+                const VkPhysicalDevice8BitStorageFeatures* currentNext = reinterpret_cast<const VkPhysicalDevice8BitStorageFeatures*>(next);
+                VkPhysicalDevice8BitStorageFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->storageBuffer8BitAccess == VK_TRUE) && (query.storageBuffer8BitAccess == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature storageBuffer8BitAccess, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevice8BitStorageFeatures*>(currentNext)->storageBuffer8BitAccess = VK_FALSE;
+                }
+                if ((currentNext->uniformAndStorageBuffer8BitAccess == VK_TRUE) && (query.uniformAndStorageBuffer8BitAccess == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature uniformAndStorageBuffer8BitAccess, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevice8BitStorageFeatures*>(currentNext)->uniformAndStorageBuffer8BitAccess = VK_FALSE;
+                }
+                if ((currentNext->storagePushConstant8 == VK_TRUE) && (query.storagePushConstant8 == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature storagePushConstant8, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevice8BitStorageFeatures*>(currentNext)->storagePushConstant8 = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES:
+            {
+                const VkPhysicalDeviceShaderAtomicInt64Features* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64Features*>(next);
+                VkPhysicalDeviceShaderAtomicInt64Features query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->shaderBufferInt64Atomics == VK_TRUE) && (query.shaderBufferInt64Atomics == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderBufferInt64Atomics, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderAtomicInt64Features*>(currentNext)->shaderBufferInt64Atomics = VK_FALSE;
+                }
+                if ((currentNext->shaderSharedInt64Atomics == VK_TRUE) && (query.shaderSharedInt64Atomics == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderSharedInt64Atomics, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderAtomicInt64Features*>(currentNext)->shaderSharedInt64Atomics = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES:
+            {
+                const VkPhysicalDeviceShaderFloat16Int8Features* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderFloat16Int8Features*>(next);
+                VkPhysicalDeviceShaderFloat16Int8Features query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->shaderFloat16 == VK_TRUE) && (query.shaderFloat16 == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderFloat16, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderFloat16Int8Features*>(currentNext)->shaderFloat16 = VK_FALSE;
+                }
+                if ((currentNext->shaderInt8 == VK_TRUE) && (query.shaderInt8 == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderInt8, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderFloat16Int8Features*>(currentNext)->shaderInt8 = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES:
+            {
+                const VkPhysicalDeviceDescriptorIndexingFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeatures*>(next);
+                VkPhysicalDeviceDescriptorIndexingFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->shaderInputAttachmentArrayDynamicIndexing == VK_TRUE) && (query.shaderInputAttachmentArrayDynamicIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderInputAttachmentArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderInputAttachmentArrayDynamicIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderUniformTexelBufferArrayDynamicIndexing == VK_TRUE) && (query.shaderUniformTexelBufferArrayDynamicIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderUniformTexelBufferArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderUniformTexelBufferArrayDynamicIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderStorageTexelBufferArrayDynamicIndexing == VK_TRUE) && (query.shaderStorageTexelBufferArrayDynamicIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderStorageTexelBufferArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderStorageTexelBufferArrayDynamicIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderUniformBufferArrayNonUniformIndexing == VK_TRUE) && (query.shaderUniformBufferArrayNonUniformIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderUniformBufferArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderUniformBufferArrayNonUniformIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderSampledImageArrayNonUniformIndexing == VK_TRUE) && (query.shaderSampledImageArrayNonUniformIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderSampledImageArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderSampledImageArrayNonUniformIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderStorageBufferArrayNonUniformIndexing == VK_TRUE) && (query.shaderStorageBufferArrayNonUniformIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderStorageBufferArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderStorageBufferArrayNonUniformIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderStorageImageArrayNonUniformIndexing == VK_TRUE) && (query.shaderStorageImageArrayNonUniformIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderStorageImageArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderStorageImageArrayNonUniformIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderInputAttachmentArrayNonUniformIndexing == VK_TRUE) && (query.shaderInputAttachmentArrayNonUniformIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderInputAttachmentArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderInputAttachmentArrayNonUniformIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderUniformTexelBufferArrayNonUniformIndexing == VK_TRUE) && (query.shaderUniformTexelBufferArrayNonUniformIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderUniformTexelBufferArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderUniformTexelBufferArrayNonUniformIndexing = VK_FALSE;
+                }
+                if ((currentNext->shaderStorageTexelBufferArrayNonUniformIndexing == VK_TRUE) && (query.shaderStorageTexelBufferArrayNonUniformIndexing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderStorageTexelBufferArrayNonUniformIndexing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->shaderStorageTexelBufferArrayNonUniformIndexing = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingUniformBufferUpdateAfterBind == VK_TRUE) && (query.descriptorBindingUniformBufferUpdateAfterBind == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingUniformBufferUpdateAfterBind, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingUniformBufferUpdateAfterBind = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingSampledImageUpdateAfterBind == VK_TRUE) && (query.descriptorBindingSampledImageUpdateAfterBind == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingSampledImageUpdateAfterBind, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingSampledImageUpdateAfterBind = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingStorageImageUpdateAfterBind == VK_TRUE) && (query.descriptorBindingStorageImageUpdateAfterBind == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageImageUpdateAfterBind, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingStorageImageUpdateAfterBind = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingStorageBufferUpdateAfterBind == VK_TRUE) && (query.descriptorBindingStorageBufferUpdateAfterBind == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageBufferUpdateAfterBind, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingStorageBufferUpdateAfterBind = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingUniformTexelBufferUpdateAfterBind == VK_TRUE) && (query.descriptorBindingUniformTexelBufferUpdateAfterBind == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingUniformTexelBufferUpdateAfterBind, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingUniformTexelBufferUpdateAfterBind = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingStorageTexelBufferUpdateAfterBind == VK_TRUE) && (query.descriptorBindingStorageTexelBufferUpdateAfterBind == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingStorageTexelBufferUpdateAfterBind, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingStorageTexelBufferUpdateAfterBind = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingUpdateUnusedWhilePending == VK_TRUE) && (query.descriptorBindingUpdateUnusedWhilePending == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingUpdateUnusedWhilePending, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingUpdateUnusedWhilePending = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingPartiallyBound == VK_TRUE) && (query.descriptorBindingPartiallyBound == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingPartiallyBound, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingPartiallyBound = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingVariableDescriptorCount == VK_TRUE) && (query.descriptorBindingVariableDescriptorCount == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingVariableDescriptorCount, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->descriptorBindingVariableDescriptorCount = VK_FALSE;
+                }
+                if ((currentNext->runtimeDescriptorArray == VK_TRUE) && (query.runtimeDescriptorArray == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature runtimeDescriptorArray, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(currentNext)->runtimeDescriptorArray = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES:
+            {
+                const VkPhysicalDeviceScalarBlockLayoutFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeatures*>(next);
+                VkPhysicalDeviceScalarBlockLayoutFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->scalarBlockLayout == VK_TRUE) && (query.scalarBlockLayout == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature scalarBlockLayout, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceScalarBlockLayoutFeatures*>(currentNext)->scalarBlockLayout = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES:
+            {
+                const VkPhysicalDeviceVulkanMemoryModelFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeatures*>(next);
+                VkPhysicalDeviceVulkanMemoryModelFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->vulkanMemoryModel == VK_TRUE) && (query.vulkanMemoryModel == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModel, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures*>(currentNext)->vulkanMemoryModel = VK_FALSE;
+                }
+                if ((currentNext->vulkanMemoryModelDeviceScope == VK_TRUE) && (query.vulkanMemoryModelDeviceScope == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModelDeviceScope, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures*>(currentNext)->vulkanMemoryModelDeviceScope = VK_FALSE;
+                }
+                if ((currentNext->vulkanMemoryModelAvailabilityVisibilityChains == VK_TRUE) && (query.vulkanMemoryModelAvailabilityVisibilityChains == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature vulkanMemoryModelAvailabilityVisibilityChains, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures*>(currentNext)->vulkanMemoryModelAvailabilityVisibilityChains = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES:
+            {
+                const VkPhysicalDeviceImagelessFramebufferFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceImagelessFramebufferFeatures*>(next);
+                VkPhysicalDeviceImagelessFramebufferFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->imagelessFramebuffer == VK_TRUE) && (query.imagelessFramebuffer == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature imagelessFramebuffer, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceImagelessFramebufferFeatures*>(currentNext)->imagelessFramebuffer = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES:
+            {
+                const VkPhysicalDeviceUniformBufferStandardLayoutFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceUniformBufferStandardLayoutFeatures*>(next);
+                VkPhysicalDeviceUniformBufferStandardLayoutFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->uniformBufferStandardLayout == VK_TRUE) && (query.uniformBufferStandardLayout == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature uniformBufferStandardLayout, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceUniformBufferStandardLayoutFeatures*>(currentNext)->uniformBufferStandardLayout = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES:
+            {
+                const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*>(next);
+                VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->shaderSubgroupExtendedTypes == VK_TRUE) && (query.shaderSubgroupExtendedTypes == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderSubgroupExtendedTypes, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*>(currentNext)->shaderSubgroupExtendedTypes = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES:
+            {
+                const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*>(next);
+                VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->separateDepthStencilLayouts == VK_TRUE) && (query.separateDepthStencilLayouts == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature separateDepthStencilLayouts, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*>(currentNext)->separateDepthStencilLayouts = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES:
+            {
+                const VkPhysicalDeviceHostQueryResetFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeatures*>(next);
+                VkPhysicalDeviceHostQueryResetFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->hostQueryReset == VK_TRUE) && (query.hostQueryReset == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature hostQueryReset, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceHostQueryResetFeatures*>(currentNext)->hostQueryReset = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES:
+            {
+                const VkPhysicalDeviceTimelineSemaphoreFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreFeatures*>(next);
+                VkPhysicalDeviceTimelineSemaphoreFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->timelineSemaphore == VK_TRUE) && (query.timelineSemaphore == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature timelineSemaphore, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceTimelineSemaphoreFeatures*>(currentNext)->timelineSemaphore = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES:
+            {
+                const VkPhysicalDeviceBufferDeviceAddressFeatures* currentNext = reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeatures*>(next);
+                VkPhysicalDeviceBufferDeviceAddressFeatures query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->bufferDeviceAddress == VK_TRUE) && (query.bufferDeviceAddress == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddress, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(currentNext)->bufferDeviceAddress = VK_FALSE;
+                }
+                if ((currentNext->bufferDeviceAddressCaptureReplay == VK_TRUE) && (query.bufferDeviceAddressCaptureReplay == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressCaptureReplay, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(currentNext)->bufferDeviceAddressCaptureReplay = VK_FALSE;
+                }
+                if ((currentNext->bufferDeviceAddressMultiDevice == VK_TRUE) && (query.bufferDeviceAddressMultiDevice == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressMultiDevice, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(currentNext)->bufferDeviceAddressMultiDevice = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR:
+            {
+                const VkPhysicalDevicePerformanceQueryFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDevicePerformanceQueryFeaturesKHR*>(next);
+                VkPhysicalDevicePerformanceQueryFeaturesKHR query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->performanceCounterQueryPools == VK_TRUE) && (query.performanceCounterQueryPools == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature performanceCounterQueryPools, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePerformanceQueryFeaturesKHR*>(currentNext)->performanceCounterQueryPools = VK_FALSE;
+                }
+                if ((currentNext->performanceCounterMultipleQueryPools == VK_TRUE) && (query.performanceCounterMultipleQueryPools == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature performanceCounterMultipleQueryPools, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePerformanceQueryFeaturesKHR*>(currentNext)->performanceCounterMultipleQueryPools = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR:
+            {
+                const VkPhysicalDevicePortabilitySubsetFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(next);
+                VkPhysicalDevicePortabilitySubsetFeaturesKHR query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->constantAlphaColorBlendFactors == VK_TRUE) && (query.constantAlphaColorBlendFactors == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature constantAlphaColorBlendFactors, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->constantAlphaColorBlendFactors = VK_FALSE;
+                }
+                if ((currentNext->events == VK_TRUE) && (query.events == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature events, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->events = VK_FALSE;
+                }
+                if ((currentNext->imageViewFormatReinterpretation == VK_TRUE) && (query.imageViewFormatReinterpretation == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature imageViewFormatReinterpretation, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->imageViewFormatReinterpretation = VK_FALSE;
+                }
+                if ((currentNext->imageViewFormatSwizzle == VK_TRUE) && (query.imageViewFormatSwizzle == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature imageViewFormatSwizzle, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->imageViewFormatSwizzle = VK_FALSE;
+                }
+                if ((currentNext->imageView2DOn3DImage == VK_TRUE) && (query.imageView2DOn3DImage == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature imageView2DOn3DImage, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->imageView2DOn3DImage = VK_FALSE;
+                }
+                if ((currentNext->multisampleArrayImage == VK_TRUE) && (query.multisampleArrayImage == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature multisampleArrayImage, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->multisampleArrayImage = VK_FALSE;
+                }
+                if ((currentNext->mutableComparisonSamplers == VK_TRUE) && (query.mutableComparisonSamplers == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature mutableComparisonSamplers, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->mutableComparisonSamplers = VK_FALSE;
+                }
+                if ((currentNext->pointPolygons == VK_TRUE) && (query.pointPolygons == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature pointPolygons, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->pointPolygons = VK_FALSE;
+                }
+                if ((currentNext->samplerMipLodBias == VK_TRUE) && (query.samplerMipLodBias == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature samplerMipLodBias, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->samplerMipLodBias = VK_FALSE;
+                }
+                if ((currentNext->separateStencilMaskRef == VK_TRUE) && (query.separateStencilMaskRef == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature separateStencilMaskRef, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->separateStencilMaskRef = VK_FALSE;
+                }
+                if ((currentNext->shaderSampleRateInterpolationFunctions == VK_TRUE) && (query.shaderSampleRateInterpolationFunctions == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderSampleRateInterpolationFunctions, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->shaderSampleRateInterpolationFunctions = VK_FALSE;
+                }
+                if ((currentNext->tessellationIsolines == VK_TRUE) && (query.tessellationIsolines == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature tessellationIsolines, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->tessellationIsolines = VK_FALSE;
+                }
+                if ((currentNext->tessellationPointMode == VK_TRUE) && (query.tessellationPointMode == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature tessellationPointMode, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->tessellationPointMode = VK_FALSE;
+                }
+                if ((currentNext->triangleFans == VK_TRUE) && (query.triangleFans == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature triangleFans, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->triangleFans = VK_FALSE;
+                }
+                if ((currentNext->vertexAttributeAccessBeyondStride == VK_TRUE) && (query.vertexAttributeAccessBeyondStride == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature vertexAttributeAccessBeyondStride, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(currentNext)->vertexAttributeAccessBeyondStride = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR:
+            {
+                const VkPhysicalDeviceShaderClockFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderClockFeaturesKHR*>(next);
+                VkPhysicalDeviceShaderClockFeaturesKHR query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->shaderSubgroupClock == VK_TRUE) && (query.shaderSubgroupClock == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderSubgroupClock, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderClockFeaturesKHR*>(currentNext)->shaderSubgroupClock = VK_FALSE;
+                }
+                if ((currentNext->shaderDeviceClock == VK_TRUE) && (query.shaderDeviceClock == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderDeviceClock, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderClockFeaturesKHR*>(currentNext)->shaderDeviceClock = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR:
+            {
+                const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR*>(next);
+                VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->pipelineExecutableInfo == VK_TRUE) && (query.pipelineExecutableInfo == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature pipelineExecutableInfo, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR*>(currentNext)->pipelineExecutableInfo = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceTransformFeedbackFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(next);
+                VkPhysicalDeviceTransformFeedbackFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->transformFeedback == VK_TRUE) && (query.transformFeedback == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature transformFeedback, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(currentNext)->transformFeedback = VK_FALSE;
+                }
+                if ((currentNext->geometryStreams == VK_TRUE) && (query.geometryStreams == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature geometryStreams, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(currentNext)->geometryStreams = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV:
+            {
+                const VkPhysicalDeviceCornerSampledImageFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV*>(next);
+                VkPhysicalDeviceCornerSampledImageFeaturesNV query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->cornerSampledImage == VK_TRUE) && (query.cornerSampledImage == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature cornerSampledImage, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceCornerSampledImageFeaturesNV*>(currentNext)->cornerSampledImage = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT*>(next);
+                VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->textureCompressionASTC_HDR == VK_TRUE) && (query.textureCompressionASTC_HDR == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature textureCompressionASTC_HDR, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT*>(currentNext)->textureCompressionASTC_HDR = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceASTCDecodeFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT*>(next);
+                VkPhysicalDeviceASTCDecodeFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->decodeModeSharedExponent == VK_TRUE) && (query.decodeModeSharedExponent == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature decodeModeSharedExponent, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceASTCDecodeFeaturesEXT*>(currentNext)->decodeModeSharedExponent = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceConditionalRenderingFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(next);
+                VkPhysicalDeviceConditionalRenderingFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->conditionalRendering == VK_TRUE) && (query.conditionalRendering == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature conditionalRendering, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(currentNext)->conditionalRendering = VK_FALSE;
+                }
+                if ((currentNext->inheritedConditionalRendering == VK_TRUE) && (query.inheritedConditionalRendering == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature inheritedConditionalRendering, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(currentNext)->inheritedConditionalRendering = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceDepthClipEnableFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(next);
+                VkPhysicalDeviceDepthClipEnableFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->depthClipEnable == VK_TRUE) && (query.depthClipEnable == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature depthClipEnable, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(currentNext)->depthClipEnable = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceInlineUniformBlockFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeaturesEXT*>(next);
+                VkPhysicalDeviceInlineUniformBlockFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->inlineUniformBlock == VK_TRUE) && (query.inlineUniformBlock == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature inlineUniformBlock, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceInlineUniformBlockFeaturesEXT*>(currentNext)->inlineUniformBlock = VK_FALSE;
+                }
+                if ((currentNext->descriptorBindingInlineUniformBlockUpdateAfterBind == VK_TRUE) && (query.descriptorBindingInlineUniformBlockUpdateAfterBind == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature descriptorBindingInlineUniformBlockUpdateAfterBind, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceInlineUniformBlockFeaturesEXT*>(currentNext)->descriptorBindingInlineUniformBlockUpdateAfterBind = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(next);
+                VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->advancedBlendCoherentOperations == VK_TRUE) && (query.advancedBlendCoherentOperations == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature advancedBlendCoherentOperations, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(currentNext)->advancedBlendCoherentOperations = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_FEATURES_NV:
+            {
+                const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV*>(next);
+                VkPhysicalDeviceShaderSMBuiltinsFeaturesNV query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_FEATURES_NV, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->shaderSMBuiltins == VK_TRUE) && (query.shaderSMBuiltins == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderSMBuiltins, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderSMBuiltinsFeaturesNV*>(currentNext)->shaderSMBuiltins = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_FEATURES_NV:
+            {
+                const VkPhysicalDeviceShadingRateImageFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV*>(next);
+                VkPhysicalDeviceShadingRateImageFeaturesNV query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_FEATURES_NV, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->shadingRateImage == VK_TRUE) && (query.shadingRateImage == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shadingRateImage, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShadingRateImageFeaturesNV*>(currentNext)->shadingRateImage = VK_FALSE;
+                }
+                if ((currentNext->shadingRateCoarseSampleOrder == VK_TRUE) && (query.shadingRateCoarseSampleOrder == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shadingRateCoarseSampleOrder, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShadingRateImageFeaturesNV*>(currentNext)->shadingRateCoarseSampleOrder = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV:
+            {
+                const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(next);
+                VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->representativeFragmentTest == VK_TRUE) && (query.representativeFragmentTest == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature representativeFragmentTest, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(currentNext)->representativeFragmentTest = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT*>(next);
+                VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->vertexAttributeInstanceRateDivisor == VK_TRUE) && (query.vertexAttributeInstanceRateDivisor == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature vertexAttributeInstanceRateDivisor, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT*>(currentNext)->vertexAttributeInstanceRateDivisor = VK_FALSE;
+                }
+                if ((currentNext->vertexAttributeInstanceRateZeroDivisor == VK_TRUE) && (query.vertexAttributeInstanceRateZeroDivisor == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature vertexAttributeInstanceRateZeroDivisor, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT*>(currentNext)->vertexAttributeInstanceRateZeroDivisor = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV:
+            {
+                const VkPhysicalDeviceComputeShaderDerivativesFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesNV*>(next);
+                VkPhysicalDeviceComputeShaderDerivativesFeaturesNV query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->computeDerivativeGroupQuads == VK_TRUE) && (query.computeDerivativeGroupQuads == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature computeDerivativeGroupQuads, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceComputeShaderDerivativesFeaturesNV*>(currentNext)->computeDerivativeGroupQuads = VK_FALSE;
+                }
+                if ((currentNext->computeDerivativeGroupLinear == VK_TRUE) && (query.computeDerivativeGroupLinear == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature computeDerivativeGroupLinear, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceComputeShaderDerivativesFeaturesNV*>(currentNext)->computeDerivativeGroupLinear = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV:
+            {
+                const VkPhysicalDeviceMeshShaderFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV*>(next);
+                VkPhysicalDeviceMeshShaderFeaturesNV query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->taskShader == VK_TRUE) && (query.taskShader == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature taskShader, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceMeshShaderFeaturesNV*>(currentNext)->taskShader = VK_FALSE;
+                }
+                if ((currentNext->meshShader == VK_TRUE) && (query.meshShader == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature meshShader, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceMeshShaderFeaturesNV*>(currentNext)->meshShader = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_NV:
+            {
+                const VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV*>(next);
+                VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_NV, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->fragmentShaderBarycentric == VK_TRUE) && (query.fragmentShaderBarycentric == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature fragmentShaderBarycentric, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV*>(currentNext)->fragmentShaderBarycentric = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV:
+            {
+                const VkPhysicalDeviceShaderImageFootprintFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(next);
+                VkPhysicalDeviceShaderImageFootprintFeaturesNV query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->imageFootprint == VK_TRUE) && (query.imageFootprint == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature imageFootprint, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(currentNext)->imageFootprint = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV:
+            {
+                const VkPhysicalDeviceExclusiveScissorFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV*>(next);
+                VkPhysicalDeviceExclusiveScissorFeaturesNV query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->exclusiveScissor == VK_TRUE) && (query.exclusiveScissor == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature exclusiveScissor, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceExclusiveScissorFeaturesNV*>(currentNext)->exclusiveScissor = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL:
+            {
+                const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*>(next);
+                VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->shaderIntegerFunctions2 == VK_TRUE) && (query.shaderIntegerFunctions2 == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderIntegerFunctions2, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*>(currentNext)->shaderIntegerFunctions2 = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceFragmentDensityMapFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(next);
+                VkPhysicalDeviceFragmentDensityMapFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->fragmentDensityMap == VK_TRUE) && (query.fragmentDensityMap == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature fragmentDensityMap, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(currentNext)->fragmentDensityMap = VK_FALSE;
+                }
+                if ((currentNext->fragmentDensityMapDynamic == VK_TRUE) && (query.fragmentDensityMapDynamic == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature fragmentDensityMapDynamic, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(currentNext)->fragmentDensityMapDynamic = VK_FALSE;
+                }
+                if ((currentNext->fragmentDensityMapNonSubsampledImages == VK_TRUE) && (query.fragmentDensityMapNonSubsampledImages == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature fragmentDensityMapNonSubsampledImages, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(currentNext)->fragmentDensityMapNonSubsampledImages = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceSubgroupSizeControlFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlFeaturesEXT*>(next);
+                VkPhysicalDeviceSubgroupSizeControlFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->subgroupSizeControl == VK_TRUE) && (query.subgroupSizeControl == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature subgroupSizeControl, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceSubgroupSizeControlFeaturesEXT*>(currentNext)->subgroupSizeControl = VK_FALSE;
+                }
+                if ((currentNext->computeFullSubgroups == VK_TRUE) && (query.computeFullSubgroups == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature computeFullSubgroups, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceSubgroupSizeControlFeaturesEXT*>(currentNext)->computeFullSubgroups = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD:
+            {
+                const VkPhysicalDeviceCoherentMemoryFeaturesAMD* currentNext = reinterpret_cast<const VkPhysicalDeviceCoherentMemoryFeaturesAMD*>(next);
+                VkPhysicalDeviceCoherentMemoryFeaturesAMD query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->deviceCoherentMemory == VK_TRUE) && (query.deviceCoherentMemory == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature deviceCoherentMemory, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceCoherentMemoryFeaturesAMD*>(currentNext)->deviceCoherentMemory = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceMemoryPriorityFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(next);
+                VkPhysicalDeviceMemoryPriorityFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->memoryPriority == VK_TRUE) && (query.memoryPriority == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature memoryPriority, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(currentNext)->memoryPriority = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV:
+            {
+                const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(next);
+                VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->dedicatedAllocationImageAliasing == VK_TRUE) && (query.dedicatedAllocationImageAliasing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature dedicatedAllocationImageAliasing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(currentNext)->dedicatedAllocationImageAliasing = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(next);
+                VkPhysicalDeviceBufferDeviceAddressFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->bufferDeviceAddress == VK_TRUE) && (query.bufferDeviceAddress == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddress, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(currentNext)->bufferDeviceAddress = VK_FALSE;
+                }
+                if ((currentNext->bufferDeviceAddressCaptureReplay == VK_TRUE) && (query.bufferDeviceAddressCaptureReplay == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressCaptureReplay, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(currentNext)->bufferDeviceAddressCaptureReplay = VK_FALSE;
+                }
+                if ((currentNext->bufferDeviceAddressMultiDevice == VK_TRUE) && (query.bufferDeviceAddressMultiDevice == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature bufferDeviceAddressMultiDevice, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(currentNext)->bufferDeviceAddressMultiDevice = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV:
+            {
+                const VkPhysicalDeviceCooperativeMatrixFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(next);
+                VkPhysicalDeviceCooperativeMatrixFeaturesNV query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->cooperativeMatrix == VK_TRUE) && (query.cooperativeMatrix == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature cooperativeMatrix, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(currentNext)->cooperativeMatrix = VK_FALSE;
+                }
+                if ((currentNext->cooperativeMatrixRobustBufferAccess == VK_TRUE) && (query.cooperativeMatrixRobustBufferAccess == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature cooperativeMatrixRobustBufferAccess, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(currentNext)->cooperativeMatrixRobustBufferAccess = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV:
+            {
+                const VkPhysicalDeviceCoverageReductionModeFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceCoverageReductionModeFeaturesNV*>(next);
+                VkPhysicalDeviceCoverageReductionModeFeaturesNV query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->coverageReductionMode == VK_TRUE) && (query.coverageReductionMode == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature coverageReductionMode, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceCoverageReductionModeFeaturesNV*>(currentNext)->coverageReductionMode = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(next);
+                VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->fragmentShaderSampleInterlock == VK_TRUE) && (query.fragmentShaderSampleInterlock == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature fragmentShaderSampleInterlock, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(currentNext)->fragmentShaderSampleInterlock = VK_FALSE;
+                }
+                if ((currentNext->fragmentShaderPixelInterlock == VK_TRUE) && (query.fragmentShaderPixelInterlock == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature fragmentShaderPixelInterlock, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(currentNext)->fragmentShaderPixelInterlock = VK_FALSE;
+                }
+                if ((currentNext->fragmentShaderShadingRateInterlock == VK_TRUE) && (query.fragmentShaderShadingRateInterlock == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature fragmentShaderShadingRateInterlock, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(currentNext)->fragmentShaderShadingRateInterlock = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(next);
+                VkPhysicalDeviceYcbcrImageArraysFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->ycbcrImageArrays == VK_TRUE) && (query.ycbcrImageArrays == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature ycbcrImageArrays, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(currentNext)->ycbcrImageArrays = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceLineRasterizationFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceLineRasterizationFeaturesEXT*>(next);
+                VkPhysicalDeviceLineRasterizationFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->rectangularLines == VK_TRUE) && (query.rectangularLines == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature rectangularLines, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->rectangularLines = VK_FALSE;
+                }
+                if ((currentNext->bresenhamLines == VK_TRUE) && (query.bresenhamLines == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature bresenhamLines, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->bresenhamLines = VK_FALSE;
+                }
+                if ((currentNext->smoothLines == VK_TRUE) && (query.smoothLines == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature smoothLines, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->smoothLines = VK_FALSE;
+                }
+                if ((currentNext->stippledRectangularLines == VK_TRUE) && (query.stippledRectangularLines == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature stippledRectangularLines, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->stippledRectangularLines = VK_FALSE;
+                }
+                if ((currentNext->stippledBresenhamLines == VK_TRUE) && (query.stippledBresenhamLines == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature stippledBresenhamLines, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->stippledBresenhamLines = VK_FALSE;
+                }
+                if ((currentNext->stippledSmoothLines == VK_TRUE) && (query.stippledSmoothLines == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature stippledSmoothLines, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT*>(currentNext)->stippledSmoothLines = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(next);
+                VkPhysicalDeviceShaderAtomicFloatFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->shaderBufferFloat32Atomics == VK_TRUE) && (query.shaderBufferFloat32Atomics == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat32Atomics, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderBufferFloat32Atomics = VK_FALSE;
+                }
+                if ((currentNext->shaderBufferFloat32AtomicAdd == VK_TRUE) && (query.shaderBufferFloat32AtomicAdd == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat32AtomicAdd, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderBufferFloat32AtomicAdd = VK_FALSE;
+                }
+                if ((currentNext->shaderBufferFloat64Atomics == VK_TRUE) && (query.shaderBufferFloat64Atomics == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat64Atomics, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderBufferFloat64Atomics = VK_FALSE;
+                }
+                if ((currentNext->shaderBufferFloat64AtomicAdd == VK_TRUE) && (query.shaderBufferFloat64AtomicAdd == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderBufferFloat64AtomicAdd, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderBufferFloat64AtomicAdd = VK_FALSE;
+                }
+                if ((currentNext->shaderSharedFloat32Atomics == VK_TRUE) && (query.shaderSharedFloat32Atomics == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat32Atomics, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderSharedFloat32Atomics = VK_FALSE;
+                }
+                if ((currentNext->shaderSharedFloat32AtomicAdd == VK_TRUE) && (query.shaderSharedFloat32AtomicAdd == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat32AtomicAdd, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderSharedFloat32AtomicAdd = VK_FALSE;
+                }
+                if ((currentNext->shaderSharedFloat64Atomics == VK_TRUE) && (query.shaderSharedFloat64Atomics == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat64Atomics, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderSharedFloat64Atomics = VK_FALSE;
+                }
+                if ((currentNext->shaderSharedFloat64AtomicAdd == VK_TRUE) && (query.shaderSharedFloat64AtomicAdd == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderSharedFloat64AtomicAdd, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderSharedFloat64AtomicAdd = VK_FALSE;
+                }
+                if ((currentNext->shaderImageFloat32Atomics == VK_TRUE) && (query.shaderImageFloat32Atomics == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderImageFloat32Atomics, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderImageFloat32Atomics = VK_FALSE;
+                }
+                if ((currentNext->shaderImageFloat32AtomicAdd == VK_TRUE) && (query.shaderImageFloat32AtomicAdd == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderImageFloat32AtomicAdd, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->shaderImageFloat32AtomicAdd = VK_FALSE;
+                }
+                if ((currentNext->sparseImageFloat32Atomics == VK_TRUE) && (query.sparseImageFloat32Atomics == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature sparseImageFloat32Atomics, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->sparseImageFloat32Atomics = VK_FALSE;
+                }
+                if ((currentNext->sparseImageFloat32AtomicAdd == VK_TRUE) && (query.sparseImageFloat32AtomicAdd == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature sparseImageFloat32AtomicAdd, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(currentNext)->sparseImageFloat32AtomicAdd = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceIndexTypeUint8FeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceIndexTypeUint8FeaturesEXT*>(next);
+                VkPhysicalDeviceIndexTypeUint8FeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->indexTypeUint8 == VK_TRUE) && (query.indexTypeUint8 == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature indexTypeUint8, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceIndexTypeUint8FeaturesEXT*>(currentNext)->indexTypeUint8 = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*>(next);
+                VkPhysicalDeviceExtendedDynamicStateFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->extendedDynamicState == VK_TRUE) && (query.extendedDynamicState == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature extendedDynamicState, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*>(currentNext)->extendedDynamicState = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT*>(next);
+                VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->shaderDemoteToHelperInvocation == VK_TRUE) && (query.shaderDemoteToHelperInvocation == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature shaderDemoteToHelperInvocation, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT*>(currentNext)->shaderDemoteToHelperInvocation = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_NV:
+            {
+                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV*>(next);
+                VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_NV, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->deviceGeneratedCommands == VK_TRUE) && (query.deviceGeneratedCommands == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature deviceGeneratedCommands, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV*>(currentNext)->deviceGeneratedCommands = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*>(next);
+                VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->texelBufferAlignment == VK_TRUE) && (query.texelBufferAlignment == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature texelBufferAlignment, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*>(currentNext)->texelBufferAlignment = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceRobustness2FeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesEXT*>(next);
+                VkPhysicalDeviceRobustness2FeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->robustBufferAccess2 == VK_TRUE) && (query.robustBufferAccess2 == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature robustBufferAccess2, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceRobustness2FeaturesEXT*>(currentNext)->robustBufferAccess2 = VK_FALSE;
+                }
+                if ((currentNext->robustImageAccess2 == VK_TRUE) && (query.robustImageAccess2 == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature robustImageAccess2, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceRobustness2FeaturesEXT*>(currentNext)->robustImageAccess2 = VK_FALSE;
+                }
+                if ((currentNext->nullDescriptor == VK_TRUE) && (query.nullDescriptor == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature nullDescriptor, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceRobustness2FeaturesEXT*>(currentNext)->nullDescriptor = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceCustomBorderColorFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(next);
+                VkPhysicalDeviceCustomBorderColorFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->customBorderColors == VK_TRUE) && (query.customBorderColors == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature customBorderColors, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(currentNext)->customBorderColors = VK_FALSE;
+                }
+                if ((currentNext->customBorderColorWithoutFormat == VK_TRUE) && (query.customBorderColorWithoutFormat == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature customBorderColorWithoutFormat, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(currentNext)->customBorderColorWithoutFormat = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES_EXT:
+            {
+                const VkPhysicalDevicePrivateDataFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDevicePrivateDataFeaturesEXT*>(next);
+                VkPhysicalDevicePrivateDataFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->privateData == VK_TRUE) && (query.privateData == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature privateData, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePrivateDataFeaturesEXT*>(currentNext)->privateData = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES_EXT:
+            {
+                const VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT*>(next);
+                VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->pipelineCreationCacheControl == VK_TRUE) && (query.pipelineCreationCacheControl == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature pipelineCreationCacheControl, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT*>(currentNext)->pipelineCreationCacheControl = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DIAGNOSTICS_CONFIG_FEATURES_NV:
+            {
+                const VkPhysicalDeviceDiagnosticsConfigFeaturesNV* currentNext = reinterpret_cast<const VkPhysicalDeviceDiagnosticsConfigFeaturesNV*>(next);
+                VkPhysicalDeviceDiagnosticsConfigFeaturesNV query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DIAGNOSTICS_CONFIG_FEATURES_NV, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->diagnosticsConfig == VK_TRUE) && (query.diagnosticsConfig == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature diagnosticsConfig, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceDiagnosticsConfigFeaturesNV*>(currentNext)->diagnosticsConfig = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT*>(next);
+                VkPhysicalDeviceFragmentDensityMap2FeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->fragmentDensityMapDeferred == VK_TRUE) && (query.fragmentDensityMapDeferred == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature fragmentDensityMapDeferred, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceFragmentDensityMap2FeaturesEXT*>(currentNext)->fragmentDensityMapDeferred = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT:
+            {
+                const VkPhysicalDeviceImageRobustnessFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeaturesEXT*>(next);
+                VkPhysicalDeviceImageRobustnessFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->robustImageAccess == VK_TRUE) && (query.robustImageAccess == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature robustImageAccess, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceImageRobustnessFeaturesEXT*>(currentNext)->robustImageAccess = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT:
+            {
+                const VkPhysicalDevice4444FormatsFeaturesEXT* currentNext = reinterpret_cast<const VkPhysicalDevice4444FormatsFeaturesEXT*>(next);
+                VkPhysicalDevice4444FormatsFeaturesEXT query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->formatA4R4G4B4 == VK_TRUE) && (query.formatA4R4G4B4 == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature formatA4R4G4B4, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevice4444FormatsFeaturesEXT*>(currentNext)->formatA4R4G4B4 = VK_FALSE;
+                }
+                if ((currentNext->formatA4B4G4R4 == VK_TRUE) && (query.formatA4B4G4R4 == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature formatA4B4G4R4, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDevice4444FormatsFeaturesEXT*>(currentNext)->formatA4B4G4R4 = VK_FALSE;
+                }
+                break;
+             }
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_FEATURES_KHR:
+            {
+                const VkPhysicalDeviceRayTracingFeaturesKHR* currentNext = reinterpret_cast<const VkPhysicalDeviceRayTracingFeaturesKHR*>(next);
+                VkPhysicalDeviceRayTracingFeaturesKHR query = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_FEATURES_KHR, nullptr };
+                physicalDeviceFeatures2.pNext = &query;
+                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);
+                if ((currentNext->rayTracing == VK_TRUE) && (query.rayTracing == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature rayTracing, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceRayTracingFeaturesKHR*>(currentNext)->rayTracing = VK_FALSE;
+                }
+                if ((currentNext->rayTracingShaderGroupHandleCaptureReplay == VK_TRUE) && (query.rayTracingShaderGroupHandleCaptureReplay == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature rayTracingShaderGroupHandleCaptureReplay, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceRayTracingFeaturesKHR*>(currentNext)->rayTracingShaderGroupHandleCaptureReplay = VK_FALSE;
+                }
+                if ((currentNext->rayTracingShaderGroupHandleCaptureReplayMixed == VK_TRUE) && (query.rayTracingShaderGroupHandleCaptureReplayMixed == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature rayTracingShaderGroupHandleCaptureReplayMixed, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceRayTracingFeaturesKHR*>(currentNext)->rayTracingShaderGroupHandleCaptureReplayMixed = VK_FALSE;
+                }
+                if ((currentNext->rayTracingAccelerationStructureCaptureReplay == VK_TRUE) && (query.rayTracingAccelerationStructureCaptureReplay == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature rayTracingAccelerationStructureCaptureReplay, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceRayTracingFeaturesKHR*>(currentNext)->rayTracingAccelerationStructureCaptureReplay = VK_FALSE;
+                }
+                if ((currentNext->rayTracingIndirectTraceRays == VK_TRUE) && (query.rayTracingIndirectTraceRays == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature rayTracingIndirectTraceRays, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceRayTracingFeaturesKHR*>(currentNext)->rayTracingIndirectTraceRays = VK_FALSE;
+                }
+                if ((currentNext->rayTracingIndirectAccelerationStructureBuild == VK_TRUE) && (query.rayTracingIndirectAccelerationStructureBuild == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature rayTracingIndirectAccelerationStructureBuild, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceRayTracingFeaturesKHR*>(currentNext)->rayTracingIndirectAccelerationStructureBuild = VK_FALSE;
+                }
+                if ((currentNext->rayTracingHostAccelerationStructureCommands == VK_TRUE) && (query.rayTracingHostAccelerationStructureCommands == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature rayTracingHostAccelerationStructureCommands, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceRayTracingFeaturesKHR*>(currentNext)->rayTracingHostAccelerationStructureCommands = VK_FALSE;
+                }
+                if ((currentNext->rayQuery == VK_TRUE) && (query.rayQuery == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature rayQuery, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceRayTracingFeaturesKHR*>(currentNext)->rayQuery = VK_FALSE;
+                }
+                if ((currentNext->rayTracingPrimitiveCulling == VK_TRUE) && (query.rayTracingPrimitiveCulling == VK_FALSE))
+                {
+                    GFXRECON_LOG_WARNING("Feature rayTracingPrimitiveCulling, which is not supported by the replay device, will not be enabled");
+                    const_cast<VkPhysicalDeviceRayTracingFeaturesKHR*>(currentNext)->rayTracingPrimitiveCulling = VK_FALSE;
+                }
+                break;
+             }
+             default:
+                break;
+            }
+            next = reinterpret_cast<const VkDeviceCreateInfo*>(next->pNext);
+        }
+    }
+
+    if ((GetPhysicalDeviceFeatures != nullptr) && (physicalDeviceFeatures != nullptr))
+    {
+        VkPhysicalDeviceFeatures query = {};
+        GetPhysicalDeviceFeatures(physicalDevice, &query);
+        if ((physicalDeviceFeatures->robustBufferAccess == VK_TRUE) && (query.robustBufferAccess == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature robustBufferAccess, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->robustBufferAccess = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->fullDrawIndexUint32 == VK_TRUE) && (query.fullDrawIndexUint32 == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature fullDrawIndexUint32, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->fullDrawIndexUint32 = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->imageCubeArray == VK_TRUE) && (query.imageCubeArray == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature imageCubeArray, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->imageCubeArray = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->independentBlend == VK_TRUE) && (query.independentBlend == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature independentBlend, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->independentBlend = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->geometryShader == VK_TRUE) && (query.geometryShader == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature geometryShader, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->geometryShader = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->tessellationShader == VK_TRUE) && (query.tessellationShader == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature tessellationShader, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->tessellationShader = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->sampleRateShading == VK_TRUE) && (query.sampleRateShading == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature sampleRateShading, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sampleRateShading = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->dualSrcBlend == VK_TRUE) && (query.dualSrcBlend == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature dualSrcBlend, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->dualSrcBlend = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->logicOp == VK_TRUE) && (query.logicOp == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature logicOp, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->logicOp = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->multiDrawIndirect == VK_TRUE) && (query.multiDrawIndirect == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature multiDrawIndirect, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->multiDrawIndirect = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->drawIndirectFirstInstance == VK_TRUE) && (query.drawIndirectFirstInstance == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature drawIndirectFirstInstance, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->drawIndirectFirstInstance = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->depthClamp == VK_TRUE) && (query.depthClamp == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature depthClamp, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->depthClamp = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->depthBiasClamp == VK_TRUE) && (query.depthBiasClamp == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature depthBiasClamp, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->depthBiasClamp = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->fillModeNonSolid == VK_TRUE) && (query.fillModeNonSolid == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature fillModeNonSolid, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->fillModeNonSolid = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->depthBounds == VK_TRUE) && (query.depthBounds == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature depthBounds, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->depthBounds = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->wideLines == VK_TRUE) && (query.wideLines == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature wideLines, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->wideLines = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->largePoints == VK_TRUE) && (query.largePoints == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature largePoints, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->largePoints = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->alphaToOne == VK_TRUE) && (query.alphaToOne == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature alphaToOne, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->alphaToOne = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->multiViewport == VK_TRUE) && (query.multiViewport == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature multiViewport, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->multiViewport = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->samplerAnisotropy == VK_TRUE) && (query.samplerAnisotropy == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature samplerAnisotropy, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->samplerAnisotropy = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->textureCompressionETC2 == VK_TRUE) && (query.textureCompressionETC2 == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature textureCompressionETC2, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->textureCompressionETC2 = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->textureCompressionASTC_LDR == VK_TRUE) && (query.textureCompressionASTC_LDR == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature textureCompressionASTC_LDR, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->textureCompressionASTC_LDR = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->textureCompressionBC == VK_TRUE) && (query.textureCompressionBC == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature textureCompressionBC, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->textureCompressionBC = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->occlusionQueryPrecise == VK_TRUE) && (query.occlusionQueryPrecise == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature occlusionQueryPrecise, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->occlusionQueryPrecise = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->pipelineStatisticsQuery == VK_TRUE) && (query.pipelineStatisticsQuery == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature pipelineStatisticsQuery, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->pipelineStatisticsQuery = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->vertexPipelineStoresAndAtomics == VK_TRUE) && (query.vertexPipelineStoresAndAtomics == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature vertexPipelineStoresAndAtomics, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->vertexPipelineStoresAndAtomics = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->fragmentStoresAndAtomics == VK_TRUE) && (query.fragmentStoresAndAtomics == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature fragmentStoresAndAtomics, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->fragmentStoresAndAtomics = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderTessellationAndGeometryPointSize == VK_TRUE) && (query.shaderTessellationAndGeometryPointSize == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderTessellationAndGeometryPointSize, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderTessellationAndGeometryPointSize = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderImageGatherExtended == VK_TRUE) && (query.shaderImageGatherExtended == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderImageGatherExtended, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderImageGatherExtended = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderStorageImageExtendedFormats == VK_TRUE) && (query.shaderStorageImageExtendedFormats == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderStorageImageExtendedFormats, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageImageExtendedFormats = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderStorageImageMultisample == VK_TRUE) && (query.shaderStorageImageMultisample == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderStorageImageMultisample, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageImageMultisample = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderStorageImageReadWithoutFormat == VK_TRUE) && (query.shaderStorageImageReadWithoutFormat == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderStorageImageReadWithoutFormat, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageImageReadWithoutFormat = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderStorageImageWriteWithoutFormat == VK_TRUE) && (query.shaderStorageImageWriteWithoutFormat == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderStorageImageWriteWithoutFormat, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageImageWriteWithoutFormat = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderUniformBufferArrayDynamicIndexing == VK_TRUE) && (query.shaderUniformBufferArrayDynamicIndexing == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderUniformBufferArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderUniformBufferArrayDynamicIndexing = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderSampledImageArrayDynamicIndexing == VK_TRUE) && (query.shaderSampledImageArrayDynamicIndexing == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderSampledImageArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderSampledImageArrayDynamicIndexing = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderStorageBufferArrayDynamicIndexing == VK_TRUE) && (query.shaderStorageBufferArrayDynamicIndexing == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderStorageBufferArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageBufferArrayDynamicIndexing = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderStorageImageArrayDynamicIndexing == VK_TRUE) && (query.shaderStorageImageArrayDynamicIndexing == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderStorageImageArrayDynamicIndexing, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderStorageImageArrayDynamicIndexing = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderClipDistance == VK_TRUE) && (query.shaderClipDistance == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderClipDistance, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderClipDistance = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderCullDistance == VK_TRUE) && (query.shaderCullDistance == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderCullDistance, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderCullDistance = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderFloat64 == VK_TRUE) && (query.shaderFloat64 == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderFloat64, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderFloat64 = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderInt64 == VK_TRUE) && (query.shaderInt64 == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderInt64, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderInt64 = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderInt16 == VK_TRUE) && (query.shaderInt16 == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderInt16, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderInt16 = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderResourceResidency == VK_TRUE) && (query.shaderResourceResidency == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderResourceResidency, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderResourceResidency = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->shaderResourceMinLod == VK_TRUE) && (query.shaderResourceMinLod == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature shaderResourceMinLod, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->shaderResourceMinLod = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->sparseBinding == VK_TRUE) && (query.sparseBinding == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature sparseBinding, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseBinding = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->sparseResidencyBuffer == VK_TRUE) && (query.sparseResidencyBuffer == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature sparseResidencyBuffer, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidencyBuffer = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->sparseResidencyImage2D == VK_TRUE) && (query.sparseResidencyImage2D == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature sparseResidencyImage2D, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidencyImage2D = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->sparseResidencyImage3D == VK_TRUE) && (query.sparseResidencyImage3D == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature sparseResidencyImage3D, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidencyImage3D = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->sparseResidency2Samples == VK_TRUE) && (query.sparseResidency2Samples == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature sparseResidency2Samples, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidency2Samples = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->sparseResidency4Samples == VK_TRUE) && (query.sparseResidency4Samples == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature sparseResidency4Samples, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidency4Samples = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->sparseResidency8Samples == VK_TRUE) && (query.sparseResidency8Samples == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature sparseResidency8Samples, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidency8Samples = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->sparseResidency16Samples == VK_TRUE) && (query.sparseResidency16Samples == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature sparseResidency16Samples, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidency16Samples = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->sparseResidencyAliased == VK_TRUE) && (query.sparseResidencyAliased == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature sparseResidencyAliased, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->sparseResidencyAliased = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->variableMultisampleRate == VK_TRUE) && (query.variableMultisampleRate == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature variableMultisampleRate, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->variableMultisampleRate = VK_FALSE;
+        }
+        if ((physicalDeviceFeatures->inheritedQueries == VK_TRUE) && (query.inheritedQueries == VK_FALSE))
+        {
+            GFXRECON_LOG_WARNING("Feature inheritedQueries, which is not supported by the replay device, will not be enabled");
+            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->inheritedQueries = VK_FALSE;
+        }
+    }
+}
+
+GFXRECON_END_NAMESPACE(feature_util)
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/vulkan_generators/codegen.pyproj
+++ b/framework/generated/vulkan_generators/codegen.pyproj
@@ -30,6 +30,7 @@
     <Compile Include="vulkan_api_call_encoders_body_generator.py" />
     <Compile Include="vulkan_api_call_encoders_header_generator.py" />
     <Compile Include="vulkan_dispatch_table_generator.py" />
+    <Compile Include="vulkan_feature_util_body_generator.py" />
     <Compile Include="vulkan_referenced_resource_consumer_body_generator.py" />
     <Compile Include="vulkan_referenced_resource_consumer_header_generator.py" />
     <Compile Include="vulkan_replay_consumer_body_generator.py" />

--- a/framework/generated/vulkan_generators/gencode.py
+++ b/framework/generated/vulkan_generators/gencode.py
@@ -38,6 +38,7 @@ from vulkan_referenced_resource_consumer_header_generator import VulkanReference
 from vulkan_referenced_resource_consumer_body_generator import VulkanReferencedResourceBodyGenerator,VulkanReferencedResourceBodyGeneratorOptions
 from vulkan_struct_handle_mappers_header_generator import VulkanStructHandleMappersHeaderGenerator,VulkanStructHandleMappersHeaderGeneratorOptions
 from vulkan_struct_handle_mappers_body_generator import VulkanStructHandleMappersBodyGenerator,VulkanStructHandleMappersBodyGeneratorOptions
+from vulkan_feature_util_body_generator import VulkanFeatureUtilBodyGenerator,VulkanFeatureUtilBodyGeneratorOptions
 
 # API Call Encoders
 from vulkan_api_call_encoders_body_generator import VulkanApiCallEncodersBodyGenerator,VulkanApiCallEncodersBodyGeneratorOptions
@@ -315,6 +316,17 @@ def makeGenOpts(args):
             protectFile       = False,
             protectFeature    = False)
         ]
+
+    genOpts['generated_vulkan_feature_util.cpp'] = [
+        VulkanFeatureUtilBodyGenerator,
+        VulkanFeatureUtilBodyGeneratorOptions(
+        filename          = 'generated_vulkan_feature_util.cpp',
+        directory         = directory,
+        platformTypes     = platformTypes,
+        prefixText        = prefixStrings + vkPrefixStrings,
+        protectFile       = False,
+        protectFeature    = False)
+    ]
 
     #
     # API call encoder generators

--- a/framework/generated/vulkan_generators/vulkan_feature_util_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_feature_util_body_generator.py
@@ -1,0 +1,169 @@
+#!/usr/bin/python3 -i
+#
+# Copyright (c) 2020 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os,re,sys,json
+from base_generator import *
+
+class VulkanFeatureUtilBodyGeneratorOptions(BaseGeneratorOptions):
+    """Options for generating C++ code to alter Vulkan device createtion features"""
+    def __init__(self,
+                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+                 filename = None,
+                 directory = '.',
+                 prefixText = '',
+                 protectFile = False,
+                 protectFeature = True):
+        BaseGeneratorOptions.__init__(self,
+                                      platformTypes=platformTypes,
+                                      filename=filename,
+                                      directory=directory,
+                                      prefixText=prefixText,
+                                      protectFile=protectFile,
+                                      protectFeature=protectFeature)
+
+# VulkanFeatureUtilBodyGenerator - subclass of BaseGenerator.
+# Generates C++ functions to alter Vulkan device creation features.
+class VulkanFeatureUtilBodyGenerator(BaseGenerator):
+    """Generate C++ code to alter Vulkan device creation features"""
+
+    def __init__(self,
+                 errFile = sys.stderr,
+                 warnFile = sys.stderr,
+                 diagFile = sys.stdout):
+        BaseGenerator.__init__(self,
+                               processCmds=False, processStructs=True, featureBreak=True,
+                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+
+        self.physicalDeviceFeatures2sTypes = dict()
+        # List of 1.0 features
+        self.physicalDeviceFeatures = []
+
+    # Method override
+    def beginFile(self, genOpts):
+        BaseGenerator.beginFile(self, genOpts)
+
+        write('#include "decode/vulkan_feature_util.h"', file=self.outFile)
+        self.newline()
+        write('#include "util/logging.h"', file=self.outFile)
+        self.newline()
+        write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
+        write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)
+        write('GFXRECON_BEGIN_NAMESPACE(feature_util)', file=self.outFile)
+
+    # Method override
+    def endFile(self):
+        self.newline()
+        write(self.makeFeatureHelper(), file=self.outFile)
+        self.newline()
+        write('GFXRECON_END_NAMESPACE(feature_util)', file=self.outFile)
+        write('GFXRECON_END_NAMESPACE(decode)', file=self.outFile)
+        write('GFXRECON_END_NAMESPACE(gfxrecon)', file=self.outFile)
+
+        # Finish processing in superclass
+        BaseGenerator.endFile(self)
+
+    #
+    # Method override
+    def genStruct(self, typeinfo, typename, alias):
+        BaseGenerator.genStruct(self, typeinfo, typename, alias)
+
+        if not alias:
+            # Track this struct if it can be present in a pNext chain for features
+            parentStructs = typeinfo.elem.get('structextends')
+            if parentStructs:
+                if "VkPhysicalDeviceFeatures2" in parentStructs:
+                    # Build list of all boolean members which are the feature bits
+                    members = []
+                    for member in self.featureStructMembers[typename]:
+                        if member.baseType == "VkBool32":
+                            members.append(member.name)
+                    self.physicalDeviceFeatures2sTypes[typename] = {
+                        'sType' : self.makeStructureTypeEnum(typeinfo, typename),
+                        'members' : members
+                    }
+
+            #  Get all core 1.0 features
+            if typename == "VkPhysicalDeviceFeatures":
+                for member in self.featureStructMembers[typename]:
+                    self.physicalDeviceFeatures.append(member.name)
+
+    #
+    # Indicates that the current feature has C++ code to generate.
+    def needFeatureGeneration(self):
+        return False
+
+    #
+    # Generate help function for features on replaying at device creation time
+    def makeFeatureHelper(self):
+        result = 'void RemoveUnsupportedFeatures(VkPhysicalDevice physicalDevice, PFN_vkGetPhysicalDeviceFeatures GetPhysicalDeviceFeatures, PFN_vkGetPhysicalDeviceFeatures2 GetPhysicalDeviceFeatures2, const void* pNext, const VkPhysicalDeviceFeatures* pEnabledFeatures)\n'
+        result += '{\n'
+        result += '    // If the pNext chain includes a VkPhysicalDeviceFeatures2 structure, then pEnabledFeatures must be NULL\n'
+        result += '    const VkPhysicalDeviceFeatures* physicalDeviceFeatures = nullptr;\n'
+        result += '    if (pEnabledFeatures != nullptr)\n'
+        result += '    {\n'
+        result += '        physicalDeviceFeatures = pEnabledFeatures;\n'
+        result += '    }\n\n'
+
+        result += '    if (GetPhysicalDeviceFeatures2 != nullptr)\n'
+        result += '    {\n'
+        result += '        VkPhysicalDeviceFeatures2 physicalDeviceFeatures2 = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, nullptr };\n'
+        result += '        const VkDeviceCreateInfo* next = reinterpret_cast<const VkDeviceCreateInfo*>(pNext);\n'
+        result += '        while (next != nullptr)\n'
+        result += '        {\n'
+        result += '            switch (next->sType)\n'
+        result += '            {\n'
+        result += '            // Special case to set VkPhysicalDeviceFeatures if passed in pNext\n'
+        result += '            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2:\n'
+        result += '                physicalDeviceFeatures = &reinterpret_cast<const VkPhysicalDeviceFeatures2*>(next)->features;\n'
+        result += '                break;\n'
+
+        for typename, info in self.physicalDeviceFeatures2sTypes.items():
+
+            result += '            case {}:\n'.format(info['sType'])
+            result += '            {\n'
+            result += '                const {}* currentNext = reinterpret_cast<const {}*>(next);\n'.format(typename, typename)
+            result += '                {} query = {{ {}, nullptr }};\n'.format(typename, info['sType'])
+            result += '                physicalDeviceFeatures2.pNext = &query;\n'
+            result += '                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);\n'
+            for member in info['members']:
+                result += '                if ((currentNext->{} == VK_TRUE) && (query.{} == VK_FALSE))\n'.format(member, member)
+                result += '                {\n'
+                result += '                    GFXRECON_LOG_WARNING("Feature {}, which is not supported by the replay device, will not be enabled");\n'.format(member)
+                result += '                    const_cast<{}*>(currentNext)->{} = VK_FALSE;\n'.format(typename, member)
+                result += '                }\n'
+            result += '                break;\n'
+            result += '             }\n'
+
+        result += '             default:\n'
+        result += '                break;\n'
+        result += '            }\n'
+        result += '            next = reinterpret_cast<const VkDeviceCreateInfo*>(next->pNext);\n'
+        result += '        }\n'
+        result += '    }\n\n'
+
+        result += '    if ((GetPhysicalDeviceFeatures != nullptr) && (physicalDeviceFeatures != nullptr))\n'
+        result += '    {\n'
+        result += '        VkPhysicalDeviceFeatures query = {};\n'
+        result += '        GetPhysicalDeviceFeatures(physicalDevice, &query);\n'
+        for feature in self.physicalDeviceFeatures:
+            result += '        if ((physicalDeviceFeatures->{} == VK_TRUE) && (query.{} == VK_FALSE))\n'.format(feature, feature)
+            result += '        {\n'
+            result += '            GFXRECON_LOG_WARNING("Feature {}, which is not supported by the replay device, will not be enabled");\n'.format(feature)
+            result += '            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->{} = VK_FALSE;\n'.format(feature)
+            result += '        }\n'
+        result += '    }\n'
+        result += '}'
+        return result

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -59,6 +59,7 @@ const char kSurfaceIndexArgument[]             = "--surface-index";
 const char kMemoryPortabilityShortOption[]     = "-m";
 const char kMemoryPortabilityLongOption[]      = "--memory-translation";
 const char kSyncOption[]                       = "--sync";
+const char kRemoveUnsupportedOption[]          = "--remove-unsupported";
 const char kShaderReplaceArgument[]            = "--replace-shaders";
 const char kScreenshotAllOption[]              = "--screenshot-all";
 const char kScreenshotRangeArgument[]          = "--screenshots";
@@ -67,7 +68,7 @@ const char kScreenshotDirArgument[]            = "--screenshot-dir";
 const char kScreenshotFilePrefixArgument[]     = "--screenshot-prefix";
 
 const char kOptions[] = "-h|--help,--version,--no-debug-popup,--paused,--sync,--sfa|--skip-failed-allocations,--"
-                        "opcd|--omit-pipeline-cache-data,--screenshot-all";
+                        "opcd|--omit-pipeline-cache-data,--remove-unsupported,--screenshot-all";
 const char kArguments[] =
     "--gpu,--pause-frame,--wsi,--surface-index,-m|--memory-translation,--replace-shaders,--screenshots,--"
     "screenshot-format,--screenshot-dir,--screenshot-prefix";
@@ -507,6 +508,11 @@ GetReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parser,
         replay_options.sync_queue_submissions = true;
     }
 
+    if (arg_parser.IsOptionSet(kRemoveUnsupportedOption))
+    {
+        replay_options.remove_unsupported_features = true;
+    }
+
     if (arg_parser.IsOptionSet(kSkipFailedAllocationLongOption) ||
         arg_parser.IsOptionSet(kSkipFailedAllocationShortOption))
     {
@@ -580,11 +586,13 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--screenshot-dir <dir>] [--screenshot-prefix <file-prefix>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--sfa | --skip-failed-allocations] [--replace-shaders <dir>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--opcd | --omit-pipeline-cache-data] [--wsi <platform>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--surface-index <N>] [-m <mode> | --memory-translation <mode>]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--surface-index <N>] [--remove-unsupported]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[-m <mode> | --memory-translation <mode>]");
 #if defined(WIN32) && defined(_DEBUG)
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--no-debug-popup]");
-#endif
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--no-debug-popup] <file>\n");
+#else
     GFXRECON_WRITE_CONSOLE("\t\t\t<file>\n");
+#endif
     GFXRECON_WRITE_CONSOLE("Required arguments:");
     GFXRECON_WRITE_CONSOLE("  <file>\t\tPath to the capture file to replay.");
     GFXRECON_WRITE_CONSOLE("\nOptional arguments:");
@@ -640,6 +648,8 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("                  \tUsed with captures that include multiple surfaces.  Default");
     GFXRECON_WRITE_CONSOLE("                  \tis -1 (render to all surfaces).");
     GFXRECON_WRITE_CONSOLE("  --sync\t\tSynchronize after each queue submission with vkQueueWaitIdle.");
+    GFXRECON_WRITE_CONSOLE("  --remove-unsupported\tRemove unsupported extensions and features from instance");
+    GFXRECON_WRITE_CONSOLE("                      \tand device creation parameters.");
     GFXRECON_WRITE_CONSOLE("  -m <mode>\t\tEnable memory translation for replay on GPUs with memory");
     GFXRECON_WRITE_CONSOLE("          \t\ttypes that are not compatible with the capture GPU's");
     GFXRECON_WRITE_CONSOLE("          \t\tmemory types.  Available modes are:");


### PR DESCRIPTION
Adds a new option named --remove-unsupported to adjust instance and device creation parameters to remove unsupported extensions and features.  This can cause replay to fail if the extensions/features are required, but can in some cases make replay work on different devices/drivers for applications that enable more features than they use.