### PR TITLE
Fix acquire/present image index mismatch on replay

### DIFF
--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -343,6 +343,7 @@ struct SwapchainKHRInfo : public VulkanObjectInfo<VkSwapchainKHR>
     uint32_t                             height{ 0 };
     VkFormat                             format{ VK_FORMAT_UNDEFINED };
     std::vector<VkImage>                 images;
+    std::vector<uint32_t>                acquired_indices;
     std::unordered_map<uint32_t, size_t> array_counts;
 
     // The following values are only used when loading the initial state for trimmed files.

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4159,6 +4159,8 @@ VkResult VulkanReplayConsumerBase::OverrideGetSwapchainImagesKHR(PFN_vkGetSwapch
         {
             uint32_t count = (*replay_image_count);
 
+            swapchain_info->acquired_indices.resize(count);
+
             for (uint32_t i = 0; i < count; ++i)
             {
                 auto image_info = reinterpret_cast<ImageInfo*>(pSwapchainImages->GetConsumerData(i));
@@ -4191,13 +4193,13 @@ VkResult VulkanReplayConsumerBase::OverrideGetSwapchainImagesKHR(PFN_vkGetSwapch
 VkResult VulkanReplayConsumerBase::OverrideAcquireNextImageKHR(PFN_vkAcquireNextImageKHR func,
                                                                VkResult                  original_result,
                                                                const DeviceInfo*         device_info,
-                                                               const SwapchainKHRInfo*   swapchain_info,
+                                                               SwapchainKHRInfo*         swapchain_info,
                                                                uint64_t                  timeout,
                                                                SemaphoreInfo*            semaphore_info,
                                                                FenceInfo*                fence_info,
                                                                PointerDecoder<uint32_t>* pImageIndex)
 {
-    GFXRECON_UNREFERENCED_PARAMETER(original_result);
+    assert(swapchain_info != nullptr);
 
     VkResult result = VK_SUCCESS;
 
@@ -4210,8 +4212,7 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImageKHR(PFN_vkAcquireNext
     }
     else if (swapchain_info->surface != VK_NULL_HANDLE)
     {
-        assert((device_info != nullptr) && (swapchain_info != nullptr) && (pImageIndex != nullptr) &&
-               (pImageIndex->GetPointer() != nullptr));
+        assert((device_info != nullptr) && (pImageIndex != nullptr) && !pImageIndex->IsNull());
 
         VkDevice       device               = device_info->handle;
         VkSwapchainKHR swapchain            = swapchain_info->handle;
@@ -4226,6 +4227,8 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImageKHR(PFN_vkAcquireNext
         {
             auto table = GetDeviceTable(device);
             assert(table != nullptr);
+
+            swapchain_info->acquired_indices[captured_index] = captured_index;
 
             // The image has already been acquired. Swap the synchronization objects.
             if (semaphore != VK_NULL_HANDLE)
@@ -4251,9 +4254,14 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImageKHR(PFN_vkAcquireNext
         }
         else
         {
-            assert(pImageIndex->GetOutputPointer() != nullptr);
+            auto replay_index = pImageIndex->GetOutputPointer();
 
-            result = func(device, swapchain, timeout, semaphore, fence, pImageIndex->GetOutputPointer());
+            assert(replay_index != nullptr);
+
+            result = func(device, swapchain, timeout, semaphore, fence, replay_index);
+
+            // Track the index that was acquired on replay, which may be different than the captured index.
+            swapchain_info->acquired_indices[captured_index] = (*replay_index);
         }
     }
     else
@@ -4283,13 +4291,12 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
     const StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>* pAcquireInfo,
     PointerDecoder<uint32_t>*                                      pImageIndex)
 {
-    GFXRECON_UNREFERENCED_PARAMETER(original_result);
-
     assert((pAcquireInfo != nullptr) && !pAcquireInfo->IsNull());
 
     VkResult          result            = VK_SUCCESS;
     auto              acquire_meta_info = pAcquireInfo->GetMetaStructPointer();
     SwapchainKHRInfo* swapchain_info    = object_info_table_.GetSwapchainKHRInfo(acquire_meta_info->swapchain);
+    assert(swapchain_info != nullptr);
 
     // If image acquire failed at capture, there is nothing worth replaying as the fence and semaphore aren't processed
     // and a successful acquire on replay of an image that does not have a corresponding present to replay can lead to
@@ -4313,6 +4320,11 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
         {
             auto table = GetDeviceTable(device);
             assert(table != nullptr);
+
+            if (swapchain_info != nullptr)
+            {
+                swapchain_info->acquired_indices[captured_index] = captured_index;
+            }
 
             // The image has already been acquired. Swap the synchronization objects.
             if (replay_acquire_info->semaphore != VK_NULL_HANDLE)
@@ -4338,9 +4350,14 @@ VkResult VulkanReplayConsumerBase::OverrideAcquireNextImage2KHR(
         }
         else
         {
-            assert(pImageIndex->GetOutputPointer() != nullptr);
+            auto replay_index = pImageIndex->GetOutputPointer();
 
-            result = func(device, replay_acquire_info, pImageIndex->GetOutputPointer());
+            assert(replay_index != nullptr);
+
+            result = func(device, replay_acquire_info, replay_index);
+
+            // Track the index that was acquired on replay, which may be different than the captured index.
+            swapchain_info->acquired_indices[captured_index] = (*replay_index);
         }
     }
     else
@@ -4414,7 +4431,7 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
             if ((swapchain_info != nullptr) && (swapchain_info->surface != VK_NULL_HANDLE))
             {
                 valid_swapchains.push_back(swapchain_info->handle);
-                modified_image_indices.push_back(present_info->pImageIndices[i]);
+                modified_image_indices.push_back(swapchain_info->acquired_indices[present_info->pImageIndices[i]]);
             }
             else
             {
@@ -4514,6 +4531,27 @@ VulkanReplayConsumerBase::OverrideQueuePresentKHR(PFN_vkQueuePresentKHR         
         modified_present_info.swapchainCount = static_cast<uint32_t>(valid_swapchains.size());
         modified_present_info.pSwapchains    = valid_swapchains.data();
         modified_present_info.pImageIndices  = modified_image_indices.data();
+    }
+    else
+    {
+        // Need to match the last acquired image index from replay to avoid OUT_OF_DATE errors from present.
+        modified_image_indices.insert(modified_image_indices.end(),
+                                      present_info->pImageIndices,
+                                      std::next(present_info->pImageIndices, present_info->swapchainCount));
+
+        const auto swapchain_ids = present_info_data->pSwapchains.GetPointer();
+        for (uint32_t i = 0; i < present_info->swapchainCount; ++i)
+        {
+            assert(swapchain_ids != nullptr);
+
+            const auto swapchain_info = object_info_table_.GetSwapchainKHRInfo(swapchain_ids[i]);
+            if (swapchain_info != nullptr)
+            {
+                modified_image_indices[i] = swapchain_info->acquired_indices[present_info->pImageIndices[i]];
+            }
+        }
+
+        modified_present_info.pImageIndices = modified_image_indices.data();
     }
 
     // Only attempt to find imported or shadow semaphores if we know at least one around.

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -642,7 +642,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     VkResult OverrideAcquireNextImageKHR(PFN_vkAcquireNextImageKHR func,
                                          VkResult                  original_result,
                                          const DeviceInfo*         device_info,
-                                         const SwapchainKHRInfo*   swapchain_info,
+                                         SwapchainKHRInfo*         swapchain_info,
                                          uint64_t                  timeout,
                                          SemaphoreInfo*            semaphore_info,
                                          FenceInfo*                fence_info,


### PR DESCRIPTION
Replay will now alter the vkQueuePresentKHR pPresentInfo parameter to ensure that its image indices match the indices returned by vkAcquireNextImageKHR.  This prevents OUT_OF_DATE errors generated by an acquire/present index
mismatch when replaying on Android.  In the case of an index mismatch, rendering is still performed with the image that was acquired on capture, and not the image acquired on replay.  The incorrect render target issue will be addressed by #277.
