### PR TITLE
Add assert to fatal log errors for Android

### DIFF
--- a/framework/util/logging.cpp
+++ b/framework/util/logging.cpp
@@ -273,7 +273,7 @@ void Log::LogMessage(
                     __android_log_print(ANDROID_LOG_ERROR, process_tag, "%s", output_message.c_str());
                     break;
                 case kFatalSeverity:
-                    __android_log_print(ANDROID_LOG_FATAL, process_tag, "%s", output_message.c_str());
+                    __android_log_assert(nullptr, process_tag, "%s", output_message.c_str());
                     break;
                 default:
                     __android_log_print(ANDROID_LOG_VERBOSE, process_tag, "%s", output_message.c_str());


### PR DESCRIPTION
Change the Android logging code responsible for processing the fatal log level to use __android_log_assert, which generates an ANDROID_LOG_FATAL log entry before calling abort, instead of __android_log_print(ANDROID_LOG_FATAL).
