### PR TITLE
Apply /bigobj option to VS2017 builds

### DIFF
--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -109,8 +109,8 @@ target_sources(gfxrecon_decode
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_decode_pnext_struct.cpp
 )
 
-if (MSVC AND (MSVC_VERSION LESS 1910))
-    # This file fails to compile with VS2015, requiring the default section limit of 2^16 to be increased.
+if (MSVC AND (MSVC_VERSION LESS 1920))
+    # These files may fail to compile with VS2017 and older, requiring the default section limit of 2^16 to be increased.
     set_source_files_properties(${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_replay_consumer.cpp PROPERTIES COMPILE_FLAGS /bigobj)
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/vulkan_object_cleanup_util.cpp PROPERTIES COMPILE_FLAGS /bigobj)
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/vulkan_replay_consumer_base.cpp PROPERTIES COMPILE_FLAGS /bigobj)

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -59,8 +59,8 @@ target_sources(gfxrecon_encode
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_struct_handle_wrappers.cpp
 )
 
-if (MSVC AND (MSVC_VERSION LESS 1910))
-    # This file fails to compile with VS2015, requiring the default section limit of 2^16 to be increased.
+if (MSVC AND (MSVC_VERSION LESS 1920))
+    # This file may fail to compile with VS2017 and older, requiring the default section limit of 2^16 to be increased.
     set_source_files_properties(${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_api_call_encoders.cpp PROPERTIES COMPILE_FLAGS /bigobj)
 endif()
 


### PR DESCRIPTION
Update the CMake logic responsible for enabling /bigobj for some files to apply this option for MSVC_VERSION values less than 1920.  It was previously applied for MSVC_VERSION values less than 1910.  This will apply the option for VS2017 and older.
