### PR TITLE
Debug extension fixes

### DIFF
--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -44,6 +44,7 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_feature_util.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_feature_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_handle_mapping_util.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_handle_mapping_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_object_cleanup_util.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_object_cleanup_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/vulkan_object_info.h

--- a/android/framework/encode/CMakeLists.txt
+++ b/android/framework/encode/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(gfxrecon_encode
                    ${GFXRECON_SOURCE_DIR}/framework/encode/trace_manager.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_handle_wrappers.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_handle_wrapper_util.h
+                   ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_handle_wrapper_util.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_state_info.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_state_table.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_state_tracker.h

--- a/framework/application/CMakeLists.txt
+++ b/framework/application/CMakeLists.txt
@@ -62,6 +62,7 @@ if (${RUN_TESTS})
     add_executable(gfxrecon_application_test "")
     target_sources(gfxrecon_application_test PRIVATE
             ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp)
+    target_link_libraries(gfxrecon_application_test PRIVATE gfxrecon_application)
     common_build_directives(gfxrecon_application_test)
     common_test_directives(gfxrecon_application_test)
 endif()

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -66,6 +66,7 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_feature_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_feature_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_mapping_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_mapping_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_object_cleanup_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_object_cleanup_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_object_info.h

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -129,6 +129,7 @@ if (${RUN_TESTS})
     add_executable(gfxrecon_decode_test "")
     target_sources(gfxrecon_decode_test PRIVATE
             ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp)
+    target_link_libraries(gfxrecon_decode_test PRIVATE gfxrecon_decode)
     common_build_directives(gfxrecon_decode_test)
     common_test_directives(gfxrecon_decode_test)
 endif()

--- a/framework/decode/test/main.cpp
+++ b/framework/decode/test/main.cpp
@@ -19,3 +19,121 @@
 
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
+
+#include "decode/vulkan_handle_mapping_util.h"
+#include "decode/vulkan_object_info.h"
+#include "decode/vulkan_object_info_table.h"
+#include "format/format.h"
+#include "format/format_util.h"
+
+#include "vulkan/vulkan.h"
+
+#include <vector>
+
+const VkBuffer                   kBufferHandles[] = { gfxrecon::format::FromHandleId<VkBuffer>(0xabcd),
+                                    gfxrecon::format::FromHandleId<VkBuffer>(0xbcda),
+                                    gfxrecon::format::FromHandleId<VkBuffer>(0xcdab),
+                                    gfxrecon::format::FromHandleId<VkBuffer>(0xdabc) };
+const gfxrecon::format::HandleId kBufferIds[]     = { 12, 24, 48, 96 };
+const gfxrecon::format::HandleId kDeviceId        = 6;
+
+TEST_CASE("handle IDs need to be mapped to valid handles", "[wrapper]")
+{
+    gfxrecon::decode::VulkanObjectInfoTable info_table;
+
+    // Basic add.
+    gfxrecon::decode::handle_mapping::AddHandle<gfxrecon::decode::BufferInfo>(
+        kDeviceId,
+        kBufferIds[0],
+        kBufferHandles[0],
+        &info_table,
+        &gfxrecon::decode::VulkanObjectInfoTable::AddBufferInfo);
+
+    SECTION("Add a total of four entries to the object table")
+    {
+        // Basic array add.
+        gfxrecon::decode::handle_mapping::AddHandleArray<gfxrecon::decode::BufferInfo>(
+            kDeviceId,
+            &kBufferIds[1],
+            1,
+            &kBufferHandles[1],
+            1,
+            &info_table,
+            &gfxrecon::decode::VulkanObjectInfoTable::AddBufferInfo);
+
+        // Array add with info and different ID/handle counts.
+        gfxrecon::decode::handle_mapping::AddHandleArray<gfxrecon::decode::BufferInfo>(
+            kDeviceId,
+            &kBufferIds[2],
+            1,
+            &kBufferHandles[2],
+            2,
+            std::vector<gfxrecon::decode::BufferInfo>(1),
+            &info_table,
+            &gfxrecon::decode::VulkanObjectInfoTable::AddBufferInfo);
+
+        // Add with info.
+        gfxrecon::decode::handle_mapping::AddHandle<gfxrecon::decode::BufferInfo>(
+            kDeviceId,
+            kBufferIds[3],
+            kBufferHandles[3],
+            gfxrecon::decode::BufferInfo{},
+            &info_table,
+            &gfxrecon::decode::VulkanObjectInfoTable::AddBufferInfo);
+
+        std::vector<const gfxrecon::decode::BufferInfo*> buffers;
+        info_table.VisitBufferInfo([&buffers](const gfxrecon::decode::BufferInfo* info) { buffers.push_back(info); });
+
+        REQUIRE(buffers.size() == 4);
+    }
+
+    SECTION("Add a duplicate entry to the object table, which is ignored")
+    {
+        gfxrecon::decode::handle_mapping::AddHandle<gfxrecon::decode::BufferInfo>(
+            kDeviceId,
+            kBufferIds[0],
+            kBufferHandles[0],
+            &info_table,
+            &gfxrecon::decode::VulkanObjectInfoTable::AddBufferInfo);
+
+        std::vector<const gfxrecon::decode::BufferInfo*> buffers;
+        info_table.VisitBufferInfo([&buffers](const gfxrecon::decode::BufferInfo* info) { buffers.push_back(info); });
+
+        REQUIRE(buffers.size() == 1);
+    }
+
+    SECTION("Remove an entry from the object table")
+    {
+        gfxrecon::decode::handle_mapping::RemoveHandle(
+            kBufferIds[0], &info_table, &gfxrecon::decode::VulkanObjectInfoTable::RemoveBufferInfo);
+
+        std::vector<const gfxrecon::decode::BufferInfo*> buffers;
+        info_table.VisitBufferInfo([&buffers](const gfxrecon::decode::BufferInfo* info) { buffers.push_back(info); });
+
+        REQUIRE(buffers.size() == 0);
+    }
+
+    SECTION("Buffer ID 12 maps to a valid buffer handle")
+    {
+        auto buffer = gfxrecon::decode::handle_mapping::MapHandle<gfxrecon::decode::BufferInfo>(
+            kBufferIds[0], info_table, &gfxrecon::decode::VulkanObjectInfoTable::GetBufferInfo);
+
+        REQUIRE(buffer == kBufferHandles[0]);
+    }
+
+    SECTION("Invalid buffer ID 99 does not map to a valid buffer handle")
+    {
+        auto buffer = gfxrecon::decode::handle_mapping::MapHandle<gfxrecon::decode::BufferInfo>(
+            99, info_table, &gfxrecon::decode::VulkanObjectInfoTable::GetBufferInfo);
+
+        REQUIRE(buffer == VK_NULL_HANDLE);
+    }
+
+    SECTION("An integer ID with value 12 and type VK_OBJECT_TYPE_BUFFER maps to a valid buffer handle represented as "
+            "an integer")
+    {
+        auto object = gfxrecon::decode::handle_mapping::MapHandle(kBufferIds[0], VK_OBJECT_TYPE_BUFFER, info_table);
+
+        REQUIRE(object == gfxrecon::format::ToHandleId(kBufferHandles[0]));
+    }
+}

--- a/framework/decode/vulkan_handle_mapping_util.cpp
+++ b/framework/decode/vulkan_handle_mapping_util.cpp
@@ -1,0 +1,285 @@
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include "decode/vulkan_handle_mapping_util.h"
+
+#include "decode/vulkan_object_info.h"
+#include "format/format_util.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+GFXRECON_BEGIN_NAMESPACE(handle_mapping)
+
+uint64_t MapHandle(uint64_t object, VkObjectType object_type, const VulkanObjectInfoTable& object_info_table)
+{
+    switch (object_type)
+    {
+        case VK_OBJECT_TYPE_INSTANCE:
+            return format::ToHandleId(
+                MapHandle<InstanceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetInstanceInfo));
+        case VK_OBJECT_TYPE_PHYSICAL_DEVICE:
+            return format::ToHandleId(MapHandle<PhysicalDeviceInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+        case VK_OBJECT_TYPE_DEVICE:
+            return format::ToHandleId(
+                MapHandle<DeviceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetDeviceInfo));
+        case VK_OBJECT_TYPE_QUEUE:
+            return format::ToHandleId(
+                MapHandle<QueueInfo>(object, object_info_table, &VulkanObjectInfoTable::GetQueueInfo));
+        case VK_OBJECT_TYPE_SEMAPHORE:
+            return format::ToHandleId(
+                MapHandle<SemaphoreInfo>(object, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo));
+        case VK_OBJECT_TYPE_COMMAND_BUFFER:
+            return format::ToHandleId(
+                MapHandle<CommandBufferInfo>(object, object_info_table, &VulkanObjectInfoTable::GetCommandBufferInfo));
+        case VK_OBJECT_TYPE_FENCE:
+            return format::ToHandleId(
+                MapHandle<FenceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetFenceInfo));
+        case VK_OBJECT_TYPE_DEVICE_MEMORY:
+            return format::ToHandleId(
+                MapHandle<DeviceMemoryInfo>(object, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo));
+        case VK_OBJECT_TYPE_BUFFER:
+            return format::ToHandleId(
+                MapHandle<BufferInfo>(object, object_info_table, &VulkanObjectInfoTable::GetBufferInfo));
+        case VK_OBJECT_TYPE_IMAGE:
+            return format::ToHandleId(
+                MapHandle<ImageInfo>(object, object_info_table, &VulkanObjectInfoTable::GetImageInfo));
+        case VK_OBJECT_TYPE_EVENT:
+            return format::ToHandleId(
+                MapHandle<EventInfo>(object, object_info_table, &VulkanObjectInfoTable::GetEventInfo));
+        case VK_OBJECT_TYPE_QUERY_POOL:
+            return format::ToHandleId(
+                MapHandle<QueryPoolInfo>(object, object_info_table, &VulkanObjectInfoTable::GetQueryPoolInfo));
+        case VK_OBJECT_TYPE_BUFFER_VIEW:
+            return format::ToHandleId(
+                MapHandle<BufferViewInfo>(object, object_info_table, &VulkanObjectInfoTable::GetBufferViewInfo));
+        case VK_OBJECT_TYPE_IMAGE_VIEW:
+            return format::ToHandleId(
+                MapHandle<ImageViewInfo>(object, object_info_table, &VulkanObjectInfoTable::GetImageViewInfo));
+        case VK_OBJECT_TYPE_SHADER_MODULE:
+            return format::ToHandleId(
+                MapHandle<ShaderModuleInfo>(object, object_info_table, &VulkanObjectInfoTable::GetShaderModuleInfo));
+        case VK_OBJECT_TYPE_PIPELINE_CACHE:
+            return format::ToHandleId(
+                MapHandle<PipelineCacheInfo>(object, object_info_table, &VulkanObjectInfoTable::GetPipelineCacheInfo));
+        case VK_OBJECT_TYPE_PIPELINE_LAYOUT:
+            return format::ToHandleId(MapHandle<PipelineLayoutInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo));
+        case VK_OBJECT_TYPE_RENDER_PASS:
+            return format::ToHandleId(
+                MapHandle<RenderPassInfo>(object, object_info_table, &VulkanObjectInfoTable::GetRenderPassInfo));
+        case VK_OBJECT_TYPE_PIPELINE:
+            return format::ToHandleId(
+                MapHandle<PipelineInfo>(object, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo));
+        case VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT:
+            return format::ToHandleId(MapHandle<DescriptorSetLayoutInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetLayoutInfo));
+        case VK_OBJECT_TYPE_SAMPLER:
+            return format::ToHandleId(
+                MapHandle<SamplerInfo>(object, object_info_table, &VulkanObjectInfoTable::GetSamplerInfo));
+        case VK_OBJECT_TYPE_DESCRIPTOR_POOL:
+            return format::ToHandleId(MapHandle<DescriptorPoolInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetDescriptorPoolInfo));
+        case VK_OBJECT_TYPE_DESCRIPTOR_SET:
+            return format::ToHandleId(
+                MapHandle<DescriptorSetInfo>(object, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetInfo));
+        case VK_OBJECT_TYPE_FRAMEBUFFER:
+            return format::ToHandleId(
+                MapHandle<FramebufferInfo>(object, object_info_table, &VulkanObjectInfoTable::GetFramebufferInfo));
+        case VK_OBJECT_TYPE_COMMAND_POOL:
+            return format::ToHandleId(
+                MapHandle<CommandPoolInfo>(object, object_info_table, &VulkanObjectInfoTable::GetCommandPoolInfo));
+        case VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION:
+            return format::ToHandleId(MapHandle<SamplerYcbcrConversionInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetSamplerYcbcrConversionInfo));
+        case VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE:
+            return format::ToHandleId(MapHandle<DescriptorUpdateTemplateInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetDescriptorUpdateTemplateInfo));
+        case VK_OBJECT_TYPE_SURFACE_KHR:
+            return format::ToHandleId(
+                MapHandle<SurfaceKHRInfo>(object, object_info_table, &VulkanObjectInfoTable::GetSurfaceKHRInfo));
+        case VK_OBJECT_TYPE_SWAPCHAIN_KHR:
+            return format::ToHandleId(
+                MapHandle<SwapchainKHRInfo>(object, object_info_table, &VulkanObjectInfoTable::GetSwapchainKHRInfo));
+        case VK_OBJECT_TYPE_DISPLAY_KHR:
+            return format::ToHandleId(
+                MapHandle<DisplayKHRInfo>(object, object_info_table, &VulkanObjectInfoTable::GetDisplayKHRInfo));
+        case VK_OBJECT_TYPE_DISPLAY_MODE_KHR:
+            return format::ToHandleId(MapHandle<DisplayModeKHRInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetDisplayModeKHRInfo));
+        case VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT:
+            return format::ToHandleId(MapHandle<DebugReportCallbackEXTInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetDebugReportCallbackEXTInfo));
+        case VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT:
+            return format::ToHandleId(MapHandle<DebugUtilsMessengerEXTInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetDebugUtilsMessengerEXTInfo));
+        // TODO: Handle acceleration structure handles separately.
+        // case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR:
+        //    return format::ToHandleId(MapHandle<AccelerationStructureKHRInfo>(
+        //        object, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo));
+        case VK_OBJECT_TYPE_VALIDATION_CACHE_EXT:
+            return format::ToHandleId(MapHandle<ValidationCacheEXTInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetValidationCacheEXTInfo));
+        case VK_OBJECT_TYPE_PERFORMANCE_CONFIGURATION_INTEL:
+            return format::ToHandleId(MapHandle<PerformanceConfigurationINTELInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetPerformanceConfigurationINTELInfo));
+        case VK_OBJECT_TYPE_DEFERRED_OPERATION_KHR:
+            return format::ToHandleId(MapHandle<DeferredOperationKHRInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetDeferredOperationKHRInfo));
+        case VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NV:
+            return format::ToHandleId(MapHandle<IndirectCommandsLayoutNVInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetIndirectCommandsLayoutNVInfo));
+        case VK_OBJECT_TYPE_PRIVATE_DATA_SLOT_EXT:
+            return format::ToHandleId(MapHandle<PrivateDataSlotEXTInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetPrivateDataSlotEXTInfo));
+        case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV:
+            return format::ToHandleId(MapHandle<AccelerationStructureNVInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureNVInfo));
+        case VK_OBJECT_TYPE_UNKNOWN:
+            // No conversion will be performed for unknown objects.
+            GFXRECON_LOG_WARNING("Skipping handle unwrapping for unknown debug marker object type.");
+            return object;
+        default:
+            GFXRECON_LOG_WARNING("Skipping handle unwrapping for unrecognized debug marker object type %d",
+                                 object_type);
+            return object;
+    }
+}
+
+uint64_t
+MapHandle(uint64_t object, VkDebugReportObjectTypeEXT object_type, const VulkanObjectInfoTable& object_info_table)
+{
+    switch (object_type)
+    {
+        case VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT:
+            return format::ToHandleId(
+                MapHandle<InstanceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetInstanceInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT:
+            return format::ToHandleId(MapHandle<PhysicalDeviceInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetPhysicalDeviceInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT:
+            return format::ToHandleId(
+                MapHandle<DeviceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetDeviceInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT:
+            return format::ToHandleId(
+                MapHandle<QueueInfo>(object, object_info_table, &VulkanObjectInfoTable::GetQueueInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT:
+            return format::ToHandleId(
+                MapHandle<SemaphoreInfo>(object, object_info_table, &VulkanObjectInfoTable::GetSemaphoreInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT:
+            return format::ToHandleId(
+                MapHandle<CommandBufferInfo>(object, object_info_table, &VulkanObjectInfoTable::GetCommandBufferInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT:
+            return format::ToHandleId(
+                MapHandle<FenceInfo>(object, object_info_table, &VulkanObjectInfoTable::GetFenceInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT:
+            return format::ToHandleId(
+                MapHandle<DeviceMemoryInfo>(object, object_info_table, &VulkanObjectInfoTable::GetDeviceMemoryInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT:
+            return format::ToHandleId(
+                MapHandle<BufferInfo>(object, object_info_table, &VulkanObjectInfoTable::GetBufferInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT:
+            return format::ToHandleId(
+                MapHandle<ImageInfo>(object, object_info_table, &VulkanObjectInfoTable::GetImageInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT:
+            return format::ToHandleId(
+                MapHandle<EventInfo>(object, object_info_table, &VulkanObjectInfoTable::GetEventInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT:
+            return format::ToHandleId(
+                MapHandle<QueryPoolInfo>(object, object_info_table, &VulkanObjectInfoTable::GetQueryPoolInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT:
+            return format::ToHandleId(
+                MapHandle<BufferViewInfo>(object, object_info_table, &VulkanObjectInfoTable::GetBufferViewInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT:
+            return format::ToHandleId(
+                MapHandle<ImageViewInfo>(object, object_info_table, &VulkanObjectInfoTable::GetImageViewInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT:
+            return format::ToHandleId(
+                MapHandle<ShaderModuleInfo>(object, object_info_table, &VulkanObjectInfoTable::GetShaderModuleInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT:
+            return format::ToHandleId(
+                MapHandle<PipelineCacheInfo>(object, object_info_table, &VulkanObjectInfoTable::GetPipelineCacheInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT:
+            return format::ToHandleId(MapHandle<PipelineLayoutInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT:
+            return format::ToHandleId(
+                MapHandle<RenderPassInfo>(object, object_info_table, &VulkanObjectInfoTable::GetRenderPassInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT:
+            return format::ToHandleId(
+                MapHandle<PipelineInfo>(object, object_info_table, &VulkanObjectInfoTable::GetPipelineInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT:
+            return format::ToHandleId(MapHandle<DescriptorSetLayoutInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetLayoutInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT:
+            return format::ToHandleId(
+                MapHandle<SamplerInfo>(object, object_info_table, &VulkanObjectInfoTable::GetSamplerInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT:
+            return format::ToHandleId(MapHandle<DescriptorPoolInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetDescriptorPoolInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT:
+            return format::ToHandleId(
+                MapHandle<DescriptorSetInfo>(object, object_info_table, &VulkanObjectInfoTable::GetDescriptorSetInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT:
+            return format::ToHandleId(
+                MapHandle<FramebufferInfo>(object, object_info_table, &VulkanObjectInfoTable::GetFramebufferInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT:
+            return format::ToHandleId(
+                MapHandle<CommandPoolInfo>(object, object_info_table, &VulkanObjectInfoTable::GetCommandPoolInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT:
+            return format::ToHandleId(
+                MapHandle<SurfaceKHRInfo>(object, object_info_table, &VulkanObjectInfoTable::GetSurfaceKHRInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT:
+            return format::ToHandleId(
+                MapHandle<SwapchainKHRInfo>(object, object_info_table, &VulkanObjectInfoTable::GetSwapchainKHRInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT:
+            return format::ToHandleId(MapHandle<DebugReportCallbackEXTInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetDebugReportCallbackEXTInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT:
+            return format::ToHandleId(
+                MapHandle<DisplayKHRInfo>(object, object_info_table, &VulkanObjectInfoTable::GetDisplayKHRInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT:
+            return format::ToHandleId(MapHandle<DisplayModeKHRInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetDisplayModeKHRInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT:
+            return format::ToHandleId(MapHandle<ValidationCacheEXTInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetValidationCacheEXTInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT:
+            return format::ToHandleId(MapHandle<SamplerYcbcrConversionInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetSamplerYcbcrConversionInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT:
+            return format::ToHandleId(MapHandle<DescriptorUpdateTemplateInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetDescriptorUpdateTemplateInfo));
+        // TODO: Handle acceleration structure handles separately.
+        // case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT:
+        //    return format::ToHandleId(MapHandle<AccelerationStructureKHRInfo>(
+        //        object, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT:
+            return format::ToHandleId(MapHandle<AccelerationStructureNVInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureNVInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT:
+            // No conversion will be performed for unknown objects.
+            GFXRECON_LOG_WARNING("Skipping handle mapping for unknown debug marker object type.");
+            return object;
+        default:
+            GFXRECON_LOG_WARNING("Skipping handle mapping for unrecognized debug marker object type %d", object_type);
+            return object;
+    }
+}
+
+GFXRECON_END_NAMESPACE(handle_mapping)
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_handle_mapping_util.h
+++ b/framework/decode/vulkan_handle_mapping_util.h
@@ -55,6 +55,11 @@ static typename T::HandleType MapHandle(format::HandleId             id,
     return handle;
 }
 
+uint64_t MapHandle(uint64_t object, VkObjectType object_type, const VulkanObjectInfoTable& object_info_table);
+
+uint64_t
+MapHandle(uint64_t object, VkDebugReportObjectTypeEXT object_type, const VulkanObjectInfoTable& object_info_table);
+
 template <typename T>
 static typename T::HandleType* MapHandleArray(HandlePointerDecoder<typename T::HandleType>* handles_pointer,
                                               const VulkanObjectInfoTable&                  object_info_table,

--- a/framework/decode/vulkan_object_info_table.h
+++ b/framework/decode/vulkan_object_info_table.h
@@ -66,7 +66,6 @@ class VulkanObjectInfoTable
     void AddSwapchainKHRInfo(SwapchainKHRInfo&& info)                                   { AddObjectInfo(std::move(info), &swapchain_khr_map_); }
     void AddDisplayKHRInfo(DisplayKHRInfo&& info)                                       { AddObjectInfo(std::move(info), &display_khr_map_); }
     void AddDisplayModeKHRInfo(DisplayModeKHRInfo&& info)                               { AddObjectInfo(std::move(info), &display_mode_khr_map_); }
-    void AddSamplerYcbcrConversionKHRInfo(SamplerYcbcrConversionKHRInfo&& info)         { AddObjectInfo(std::move(info), &sampler_ycbcr_conversion_khr_map_); }
     void AddDebugReportCallbackEXTInfo(DebugReportCallbackEXTInfo&& info)               { AddObjectInfo(std::move(info), &debug_report_callback_ext_map_); }
     void AddIndirectCommandsLayoutNVInfo(IndirectCommandsLayoutNVInfo&& info)           { AddObjectInfo(std::move(info), &indirect_commands_layout_nv_map_); }
     void AddDebugUtilsMessengerEXTInfo(DebugUtilsMessengerEXTInfo&& info)               { AddObjectInfo(std::move(info), &debug_utils_messenger_ext_map_); }
@@ -108,7 +107,6 @@ class VulkanObjectInfoTable
     void RemoveSwapchainKHRInfo(format::HandleId id)                  { swapchain_khr_map_.erase(id); }
     void RemoveDisplayKHRInfo(format::HandleId id)                    { display_khr_map_.erase(id); }
     void RemoveDisplayModeKHRInfo(format::HandleId id)                { display_mode_khr_map_.erase(id); }
-    void RemoveSamplerYcbcrConversionKHRInfo(format::HandleId id)     { sampler_ycbcr_conversion_khr_map_.erase(id); }
     void RemoveDebugReportCallbackEXTInfo(format::HandleId id)        { debug_report_callback_ext_map_.erase(id); }
     void RemoveIndirectCommandsLayoutNVInfo(format::HandleId id)      { indirect_commands_layout_nv_map_.erase(id); }
     void RemoveDebugUtilsMessengerEXTInfo(format::HandleId id)        { debug_utils_messenger_ext_map_.erase(id); }
@@ -150,7 +148,6 @@ class VulkanObjectInfoTable
     const SwapchainKHRInfo*                  GetSwapchainKHRInfo(format::HandleId id) const                   { return GetObjectInfo<SwapchainKHRInfo>(id, &swapchain_khr_map_); }
     const DisplayKHRInfo*                    GetDisplayKHRInfo(format::HandleId id) const                     { return GetObjectInfo<DisplayKHRInfo>(id, &display_khr_map_); }
     const DisplayModeKHRInfo*                GetDisplayModeKHRInfo(format::HandleId id) const                 { return GetObjectInfo<DisplayModeKHRInfo>(id, &display_mode_khr_map_); }
-    const SamplerYcbcrConversionKHRInfo*     GetSamplerYcbcrConversionKHRInfo(format::HandleId id) const      { return GetObjectInfo<SamplerYcbcrConversionKHRInfo>(id, &sampler_ycbcr_conversion_khr_map_); }
     const DebugReportCallbackEXTInfo*        GetDebugReportCallbackEXTInfo(format::HandleId id) const         { return GetObjectInfo<DebugReportCallbackEXTInfo>(id, &debug_report_callback_ext_map_); }
     const IndirectCommandsLayoutNVInfo*      GetIndirectCommandsLayoutNVInfo(format::HandleId id) const       { return GetObjectInfo<IndirectCommandsLayoutNVInfo>(id, &indirect_commands_layout_nv_map_); }
     const DebugUtilsMessengerEXTInfo*        GetDebugUtilsMessengerEXTInfo(format::HandleId id) const         { return GetObjectInfo<DebugUtilsMessengerEXTInfo>(id, &debug_utils_messenger_ext_map_); }
@@ -192,7 +189,6 @@ class VulkanObjectInfoTable
     SwapchainKHRInfo*                  GetSwapchainKHRInfo(format::HandleId id)                   { return GetObjectInfo<SwapchainKHRInfo>(id, &swapchain_khr_map_); }
     DisplayKHRInfo*                    GetDisplayKHRInfo(format::HandleId id)                     { return GetObjectInfo<DisplayKHRInfo>(id, &display_khr_map_); }
     DisplayModeKHRInfo*                GetDisplayModeKHRInfo(format::HandleId id)                 { return GetObjectInfo<DisplayModeKHRInfo>(id, &display_mode_khr_map_); }
-    SamplerYcbcrConversionKHRInfo*     GetSamplerYcbcrConversionKHRInfo(format::HandleId id)      { return GetObjectInfo<SamplerYcbcrConversionKHRInfo>(id, &sampler_ycbcr_conversion_khr_map_); }
     DebugReportCallbackEXTInfo*        GetDebugReportCallbackEXTInfo(format::HandleId id)         { return GetObjectInfo<DebugReportCallbackEXTInfo>(id, &debug_report_callback_ext_map_); }
     IndirectCommandsLayoutNVInfo*      GetIndirectCommandsLayoutNVInfo(format::HandleId id)       { return GetObjectInfo<IndirectCommandsLayoutNVInfo>(id, &indirect_commands_layout_nv_map_); }
     DebugUtilsMessengerEXTInfo*        GetDebugUtilsMessengerEXTInfo(format::HandleId id)         { return GetObjectInfo<DebugUtilsMessengerEXTInfo>(id, &debug_utils_messenger_ext_map_); }
@@ -370,7 +366,6 @@ class VulkanObjectInfoTable
     std::unordered_map<format::HandleId, SwapchainKHRInfo>                  swapchain_khr_map_;
     std::unordered_map<format::HandleId, DisplayKHRInfo>                    display_khr_map_;
     std::unordered_map<format::HandleId, DisplayModeKHRInfo>                display_mode_khr_map_;
-    std::unordered_map<format::HandleId, SamplerYcbcrConversionKHRInfo>     sampler_ycbcr_conversion_khr_map_;
     std::unordered_map<format::HandleId, DebugReportCallbackEXTInfo>        debug_report_callback_ext_map_;
     std::unordered_map<format::HandleId, IndirectCommandsLayoutNVInfo>      indirect_commands_layout_nv_map_;
     std::unordered_map<format::HandleId, DebugUtilsMessengerEXTInfo>        debug_utils_messenger_ext_map_;

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -850,6 +850,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                                   uint32_t       last_presented_image,
                                                   const std::vector<format::SwapchainImageStateInfo>& image_info);
 
+    void ProcessCreateInstanceDebugCallbackInfo(const Decoded_VkInstanceCreateInfo* instance_info);
+
     void ProcessSwapchainFullScreenExclusiveInfo(const Decoded_VkSwapchainCreateInfoKHR* swapchain_info);
 
     void ProcessImportAndroidHardwareBufferInfo(const Decoded_VkMemoryAllocateInfo* allocate_info);

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -175,6 +175,16 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         return handle_mapping::MapHandle(id, object_info_table_, MapFunc);
     }
 
+    uint64_t MapHandle(uint64_t object, VkObjectType object_type)
+    {
+        return handle_mapping::MapHandle(object, object_type, object_info_table_);
+    }
+
+    uint64_t MapHandle(uint64_t object, VkDebugReportObjectTypeEXT object_type)
+    {
+        return handle_mapping::MapHandle(object, object_type, object_info_table_);
+    }
+
     template <typename T>
     typename T::HandleType* MapHandles(HandlePointerDecoder<typename T::HandleType>* handles_pointer,
                                        size_t                                        handles_len,

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -78,6 +78,7 @@ if (${RUN_TESTS})
     add_executable(gfxrecon_encode_test "")
     target_sources(gfxrecon_encode_test PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp)
+    target_link_libraries(gfxrecon_encode_test PRIVATE gfxrecon_encode)
     common_build_directives(gfxrecon_encode_test)
     common_test_directives(gfxrecon_encode_test)
 endif()

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -40,6 +40,7 @@ target_sources(gfxrecon_encode
                     ${CMAKE_CURRENT_LIST_DIR}/trace_manager.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_wrappers.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_wrapper_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_wrapper_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_state_info.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_state_table.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_state_tracker.h

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -1387,8 +1387,10 @@ VkResult TraceManager::OverrideGetPhysicalDeviceToolPropertiesEXT(VkPhysicalDevi
         }
     }
 
+    auto physicalDevice_unwrapped = GetWrappedHandle<VkPhysicalDevice>(physicalDevice);
+
     VkResult result = GetInstanceTable(physicalDevice)
-                          ->GetPhysicalDeviceToolPropertiesEXT(physicalDevice, pToolCount, pToolProperties);
+                          ->GetPhysicalDeviceToolPropertiesEXT(physicalDevice_unwrapped, pToolCount, pToolProperties);
 
     if (original_pToolProperties != nullptr)
     {

--- a/framework/encode/vulkan_handle_wrapper_util.cpp
+++ b/framework/encode/vulkan_handle_wrapper_util.cpp
@@ -1,0 +1,387 @@
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#include "encode/vulkan_handle_wrapper_util.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(encode)
+
+uint64_t GetWrappedHandle(uint64_t object, VkObjectType object_type)
+{
+    switch (object_type)
+    {
+        case VK_OBJECT_TYPE_INSTANCE:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkInstance>(object)));
+        case VK_OBJECT_TYPE_PHYSICAL_DEVICE:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkPhysicalDevice>(object)));
+        case VK_OBJECT_TYPE_DEVICE:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDevice>(object)));
+        case VK_OBJECT_TYPE_QUEUE:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkQueue>(object)));
+        case VK_OBJECT_TYPE_SEMAPHORE:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkSemaphore>(object)));
+        case VK_OBJECT_TYPE_COMMAND_BUFFER:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkCommandBuffer>(object)));
+        case VK_OBJECT_TYPE_FENCE:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkFence>(object)));
+        case VK_OBJECT_TYPE_DEVICE_MEMORY:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDeviceMemory>(object)));
+        case VK_OBJECT_TYPE_BUFFER:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkBuffer>(object)));
+        case VK_OBJECT_TYPE_IMAGE:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkImage>(object)));
+        case VK_OBJECT_TYPE_EVENT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkEvent>(object)));
+        case VK_OBJECT_TYPE_QUERY_POOL:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkQueryPool>(object)));
+        case VK_OBJECT_TYPE_BUFFER_VIEW:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkBufferView>(object)));
+        case VK_OBJECT_TYPE_IMAGE_VIEW:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkImageView>(object)));
+        case VK_OBJECT_TYPE_SHADER_MODULE:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkShaderModule>(object)));
+        case VK_OBJECT_TYPE_PIPELINE_CACHE:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkPipelineCache>(object)));
+        case VK_OBJECT_TYPE_PIPELINE_LAYOUT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkPipelineLayout>(object)));
+        case VK_OBJECT_TYPE_RENDER_PASS:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkRenderPass>(object)));
+        case VK_OBJECT_TYPE_PIPELINE:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkPipeline>(object)));
+        case VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDescriptorSetLayout>(object)));
+        case VK_OBJECT_TYPE_SAMPLER:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkSampler>(object)));
+        case VK_OBJECT_TYPE_DESCRIPTOR_POOL:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDescriptorPool>(object)));
+        case VK_OBJECT_TYPE_DESCRIPTOR_SET:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDescriptorSet>(object)));
+        case VK_OBJECT_TYPE_FRAMEBUFFER:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkFramebuffer>(object)));
+        case VK_OBJECT_TYPE_COMMAND_POOL:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkCommandPool>(object)));
+        case VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkSamplerYcbcrConversion>(object)));
+        case VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDescriptorUpdateTemplate>(object)));
+        case VK_OBJECT_TYPE_SURFACE_KHR:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkSurfaceKHR>(object)));
+        case VK_OBJECT_TYPE_SWAPCHAIN_KHR:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkSwapchainKHR>(object)));
+        case VK_OBJECT_TYPE_DISPLAY_KHR:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDisplayKHR>(object)));
+        case VK_OBJECT_TYPE_DISPLAY_MODE_KHR:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDisplayModeKHR>(object)));
+        case VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDebugReportCallbackEXT>(object)));
+        case VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDebugUtilsMessengerEXT>(object)));
+        // TODO: Handle acceleration structure handles separately.
+        // case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR:
+        //    return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkAccelerationStructureKHR>(object)));
+        case VK_OBJECT_TYPE_VALIDATION_CACHE_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkValidationCacheEXT>(object)));
+        case VK_OBJECT_TYPE_PERFORMANCE_CONFIGURATION_INTEL:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkPerformanceConfigurationINTEL>(object)));
+        case VK_OBJECT_TYPE_DEFERRED_OPERATION_KHR:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDeferredOperationKHR>(object)));
+        case VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NV:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkIndirectCommandsLayoutNV>(object)));
+        case VK_OBJECT_TYPE_PRIVATE_DATA_SLOT_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkPrivateDataSlotEXT>(object)));
+        case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkAccelerationStructureNV>(object)));
+        case VK_OBJECT_TYPE_UNKNOWN:
+            // No conversion will be performed for unknown objects.
+            GFXRECON_LOG_WARNING("Skipping handle unwrapping for unknown debug marker object type.");
+            return object;
+        default:
+            GFXRECON_LOG_WARNING("Skipping handle unwrapping for unrecognized debug marker object type %d",
+                                 object_type);
+            return object;
+    }
+}
+
+uint64_t GetWrappedHandle(uint64_t object, VkDebugReportObjectTypeEXT object_type)
+{
+    switch (object_type)
+    {
+        case VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkInstance>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkPhysicalDevice>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDevice>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkQueue>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkSemaphore>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkCommandBuffer>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkFence>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDeviceMemory>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkBuffer>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkImage>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkEvent>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkQueryPool>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkBufferView>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkImageView>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkShaderModule>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkPipelineCache>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkPipelineLayout>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkRenderPass>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkPipeline>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDescriptorSetLayout>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkSampler>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDescriptorPool>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDescriptorSet>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkFramebuffer>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkCommandPool>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkSurfaceKHR>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkSwapchainKHR>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDebugReportCallbackEXT>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDisplayKHR>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDisplayModeKHR>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkValidationCacheEXT>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkSamplerYcbcrConversion>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDescriptorUpdateTemplate>(object)));
+        // TODO: Handle acceleration structure handles separately.
+        // case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT:
+        //    return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkAccelerationStructureKHR>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkAccelerationStructureNV>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT:
+            // No conversion will be performed for unknown objects.
+            GFXRECON_LOG_WARNING("Skipping handle unwrapping for unknown debug marker object type.");
+            return object;
+        default:
+            GFXRECON_LOG_WARNING("Skipping handle unwrapping for unrecognized debug marker object type %d",
+                                 object_type);
+            return object;
+    }
+}
+
+uint64_t GetWrappedId(uint64_t object, VkObjectType object_type)
+{
+    switch (object_type)
+    {
+        case VK_OBJECT_TYPE_INSTANCE:
+            return GetWrappedId(format::FromHandleId<VkInstance>(object));
+        case VK_OBJECT_TYPE_PHYSICAL_DEVICE:
+            return GetWrappedId(format::FromHandleId<VkPhysicalDevice>(object));
+        case VK_OBJECT_TYPE_DEVICE:
+            return GetWrappedId(format::FromHandleId<VkDevice>(object));
+        case VK_OBJECT_TYPE_QUEUE:
+            return GetWrappedId(format::FromHandleId<VkQueue>(object));
+        case VK_OBJECT_TYPE_SEMAPHORE:
+            return GetWrappedId(format::FromHandleId<VkSemaphore>(object));
+        case VK_OBJECT_TYPE_COMMAND_BUFFER:
+            return GetWrappedId(format::FromHandleId<VkCommandBuffer>(object));
+        case VK_OBJECT_TYPE_FENCE:
+            return GetWrappedId(format::FromHandleId<VkFence>(object));
+        case VK_OBJECT_TYPE_DEVICE_MEMORY:
+            return GetWrappedId(format::FromHandleId<VkDeviceMemory>(object));
+        case VK_OBJECT_TYPE_BUFFER:
+            return GetWrappedId(format::FromHandleId<VkBuffer>(object));
+        case VK_OBJECT_TYPE_IMAGE:
+            return GetWrappedId(format::FromHandleId<VkImage>(object));
+        case VK_OBJECT_TYPE_EVENT:
+            return GetWrappedId(format::FromHandleId<VkEvent>(object));
+        case VK_OBJECT_TYPE_QUERY_POOL:
+            return GetWrappedId(format::FromHandleId<VkQueryPool>(object));
+        case VK_OBJECT_TYPE_BUFFER_VIEW:
+            return GetWrappedId(format::FromHandleId<VkBufferView>(object));
+        case VK_OBJECT_TYPE_IMAGE_VIEW:
+            return GetWrappedId(format::FromHandleId<VkImageView>(object));
+        case VK_OBJECT_TYPE_SHADER_MODULE:
+            return GetWrappedId(format::FromHandleId<VkShaderModule>(object));
+        case VK_OBJECT_TYPE_PIPELINE_CACHE:
+            return GetWrappedId(format::FromHandleId<VkPipelineCache>(object));
+        case VK_OBJECT_TYPE_PIPELINE_LAYOUT:
+            return GetWrappedId(format::FromHandleId<VkPipelineLayout>(object));
+        case VK_OBJECT_TYPE_RENDER_PASS:
+            return GetWrappedId(format::FromHandleId<VkRenderPass>(object));
+        case VK_OBJECT_TYPE_PIPELINE:
+            return GetWrappedId(format::FromHandleId<VkPipeline>(object));
+        case VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT:
+            return GetWrappedId(format::FromHandleId<VkDescriptorSetLayout>(object));
+        case VK_OBJECT_TYPE_SAMPLER:
+            return GetWrappedId(format::FromHandleId<VkSampler>(object));
+        case VK_OBJECT_TYPE_DESCRIPTOR_POOL:
+            return GetWrappedId(format::FromHandleId<VkDescriptorPool>(object));
+        case VK_OBJECT_TYPE_DESCRIPTOR_SET:
+            return GetWrappedId(format::FromHandleId<VkDescriptorSet>(object));
+        case VK_OBJECT_TYPE_FRAMEBUFFER:
+            return GetWrappedId(format::FromHandleId<VkFramebuffer>(object));
+        case VK_OBJECT_TYPE_COMMAND_POOL:
+            return GetWrappedId(format::FromHandleId<VkCommandPool>(object));
+        case VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION:
+            return GetWrappedId(format::FromHandleId<VkSamplerYcbcrConversion>(object));
+        case VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE:
+            return GetWrappedId(format::FromHandleId<VkDescriptorUpdateTemplate>(object));
+        case VK_OBJECT_TYPE_SURFACE_KHR:
+            return GetWrappedId(format::FromHandleId<VkSurfaceKHR>(object));
+        case VK_OBJECT_TYPE_SWAPCHAIN_KHR:
+            return GetWrappedId(format::FromHandleId<VkSwapchainKHR>(object));
+        case VK_OBJECT_TYPE_DISPLAY_KHR:
+            return GetWrappedId(format::FromHandleId<VkDisplayKHR>(object));
+        case VK_OBJECT_TYPE_DISPLAY_MODE_KHR:
+            return GetWrappedId(format::FromHandleId<VkDisplayModeKHR>(object));
+        case VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT:
+            return GetWrappedId(format::FromHandleId<VkDebugReportCallbackEXT>(object));
+        case VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT:
+            return GetWrappedId(format::FromHandleId<VkDebugUtilsMessengerEXT>(object));
+        // TODO: Handle acceleration structure handles separately.
+        // case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR:
+        //    return GetWrappedId(format::FromHandleId<VkAccelerationStructureKHR>(object));
+        case VK_OBJECT_TYPE_VALIDATION_CACHE_EXT:
+            return GetWrappedId(format::FromHandleId<VkValidationCacheEXT>(object));
+        case VK_OBJECT_TYPE_PERFORMANCE_CONFIGURATION_INTEL:
+            return GetWrappedId(format::FromHandleId<VkPerformanceConfigurationINTEL>(object));
+        case VK_OBJECT_TYPE_DEFERRED_OPERATION_KHR:
+            return GetWrappedId(format::FromHandleId<VkDeferredOperationKHR>(object));
+        case VK_OBJECT_TYPE_INDIRECT_COMMANDS_LAYOUT_NV:
+            return GetWrappedId(format::FromHandleId<VkIndirectCommandsLayoutNV>(object));
+        case VK_OBJECT_TYPE_PRIVATE_DATA_SLOT_EXT:
+            return GetWrappedId(format::FromHandleId<VkPrivateDataSlotEXT>(object));
+        case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV:
+            return GetWrappedId(format::FromHandleId<VkAccelerationStructureNV>(object));
+        case VK_OBJECT_TYPE_UNKNOWN:
+            // No conversion will be performed for unknown objects.
+            GFXRECON_LOG_WARNING("Skipping handle unwrapping for unknown debug marker object type.");
+            return object;
+        default:
+            GFXRECON_LOG_WARNING("Skipping handle unwrapping for unrecognized debug marker object type %d",
+                                 object_type);
+            return object;
+    }
+}
+
+uint64_t GetWrappedId(uint64_t object, VkDebugReportObjectTypeEXT object_type)
+{
+    switch (object_type)
+    {
+        case VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT:
+            return GetWrappedId(format::FromHandleId<VkInstance>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT:
+            return GetWrappedId(format::FromHandleId<VkPhysicalDevice>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT:
+            return GetWrappedId(format::FromHandleId<VkDevice>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT:
+            return GetWrappedId(format::FromHandleId<VkQueue>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT:
+            return GetWrappedId(format::FromHandleId<VkSemaphore>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT:
+            return GetWrappedId(format::FromHandleId<VkCommandBuffer>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT:
+            return GetWrappedId(format::FromHandleId<VkFence>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT:
+            return GetWrappedId(format::FromHandleId<VkDeviceMemory>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT:
+            return GetWrappedId(format::FromHandleId<VkBuffer>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT:
+            return GetWrappedId(format::FromHandleId<VkImage>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT:
+            return GetWrappedId(format::FromHandleId<VkEvent>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT:
+            return GetWrappedId(format::FromHandleId<VkQueryPool>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT:
+            return GetWrappedId(format::FromHandleId<VkBufferView>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT:
+            return GetWrappedId(format::FromHandleId<VkImageView>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT:
+            return GetWrappedId(format::FromHandleId<VkShaderModule>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT:
+            return GetWrappedId(format::FromHandleId<VkPipelineCache>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT:
+            return GetWrappedId(format::FromHandleId<VkPipelineLayout>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT:
+            return GetWrappedId(format::FromHandleId<VkRenderPass>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT:
+            return GetWrappedId(format::FromHandleId<VkPipeline>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT:
+            return GetWrappedId(format::FromHandleId<VkDescriptorSetLayout>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT:
+            return GetWrappedId(format::FromHandleId<VkSampler>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT:
+            return GetWrappedId(format::FromHandleId<VkDescriptorPool>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT:
+            return GetWrappedId(format::FromHandleId<VkDescriptorSet>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT:
+            return GetWrappedId(format::FromHandleId<VkFramebuffer>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT:
+            return GetWrappedId(format::FromHandleId<VkCommandPool>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT:
+            return GetWrappedId(format::FromHandleId<VkSurfaceKHR>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT:
+            return GetWrappedId(format::FromHandleId<VkSwapchainKHR>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT:
+            return GetWrappedId(format::FromHandleId<VkDebugReportCallbackEXT>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT:
+            return GetWrappedId(format::FromHandleId<VkDisplayKHR>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT:
+            return GetWrappedId(format::FromHandleId<VkDisplayModeKHR>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT:
+            return GetWrappedId(format::FromHandleId<VkValidationCacheEXT>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT:
+            return GetWrappedId(format::FromHandleId<VkSamplerYcbcrConversion>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT:
+            return GetWrappedId(format::FromHandleId<VkDescriptorUpdateTemplate>(object));
+        // TODO: Handle acceleration structure handles separately.
+        // case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT:
+        //    return GetWrappedId(format::FromHandleId<VkAccelerationStructureKHR>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT:
+            return GetWrappedId(format::FromHandleId<VkAccelerationStructureNV>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT:
+            // No conversion will be performed for unknown objects.
+            GFXRECON_LOG_WARNING("Skipping handle unwrapping for unknown debug marker object type.");
+            return object;
+        default:
+            GFXRECON_LOG_WARNING("Skipping handle unwrapping for unrecognized debug marker object type %d",
+                                 object_type);
+            return object;
+    }
+}
+
+GFXRECON_END_NAMESPACE(encode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -101,6 +101,14 @@ format::HandleId GetWrappedId(const T& handle)
     return (handle != VK_NULL_HANDLE) ? reinterpret_cast<HandleWrapper<T>*>(handle)->handle_id : 0;
 }
 
+uint64_t GetWrappedHandle(uint64_t, VkObjectType object_type);
+
+uint64_t GetWrappedHandle(uint64_t object, VkDebugReportObjectTypeEXT object_type);
+
+uint64_t GetWrappedId(uint64_t, VkObjectType object_type);
+
+uint64_t GetWrappedId(uint64_t object, VkDebugReportObjectTypeEXT object_type);
+
 inline const InstanceTable* GetInstanceTable(VkInstance handle)
 {
     assert(handle != VK_NULL_HANDLE);

--- a/framework/format/CMakeLists.txt
+++ b/framework/format/CMakeLists.txt
@@ -43,6 +43,7 @@ if (${RUN_TESTS})
     add_executable(gfxrecon_format_test "")
     target_sources(gfxrecon_format_test PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp)
+    target_link_libraries(gfxrecon_format_test PRIVATE gfxrecon_format)
     common_build_directives(gfxrecon_format_test)
     common_test_directives(gfxrecon_format_test)
 endif()

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -8258,7 +8258,7 @@ VKAPI_ATTR void VKAPI_CALL DebugReportMessageEXT(
         encoder->EncodeHandleValue(instance);
         encoder->EncodeFlagsValue(flags);
         encoder->EncodeEnumValue(objectType);
-        encoder->EncodeUInt64Value(object);
+        encoder->EncodeUInt64Value(GetWrappedId(object, objectType));
         encoder->EncodeSizeTValue(location);
         encoder->EncodeInt32Value(messageCode);
         encoder->EncodeString(pLayerPrefix);
@@ -8267,8 +8267,9 @@ VKAPI_ATTR void VKAPI_CALL DebugReportMessageEXT(
     }
 
     VkInstance instance_unwrapped = GetWrappedHandle<VkInstance>(instance);
+    uint64_t object_unwrapped = GetWrappedHandle(object, objectType);
 
-    GetInstanceTable(instance)->DebugReportMessageEXT(instance_unwrapped, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage);
+    GetInstanceTable(instance)->DebugReportMessageEXT(instance_unwrapped, flags, objectType, object_unwrapped, location, messageCode, pLayerPrefix, pMessage);
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDebugReportMessageEXT>::Dispatch(TraceManager::Get(), instance, flags, objectType, object, location, messageCode, pLayerPrefix, pMessage);
 }
@@ -8279,9 +8280,11 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectTagEXT(
 {
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDebugMarkerSetObjectTagEXT>::Dispatch(TraceManager::Get(), device, pTagInfo);
 
+    auto handle_unwrap_memory = TraceManager::Get()->GetHandleUnwrapMemory();
     VkDevice device_unwrapped = GetWrappedHandle<VkDevice>(device);
+    const VkDebugMarkerObjectTagInfoEXT* pTagInfo_unwrapped = UnwrapStructPtrHandles(pTagInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->DebugMarkerSetObjectTagEXT(device_unwrapped, pTagInfo);
+    VkResult result = GetDeviceTable(device)->DebugMarkerSetObjectTagEXT(device_unwrapped, pTagInfo_unwrapped);
 
     auto encoder = TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDebugMarkerSetObjectTagEXT);
     if (encoder)
@@ -8303,9 +8306,11 @@ VKAPI_ATTR VkResult VKAPI_CALL DebugMarkerSetObjectNameEXT(
 {
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDebugMarkerSetObjectNameEXT>::Dispatch(TraceManager::Get(), device, pNameInfo);
 
+    auto handle_unwrap_memory = TraceManager::Get()->GetHandleUnwrapMemory();
     VkDevice device_unwrapped = GetWrappedHandle<VkDevice>(device);
+    const VkDebugMarkerObjectNameInfoEXT* pNameInfo_unwrapped = UnwrapStructPtrHandles(pNameInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->DebugMarkerSetObjectNameEXT(device_unwrapped, pNameInfo);
+    VkResult result = GetDeviceTable(device)->DebugMarkerSetObjectNameEXT(device_unwrapped, pNameInfo_unwrapped);
 
     auto encoder = TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDebugMarkerSetObjectNameEXT);
     if (encoder)
@@ -9414,9 +9419,11 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectNameEXT(
 {
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkSetDebugUtilsObjectNameEXT>::Dispatch(TraceManager::Get(), device, pNameInfo);
 
+    auto handle_unwrap_memory = TraceManager::Get()->GetHandleUnwrapMemory();
     VkDevice device_unwrapped = GetWrappedHandle<VkDevice>(device);
+    const VkDebugUtilsObjectNameInfoEXT* pNameInfo_unwrapped = UnwrapStructPtrHandles(pNameInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->SetDebugUtilsObjectNameEXT(device_unwrapped, pNameInfo);
+    VkResult result = GetDeviceTable(device)->SetDebugUtilsObjectNameEXT(device_unwrapped, pNameInfo_unwrapped);
 
     auto encoder = TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkSetDebugUtilsObjectNameEXT);
     if (encoder)
@@ -9438,9 +9445,11 @@ VKAPI_ATTR VkResult VKAPI_CALL SetDebugUtilsObjectTagEXT(
 {
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkSetDebugUtilsObjectTagEXT>::Dispatch(TraceManager::Get(), device, pTagInfo);
 
+    auto handle_unwrap_memory = TraceManager::Get()->GetHandleUnwrapMemory();
     VkDevice device_unwrapped = GetWrappedHandle<VkDevice>(device);
+    const VkDebugUtilsObjectTagInfoEXT* pTagInfo_unwrapped = UnwrapStructPtrHandles(pTagInfo, handle_unwrap_memory);
 
-    VkResult result = GetDeviceTable(device)->SetDebugUtilsObjectTagEXT(device_unwrapped, pTagInfo);
+    VkResult result = GetDeviceTable(device)->SetDebugUtilsObjectTagEXT(device_unwrapped, pTagInfo_unwrapped);
 
     auto encoder = TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkSetDebugUtilsObjectTagEXT);
     if (encoder)
@@ -12025,16 +12034,17 @@ VKAPI_ATTR VkResult VKAPI_CALL SetPrivateDataEXT(
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkSetPrivateDataEXT>::Dispatch(TraceManager::Get(), device, objectType, objectHandle, privateDataSlot, data);
 
     VkDevice device_unwrapped = GetWrappedHandle<VkDevice>(device);
+    uint64_t objectHandle_unwrapped = GetWrappedHandle(objectHandle, objectType);
     VkPrivateDataSlotEXT privateDataSlot_unwrapped = GetWrappedHandle<VkPrivateDataSlotEXT>(privateDataSlot);
 
-    VkResult result = GetDeviceTable(device)->SetPrivateDataEXT(device_unwrapped, objectType, objectHandle, privateDataSlot_unwrapped, data);
+    VkResult result = GetDeviceTable(device)->SetPrivateDataEXT(device_unwrapped, objectType, objectHandle_unwrapped, privateDataSlot_unwrapped, data);
 
     auto encoder = TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkSetPrivateDataEXT);
     if (encoder)
     {
         encoder->EncodeHandleValue(device);
         encoder->EncodeEnumValue(objectType);
-        encoder->EncodeUInt64Value(objectHandle);
+        encoder->EncodeUInt64Value(GetWrappedId(objectHandle, objectType));
         encoder->EncodeHandleValue(privateDataSlot);
         encoder->EncodeUInt64Value(data);
         encoder->EncodeEnumValue(result);
@@ -12056,16 +12066,17 @@ VKAPI_ATTR void VKAPI_CALL GetPrivateDataEXT(
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPrivateDataEXT>::Dispatch(TraceManager::Get(), device, objectType, objectHandle, privateDataSlot, pData);
 
     VkDevice device_unwrapped = GetWrappedHandle<VkDevice>(device);
+    uint64_t objectHandle_unwrapped = GetWrappedHandle(objectHandle, objectType);
     VkPrivateDataSlotEXT privateDataSlot_unwrapped = GetWrappedHandle<VkPrivateDataSlotEXT>(privateDataSlot);
 
-    GetDeviceTable(device)->GetPrivateDataEXT(device_unwrapped, objectType, objectHandle, privateDataSlot_unwrapped, pData);
+    GetDeviceTable(device)->GetPrivateDataEXT(device_unwrapped, objectType, objectHandle_unwrapped, privateDataSlot_unwrapped, pData);
 
     auto encoder = TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkGetPrivateDataEXT);
     if (encoder)
     {
         encoder->EncodeHandleValue(device);
         encoder->EncodeEnumValue(objectType);
-        encoder->EncodeUInt64Value(objectHandle);
+        encoder->EncodeUInt64Value(GetWrappedId(objectHandle, objectType));
         encoder->EncodeHandleValue(privateDataSlot);
         encoder->EncodeUInt64Ptr(pData);
         TraceManager::Get()->EndApiCallTrace(encoder);

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -4044,10 +4044,11 @@ void VulkanReplayConsumer::Process_vkDebugReportMessageEXT(
     StringDecoder*                              pMessage)
 {
     VkInstance in_instance = MapHandle<InstanceInfo>(instance, &VulkanObjectInfoTable::GetInstanceInfo);
+    uint64_t in_object = MapHandle(object, objectType);
     const char* in_pLayerPrefix = pLayerPrefix->GetPointer();
     const char* in_pMessage = pMessage->GetPointer();
 
-    GetInstanceTable(in_instance)->DebugReportMessageEXT(in_instance, flags, objectType, object, location, messageCode, in_pLayerPrefix, in_pMessage);
+    GetInstanceTable(in_instance)->DebugReportMessageEXT(in_instance, flags, objectType, in_object, location, messageCode, in_pLayerPrefix, in_pMessage);
 }
 
 void VulkanReplayConsumer::Process_vkDebugMarkerSetObjectTagEXT(
@@ -4057,6 +4058,7 @@ void VulkanReplayConsumer::Process_vkDebugMarkerSetObjectTagEXT(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkDebugMarkerObjectTagInfoEXT* in_pTagInfo = pTagInfo->GetPointer();
+    MapStructHandles(pTagInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->DebugMarkerSetObjectTagEXT(in_device, in_pTagInfo);
     CheckResult("vkDebugMarkerSetObjectTagEXT", returnValue, replay_result);
@@ -4069,6 +4071,7 @@ void VulkanReplayConsumer::Process_vkDebugMarkerSetObjectNameEXT(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkDebugMarkerObjectNameInfoEXT* in_pNameInfo = pNameInfo->GetPointer();
+    MapStructHandles(pNameInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->DebugMarkerSetObjectNameEXT(in_device, in_pNameInfo);
     CheckResult("vkDebugMarkerSetObjectNameEXT", returnValue, replay_result);
@@ -4601,6 +4604,7 @@ void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectNameEXT(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkDebugUtilsObjectNameInfoEXT* in_pNameInfo = pNameInfo->GetPointer();
+    MapStructHandles(pNameInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->SetDebugUtilsObjectNameEXT(in_device, in_pNameInfo);
     CheckResult("vkSetDebugUtilsObjectNameEXT", returnValue, replay_result);
@@ -4613,6 +4617,7 @@ void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectTagEXT(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     const VkDebugUtilsObjectTagInfoEXT* in_pTagInfo = pTagInfo->GetPointer();
+    MapStructHandles(pTagInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
     VkResult replay_result = GetDeviceTable(in_device)->SetDebugUtilsObjectTagEXT(in_device, in_pTagInfo);
     CheckResult("vkSetDebugUtilsObjectTagEXT", returnValue, replay_result);
@@ -5849,9 +5854,10 @@ void VulkanReplayConsumer::Process_vkSetPrivateDataEXT(
     uint64_t                                    data)
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
+    uint64_t in_objectHandle = MapHandle(objectHandle, objectType);
     VkPrivateDataSlotEXT in_privateDataSlot = MapHandle<PrivateDataSlotEXTInfo>(privateDataSlot, &VulkanObjectInfoTable::GetPrivateDataSlotEXTInfo);
 
-    VkResult replay_result = GetDeviceTable(in_device)->SetPrivateDataEXT(in_device, objectType, objectHandle, in_privateDataSlot, data);
+    VkResult replay_result = GetDeviceTable(in_device)->SetPrivateDataEXT(in_device, objectType, in_objectHandle, in_privateDataSlot, data);
     CheckResult("vkSetPrivateDataEXT", returnValue, replay_result);
 }
 
@@ -5863,10 +5869,11 @@ void VulkanReplayConsumer::Process_vkGetPrivateDataEXT(
     PointerDecoder<uint64_t>*                   pData)
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
+    uint64_t in_objectHandle = MapHandle(objectHandle, objectType);
     VkPrivateDataSlotEXT in_privateDataSlot = MapHandle<PrivateDataSlotEXTInfo>(privateDataSlot, &VulkanObjectInfoTable::GetPrivateDataSlotEXTInfo);
     uint64_t* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(1, static_cast<uint64_t>(0));
 
-    GetDeviceTable(in_device)->GetPrivateDataEXT(in_device, objectType, objectHandle, in_privateDataSlot, out_pData);
+    GetDeviceTable(in_device)->GetPrivateDataEXT(in_device, objectType, in_objectHandle, in_privateDataSlot, out_pData);
 }
 
 void VulkanReplayConsumer::Process_vkCreateDirectFBSurfaceEXT(

--- a/framework/generated/generated_vulkan_struct_decoders.cpp
+++ b/framework/generated/generated_vulkan_struct_decoders.cpp
@@ -6068,7 +6068,8 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugMa
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->objectType));
-    bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->object));
+    bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->object));
+    value->object = 0;
     bytes_read += wrapper->pObjectName.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pObjectName = wrapper->pObjectName.GetPointer();
 
@@ -6086,7 +6087,8 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugMa
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->objectType));
-    bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->object));
+    bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->object));
+    value->object = 0;
     bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->tagName));
     bytes_read += ValueDecoder::DecodeSizeTValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->tagSize));
     bytes_read += wrapper->pTag.DecodeVoid((buffer + bytes_read), (buffer_size - bytes_read));
@@ -7014,7 +7016,8 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugUt
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->objectType));
-    bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->objectHandle));
+    bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->objectHandle));
+    value->objectHandle = 0;
     bytes_read += wrapper->pObjectName.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pObjectName = wrapper->pObjectName.GetPointer();
 
@@ -7085,7 +7088,8 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugUt
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->objectType));
-    bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->objectHandle));
+    bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->objectHandle));
+    value->objectHandle = 0;
     bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->tagName));
     bytes_read += ValueDecoder::DecodeSizeTValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->tagSize));
     bytes_read += wrapper->pTag.DecodeVoid((buffer + bytes_read), (buffer_size - bytes_read));

--- a/framework/generated/generated_vulkan_struct_decoders.h
+++ b/framework/generated/generated_vulkan_struct_decoders.h
@@ -3292,6 +3292,7 @@ struct Decoded_VkDebugMarkerObjectNameInfoEXT
     VkDebugMarkerObjectNameInfoEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
+    uint64_t object{ 0 };
     StringDecoder pObjectName;
 };
 
@@ -3302,6 +3303,7 @@ struct Decoded_VkDebugMarkerObjectTagInfoEXT
     VkDebugMarkerObjectTagInfoEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
+    uint64_t object{ 0 };
     PointerDecoder<uint8_t> pTag;
 };
 
@@ -3807,6 +3809,7 @@ struct Decoded_VkDebugUtilsObjectNameInfoEXT
     VkDebugUtilsObjectNameInfoEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
+    uint64_t objectHandle{ 0 };
     StringDecoder pObjectName;
 };
 
@@ -3842,6 +3845,7 @@ struct Decoded_VkDebugUtilsObjectTagInfoEXT
     VkDebugUtilsObjectTagInfoEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
+    uint64_t objectHandle{ 0 };
     PointerDecoder<uint8_t> pTag;
 };
 

--- a/framework/generated/generated_vulkan_struct_encoders.cpp
+++ b/framework/generated/generated_vulkan_struct_encoders.cpp
@@ -3137,7 +3137,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDebugMarkerObjectNameInfoEX
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.objectType);
-    encoder->EncodeUInt64Value(value.object);
+    encoder->EncodeUInt64Value(GetWrappedId(value.object, value.objectType));
     encoder->EncodeString(value.pObjectName);
 }
 
@@ -3146,7 +3146,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDebugMarkerObjectTagInfoEXT
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.objectType);
-    encoder->EncodeUInt64Value(value.object);
+    encoder->EncodeUInt64Value(GetWrappedId(value.object, value.objectType));
     encoder->EncodeUInt64Value(value.tagName);
     encoder->EncodeSizeTValue(value.tagSize);
     encoder->EncodeVoidArray(value.pTag, value.tagSize);
@@ -3602,7 +3602,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsObjectNameInfoEXT
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.objectType);
-    encoder->EncodeUInt64Value(value.objectHandle);
+    encoder->EncodeUInt64Value(GetWrappedId(value.objectHandle, value.objectType));
     encoder->EncodeString(value.pObjectName);
 }
 
@@ -3638,7 +3638,7 @@ void EncodeStruct(ParameterEncoder* encoder, const VkDebugUtilsObjectTagInfoEXT&
     encoder->EncodeEnumValue(value.sType);
     EncodePNextStruct(encoder, value.pNext);
     encoder->EncodeEnumValue(value.objectType);
-    encoder->EncodeUInt64Value(value.objectHandle);
+    encoder->EncodeUInt64Value(GetWrappedId(value.objectHandle, value.objectType));
     encoder->EncodeUInt64Value(value.tagName);
     encoder->EncodeSizeTValue(value.tagSize);
     encoder->EncodeVoidArray(value.pTag, value.tagSize);

--- a/framework/generated/generated_vulkan_struct_handle_mappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.cpp
@@ -929,6 +929,26 @@ void MapStructHandles(Decoded_VkResolveImageInfo2KHR* wrapper, const VulkanObjec
     }
 }
 
+void MapStructHandles(Decoded_VkDebugMarkerObjectNameInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+{
+    if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
+    {
+        VkDebugMarkerObjectNameInfoEXT* value = wrapper->decoded_value;
+
+        value->object = handle_mapping::MapHandle(wrapper->object, value->objectType, object_info_table);
+    }
+}
+
+void MapStructHandles(Decoded_VkDebugMarkerObjectTagInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+{
+    if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
+    {
+        VkDebugMarkerObjectTagInfoEXT* value = wrapper->decoded_value;
+
+        value->object = handle_mapping::MapHandle(wrapper->object, value->objectType, object_info_table);
+    }
+}
+
 void MapStructHandles(Decoded_VkDedicatedAllocationMemoryAllocateInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table)
 {
     if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
@@ -972,6 +992,26 @@ void MapStructHandles(Decoded_VkConditionalRenderingBeginInfoEXT* wrapper, const
         VkConditionalRenderingBeginInfoEXT* value = wrapper->decoded_value;
 
         value->buffer = handle_mapping::MapHandle<BufferInfo>(wrapper->buffer, object_info_table, &VulkanObjectInfoTable::GetBufferInfo);
+    }
+}
+
+void MapStructHandles(Decoded_VkDebugUtilsObjectNameInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+{
+    if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
+    {
+        VkDebugUtilsObjectNameInfoEXT* value = wrapper->decoded_value;
+
+        value->objectHandle = handle_mapping::MapHandle(wrapper->objectHandle, value->objectType, object_info_table);
+    }
+}
+
+void MapStructHandles(Decoded_VkDebugUtilsObjectTagInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table)
+{
+    if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))
+    {
+        VkDebugUtilsObjectTagInfoEXT* value = wrapper->decoded_value;
+
+        value->objectHandle = handle_mapping::MapHandle(wrapper->objectHandle, value->objectType, object_info_table);
     }
 }
 

--- a/framework/generated/generated_vulkan_struct_handle_mappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.h
@@ -196,6 +196,10 @@ void MapStructHandles(Decoded_VkBlitImageInfo2KHR* wrapper, const VulkanObjectIn
 
 void MapStructHandles(Decoded_VkResolveImageInfo2KHR* wrapper, const VulkanObjectInfoTable& object_info_table);
 
+void MapStructHandles(Decoded_VkDebugMarkerObjectNameInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+
+void MapStructHandles(Decoded_VkDebugMarkerObjectTagInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+
 void MapStructHandles(Decoded_VkDedicatedAllocationMemoryAllocateInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
 
 void MapStructHandles(Decoded_VkImageViewHandleInfoNVX* wrapper, const VulkanObjectInfoTable& object_info_table);
@@ -203,6 +207,10 @@ void MapStructHandles(Decoded_VkImageViewHandleInfoNVX* wrapper, const VulkanObj
 void MapStructHandles(Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV* wrapper, const VulkanObjectInfoTable& object_info_table);
 
 void MapStructHandles(Decoded_VkConditionalRenderingBeginInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+
+void MapStructHandles(Decoded_VkDebugUtilsObjectNameInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
+
+void MapStructHandles(Decoded_VkDebugUtilsObjectTagInfoEXT* wrapper, const VulkanObjectInfoTable& object_info_table);
 
 void MapStructHandles(Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID* wrapper, const VulkanObjectInfoTable& object_info_table);
 

--- a/framework/generated/generated_vulkan_struct_handle_wrappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_wrappers.cpp
@@ -783,6 +783,22 @@ void UnwrapStructHandles(VkResolveImageInfo2KHR* value, HandleUnwrapMemory* unwr
     }
 }
 
+void UnwrapStructHandles(VkDebugMarkerObjectNameInfoEXT* value, HandleUnwrapMemory* unwrap_memory)
+{
+    if (value != nullptr)
+    {
+        value->object = GetWrappedHandle(value->object, value->objectType);
+    }
+}
+
+void UnwrapStructHandles(VkDebugMarkerObjectTagInfoEXT* value, HandleUnwrapMemory* unwrap_memory)
+{
+    if (value != nullptr)
+    {
+        value->object = GetWrappedHandle(value->object, value->objectType);
+    }
+}
+
 void UnwrapStructHandles(VkDedicatedAllocationMemoryAllocateInfoNV* value, HandleUnwrapMemory* unwrap_memory)
 {
     if (value != nullptr)
@@ -818,6 +834,22 @@ void UnwrapStructHandles(VkConditionalRenderingBeginInfoEXT* value, HandleUnwrap
     if (value != nullptr)
     {
         value->buffer = GetWrappedHandle<VkBuffer>(value->buffer);
+    }
+}
+
+void UnwrapStructHandles(VkDebugUtilsObjectNameInfoEXT* value, HandleUnwrapMemory* unwrap_memory)
+{
+    if (value != nullptr)
+    {
+        value->objectHandle = GetWrappedHandle(value->objectHandle, value->objectType);
+    }
+}
+
+void UnwrapStructHandles(VkDebugUtilsObjectTagInfoEXT* value, HandleUnwrapMemory* unwrap_memory)
+{
+    if (value != nullptr)
+    {
+        value->objectHandle = GetWrappedHandle(value->objectHandle, value->objectType);
     }
 }
 

--- a/framework/generated/generated_vulkan_struct_handle_wrappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_wrappers.h
@@ -195,6 +195,10 @@ void UnwrapStructHandles(VkBlitImageInfo2KHR* value, HandleUnwrapMemory* unwrap_
 
 void UnwrapStructHandles(VkResolveImageInfo2KHR* value, HandleUnwrapMemory* unwrap_memory);
 
+void UnwrapStructHandles(VkDebugMarkerObjectNameInfoEXT* value, HandleUnwrapMemory* unwrap_memory);
+
+void UnwrapStructHandles(VkDebugMarkerObjectTagInfoEXT* value, HandleUnwrapMemory* unwrap_memory);
+
 void UnwrapStructHandles(VkDedicatedAllocationMemoryAllocateInfoNV* value, HandleUnwrapMemory* unwrap_memory);
 
 void UnwrapStructHandles(VkImageViewHandleInfoNVX* value, HandleUnwrapMemory* unwrap_memory);
@@ -202,6 +206,10 @@ void UnwrapStructHandles(VkImageViewHandleInfoNVX* value, HandleUnwrapMemory* un
 void UnwrapStructHandles(VkWin32KeyedMutexAcquireReleaseInfoNV* value, HandleUnwrapMemory* unwrap_memory);
 
 void UnwrapStructHandles(VkConditionalRenderingBeginInfoEXT* value, HandleUnwrapMemory* unwrap_memory);
+
+void UnwrapStructHandles(VkDebugUtilsObjectNameInfoEXT* value, HandleUnwrapMemory* unwrap_memory);
+
+void UnwrapStructHandles(VkDebugUtilsObjectTagInfoEXT* value, HandleUnwrapMemory* unwrap_memory);
 
 void UnwrapStructHandles(VkMemoryGetAndroidHardwareBufferInfoANDROID* value, HandleUnwrapMemory* unwrap_memory);
 

--- a/framework/generated/vulkan_generators/vulkan_struct_decoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_decoders_body_generator.py
@@ -107,13 +107,13 @@ class VulkanStructDecodersBodyGenerator(BaseGenerator):
                 body += '    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->{}));\n'.format(value.name)
                 body += '    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;\n'
             else:
-                body += self.makeDecodeInvocation(value)
+                body += self.makeDecodeInvocation(name, value)
 
         return body
 
     #
     # Generate the struct member decoder function call invocation.
-    def makeDecodeInvocation(self, value):
+    def makeDecodeInvocation(self, name, value):
         bufferArgs = '(buffer + bytes_read), (buffer_size - bytes_read)'
 
         body = ''
@@ -175,6 +175,9 @@ class VulkanStructDecodersBodyGenerator(BaseGenerator):
             elif isHandle:
                 body += '    bytes_read += ValueDecoder::DecodeHandleIdValue({}, &(wrapper->{}));\n'.format(bufferArgs, value.name)
                 body += '    value->{} = VK_NULL_HANDLE;\n'.format(value.name)
+            elif self.isGenericStructHandleValue(name, value.name):
+                body += '    bytes_read += ValueDecoder::DecodeUInt64Value({}, &(wrapper->{}));\n'.format(bufferArgs, value.name)
+                body += '    value->{} = 0;\n'.format(value.name)
             elif value.bitfieldWidth:
                 # Bit fields need to be read into a tempoaray and then assigned to the struct member.
                 tempParamName = 'temp_{}'.format(value.name)

--- a/framework/generated/vulkan_generators/vulkan_struct_decoders_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_decoders_header_generator.py
@@ -114,7 +114,7 @@ class VulkanStructDecodersHeaderGenerator(BaseGenerator):
 
     #
     # Determines if a Vulkan struct member needs an associated member delcaration in the decoded struct wrapper.
-    def needsMemberDeclaration(self, value):
+    def needsMemberDeclaration(self, name, value):
         if value.isPointer or value.isArray:
             return True
         elif self.isFunctionPtr(value.baseType):
@@ -122,6 +122,8 @@ class VulkanStructDecodersHeaderGenerator(BaseGenerator):
         elif self.isHandle(value.baseType):
             return True
         elif self.isStruct(value.baseType):
+            return True
+        elif self.isGenericStructHandleValue(name, value.name):
             return True
         return False
 
@@ -145,7 +147,7 @@ class VulkanStructDecodersHeaderGenerator(BaseGenerator):
             if value.name == 'pNext':
                 # We have a special type to store the pNext chain
                 body += '    std::unique_ptr<PNextNode> pNext;\n'
-            elif self.needsMemberDeclaration(value):
+            elif self.needsMemberDeclaration(name, value):
                 typeName = self.makeDecodedParamType(value)
                 if self.isStruct(value.baseType):
                     typeName = 'std::unique_ptr<{}>'.format(typeName)

--- a/framework/generated/vulkan_generators/vulkan_struct_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_encoders_body_generator.py
@@ -84,7 +84,7 @@ class VulkanStructEncodersBodyGenerator(BaseGenerator):
             body = '' if first else '\n'
             body += 'void EncodeStruct(ParameterEncoder* encoder, const {}& value)\n'.format(struct)
             body += '{\n'
-            body += self.makeStructBody(self.featureStructMembers[struct], 'value.')
+            body += self.makeStructBody(struct, self.featureStructMembers[struct], 'value.')
             body += '}'
             write(body, file=self.outFile)
 
@@ -92,7 +92,7 @@ class VulkanStructEncodersBodyGenerator(BaseGenerator):
 
     #
     # Command definition
-    def makeStructBody(self, values, prefix):
+    def makeStructBody(self, name, values, prefix):
         # Build array of lines for function body
         body = ''
 
@@ -101,7 +101,7 @@ class VulkanStructEncodersBodyGenerator(BaseGenerator):
             if 'pNext' in value.name:
                 body += '    EncodePNextStruct(encoder, {});\n'.format(prefix + value.name)
             else:
-                methodCall = self.makeEncoderMethodCall(value, values, prefix)
+                methodCall = self.makeEncoderMethodCall(name, value, values, prefix)
                 body += '    {};\n'.format(methodCall)
 
         return body

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
@@ -162,7 +162,7 @@ class VulkanStructHandleMappersHeaderGenerator(BaseGenerator):
     # Performs C++ code generation for the feature.
     def generateFeature(self):
         for struct in self.getFilteredStructNames():
-            if struct in self.structsWithHandles:
+            if (struct in self.structsWithHandles) or (struct in self.GENERIC_HANDLE_STRUCTS):
                 body = '\n'
                 body += 'void MapStructHandles(Decoded_{}* wrapper, const VulkanObjectInfoTable& object_info_table);'.format(struct)
                 write(body, file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_wrappers_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_wrappers_header_generator.py
@@ -162,7 +162,7 @@ class VulkanStructHandleWrappersHeaderGenerator(BaseGenerator):
 
         # Generate unwrap and rewrap code for input structures.
         for struct in self.getFilteredStructNames():
-            if struct in self.structsWithHandles:
+            if (struct in self.structsWithHandles) or (struct in self.GENERIC_HANDLE_STRUCTS):
                 body = '\n'
                 body += 'void UnwrapStructHandles({}* value, HandleUnwrapMemory* unwrap_memory);'.format(struct)
                 write(body, file=self.outFile)

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -131,6 +131,7 @@ if (${RUN_TESTS})
     add_executable(gfxrecon_util_test "")
     target_sources(gfxrecon_util_test PRIVATE
             ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp)
+    target_link_libraries(gfxrecon_util_test PRIVATE gfxrecon_util)
     common_build_directives(gfxrecon_util_test)
     common_test_directives(gfxrecon_util_test)
 endif()

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -76,6 +76,7 @@ if (${RUN_TESTS})
 
     target_sources(VkLayer_gfxreconstruct_test PRIVATE
             ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp)
+    target_link_libraries(VkLayer_gfxreconstruct_test PRIVATE VkLayer_gfxreconstruct)
 
     common_build_directives(VkLayer_gfxreconstruct_test)
     common_test_directives(VkLayer_gfxreconstruct_test)


### PR DESCRIPTION
Address capture and replay issues with debug extensions:
- Add code generation support for unwrapping/mapping generic handle values with a uint64_t type and an associated enum value specifying the actual handle type.  
- Unwrap the VkPhysicalDevice handle when calling vkGetPhysicalDeviceToolPropertiesEXT from the capture layer's implementation.
- When replaying vkCreateInstance, ensure that any VkDebugUtilsMessengerCreateInfoEXT or
VkDebugReportCallbackCreateInfoEXT structs in the VkInstanceCreateInfo pNext field reference valid callback functions.

Fixes #446 