### PR TITLE
Add direct allocation calls to resource allocator

### DIFF
--- a/framework/decode/screenshot_handler.h
+++ b/framework/decode/screenshot_handler.h
@@ -54,7 +54,7 @@ class ScreenshotHandler
                     uint32_t                                width,
                     uint32_t                                height);
 
-    void DestroyDevice(VkDevice device, const encode::DeviceTable* device_table);
+    void DestroyDeviceResources(VkDevice device, const encode::DeviceTable* device_table);
 
   private:
     struct CopyResource
@@ -102,8 +102,7 @@ class ScreenshotHandler
                                 uint32_t                                height,
                                 CopyResource*                           copy_resource) const;
 
-    void
-    DestroyCopyResource(VkDevice device, const encode::DeviceTable* device_table, CopyResource* copy_resource) const;
+    void DestroyCopyResource(VkDevice device, CopyResource* copy_resource) const;
 
   private:
     uint32_t                     current_frame_number_;

--- a/framework/decode/vulkan_default_allocator.cpp
+++ b/framework/decode/vulkan_default_allocator.cpp
@@ -192,24 +192,29 @@ VkResult VulkanDefaultAllocator::BindBufferMemory(VkBuffer               buffer,
                                                   MemoryData             allocator_memory_data,
                                                   VkMemoryPropertyFlags* bind_memory_properties)
 {
-    GFXRECON_UNREFERENCED_PARAMETER(allocator_buffer_data);
-
     VkResult result = VK_ERROR_INITIALIZATION_FAILED;
 
     if (bind_memory_properties != nullptr)
     {
-        if (allocator_memory_data != 0)
-        {
-            auto memory_alloc_info    = reinterpret_cast<MemoryAllocInfo*>(allocator_memory_data);
-            (*bind_memory_properties) = memory_alloc_info->property_flags;
-        }
-        else
-        {
-            GFXRECON_LOG_WARNING(
-                "VulkanDefaultAllocator binding a VkBuffer object to a VkDeviceMemory object without allocator data");
-        }
-
         result = functions_.bind_buffer_memory(device_, buffer, memory, memory_offset);
+
+        if (result == VK_SUCCESS)
+        {
+            if ((allocator_buffer_data != 0) && (allocator_memory_data != 0))
+            {
+                auto resource_alloc_info          = reinterpret_cast<ResourceAllocInfo*>(allocator_buffer_data);
+                resource_alloc_info->bound_memory = memory;
+                resource_alloc_info->bound_offset = memory_offset;
+
+                auto memory_alloc_info    = reinterpret_cast<MemoryAllocInfo*>(allocator_memory_data);
+                (*bind_memory_properties) = memory_alloc_info->property_flags;
+            }
+            else
+            {
+                GFXRECON_LOG_WARNING("VulkanDefaultAllocator binding a VkBuffer object to a VkDeviceMemory object "
+                                     "without allocator data");
+            }
+        }
     }
 
     return result;
@@ -221,29 +226,36 @@ VkResult VulkanDefaultAllocator::BindBufferMemory2(uint32_t                     
                                                    const MemoryData*             allocator_memory_datas,
                                                    VkMemoryPropertyFlags*        bind_memory_properties)
 {
-    GFXRECON_UNREFERENCED_PARAMETER(allocator_buffer_datas);
-
     VkResult result = VK_ERROR_INITIALIZATION_FAILED;
 
-    if ((allocator_memory_datas != nullptr) && (bind_memory_properties != nullptr))
+    if ((bind_infos != nullptr) && (allocator_buffer_datas != nullptr) && (allocator_memory_datas != nullptr) &&
+        (bind_memory_properties != nullptr))
     {
-        for (uint32_t i = 0; i < bind_info_count; ++i)
-        {
-            auto allocator_memory_data = allocator_memory_datas[i];
+        result = functions_.bind_buffer_memory2(device_, bind_info_count, bind_infos);
 
-            if (allocator_memory_data != 0)
+        if (result == VK_SUCCESS)
+        {
+            for (uint32_t i = 0; i < bind_info_count; ++i)
             {
-                auto memory_alloc_info    = reinterpret_cast<MemoryAllocInfo*>(allocator_memory_data);
-                bind_memory_properties[i] = memory_alloc_info->property_flags;
-            }
-            else
-            {
-                GFXRECON_LOG_WARNING("VulkanDefaultAllocator binding a VkBuffer object to a VkDeviceMemory object "
-                                     "without allocator data");
+                auto allocator_buffer_data = allocator_buffer_datas[i];
+                auto allocator_memory_data = allocator_memory_datas[i];
+
+                if ((allocator_buffer_data != 0) && (allocator_memory_data != 0))
+                {
+                    auto resource_alloc_info          = reinterpret_cast<ResourceAllocInfo*>(allocator_buffer_data);
+                    resource_alloc_info->bound_memory = bind_infos[i].memory;
+                    resource_alloc_info->bound_offset = bind_infos[i].memoryOffset;
+
+                    auto memory_alloc_info    = reinterpret_cast<MemoryAllocInfo*>(allocator_memory_data);
+                    bind_memory_properties[i] = memory_alloc_info->property_flags;
+                }
+                else
+                {
+                    GFXRECON_LOG_WARNING("VulkanDefaultAllocator binding a VkBuffer object to a VkDeviceMemory object "
+                                         "without allocator data");
+                }
             }
         }
-
-        result = functions_.bind_buffer_memory2(device_, bind_info_count, bind_infos);
     }
 
     return result;
@@ -256,24 +268,30 @@ VkResult VulkanDefaultAllocator::BindImageMemory(VkImage                image,
                                                  MemoryData             allocator_memory_data,
                                                  VkMemoryPropertyFlags* bind_memory_properties)
 {
-    GFXRECON_UNREFERENCED_PARAMETER(allocator_image_data);
-
     VkResult result = VK_ERROR_INITIALIZATION_FAILED;
 
     if (bind_memory_properties != nullptr)
     {
-        if (allocator_memory_data != 0)
-        {
-            auto memory_alloc_info    = reinterpret_cast<MemoryAllocInfo*>(allocator_memory_data);
-            (*bind_memory_properties) = memory_alloc_info->property_flags;
-        }
-        else
-        {
-            GFXRECON_LOG_WARNING(
-                "VulkanDefaultAllocator binding a VkImage object to a VkDeviceMemory object without allocator data");
-        }
-
         result = functions_.bind_image_memory(device_, image, memory, memory_offset);
+
+        if (result == VK_SUCCESS)
+        {
+
+            if ((allocator_image_data != 0) && (allocator_memory_data != 0))
+            {
+                auto resource_alloc_info          = reinterpret_cast<ResourceAllocInfo*>(allocator_image_data);
+                resource_alloc_info->bound_memory = memory;
+                resource_alloc_info->bound_offset = memory_offset;
+
+                auto memory_alloc_info    = reinterpret_cast<MemoryAllocInfo*>(allocator_memory_data);
+                (*bind_memory_properties) = memory_alloc_info->property_flags;
+            }
+            else
+            {
+                GFXRECON_LOG_WARNING("VulkanDefaultAllocator binding a VkImage object to a VkDeviceMemory object "
+                                     "without allocator data");
+            }
+        }
     }
 
     return result;
@@ -285,29 +303,36 @@ VkResult VulkanDefaultAllocator::BindImageMemory2(uint32_t                     b
                                                   const MemoryData*            allocator_memory_datas,
                                                   VkMemoryPropertyFlags*       bind_memory_properties)
 {
-    GFXRECON_UNREFERENCED_PARAMETER(allocator_image_datas);
-
     VkResult result = VK_ERROR_INITIALIZATION_FAILED;
 
-    if ((allocator_memory_datas != nullptr) && (bind_memory_properties != nullptr))
+    if ((bind_infos != nullptr) && (allocator_image_datas != nullptr) && (allocator_memory_datas != nullptr) &&
+        (bind_memory_properties != nullptr))
     {
-        for (uint32_t i = 0; i < bind_info_count; ++i)
-        {
-            auto allocator_memory_data = allocator_memory_datas[i];
+        result = functions_.bind_image_memory2(device_, bind_info_count, bind_infos);
 
-            if (allocator_memory_data != 0)
+        if (result == VK_SUCCESS)
+        {
+            for (uint32_t i = 0; i < bind_info_count; ++i)
             {
-                auto memory_alloc_info    = reinterpret_cast<MemoryAllocInfo*>(allocator_memory_data);
-                bind_memory_properties[i] = memory_alloc_info->property_flags;
-            }
-            else
-            {
-                GFXRECON_LOG_WARNING("VulkanDefaultAllocator binding a VkImage object to a VkDeviceMemory object "
-                                     "without allocator data");
+                auto allocator_image_data  = allocator_image_datas[i];
+                auto allocator_memory_data = allocator_memory_datas[i];
+
+                if ((allocator_image_data != 0) && (allocator_memory_data != 0))
+                {
+                    auto resource_alloc_info          = reinterpret_cast<ResourceAllocInfo*>(allocator_image_data);
+                    resource_alloc_info->bound_memory = bind_infos[i].memory;
+                    resource_alloc_info->bound_offset = bind_infos[i].memoryOffset;
+
+                    auto memory_alloc_info    = reinterpret_cast<MemoryAllocInfo*>(allocator_memory_data);
+                    bind_memory_properties[i] = memory_alloc_info->property_flags;
+                }
+                else
+                {
+                    GFXRECON_LOG_WARNING("VulkanDefaultAllocator binding a VkImage object to a VkDeviceMemory object "
+                                         "without allocator data");
+                }
             }
         }
-
-        result = functions_.bind_image_memory2(device_, bind_info_count, bind_infos);
     }
 
     return result;
@@ -509,6 +534,40 @@ void VulkanDefaultAllocator::ReportBindIncompatibility(const VkMemoryRequirement
 
                 break;
             }
+        }
+    }
+}
+
+VkResult VulkanDefaultAllocator::MapResourceMemoryDirect(VkDeviceSize     size,
+                                                         VkMemoryMapFlags flags,
+                                                         void**           data,
+                                                         ResourceData     allocator_data)
+{
+    VkResult result = VK_ERROR_MEMORY_MAP_FAILED;
+
+    if (allocator_data != 0)
+    {
+        auto resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
+
+        if (resource_alloc_info->bound_memory != VK_NULL_HANDLE)
+        {
+            result = functions_.map_memory(
+                device_, resource_alloc_info->bound_memory, resource_alloc_info->bound_offset, size, flags, data);
+        }
+    }
+
+    return result;
+}
+
+void VulkanDefaultAllocator::UnmapResourceMemoryDirect(ResourceData allocator_data)
+{
+    if (allocator_data != 0)
+    {
+        auto resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
+
+        if (resource_alloc_info->bound_memory != VK_NULL_HANDLE)
+        {
+            functions_.unmap_memory(device_, resource_alloc_info->bound_memory);
         }
     }
 }

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -273,10 +273,7 @@ struct BufferInfo : public VulkanObjectInfo<VkBuffer>
     VulkanResourceAllocator::ResourceData allocator_data{ 0 };
 
     // The following values are only used when loading the initial state for trimmed files.
-    VkDeviceMemory                      memory{ VK_NULL_HANDLE };
-    VulkanResourceAllocator::MemoryData memory_allocator_data{ 0 };
     VkMemoryPropertyFlags               memory_property_flags{ 0 };
-    VkDeviceSize                        bind_offset{ 0 };
     VkBufferUsageFlags                  usage{ 0 };
     uint32_t                            queue_family_index{ 0 };
 };
@@ -295,7 +292,6 @@ struct ImageInfo : public VulkanObjectInfo<VkImage>
     VkDeviceMemory                      memory{ VK_NULL_HANDLE };
     VulkanResourceAllocator::MemoryData memory_allocator_data{ 0 };
     VkMemoryPropertyFlags               memory_property_flags{ 0 };
-    VkDeviceSize                        bind_offset{ 0 };
     VkImageUsageFlags                   usage{ 0 };
     VkImageType                         type{};
     VkFormat                            format{};

--- a/framework/decode/vulkan_rebind_allocator.cpp
+++ b/framework/decode/vulkan_rebind_allocator.cpp
@@ -1303,5 +1303,34 @@ void VulkanRebindAllocator::ReportBindIncompatibility(const ResourceData* alloca
     }
 }
 
+VkResult VulkanRebindAllocator::MapResourceMemoryDirect(VkDeviceSize     size,
+                                                        VkMemoryMapFlags flags,
+                                                        void**           data,
+                                                        ResourceData     allocator_data)
+{
+    VkResult result = VK_ERROR_MEMORY_MAP_FAILED;
+
+    if ((data != nullptr) && (allocator_data != 0))
+    {
+        auto resource_alloc_info = reinterpret_cast<ResourceAllocInfo*>(allocator_data);
+
+        if (resource_alloc_info->mapped_pointer == nullptr)
+        {
+            result = vmaMapMemory(allocator_, resource_alloc_info->allocation, &resource_alloc_info->mapped_pointer);
+        }
+        else
+        {
+            result = VK_SUCCESS;
+        }
+
+        if (result == VK_SUCCESS)
+        {
+            (*data) = reinterpret_cast<uint8_t*>(resource_alloc_info->mapped_pointer);
+        }
+    }
+
+    return result;
+}
+
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -156,6 +156,97 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
                                                  const ResourceData*          allocator_resource_datas,
                                                  const MemoryData*            allocator_memory_datas) override;
 
+    // Direct allocation methods that perform memory allocation and resource creation without performing memory
+    // translation.  These methods allow the replay tool to allocate staging resources through the resource allocator so
+    // that the allocator is aware of all allocations performed at replay.
+    virtual VkResult CreateBufferDirect(const VkBufferCreateInfo*    create_info,
+                                        const VkAllocationCallbacks* allocation_callbacks,
+                                        VkBuffer*                    buffer,
+                                        ResourceData*                allocator_data) override
+    {
+        return CreateBuffer(create_info, allocation_callbacks, format::kNullHandleId, buffer, allocator_data);
+    }
+
+    virtual void DestroyBufferDirect(VkBuffer                     buffer,
+                                     const VkAllocationCallbacks* allocation_callbacks,
+                                     ResourceData                 allocator_data) override
+    {
+        DestroyBuffer(buffer, allocation_callbacks, allocator_data);
+    }
+
+    virtual VkResult CreateImageDirect(const VkImageCreateInfo*     create_info,
+                                       const VkAllocationCallbacks* allocation_callbacks,
+                                       VkImage*                     image,
+                                       ResourceData*                allocator_data) override
+    {
+        return CreateImage(create_info, allocation_callbacks, format::kNullHandleId, image, allocator_data);
+    }
+
+    virtual void DestroyImageDirect(VkImage                      image,
+                                    const VkAllocationCallbacks* allocation_callbacks,
+                                    ResourceData                 allocator_data) override
+    {
+        DestroyImage(image, allocation_callbacks, allocator_data);
+    }
+
+    virtual VkResult AllocateMemoryDirect(const VkMemoryAllocateInfo*  allocate_info,
+                                          const VkAllocationCallbacks* allocation_callbacks,
+                                          VkDeviceMemory*              memory,
+                                          MemoryData*                  allocator_data) override
+    {
+        return AllocateMemory(allocate_info, allocation_callbacks, format::kNullHandleId, memory, allocator_data);
+    }
+
+    virtual void FreeMemoryDirect(VkDeviceMemory               memory,
+                                  const VkAllocationCallbacks* allocation_callbacks,
+                                  MemoryData                   allocator_data) override
+    {
+        FreeMemory(memory, allocation_callbacks, allocator_data);
+    }
+
+    virtual VkResult BindBufferMemoryDirect(VkBuffer               buffer,
+                                            VkDeviceMemory         memory,
+                                            VkDeviceSize           memory_offset,
+                                            ResourceData           allocator_buffer_data,
+                                            MemoryData             allocator_memory_data,
+                                            VkMemoryPropertyFlags* bind_memory_properties) override
+    {
+        return BindBufferMemory(
+            buffer, memory, memory_offset, allocator_buffer_data, allocator_memory_data, bind_memory_properties);
+    }
+
+    virtual VkResult BindImageMemoryDirect(VkImage                image,
+                                           VkDeviceMemory         memory,
+                                           VkDeviceSize           memory_offset,
+                                           ResourceData           allocator_image_data,
+                                           MemoryData             allocator_memory_data,
+                                           VkMemoryPropertyFlags* bind_memory_properties) override
+    {
+        return BindImageMemory(
+            image, memory, memory_offset, allocator_image_data, allocator_memory_data, bind_memory_properties);
+    }
+
+    virtual VkResult MapResourceMemoryDirect(VkDeviceSize     size,
+                                             VkMemoryMapFlags flags,
+                                             void**           data,
+                                             ResourceData     allocator_data) override;
+
+    virtual void UnmapResourceMemoryDirect(ResourceData) override {}
+
+    virtual VkResult FlushMappedMemoryRangesDirect(uint32_t                   memory_range_count,
+                                                   const VkMappedMemoryRange* memory_ranges,
+                                                   const MemoryData*          allocator_datas) override
+    {
+        return FlushMappedMemoryRanges(memory_range_count, memory_ranges, allocator_datas);
+    }
+
+    virtual VkResult InvalidateMappedMemoryRangesDirect(uint32_t                   memory_range_count,
+                                                        const VkMappedMemoryRange* memory_ranges,
+                                                        const MemoryData*          allocator_datas) override
+    {
+        return InvalidateMappedMemoryRanges(memory_range_count, memory_ranges, allocator_datas);
+    }
+
   private:
     struct MemoryAllocInfo;
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1242,10 +1242,7 @@ void VulkanReplayConsumerBase::ProcessInitBufferCommand(format::HandleId device_
             if ((buffer_info->memory_property_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) ==
                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
             {
-                assert(buffer_info->memory != VK_NULL_HANDLE);
-
-                result = initializer->LoadData(
-                    buffer_info->memory, buffer_info->bind_offset, data_size, data, buffer_info->memory_allocator_data);
+                result = initializer->LoadData(data_size, data, buffer_info->allocator_data);
 
                 if (result != VK_SUCCESS)
                 {
@@ -1327,13 +1324,7 @@ void VulkanReplayConsumerBase::ProcessInitImageCommand(format::HandleId         
                     (image_info->memory_property_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) ==
                         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
                 {
-                    assert(image_info->memory != VK_NULL_HANDLE);
-
-                    result = initializer->LoadData(image_info->memory,
-                                                   image_info->bind_offset,
-                                                   data_size,
-                                                   data,
-                                                   image_info->memory_allocator_data);
+                    result = initializer->LoadData(data_size, data, image_info->allocator_data);
 
                     if (result != VK_SUCCESS)
                     {
@@ -2470,7 +2461,7 @@ void VulkanReplayConsumerBase::OverrideDestroyDevice(
 
         if (screenshot_handler_ != nullptr)
         {
-            screenshot_handler_->DestroyDevice(device, GetDeviceTable(device));
+            screenshot_handler_->DestroyDeviceResources(device, GetDeviceTable(device));
         }
     }
 
@@ -3395,13 +3386,7 @@ VkResult VulkanReplayConsumerBase::OverrideBindBufferMemory(PFN_vkBindBufferMemo
                                                   memory_info->allocator_data,
                                                   &buffer_info->memory_property_flags);
 
-    if (result == VK_SUCCESS)
-    {
-        buffer_info->memory                = memory_info->handle;
-        buffer_info->memory_allocator_data = memory_info->allocator_data;
-        buffer_info->bind_offset           = memoryOffset;
-    }
-    else if (original_result == VK_SUCCESS)
+    if ((result != VK_SUCCESS) && (original_result == VK_SUCCESS))
     {
         // When bind fails at replay, but succeeded at capture, check for memory incompatibilities and recommend
         // enabling memory translation.
@@ -3468,16 +3453,10 @@ VkResult VulkanReplayConsumerBase::OverrideBindBufferMemory2(
     {
         for (uint32_t i = 0; i < bindInfoCount; ++i)
         {
-            const VkBindBufferMemoryInfo* bind_info = &replay_bind_infos[i];
-
             auto buffer_info = buffer_infos[i];
-            auto memory_info = memory_infos[i];
 
-            if ((buffer_info != nullptr) && (memory_info != nullptr))
+            if (buffer_info != nullptr)
             {
-                buffer_info->bind_offset           = bind_info->memoryOffset;
-                buffer_info->memory                = memory_info->handle;
-                buffer_info->memory_allocator_data = memory_info->allocator_data;
                 buffer_info->memory_property_flags = memory_property_flags[i];
             }
         }
@@ -3515,13 +3494,7 @@ VkResult VulkanReplayConsumerBase::OverrideBindImageMemory(PFN_vkBindImageMemory
                                                  memory_info->allocator_data,
                                                  &image_info->memory_property_flags);
 
-    if (result == VK_SUCCESS)
-    {
-        image_info->memory                = memory_info->handle;
-        image_info->memory_allocator_data = memory_info->allocator_data;
-        image_info->bind_offset           = memoryOffset;
-    }
-    else if (original_result == VK_SUCCESS)
+    if ((result != VK_SUCCESS) && (original_result == VK_SUCCESS))
     {
         // When bind fails at replay, but succeeded at capture, check for memory incompatibilities and recommend
         // enabling memory translation.
@@ -3589,15 +3562,12 @@ VkResult VulkanReplayConsumerBase::OverrideBindImageMemory2(
 
         for (uint32_t i = 0; i < bindInfoCount; ++i)
         {
-            const VkBindImageMemoryInfo* bind_info = &replay_bind_infos[i];
+            auto image_info = image_infos[i];
 
-            auto image_info  = image_infos[i];
-            auto memory_info = memory_infos[i];
-
-            image_info->bind_offset           = bind_info->memoryOffset;
-            image_info->memory                = memory_info->handle;
-            image_info->memory_allocator_data = memory_info->allocator_data;
-            image_info->memory_property_flags = memory_property_flags[i];
+            if (image_info != nullptr)
+            {
+                image_info->memory_property_flags = memory_property_flags[i];
+            }
         }
     }
     else if (original_result == VK_SUCCESS)
@@ -4234,8 +4204,8 @@ void VulkanReplayConsumerBase::OverrideDestroySwapchainKHR(
 
         for (const ImageInfo& image_info : swapchain_info->image_infos)
         {
-            allocator->DestroyImage(image_info.handle, nullptr, image_info.allocator_data);
-            allocator->FreeMemory(image_info.memory, nullptr, image_info.memory_allocator_data);
+            allocator->DestroyImageDirect(image_info.handle, nullptr, image_info.allocator_data);
+            allocator->FreeMemoryDirect(image_info.memory, nullptr, image_info.memory_allocator_data);
         }
     }
     else
@@ -4273,10 +4243,6 @@ VkResult VulkanReplayConsumerBase::OverrideGetSwapchainImagesKHR(PFN_vkGetSwapch
         }
         else
         {
-            assert(!pSwapchainImages->IsNull());
-
-            const format::HandleId* capture_ids = pSwapchainImages->GetPointer();
-
             // Create an image for the null swapchain.  Based on vkspec.html#swapchain-wsi-image-create-info.
             VkImageCreateInfo image_create_info     = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
             image_create_info.pNext                 = nullptr;
@@ -4307,12 +4273,11 @@ VkResult VulkanReplayConsumerBase::OverrideGetSwapchainImagesKHR(PFN_vkGetSwapch
 
             for (uint32_t i = 0; i < swapchain_image_count; ++i)
             {
-                format::HandleId capture_id   = capture_ids[i];
-                VkImage*         replay_image = &(replay_images[i]);
-                ImageInfo*       image_info   = reinterpret_cast<ImageInfo*>(pSwapchainImages->GetConsumerData(i));
+                VkImage*   replay_image = &(replay_images[i]);
+                ImageInfo* image_info   = reinterpret_cast<ImageInfo*>(pSwapchainImages->GetConsumerData(i));
                 assert(image_info != nullptr);
 
-                result = CreateSwapchainImage(device_info, &image_create_info, replay_image, capture_id, image_info);
+                result = CreateSwapchainImage(device_info, &image_create_info, replay_image, image_info);
 
                 if ((result != VK_SUCCESS) || (replay_image == VK_NULL_HANDLE))
                 {
@@ -5288,7 +5253,6 @@ void VulkanReplayConsumerBase::GetNonForwardProgress(const HandlePointerDecoder<
 VkResult VulkanReplayConsumerBase::CreateSwapchainImage(const DeviceInfo*        device_info,
                                                         const VkImageCreateInfo* image_create_info,
                                                         VkImage*                 image,
-                                                        format::HandleId         image_id,
                                                         ImageInfo*               image_info)
 {
     // TODO - Rename/repurpose CreateStagingImage to be more allow single place to create image resources.
@@ -5296,7 +5260,7 @@ VkResult VulkanReplayConsumerBase::CreateSwapchainImage(const DeviceInfo*       
     assert(allocator != nullptr);
 
     VulkanResourceAllocator::ResourceData allocator_image_data;
-    VkResult result = allocator->CreateImage(image_create_info, nullptr, image_id, image, &allocator_image_data);
+    VkResult result = allocator->CreateImageDirect(image_create_info, nullptr, image, &allocator_image_data);
 
     if (result == VK_SUCCESS)
     {
@@ -5334,13 +5298,13 @@ VkResult VulkanReplayConsumerBase::CreateSwapchainImage(const DeviceInfo*       
         alloc_info.memoryTypeIndex      = memory_type_index;
         alloc_info.allocationSize       = memory_reqs.size;
 
-        result =
-            allocator->AllocateMemory(&alloc_info, nullptr, format::kNullHandleId, &memory, &allocator_memory_data);
+        result = allocator->AllocateMemoryDirect(&alloc_info, nullptr, &memory, &allocator_memory_data);
 
         if (result == VK_SUCCESS)
         {
             VkMemoryPropertyFlags flags;
-            result = allocator->BindImageMemory(*image, memory, 0, allocator_image_data, allocator_memory_data, &flags);
+            result = allocator->BindImageMemoryDirect(
+                *image, memory, 0, allocator_image_data, allocator_memory_data, &flags);
         }
 
         if (result == VK_SUCCESS)
@@ -5354,7 +5318,7 @@ VkResult VulkanReplayConsumerBase::CreateSwapchainImage(const DeviceInfo*       
         }
         else
         {
-            allocator->DestroyImage(*image, nullptr, allocator_image_data);
+            allocator->DestroyImageDirect(*image, nullptr, allocator_image_data);
         }
     }
     return result;

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -831,7 +831,6 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     VkResult CreateSwapchainImage(const DeviceInfo*        device_info,
                                   const VkImageCreateInfo* image_create_info,
                                   VkImage*                 image,
-                                  format::HandleId         image_id,
                                   ImageInfo*               image_info);
 
     // When processing swapchain image state for the trimming state setup, acquire all swapchain images to transition to

--- a/framework/decode/vulkan_resource_allocator.h
+++ b/framework/decode/vulkan_resource_allocator.h
@@ -187,6 +187,65 @@ class VulkanResourceAllocator
                                                  const VkBindImageMemoryInfo* bind_infos,
                                                  const ResourceData*          allocator_resource_datas,
                                                  const MemoryData*            allocator_memory_datas) = 0;
+
+    // Direct allocation methods that perform memory allocation and resource creation without performing memory
+    // translation.  These methods allow the replay tool to allocate staging resources through the resource allocator so
+    // that the allocator is aware of all allocations performed at replay.
+    virtual VkResult CreateBufferDirect(const VkBufferCreateInfo*    create_info,
+                                        const VkAllocationCallbacks* allocation_callbacks,
+                                        VkBuffer*                    buffer,
+                                        ResourceData*                allocator_data) = 0;
+
+    virtual void DestroyBufferDirect(VkBuffer                     buffer,
+                                     const VkAllocationCallbacks* allocation_callbacks,
+                                     ResourceData                 allocator_data) = 0;
+
+    virtual VkResult CreateImageDirect(const VkImageCreateInfo*     create_info,
+                                       const VkAllocationCallbacks* allocation_callbacks,
+                                       VkImage*                     image,
+                                       ResourceData*                allocator_data) = 0;
+
+    virtual void DestroyImageDirect(VkImage                      image,
+                                    const VkAllocationCallbacks* allocation_callbacks,
+                                    ResourceData                 allocator_data) = 0;
+
+    virtual VkResult AllocateMemoryDirect(const VkMemoryAllocateInfo*  allocate_info,
+                                          const VkAllocationCallbacks* allocation_callbacks,
+                                          VkDeviceMemory*              memory,
+                                          MemoryData*                  allocator_data) = 0;
+
+    virtual void FreeMemoryDirect(VkDeviceMemory               memory,
+                                  const VkAllocationCallbacks* allocation_callbacks,
+                                  MemoryData                   allocator_data) = 0;
+
+    virtual VkResult BindBufferMemoryDirect(VkBuffer               buffer,
+                                            VkDeviceMemory         memory,
+                                            VkDeviceSize           memory_offset,
+                                            ResourceData           allocator_buffer_data,
+                                            MemoryData             allocator_memory_data,
+                                            VkMemoryPropertyFlags* bind_memory_properties) = 0;
+
+    virtual VkResult BindImageMemoryDirect(VkImage                image,
+                                           VkDeviceMemory         memory,
+                                           VkDeviceSize           memory_offset,
+                                           ResourceData           allocator_image_data,
+                                           MemoryData             allocator_memory_data,
+                                           VkMemoryPropertyFlags* bind_memory_properties) = 0;
+
+    // Map the memory that the buffer was bound to.  The returned pointer references the start of the buffer memory (it
+    // is the start of the memory the resource was bound to plus the resource bind offset).
+    virtual VkResult
+    MapResourceMemoryDirect(VkDeviceSize size, VkMemoryMapFlags flags, void** data, ResourceData allocator_data) = 0;
+
+    virtual void UnmapResourceMemoryDirect(ResourceData allocator_data) = 0;
+
+    virtual VkResult FlushMappedMemoryRangesDirect(uint32_t                   memory_range_count,
+                                                   const VkMappedMemoryRange* memory_ranges,
+                                                   const MemoryData*          allocator_datas) = 0;
+
+    virtual VkResult InvalidateMappedMemoryRangesDirect(uint32_t                   memory_range_count,
+                                                        const VkMappedMemoryRange* memory_ranges,
+                                                        const MemoryData*          allocator_datas) = 0;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_resource_initializer.h
+++ b/framework/decode/vulkan_resource_initializer.h
@@ -41,11 +41,7 @@ class VulkanResourceInitializer
 
     ~VulkanResourceInitializer();
 
-    VkResult LoadData(VkDeviceMemory                      memory,
-                      VkDeviceSize                        offset,
-                      VkDeviceSize                        size,
-                      const uint8_t*                      data,
-                      VulkanResourceAllocator::MemoryData allocator_data);
+    VkResult LoadData(VkDeviceSize size, const uint8_t* data, VulkanResourceAllocator::ResourceData allocator_data);
 
     VkResult InitializeBuffer(VkDeviceSize        data_size,
                               const uint8_t*      data,


### PR DESCRIPTION
Adds new methods to the VulkanResourceAllocator interface that allow replay to allocate staging resources through the resource allocator, while bypassing the capture-memory-type to replay-memory-type translation that is performed by some allocator implementations.  Replay allocates staging resources, which were not created during capture, for operations such as screen shot creation and resource initialization during the initial state setup for trimmed files.  Allocating staging resources through the resource allocator allows the resource allocator to be aware of all memory allocations performed for replay.