### PR TITLE
CMake Updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ endif()
 
 configure_file("${CMAKE_SOURCE_DIR}/project_version.h.in" "${CMAKE_BINARY_DIR}/project_version.h")
 
-option(BUILD_WERROR "Build with -Werror" ON)
+option(BUILD_WERROR "Build with warnings as errors" ON)
 
 # Code checks
 include("CodeStyle")
@@ -126,7 +126,6 @@ endif(UNIX)
 
 add_library(windows_specific INTERFACE)
 target_compile_definitions(windows_specific INTERFACE WIN32_LEAN_AND_MEAN NOMINMAX VK_USE_PLATFORM_WIN32_KHR)
-target_compile_options(windows_specific INTERFACE /WX)
 
 add_library(linux_specific INTERFACE)
 target_compile_definitions(linux_specific INTERFACE _FILE_OFFSET_BITS=64 PAGE_GUARD_ENABLE_UCONTEXT_WRITE_DETECTION
@@ -135,14 +134,18 @@ target_compile_definitions(linux_specific INTERFACE _FILE_OFFSET_BITS=64 PAGE_GU
     $<$<BOOL:${XCB_FOUND}>:VK_USE_PLATFORM_XCB_KHR>
     $<$<BOOL:${WAYLAND_FOUND}>:VK_USE_PLATFORM_WAYLAND_KHR>)
 
-if(BUILD_WERROR)
-    target_compile_options(linux_specific INTERFACE -Werror)
-endif(BUILD_WERROR)
-
 add_library(platform_specific INTERFACE)
 target_link_libraries(platform_specific INTERFACE
     $<$<BOOL:${WIN32}>:windows_specific>
     $<$<NOT:$<BOOL:${WIN32}>>:linux_specific>)
+
+if(BUILD_WERROR)
+    if(MSVC)
+        target_compile_options(platform_specific INTERFACE /WX)
+    else()
+        target_compile_options(platform_specific INTERFACE -Werror)
+    endif()
+endif()
 
 add_library(vulkan_registry INTERFACE)
 target_include_directories(vulkan_registry INTERFACE ${CMAKE_SOURCE_DIR}/external/Vulkan-Headers/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 # Description: CMake script for framework util target
 ###############################################################################
 
-cmake_minimum_required(VERSION 3.4.1)
+cmake_minimum_required(VERSION 3.10.2)
 project(GFXReconstruct)
 
 set_property(GLOBAL PROPERTY TEST_SCRIPT ${CMAKE_ROOT})

--- a/cmake/CodeStyle.cmake
+++ b/cmake/CodeStyle.cmake
@@ -44,27 +44,29 @@ endmacro()
 
 # Apply code style build directives
 function(target_code_style_build_directives TARGET)
-    generate_target_source_files(${TARGET} TARGET_SRC_FILES TARGET_SOURCE_FILES)
-    if(${APPLY_CPP_CODE_STYLE})
-        if(CLANG_FORMAT-NOTFOUND STREQUAL ${CLANG_FORMAT})
-            message(FATAL_ERROR "Failed to find clang-format in system path")
+    if(${APPLY_CPP_CODE_STYLE} OR ${CHECK_CPP_CODE_STYLE})
+        generate_target_source_files(${TARGET} TARGET_SRC_FILES TARGET_SOURCE_FILES)
+        if(${APPLY_CPP_CODE_STYLE})
+            if(CLANG_FORMAT-NOTFOUND STREQUAL ${CLANG_FORMAT})
+                message(FATAL_ERROR "Failed to find clang-format in system path")
+            endif()
+            # If apply code style is on, turn off check code style
+            set(CHECK_CPP_CODE_STYLE OFF)
+            add_custom_target("${TARGET}ClangFormat"
+                    COMMAND ${CLANG_FORMAT} -i ${TARGET_SRC_FILES}
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+                    COMMENT "Run clang format for ${TARGET}"
+                    COMMAND_EXPAND_LISTS)
+            add_dependencies(${TARGET} "${TARGET}ClangFormat")
         endif()
-        # If apply code style is on, turn off check code style
-        set(CHECK_CPP_CODE_STYLE OFF)
-        add_custom_target("${TARGET}ClangFormat"
-                COMMAND ${CLANG_FORMAT} -i ${TARGET_SRC_FILES}
-                WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-                COMMENT "Run clang format for ${TARGET}"
-                COMMAND_EXPAND_LISTS)
-        add_dependencies(${TARGET} "${TARGET}ClangFormat")
-    endif()
-    if(${CHECK_CPP_CODE_STYLE})
-        # Call the script to check formatting
-        add_custom_target("${TARGET}CodeStyleCheck"
-                COMMAND "${PYTHON}" ${CMAKE_SOURCE_DIR}/scripts/check_code_style.py
-                --sourcefile ${TARGET_SRC_FILES} --base ${CHECK_CPP_CODE_STYLE_BASE}
-                WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-                COMMENT "Check code style for ${TARGET}")
-        add_dependencies(${TARGET} "${TARGET}CodeStyleCheck")
+        if(${CHECK_CPP_CODE_STYLE})
+            # Call the script to check formatting
+            add_custom_target("${TARGET}CodeStyleCheck"
+                    COMMAND "${PYTHON}" ${CMAKE_SOURCE_DIR}/scripts/check_code_style.py
+                    --sourcefile ${TARGET_SRC_FILES} --base ${CHECK_CPP_CODE_STYLE_BASE}
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+                    COMMENT "Check code style for ${TARGET}")
+            add_dependencies(${TARGET} "${TARGET}CodeStyleCheck")
+        endif()
     endif()
 endfunction()

--- a/cmake/CodeStyle.cmake
+++ b/cmake/CodeStyle.cmake
@@ -17,8 +17,6 @@
 # Description: CMake code style build directives
 ###############################################################################
 
-cmake_minimum_required(VERSION 3.4.1)
-
 option(APPLY_CPP_CODE_STYLE "Apply C++ code style using clang format" OFF)
 option(CHECK_CPP_CODE_STYLE "Check C++ code style using clang format" OFF)
 option(CHECK_CPP_CODE_STYLE_BASE "Git branch/commit for C++ code style comparison" "HEAD")


### PR DESCRIPTION
- Apply the BUILD_WERROR option to MSVC builds.
- Set the minimum required CMake version to 3.10.2

Fixes #460 