### PR TITLE
Fix Xlib GetPhysicalDevicePresentationSupport

### DIFF
--- a/framework/util/xlib_loader.cpp
+++ b/framework/util/xlib_loader.cpp
@@ -87,6 +87,8 @@ bool XlibLoader::Initialize()
             function_table_.Sync = reinterpret_cast<decltype(XSync)*>(util::platform::GetProcAddress(libx11_, "XSync"));
             function_table_.UnmapWindow =
                 reinterpret_cast<decltype(XUnmapWindow)*>(util::platform::GetProcAddress(libx11_, "XUnmapWindow"));
+            function_table_.VisualIDFromVisual = reinterpret_cast<decltype(XVisualIDFromVisual)*>(
+                util::platform::GetProcAddress(libx11_, "XVisualIDFromVisual"));
         }
         else
         {

--- a/framework/util/xlib_loader.h
+++ b/framework/util/xlib_loader.h
@@ -49,6 +49,7 @@ class XlibLoader
         decltype(XStoreName)*           StoreName;
         decltype(XSync)*                Sync;
         decltype(XUnmapWindow)*         UnmapWindow;
+        decltype(XVisualIDFromVisual)*  VisualIDFromVisual;
     };
 
   public:


### PR DESCRIPTION
Obtain a valid Display* and VisualID to use in vkGetPhysicalDeviceXlibPresentationSupportKHR instead of nullptr and 0.
