### PR TITLE
Set log level for tests to error and above

### DIFF
--- a/framework/decode/test/main.cpp
+++ b/framework/decode/test/main.cpp
@@ -39,6 +39,8 @@ const gfxrecon::format::HandleId kDeviceId        = 6;
 
 TEST_CASE("handle IDs need to be mapped to valid handles", "[wrapper]")
 {
+    gfxrecon::util::Log::Init(gfxrecon::util::Log::kErrorSeverity);
+
     gfxrecon::decode::VulkanObjectInfoTable info_table;
 
     // Basic add.
@@ -136,4 +138,6 @@ TEST_CASE("handle IDs need to be mapped to valid handles", "[wrapper]")
 
         REQUIRE(object == gfxrecon::format::ToHandleId(kBufferHandles[0]));
     }
+
+    gfxrecon::util::Log::Release();
 }

--- a/framework/encode/test/main.cpp
+++ b/framework/encode/test/main.cpp
@@ -37,6 +37,8 @@ gfxrecon::format::HandleId GetHandleId()
 
 TEST_CASE("handles can be wrapped and unwrapped", "[wrapper]")
 {
+    gfxrecon::util::Log::Init(gfxrecon::util::Log::kErrorSeverity);
+
     VkBuffer buffer = kBufferHandle;
     gfxrecon::encode::CreateWrappedHandle<gfxrecon::encode::DeviceWrapper,
                                           gfxrecon::encode::NoParentWrapper,
@@ -71,4 +73,6 @@ TEST_CASE("handles can be wrapped and unwrapped", "[wrapper]")
     }
 
     gfxrecon::encode::DestroyWrappedHandle<gfxrecon::encode::BufferWrapper>(buffer);
+
+    gfxrecon::util::Log::Release();
 }


### PR DESCRIPTION
Change the log level for test cases to error and above to prevent warnings from being printed in the build output when all tests pass.
