### PR TITLE
Initialize the allocator function table based on API version/enabled extensions

### DIFF
--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -196,6 +196,7 @@ typedef VulkanObjectInfo<VkPrivateDataSlotEXT>            PrivateDataSlotEXTInfo
 struct InstanceInfo : public VulkanObjectInfo<VkInstance>
 {
     uint32_t                             api_version{ 0 };
+    std::vector<std::string>             enabled_extensions;
     std::unordered_map<uint32_t, size_t> array_counts;
 
     // Capture and replay devices sorted in the order that they were originally retrieved from
@@ -210,6 +211,7 @@ struct PhysicalDeviceInfo : public VulkanObjectInfo<VkPhysicalDevice>
 {
     VkInstance                           parent{ VK_NULL_HANDLE };
     uint32_t                             parent_api_version{ 0 };
+    std::vector<std::string>             parent_enabled_extensions;
     std::unordered_map<uint32_t, size_t> array_counts;
 
     // Capture device properties.


### PR DESCRIPTION
When creating the VulkanResourceAllocator during replay, initialize its function table based on the API version specified at VkInstance creation and the extensions enabled at VkInstance and VkDevice creation.  The logic for the function table initialization had looked like:
```
if (device_table->BindBufferMemory2 != nullptr)
    functions.bind_buffer_memory2 = device_table->BindBufferMemory2;
else
    functions.bind_buffer_memory2 = device_table->BindBufferMemory2KHR;
```
Because the function pointers in the replay dispatch tables are never null, this resulted in no-op behavior for extension or version 1.1 functions that were not enabled.