### PR TITLE
Add support for opaque buffer addresses

### DIFF
--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -102,6 +102,11 @@ class ApiDecoder
                                              const std::vector<format::DeviceMemoryType>& memory_types,
                                              const std::vector<format::DeviceMemoryHeap>& memory_heaps) = 0;
 
+    virtual void DispatchSetBufferAddressCommand(format::ThreadId thread_id,
+                                                 format::HandleId device_id,
+                                                 format::HandleId buffer_id,
+                                                 uint64_t         address) = 0;
+
     virtual void
     DispatchSetSwapchainImageStateCommand(format::ThreadId                                    thread_id,
                                           format::HandleId                                    device_id,

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -779,6 +779,31 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                                  "Failed to read set device memory properties meta-data block header");
         }
     }
+    else if (meta_type == format::MetaDataType::kSetBufferAddressCommand)
+    {
+        // This command does not support compression.
+        assert(block_header.type != format::BlockType::kCompressedMetaDataBlock);
+
+        format::SetBufferAddressCommand header;
+
+        success = ReadBytes(&header.thread_id, sizeof(header.thread_id));
+        success = success && ReadBytes(&header.device_id, sizeof(header.device_id));
+        success = success && ReadBytes(&header.buffer_id, sizeof(header.buffer_id));
+        success = success && ReadBytes(&header.address, sizeof(header.address));
+
+        if (success)
+        {
+            for (auto decoder : decoders_)
+            {
+                decoder->DispatchSetBufferAddressCommand(
+                    header.thread_id, header.device_id, header.buffer_id, header.address);
+            }
+        }
+        else
+        {
+            HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read set buffer address meta-data block header");
+        }
+    }
     else if (meta_type == format::MetaDataType::kSetSwapchainImageStateCommand)
     {
         // This command does not support compression.

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -88,6 +88,10 @@ class VulkanConsumerBase
                                                          const std::vector<format::DeviceMemoryHeap>& memory_heaps)
     {}
 
+    virtual void
+    ProcessSetBufferAddressCommand(format::HandleId device_id, format::HandleId buffer_id, uint64_t address)
+    {}
+
     virtual void ProcessSetSwapchainImageStateCommand(format::HandleId device_id,
                                                       format::HandleId swapchain_id,
                                                       uint32_t         last_presented_image,

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -161,6 +161,19 @@ void VulkanDecoderBase::DispatchSetDeviceMemoryPropertiesCommand(
     }
 }
 
+void VulkanDecoderBase::DispatchSetBufferAddressCommand(format::ThreadId thread_id,
+                                                        format::HandleId device_id,
+                                                        format::HandleId buffer_id,
+                                                        uint64_t         address)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(thread_id);
+
+    for (auto consumer : consumers_)
+    {
+        consumer->ProcessSetBufferAddressCommand(device_id, buffer_id, address);
+    }
+}
+
 void VulkanDecoderBase::DispatchSetSwapchainImageStateCommand(
     format::ThreadId                                    thread_id,
     format::HandleId                                    device_id,

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -114,6 +114,11 @@ class VulkanDecoderBase : public ApiDecoder
                                              const std::vector<format::DeviceMemoryType>& memory_types,
                                              const std::vector<format::DeviceMemoryHeap>& memory_heaps) override;
 
+    virtual void DispatchSetBufferAddressCommand(format::ThreadId thread_id,
+                                                 format::HandleId device_id,
+                                                 format::HandleId buffer_id,
+                                                 uint64_t         address) override;
+
     virtual void
     DispatchSetSwapchainImageStateCommand(format::ThreadId                                    thread_id,
                                           format::HandleId                                    device_id,

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -241,6 +241,8 @@ struct DeviceInfo : public VulkanObjectInfo<VkDevice>
     std::unique_ptr<VulkanResourceAllocator> allocator;
     std::unordered_map<uint32_t, size_t>     array_counts;
 
+    std::unordered_map<format::HandleId, uint64_t> buffer_addresses;
+
     // The following values are only used when loading the initial state for trimmed files.
     std::vector<std::string>                   extensions;
     std::unique_ptr<VulkanResourceInitializer> resource_initializer;

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -202,7 +202,7 @@ typedef VulkanObjectInfo<VkPrivateDataSlotEXT>            PrivateDataSlotEXTInfo
 
 struct InstanceInfo : public VulkanObjectInfo<VkInstance>
 {
-    uint32_t                             api_version{ 0 };
+    uint32_t                             api_version{ VK_MAKE_VERSION(1, 0, 0) };
     std::vector<std::string>             enabled_extensions;
     std::unordered_map<uint32_t, size_t> array_counts;
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -115,6 +115,9 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                             const std::vector<format::DeviceMemoryHeap>& memory_heaps) override;
 
     virtual void
+    ProcessSetBufferAddressCommand(format::HandleId device_id, format::HandleId buffer_id, uint64_t address) override;
+
+    virtual void
     ProcessSetSwapchainImageStateCommand(format::HandleId                                    device_id,
                                          format::HandleId                                    swapchain_id,
                                          uint32_t                                            last_presented_image,

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -308,6 +308,12 @@ class TraceManager
                                   const VkDeviceCreateInfo*    pCreateInfo,
                                   const VkAllocationCallbacks* pAllocator,
                                   VkDevice*                    pDevice);
+
+    VkResult OverrideCreateBuffer(VkDevice                     device,
+                                  const VkBufferCreateInfo*    pCreateInfo,
+                                  const VkAllocationCallbacks* pAllocator,
+                                  VkBuffer*                    pBuffer);
+
     VkResult OverrideAllocateMemory(VkDevice                     device,
                                     const VkMemoryAllocateInfo*  pAllocateInfo,
                                     const VkAllocationCallbacks* pAllocator,
@@ -969,6 +975,7 @@ class TraceManager
                                          const VkPhysicalDeviceProperties& properties);
     void WriteSetDeviceMemoryPropertiesCommand(format::HandleId                        physical_device_id,
                                                const VkPhysicalDeviceMemoryProperties& memory_properties);
+    void WriteSetBufferAddressCommand(format::HandleId device_id, format::HandleId buffer_id, uint64_t address);
 
     void SetDescriptorUpdateTemplateInfo(VkDescriptorUpdateTemplate                  update_template,
                                          const VkDescriptorUpdateTemplateCreateInfo* create_info);

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -169,6 +169,10 @@ struct BufferWrapper : public HandleWrapper<VkBuffer>
     VkDeviceSize     bind_offset{ 0 };
     uint32_t         queue_family_index{ 0 };
     VkDeviceSize     created_size{ 0 };
+
+    // State tracking info for buffers with device addresses.
+    format::HandleId device_id{ format::kNullHandleId };
+    VkDeviceAddress  address{ 0 };
 };
 
 struct ImageWrapper : public HandleWrapper<VkImage>

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -102,6 +102,7 @@ struct PhysicalDeviceWrapper : public HandleWrapper<VkPhysicalDevice>
 {
     InstanceTable*                  layer_table_ref{ nullptr };
     std::vector<DisplayKHRWrapper*> child_displays;
+    uint32_t                        instance_api_version{ 0 };
 
     // Track memory types for use when creating snapshots of buffer and image resource memory content.
     VkPhysicalDeviceMemoryProperties memory_properties{};
@@ -120,6 +121,7 @@ struct InstanceWrapper : public HandleWrapper<VkInstance>
     InstanceTable                       layer_table;
     std::vector<PhysicalDeviceWrapper*> child_physical_devices;
     bool                                have_device_properties{ false };
+    uint32_t                            api_version{ VK_MAKE_VERSION(1, 0, 0) };
 };
 
 struct QueueWrapper : public HandleWrapper<VkQueue>

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -214,6 +214,17 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfacePresentModes(VkPhysicalDevice
     entry.assign(modes, modes + mode_count);
 }
 
+void VulkanStateTracker::TrackBufferDeviceAddress(VkDevice device, VkBuffer buffer, VkDeviceAddress address)
+{
+    assert((device != VK_NULL_HANDLE) && (buffer != VK_NULL_HANDLE));
+
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    auto wrapper       = reinterpret_cast<BufferWrapper*>(buffer);
+    wrapper->device_id = GetWrappedId(device);
+    wrapper->address   = address;
+}
+
 void VulkanStateTracker::TrackBufferMemoryBinding(VkDevice       device,
                                                   VkBuffer       buffer,
                                                   VkDeviceMemory memory,

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -295,6 +295,8 @@ class VulkanStateTracker
                                                 uint32_t                mode_count,
                                                 const VkPresentModeKHR* modes);
 
+    void TrackBufferDeviceAddress(VkDevice device, VkBuffer buffer, VkDeviceAddress address);
+
     void TrackBufferMemoryBinding(VkDevice device, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize memoryOffset);
 
     void TrackImageMemoryBinding(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset);

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -125,6 +125,8 @@ class VulkanStateWriter
 
     void WriteSwapchainKhrState(const VulkanStateTable& state_table);
 
+    void WriteBufferState(const VulkanStateTable& state_table);
+
     void WriteDeviceMemoryState(const VulkanStateTable& state_table);
 
     void
@@ -264,6 +266,8 @@ class VulkanStateWriter
 
     void WriteSetDeviceMemoryPropertiesCommand(format::HandleId                        physical_device_id,
                                                const VkPhysicalDeviceMemoryProperties& memory_properties);
+
+    void WriteSetBufferAddressCommand(format::HandleId device_id, format::HandleId buffer_id, VkDeviceAddress address);
 
     template <typename Wrapper>
     void StandardCreateWrite(const VulkanStateTable& state_table)

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -96,7 +96,8 @@ enum MetaDataType : uint32_t
     kDestroyHardwareBufferCommand       = 10,
     kSetDevicePropertiesCommand         = 11,
     kSetDeviceMemoryPropertiesCommand   = 12,
-    kResizeWindowCommand2               = 13
+    kResizeWindowCommand2               = 13,
+    kSetBufferAddressCommand            = 14
 };
 
 enum CompressionType : uint32_t
@@ -373,6 +374,15 @@ struct SetDevicePropertiesCommand
     uint32_t         device_type;
     uint8_t          pipeline_cache_uuid[kUuidSize];
     uint32_t         device_name_len;
+};
+
+struct SetBufferAddressCommand
+{
+    MetaDataHeader   meta_header;
+    format::ThreadId thread_id;
+    format::HandleId device_id;
+    format::HandleId buffer_id;
+    uint64_t         address;
 };
 
 #pragma pack(pop)

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -1310,15 +1310,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBuffer(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateBuffer>::Dispatch(TraceManager::Get(), device, pCreateInfo, pAllocator, pBuffer);
 
-    VkDevice device_unwrapped = GetWrappedHandle<VkDevice>(device);
-
-    VkResult result = GetDeviceTable(device)->CreateBuffer(device_unwrapped, pCreateInfo, pAllocator, pBuffer);
-
-    if (result >= 0)
-    {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, BufferWrapper>(device, NoParentWrapper::kHandleValue, pBuffer, TraceManager::GetUniqueId);
-    }
-    else
+    VkResult result = TraceManager::Get()->OverrideCreateBuffer(device, pCreateInfo, pAllocator, pBuffer);
+    if (result < 0)
     {
         omit_output_data = true;
     }

--- a/framework/generated/vulkan_generators/capture_overrides.json
+++ b/framework/generated/vulkan_generators/capture_overrides.json
@@ -2,6 +2,7 @@
   "functions": {
     "vkCreateInstance": "TraceManager::OverrideCreateInstance",
     "vkCreateDevice": "TraceManager::Get()->OverrideCreateDevice",
+    "vkCreateBuffer": "TraceManager::Get()->OverrideCreateBuffer",
     "vkAllocateMemory": "TraceManager::Get()->OverrideAllocateMemory",
     "vkGetPhysicalDeviceToolPropertiesEXT": "TraceManager::Get()->OverrideGetPhysicalDeviceToolPropertiesEXT"
   }


### PR DESCRIPTION
Adds support for vkGetBufferOpaqueCaptureAddress to allow capture and replay of applications that use buffer device address features. Handles the setup of the device features and the capture and replay of the buffer addresses.

- Default initialize replay API version to 1.0
- Enable bufferDeviceAddressCaptureReplay bit
- Initial support for opaque buffer addresses