### PR TITLE
Add a custom allocator for use during decoding

### DIFF
--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -9,6 +9,8 @@ target_sources(gfxrecon_decode
                    ${GFXRECON_SOURCE_DIR}/framework/decode/custom_vulkan_struct_decoders_forward.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/custom_vulkan_struct_handle_mappers.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/custom_vulkan_struct_handle_mappers.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/decode_allocator.h
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/decode_allocator.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/descriptor_update_template_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/descriptor_update_template_decoder.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/decode/file_processor.h

--- a/android/framework/util/CMakeLists.txt
+++ b/android/framework/util/CMakeLists.txt
@@ -25,6 +25,8 @@ target_sources(gfxrecon_util
                    ${GFXRECON_SOURCE_DIR}/framework/util/zlib_compressor.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/util/memory_output_stream.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/memory_output_stream.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/util/monotonic_allocator.h
+                   ${GFXRECON_SOURCE_DIR}/framework/util/monotonic_allocator.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/util/output_stream.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/page_guard_manager.h
                    ${GFXRECON_SOURCE_DIR}/framework/util/page_guard_manager.cpp

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -39,6 +39,8 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/custom_vulkan_struct_handle_mappers.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/descriptor_update_template_decoder.h
                     ${CMAKE_CURRENT_LIST_DIR}/descriptor_update_template_decoder.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/decode_allocator.h
+                    ${CMAKE_CURRENT_LIST_DIR}/decode_allocator.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/file_processor.h
                     ${CMAKE_CURRENT_LIST_DIR}/file_processor.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/file_transformer.h

--- a/framework/decode/custom_vulkan_struct_decoders.cpp
+++ b/framework/decode/custom_vulkan_struct_decoders.cpp
@@ -34,7 +34,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-size_t DecodePNextStruct(const uint8_t* buffer, size_t buffer_size, std::unique_ptr<PNextNode>* pNext);
+size_t DecodePNextStruct(const uint8_t* buffer, size_t buffer_size, PNextNode** pNext);
 
 size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearColorValue* wrapper)
 {

--- a/framework/decode/custom_vulkan_struct_decoders.h
+++ b/framework/decode/custom_vulkan_struct_decoders.h
@@ -65,8 +65,8 @@ struct Decoded_VkClearColorValue
 struct Decoded_VkClearValue
 {
     using struct_type = VkClearValue;
-    VkClearValue*                              decoded_value{ nullptr };
-    std::unique_ptr<Decoded_VkClearColorValue> color;
+    VkClearValue*              decoded_value{ nullptr };
+    Decoded_VkClearColorValue* color{ nullptr };
 };
 
 struct Decoded_VkPipelineExecutableStatisticValueKHR
@@ -97,9 +97,9 @@ struct Decoded_VkAccelerationStructureGeometryDataKHR
     using struct_type = VkAccelerationStructureGeometryDataKHR;
     VkAccelerationStructureGeometryDataKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkAccelerationStructureGeometryTrianglesDataKHR> triangles;
-    std::unique_ptr<Decoded_VkAccelerationStructureGeometryAabbsDataKHR>     aabbs;
-    std::unique_ptr<Decoded_VkAccelerationStructureGeometryInstancesDataKHR> instances;
+    Decoded_VkAccelerationStructureGeometryTrianglesDataKHR* triangles{ nullptr };
+    Decoded_VkAccelerationStructureGeometryAabbsDataKHR*     aabbs{ nullptr };
+    Decoded_VkAccelerationStructureGeometryInstancesDataKHR* instances{ nullptr };
 };
 
 // This union wrapper does not have a DecodeStruct function.  It is decoded by the Decoded_VkPerformanceValueINTEL
@@ -130,11 +130,11 @@ struct Decoded_VkWriteDescriptorSet
 
     VkWriteDescriptorSet* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode>                                            pNext;
-    format::HandleId                                                      dstSet{ format::kNullHandleId };
-    std::unique_ptr<StructPointerDecoder<Decoded_VkDescriptorImageInfo>>  pImageInfo;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkDescriptorBufferInfo>> pBufferInfo;
-    HandlePointerDecoder<VkBufferView>                                    pTexelBufferView;
+    std::unique_ptr<PNextNode>                            pNext;
+    format::HandleId                                      dstSet{ format::kNullHandleId };
+    StructPointerDecoder<Decoded_VkDescriptorImageInfo>*  pImageInfo{ nullptr };
+    StructPointerDecoder<Decoded_VkDescriptorBufferInfo>* pBufferInfo{ nullptr };
+    HandlePointerDecoder<VkBufferView>                    pTexelBufferView;
 };
 
 struct Decoded_VkPerformanceValueINTEL
@@ -143,7 +143,7 @@ struct Decoded_VkPerformanceValueINTEL
 
     VkPerformanceValueINTEL* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkPerformanceValueDataINTEL> data;
+    Decoded_VkPerformanceValueDataINTEL* data{ nullptr };
 };
 
 struct Decoded_VkAccelerationStructureGeometryKHR
@@ -152,8 +152,8 @@ struct Decoded_VkAccelerationStructureGeometryKHR
 
     VkAccelerationStructureGeometryKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode>                                      pNext;
-    std::unique_ptr<Decoded_VkAccelerationStructureGeometryDataKHR> geometry;
+    std::unique_ptr<PNextNode>                      pNext;
+    Decoded_VkAccelerationStructureGeometryDataKHR* geometry{ nullptr };
 };
 
 // Decoded struct wrappers for SECURITY_ATTRIBUTES and related WIN32 structures.
@@ -170,13 +170,13 @@ struct Decoded_SECURITY_DESCRIPTOR
 
     SECURITY_DESCRIPTOR* decoded_value{ nullptr };
 
-    std::unique_ptr<uint8_t[]> Owner;
-    std::unique_ptr<uint8_t[]> Group;
-    PointerDecoder<uint8_t>    PackedOwner;
-    PointerDecoder<uint8_t>    PackedGroup;
+    uint8_t*                Owner{ nullptr };
+    uint8_t*                Group{ nullptr };
+    PointerDecoder<uint8_t> PackedOwner;
+    PointerDecoder<uint8_t> PackedGroup;
 
-    std::unique_ptr<StructPointerDecoder<Decoded_ACL>> Sacl;
-    std::unique_ptr<StructPointerDecoder<Decoded_ACL>> Dacl;
+    StructPointerDecoder<Decoded_ACL>* Sacl{ nullptr };
+    StructPointerDecoder<Decoded_ACL>* Dacl{ nullptr };
 };
 
 struct Decoded_SECURITY_ATTRIBUTES
@@ -185,7 +185,7 @@ struct Decoded_SECURITY_ATTRIBUTES
 
     SECURITY_ATTRIBUTES* decoded_value{ nullptr };
 
-    std::unique_ptr<StructPointerDecoder<Decoded_SECURITY_DESCRIPTOR>> lpSecurityDescriptor;
+    StructPointerDecoder<Decoded_SECURITY_DESCRIPTOR>* lpSecurityDescriptor{ nullptr };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/custom_vulkan_struct_decoders.h
+++ b/framework/decode/custom_vulkan_struct_decoders.h
@@ -51,7 +51,7 @@ struct Decoded_VkBaseOutStructure
 
     VkBaseOutStructure* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 // Decoded union wrappers.
@@ -130,7 +130,7 @@ struct Decoded_VkWriteDescriptorSet
 
     VkWriteDescriptorSet* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode>                            pNext;
+    PNextNode*                                            pNext{ nullptr };
     format::HandleId                                      dstSet{ format::kNullHandleId };
     StructPointerDecoder<Decoded_VkDescriptorImageInfo>*  pImageInfo{ nullptr };
     StructPointerDecoder<Decoded_VkDescriptorBufferInfo>* pBufferInfo{ nullptr };
@@ -152,7 +152,7 @@ struct Decoded_VkAccelerationStructureGeometryKHR
 
     VkAccelerationStructureGeometryKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode>                      pNext;
+    PNextNode*                                      pNext{ nullptr };
     Decoded_VkAccelerationStructureGeometryDataKHR* geometry{ nullptr };
 };
 

--- a/framework/decode/decode_allocator.cpp
+++ b/framework/decode/decode_allocator.cpp
@@ -1,0 +1,61 @@
+
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "decode/decode_allocator.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+DecodeAllocator* DecodeAllocator::instance_{ nullptr };
+
+void DecodeAllocator::Begin()
+{
+    if (instance_ == nullptr)
+    {
+        instance_ = new DecodeAllocator();
+    }
+    assert(!instance_->can_allocate_);
+    instance_->can_allocate_ = true;
+}
+
+void DecodeAllocator::End()
+{
+    assert((instance_ != nullptr) && instance_->can_allocate_);
+    instance_->allocator_.Clear(false);
+    instance_->can_allocate_ = false;
+}
+
+void DecodeAllocator::FreeSystemMemory()
+{
+    assert((instance_ != nullptr) && !instance_->can_allocate_);
+    instance_->allocator_.Clear(true);
+}
+
+void DecodeAllocator::DestroyInstance()
+{
+    delete instance_;
+    instance_ = nullptr;
+}
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/decode_allocator.h
+++ b/framework/decode/decode_allocator.h
@@ -1,0 +1,71 @@
+
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_DECODE_DECODE_ALLOCATOR_H
+#define GFXRECON_DECODE_DECODE_ALLOCATOR_H
+
+#include "util/defines.h"
+#include "util/monotonic_allocator.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+class DecodeAllocator
+{
+  public:
+    // Begin must be called before any calls to Allocate (either initially or since End was called). This ensures
+    // allocations are not made outside the intended scope. Also creates the allocator instance if it is nullptr.
+    static void Begin();
+
+    template <typename T>
+    static T* Allocate(size_t count = 1, bool initialize = true)
+    {
+        assert((instance_ != nullptr) && instance_->can_allocate_);
+        return instance_->can_allocate_ ? instance_->allocator_.Allocate<T>(count, initialize) : nullptr;
+    }
+
+    // End must be called to release any allocations made since last call to Begin. Currently allocated system memory
+    // is re-used for future allocations.
+    static void End();
+
+    // Free system memory blocks. Must not be called between Begin and End
+    static void FreeSystemMemory();
+
+    // Destroy the allocator instance. This will also frees all allocated memory.
+    static void DestroyInstance();
+
+  private:
+    DecodeAllocator() : allocator_(kAllocatorBlockSize), can_allocate_(false) {}
+
+  private:
+    static const size_t     kAllocatorBlockSize{ 64 * 1024 };
+    static DecodeAllocator* instance_;
+
+    util::MonotonicAllocator allocator_;
+    bool                     can_allocate_;
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_DECODE_ALLOCATOR_H

--- a/framework/decode/descriptor_update_template_decoder.h
+++ b/framework/decode/descriptor_update_template_decoder.h
@@ -42,22 +42,19 @@ class DescriptorUpdateTemplateDecoder : public PointerDecoderBase
 
     ~DescriptorUpdateTemplateDecoder();
 
-    const void* GetPointer() const { return template_memory_.get(); }
+    const void* GetPointer() const { return template_memory_; }
 
     size_t GetImageInfoCount() const { return image_info_count_; }
     size_t GetBufferInfoCount() const { return buffer_info_count_; }
     size_t GetTexelBufferViewCount() const { return texel_buffer_view_count_; }
 
-    Decoded_VkDescriptorImageInfo*  GetImageInfoMetaStructPointer() { return decoded_image_info_.get(); }
-    Decoded_VkDescriptorBufferInfo* GetBufferInfoMetaStructPointer() { return decoded_buffer_info_.get(); }
-    format::HandleId* GetTexelBufferViewHandleIdsPointer() { return decoded_texel_buffer_view_handle_ids_.get(); }
+    Decoded_VkDescriptorImageInfo*  GetImageInfoMetaStructPointer() { return decoded_image_info_; }
+    Decoded_VkDescriptorBufferInfo* GetBufferInfoMetaStructPointer() { return decoded_buffer_info_; }
+    format::HandleId* GetTexelBufferViewHandleIdsPointer() { return decoded_texel_buffer_view_handle_ids_; }
 
-    const Decoded_VkDescriptorImageInfo*  GetImageInfoMetaStructPointer() const { return decoded_image_info_.get(); }
-    const Decoded_VkDescriptorBufferInfo* GetBufferInfoMetaStructPointer() const { return decoded_buffer_info_.get(); }
-    const format::HandleId*               GetTexelBufferViewHandleIdsPointer() const
-    {
-        return decoded_texel_buffer_view_handle_ids_.get();
-    }
+    const Decoded_VkDescriptorImageInfo*  GetImageInfoMetaStructPointer() const { return decoded_image_info_; }
+    const Decoded_VkDescriptorBufferInfo* GetBufferInfoMetaStructPointer() const { return decoded_buffer_info_; }
+    const format::HandleId* GetTexelBufferViewHandleIdsPointer() const { return decoded_texel_buffer_view_handle_ids_; }
 
     VkDescriptorImageInfo*  GetImageInfoPointer() { return image_info_; }
     VkDescriptorBufferInfo* GetBufferInfoPointer() { return buffer_info_; }
@@ -70,16 +67,16 @@ class DescriptorUpdateTemplateDecoder : public PointerDecoderBase
     size_t Decode(const uint8_t* buffer, size_t buffer_size);
 
   private:
-    std::unique_ptr<uint8_t[]>                        template_memory_;
-    std::unique_ptr<Decoded_VkDescriptorImageInfo[]>  decoded_image_info_;
-    std::unique_ptr<Decoded_VkDescriptorBufferInfo[]> decoded_buffer_info_;
-    std::unique_ptr<format::HandleId[]>               decoded_texel_buffer_view_handle_ids_;
-    size_t                                            image_info_count_;
-    size_t                                            buffer_info_count_;
-    size_t                                            texel_buffer_view_count_;
-    VkDescriptorImageInfo*                            image_info_;
-    VkDescriptorBufferInfo*                           buffer_info_;
-    VkBufferView*                                     texel_buffer_views_;
+    uint8_t*                        template_memory_{ nullptr };
+    Decoded_VkDescriptorImageInfo*  decoded_image_info_{ nullptr };
+    Decoded_VkDescriptorBufferInfo* decoded_buffer_info_{ nullptr };
+    format::HandleId*               decoded_texel_buffer_view_handle_ids_{ nullptr };
+    size_t                          image_info_count_;
+    size_t                          buffer_info_count_;
+    size_t                          texel_buffer_view_count_;
+    VkDescriptorImageInfo*          image_info_;
+    VkDescriptorBufferInfo*         buffer_info_;
+    VkBufferView*                   texel_buffer_views_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -23,6 +23,7 @@
 
 #include "decode/file_processor.h"
 
+#include "decode/decode_allocator.h"
 #include "format/format_util.h"
 #include "util/compressor.h"
 #include "util/logging.h"
@@ -51,6 +52,8 @@ FileProcessor::~FileProcessor()
     {
         fclose(file_descriptor_);
     }
+
+    DecodeAllocator::DestroyInstance();
 }
 
 bool FileProcessor::Initialize(const std::string& filename)
@@ -413,7 +416,9 @@ bool FileProcessor::ProcessFunctionCall(const format::BlockHeader& block_header,
             {
                 if (decoder->SupportsApiCall(call_id))
                 {
+                    DecodeAllocator::Begin();
                     decoder->DecodeFunctionCall(call_id, call_info, parameter_buffer_.data(), parameter_buffer_size);
+                    DecodeAllocator::End();
                 }
             }
         }

--- a/framework/decode/handle_pointer_decoder.h
+++ b/framework/decode/handle_pointer_decoder.h
@@ -24,6 +24,7 @@
 #ifndef GFXRECON_DECODE_HANDLE_POINTER_DECODER_H
 #define GFXRECON_DECODE_HANDLE_POINTER_DECODER_H
 
+#include "decode/decode_allocator.h"
 #include "decode/pointer_decoder.h"
 
 #include <cassert>
@@ -107,7 +108,7 @@ class HandlePointerDecoder
         {
             if (consumer_data_ == nullptr)
             {
-                consumer_data_ = std::make_unique<void*[]>(handle_data_len_);
+                consumer_data_ = DecodeAllocator::Allocate<void*>(handle_data_len_);
             }
 
             consumer_data_[index] = consumer_data;
@@ -120,7 +121,7 @@ class HandlePointerDecoder
     size_t                              handle_data_len_;
     size_t                              capacity_;
     bool                                is_memory_external_;
-    std::unique_ptr<void*[]>            consumer_data_;
+    void**                              consumer_data_{ nullptr };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/string_decoder.h
+++ b/framework/decode/string_decoder.h
@@ -25,6 +25,7 @@
 #define GFXRECON_DECODE_STRING_DECODER_H
 
 #include "decode/pointer_decoder_base.h"
+#include "decode/decode_allocator.h"
 #include "decode/value_decoder.h"
 #include "format/format.h"
 #include "util/defines.h"
@@ -40,14 +41,6 @@ class BasicStringDecoder : public PointerDecoderBase
 {
   public:
     BasicStringDecoder() : data_(nullptr), capacity_(0), is_memory_external_(false) {}
-
-    ~BasicStringDecoder()
-    {
-        if ((data_ != nullptr) && !is_memory_external_)
-        {
-            delete[] data_;
-        }
-    }
 
     const CharT* GetPointer() const { return data_; }
 
@@ -82,7 +75,7 @@ class BasicStringDecoder : public PointerDecoderBase
             {
                 assert(data_ == nullptr);
 
-                data_     = new CharT[alloc_len];
+                data_     = DecodeAllocator::Allocate<CharT>(alloc_len, false);
                 capacity_ = alloc_len;
                 bytes_read += ValueDecoder::DecodeArrayFrom<EncodeT>(
                     (buffer + bytes_read), (buffer_size - bytes_read), data_, string_len);

--- a/framework/decode/struct_pointer_decoder.h
+++ b/framework/decode/struct_pointer_decoder.h
@@ -26,6 +26,7 @@
 
 #include "decode/custom_vulkan_struct_decoders_forward.h"
 #include "decode/pointer_decoder_base.h"
+#include "decode/decode_allocator.h"
 #include "decode/value_decoder.h"
 #include "format/format.h"
 #include "generated/generated_vulkan_struct_decoders_forward.h"
@@ -45,19 +46,6 @@ class StructPointerDecoder : public PointerDecoderBase
         decoded_structs_(nullptr), struct_memory_(nullptr), capacity_(0), is_memory_external_(false)
     {}
 
-    virtual ~StructPointerDecoder() override
-    {
-        if ((struct_memory_ != nullptr) && !is_memory_external_)
-        {
-            delete[] struct_memory_;
-        }
-
-        if (decoded_structs_ != nullptr)
-        {
-            delete[] decoded_structs_;
-        }
-    }
-
     T* GetMetaStructPointer() { return decoded_structs_; }
 
     const T* GetMetaStructPointer() const { return decoded_structs_; }
@@ -68,28 +56,28 @@ class StructPointerDecoder : public PointerDecoderBase
 
     size_t GetOutputLength() const { return output_len_; }
 
-    typename T::struct_type* GetOutputPointer() { return output_data_.get(); }
+    typename T::struct_type* GetOutputPointer() { return output_data_; }
 
-    const typename T::struct_type* GetOutputPointer() const { return output_data_.get(); }
+    const typename T::struct_type* GetOutputPointer() const { return output_data_; }
 
     typename T::struct_type* AllocateOutputData(size_t len)
     {
         output_len_  = len;
-        output_data_ = std::make_unique<typename T::struct_type[]>(len);
-        return output_data_.get();
+        output_data_ = DecodeAllocator::Allocate<typename T::struct_type>(len);
+        return output_data_;
     }
 
     typename T::struct_type* AllocateOutputData(size_t len, const typename T::struct_type& init)
     {
         output_len_  = len;
-        output_data_ = std::make_unique<typename T::struct_type[]>(len);
+        output_data_ = DecodeAllocator::Allocate<typename T::struct_type>(len);
 
         for (size_t i = 0; i < len; ++i)
         {
             output_data_[i] = init;
         }
 
-        return output_data_.get();
+        return output_data_;
     }
 
     void SetExternalMemory(typename T::struct_type* data, size_t capacity)
@@ -121,7 +109,7 @@ class StructPointerDecoder : public PointerDecoderBase
             {
                 assert(struct_memory_ == nullptr);
 
-                struct_memory_ = new typename T::struct_type[len];
+                struct_memory_ = DecodeAllocator::Allocate<typename T::struct_type>(len);
                 capacity_      = len;
             }
             else
@@ -138,12 +126,12 @@ class StructPointerDecoder : public PointerDecoderBase
                                          len);
 
                     is_memory_external_ = false;
-                    struct_memory_      = new typename T::struct_type[len];
+                    struct_memory_      = DecodeAllocator::Allocate<typename T::struct_type>(len);
                     capacity_           = len;
                 }
             }
 
-            decoded_structs_ = new T[len];
+            decoded_structs_ = DecodeAllocator::Allocate<T>(len);
 
             if (HasData())
             {
@@ -173,8 +161,8 @@ class StructPointerDecoder : public PointerDecoderBase
     /// Optional memory allocated for output pramaters when retrieving data from a function call. Allows both the data
     /// read from the file and the data retrieved from an API call to exist simultaneously, allowing the values to be
     /// compared.
-    std::unique_ptr<typename T::struct_type[]> output_data_;
-    size_t                                     output_len_; ///< Size of #output_data_.
+    typename T::struct_type* output_data_{ nullptr };
+    size_t                   output_len_; ///< Size of #output_data_.
 };
 
 template <typename T>
@@ -182,29 +170,6 @@ class StructPointerDecoder<T*> : public PointerDecoderBase
 {
   public:
     StructPointerDecoder() : decoded_structs_(nullptr), struct_memory_(nullptr) {}
-
-    virtual ~StructPointerDecoder() override
-    {
-        if ((struct_memory_ != nullptr))
-        {
-            for (size_t i = 0; i < GetLength(); ++i)
-            {
-                delete[] struct_memory_[i];
-                struct_memory_[i] = nullptr;
-            }
-            delete[] struct_memory_;
-        }
-
-        if (decoded_structs_ != nullptr)
-        {
-            for (size_t i = 0; i < GetLength(); ++i)
-            {
-                delete[] decoded_structs_[i];
-                decoded_structs_[i] = nullptr;
-            }
-            delete[] decoded_structs_;
-        }
-    }
 
     T** GetMetaStructPointer() { return decoded_structs_; }
 
@@ -227,8 +192,8 @@ class StructPointerDecoder<T*> : public PointerDecoderBase
             assert(struct_memory_ == nullptr);
 
             size_t len       = GetLength();
-            struct_memory_   = new typename T::struct_type*[len];
-            decoded_structs_ = new T*[len];
+            struct_memory_   = DecodeAllocator::Allocate<typename T::struct_type*>(len, false);
+            decoded_structs_ = DecodeAllocator::Allocate<T*>(len, false);
 
             for (size_t i = 0; i < len; ++i)
             {
@@ -251,8 +216,9 @@ class StructPointerDecoder<T*> : public PointerDecoderBase
                     bytes_read +=
                         ValueDecoder::DecodeSizeTValue((buffer + bytes_read), (buffer_size - bytes_read), &inner_len);
 
-                    typename T::struct_type* inner_struct_memory   = new typename T::struct_type[inner_len];
-                    T*                       inner_decoded_structs = new T[inner_len];
+                    typename T::struct_type* inner_struct_memory =
+                        DecodeAllocator::Allocate<typename T::struct_type>(inner_len);
+                    T* inner_decoded_structs = DecodeAllocator::Allocate<T>(inner_len);
 
                     for (size_t j = 0; j < inner_len; ++j)
                     {

--- a/framework/decode/vulkan_referenced_resource_consumer_base.cpp
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.cpp
@@ -360,7 +360,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkUpdateDescriptorSets(
                 case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
                 case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
                 {
-                    const auto image_info = meta_writes->pImageInfo.get();
+                    const auto image_info = meta_writes->pImageInfo;
                     assert(image_info != nullptr);
 
                     if (!image_info->IsNull() && image_info->HasData())
@@ -379,7 +379,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkUpdateDescriptorSets(
                 case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
                 case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
                 {
-                    const auto buffer_info = meta_writes->pBufferInfo.get();
+                    const auto buffer_info = meta_writes->pBufferInfo;
                     assert(buffer_info != nullptr);
 
                     if (!buffer_info->IsNull() && buffer_info->HasData())

--- a/framework/generated/generated_decode_pnext_struct.cpp
+++ b/framework/generated/generated_decode_pnext_struct.cpp
@@ -27,6 +27,7 @@
 */
 
 #include "decode/custom_vulkan_struct_decoders.h"
+#include "decode/decode_allocator.h"
 #include "decode/pnext_node.h"
 #include "decode/pnext_typed_node.h"
 #include "generated/generated_vulkan_struct_decoders.h"
@@ -37,7 +38,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-size_t DecodePNextStruct(const uint8_t* parameter_buffer, size_t buffer_size,  std::unique_ptr<PNextNode>* pNext)
+size_t DecodePNextStruct(const uint8_t* parameter_buffer, size_t buffer_size,  PNextNode** pNext)
 {
     assert(pNext != nullptr);
 
@@ -73,1051 +74,1051 @@ size_t DecodePNextStruct(const uint8_t* parameter_buffer, size_t buffer_size,  s
                 GFXRECON_LOG_ERROR("Failed to decode pNext value with unrecognized VkStructurType = %d", (*sType));
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceSubgroupProperties>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceSubgroupProperties>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDevice16BitStorageFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDevice16BitStorageFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkMemoryDedicatedRequirements>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkMemoryDedicatedRequirements>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkMemoryDedicatedAllocateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkMemoryDedicatedAllocateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkMemoryAllocateFlagsInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkMemoryAllocateFlagsInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEVICE_GROUP_RENDER_PASS_BEGIN_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDeviceGroupRenderPassBeginInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDeviceGroupRenderPassBeginInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEVICE_GROUP_COMMAND_BUFFER_BEGIN_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDeviceGroupCommandBufferBeginInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDeviceGroupCommandBufferBeginInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEVICE_GROUP_SUBMIT_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDeviceGroupSubmitInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDeviceGroupSubmitInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEVICE_GROUP_BIND_SPARSE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDeviceGroupBindSparseInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDeviceGroupBindSparseInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_DEVICE_GROUP_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkBindBufferMemoryDeviceGroupInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkBindBufferMemoryDeviceGroupInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_DEVICE_GROUP_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkBindImageMemoryDeviceGroupInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkBindImageMemoryDeviceGroupInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDeviceGroupDeviceCreateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDeviceGroupDeviceCreateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceFeatures2>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceFeatures2>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_POINT_CLIPPING_PROPERTIES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDevicePointClippingProperties>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDevicePointClippingProperties>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkRenderPassInputAttachmentAspectCreateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkRenderPassInputAttachmentAspectCreateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkImageViewUsageCreateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkImageViewUsageCreateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineTessellationDomainOriginStateCreateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineTessellationDomainOriginStateCreateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkRenderPassMultiviewCreateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkRenderPassMultiviewCreateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceMultiviewFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceMultiviewFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceMultiviewProperties>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceMultiviewProperties>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceVariablePointersFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceVariablePointersFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceProtectedMemoryFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceProtectedMemoryFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_PROPERTIES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceProtectedMemoryProperties>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceProtectedMemoryProperties>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PROTECTED_SUBMIT_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkProtectedSubmitInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkProtectedSubmitInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkSamplerYcbcrConversionInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkSamplerYcbcrConversionInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_BIND_IMAGE_PLANE_MEMORY_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkBindImagePlaneMemoryInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkBindImagePlaneMemoryInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_IMAGE_PLANE_MEMORY_REQUIREMENTS_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkImagePlaneMemoryRequirementsInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkImagePlaneMemoryRequirementsInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceSamplerYcbcrConversionFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceSamplerYcbcrConversionFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkSamplerYcbcrConversionImageFormatProperties>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkSamplerYcbcrConversionImageFormatProperties>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceExternalImageFormatInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceExternalImageFormatInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkExternalImageFormatProperties>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkExternalImageFormatProperties>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceIDProperties>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceIDProperties>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkExternalMemoryImageCreateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkExternalMemoryImageCreateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkExternalMemoryBufferCreateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkExternalMemoryBufferCreateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkExportMemoryAllocateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkExportMemoryAllocateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkExportFenceCreateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkExportFenceCreateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkExportSemaphoreCreateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkExportSemaphoreCreateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceMaintenance3Properties>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceMaintenance3Properties>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShaderDrawParametersFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShaderDrawParametersFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceVulkan11Features>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceVulkan11Features>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceVulkan11Properties>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceVulkan11Properties>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceVulkan12Features>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceVulkan12Features>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceVulkan12Properties>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceVulkan12Properties>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkImageFormatListCreateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkImageFormatListCreateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDevice8BitStorageFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDevice8BitStorageFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceDriverProperties>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceDriverProperties>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShaderAtomicInt64Features>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShaderAtomicInt64Features>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShaderFloat16Int8Features>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShaderFloat16Int8Features>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceFloatControlsProperties>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceFloatControlsProperties>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDescriptorSetLayoutBindingFlagsCreateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDescriptorSetLayoutBindingFlagsCreateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceDescriptorIndexingFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceDescriptorIndexingFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceDescriptorIndexingProperties>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceDescriptorIndexingProperties>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDescriptorSetVariableDescriptorCountAllocateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDescriptorSetVariableDescriptorCountAllocateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDescriptorSetVariableDescriptorCountLayoutSupport>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDescriptorSetVariableDescriptorCountLayoutSupport>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkSubpassDescriptionDepthStencilResolve>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkSubpassDescriptionDepthStencilResolve>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceDepthStencilResolveProperties>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceDepthStencilResolveProperties>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceScalarBlockLayoutFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceScalarBlockLayoutFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_IMAGE_STENCIL_USAGE_CREATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkImageStencilUsageCreateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkImageStencilUsageCreateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkSamplerReductionModeCreateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkSamplerReductionModeCreateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceSamplerFilterMinmaxProperties>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceSamplerFilterMinmaxProperties>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceVulkanMemoryModelFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceVulkanMemoryModelFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceImagelessFramebufferFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceImagelessFramebufferFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_FRAMEBUFFER_ATTACHMENTS_CREATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkFramebufferAttachmentsCreateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkFramebufferAttachmentsCreateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_RENDER_PASS_ATTACHMENT_BEGIN_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkRenderPassAttachmentBeginInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkRenderPassAttachmentBeginInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceUniformBufferStandardLayoutFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceUniformBufferStandardLayoutFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_STENCIL_LAYOUT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkAttachmentReferenceStencilLayout>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkAttachmentReferenceStencilLayout>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkAttachmentDescriptionStencilLayout>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkAttachmentDescriptionStencilLayout>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceHostQueryResetFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceHostQueryResetFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceTimelineSemaphoreFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceTimelineSemaphoreFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceTimelineSemaphoreProperties>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceTimelineSemaphoreProperties>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkSemaphoreTypeCreateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkSemaphoreTypeCreateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkTimelineSemaphoreSubmitInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkTimelineSemaphoreSubmitInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceBufferDeviceAddressFeatures>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceBufferDeviceAddressFeatures>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_BUFFER_OPAQUE_CAPTURE_ADDRESS_CREATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkBufferOpaqueCaptureAddressCreateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkBufferOpaqueCaptureAddressCreateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkMemoryOpaqueCaptureAddressAllocateInfo>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkMemoryOpaqueCaptureAddressAllocateInfo>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_IMAGE_SWAPCHAIN_CREATE_INFO_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkImageSwapchainCreateInfoKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkImageSwapchainCreateInfoKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkBindImageMemorySwapchainInfoKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkBindImageMemorySwapchainInfoKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_INFO_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDeviceGroupPresentInfoKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDeviceGroupPresentInfoKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEVICE_GROUP_SWAPCHAIN_CREATE_INFO_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDeviceGroupSwapchainCreateInfoKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDeviceGroupSwapchainCreateInfoKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DISPLAY_PRESENT_INFO_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDisplayPresentInfoKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDisplayPresentInfoKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkImportMemoryWin32HandleInfoKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkImportMemoryWin32HandleInfoKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkExportMemoryWin32HandleInfoKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkExportMemoryWin32HandleInfoKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkImportMemoryFdInfoKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkImportMemoryFdInfoKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkExportSemaphoreWin32HandleInfoKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkExportSemaphoreWin32HandleInfoKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkD3D12FenceSubmitInfoKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkD3D12FenceSubmitInfoKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDevicePushDescriptorPropertiesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDevicePushDescriptorPropertiesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPresentRegionsKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPresentRegionsKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkSharedPresentSurfaceCapabilitiesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkSharedPresentSurfaceCapabilitiesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_EXPORT_FENCE_WIN32_HANDLE_INFO_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkExportFenceWin32HandleInfoKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkExportFenceWin32HandleInfoKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDevicePerformanceQueryFeaturesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDevicePerformanceQueryFeaturesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_PROPERTIES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDevicePerformanceQueryPropertiesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDevicePerformanceQueryPropertiesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_CREATE_INFO_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkQueryPoolPerformanceCreateInfoKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkQueryPoolPerformanceCreateInfoKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PERFORMANCE_QUERY_SUBMIT_INFO_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPerformanceQuerySubmitInfoKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPerformanceQuerySubmitInfoKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDevicePortabilitySubsetFeaturesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDevicePortabilitySubsetFeaturesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDevicePortabilitySubsetPropertiesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDevicePortabilitySubsetPropertiesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShaderClockFeaturesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShaderClockFeaturesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkFragmentShadingRateAttachmentInfoKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkFragmentShadingRateAttachmentInfoKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_SHADING_RATE_STATE_CREATE_INFO_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineFragmentShadingRateStateCreateInfoKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineFragmentShadingRateStateCreateInfoKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentShadingRateFeaturesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentShadingRateFeaturesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_PROPERTIES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentShadingRatePropertiesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentShadingRatePropertiesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_SURFACE_PROTECTED_CAPABILITIES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkSurfaceProtectedCapabilitiesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkSurfaceProtectedCapabilitiesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDebugReportCallbackCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDebugReportCallbackCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineRasterizationStateRasterizationOrderAMD>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineRasterizationStateRasterizationOrderAMD>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDedicatedAllocationImageCreateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDedicatedAllocationImageCreateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDedicatedAllocationBufferCreateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDedicatedAllocationBufferCreateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDedicatedAllocationMemoryAllocateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDedicatedAllocationMemoryAllocateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceTransformFeedbackFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceTransformFeedbackFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkTextureLODGatherFormatPropertiesAMD>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkTextureLODGatherFormatPropertiesAMD>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceCornerSampledImageFeaturesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceCornerSampledImageFeaturesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkExternalMemoryImageCreateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkExternalMemoryImageCreateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkExportMemoryAllocateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkExportMemoryAllocateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkImportMemoryWin32HandleInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkImportMemoryWin32HandleInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkExportMemoryWin32HandleInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkExportMemoryWin32HandleInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkValidationFlagsEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkValidationFlagsEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_IMAGE_VIEW_ASTC_DECODE_MODE_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkImageViewASTCDecodeModeEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkImageViewASTCDecodeModeEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceASTCDecodeFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceASTCDecodeFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceConditionalRenderingFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceConditionalRenderingFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_CONDITIONAL_RENDERING_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkCommandBufferInheritanceConditionalRenderingInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkCommandBufferInheritanceConditionalRenderingInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_W_SCALING_STATE_CREATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineViewportWScalingStateCreateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineViewportWScalingStateCreateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_SWAPCHAIN_COUNTER_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkSwapchainCounterCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkSwapchainCounterCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPresentTimesInfoGOOGLE>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPresentTimesInfoGOOGLE>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineViewportSwizzleStateCreateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineViewportSwizzleStateCreateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceDiscardRectanglePropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceDiscardRectanglePropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_DEPTH_CLIP_STATE_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDebugUtilsMessengerCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDebugUtilsMessengerCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkAndroidHardwareBufferUsageANDROID>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkAndroidHardwareBufferUsageANDROID>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkAndroidHardwareBufferFormatPropertiesANDROID>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkAndroidHardwareBufferFormatPropertiesANDROID>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkImportAndroidHardwareBufferInfoANDROID>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkImportAndroidHardwareBufferInfoANDROID>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkExternalFormatANDROID>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkExternalFormatANDROID>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceInlineUniformBlockFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceInlineUniformBlockFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceInlineUniformBlockPropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceInlineUniformBlockPropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkWriteDescriptorSetInlineUniformBlockEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkWriteDescriptorSetInlineUniformBlockEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDescriptorPoolInlineUniformBlockCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDescriptorPoolInlineUniformBlockCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkSampleLocationsInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkSampleLocationsInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_RENDER_PASS_SAMPLE_LOCATIONS_BEGIN_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkRenderPassSampleLocationsBeginInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkRenderPassSampleLocationsBeginInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_SAMPLE_LOCATIONS_STATE_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineSampleLocationsStateCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineSampleLocationsStateCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceSampleLocationsPropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceSampleLocationsPropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineColorBlendAdvancedStateCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineColorBlendAdvancedStateCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_TO_COLOR_STATE_CREATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineCoverageToColorStateCreateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineCoverageToColorStateCreateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_MODULATION_STATE_CREATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineCoverageModulationStateCreateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineCoverageModulationStateCreateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_PROPERTIES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShaderSMBuiltinsPropertiesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShaderSMBuiltinsPropertiesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_FEATURES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShaderSMBuiltinsFeaturesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShaderSMBuiltinsFeaturesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDrmFormatModifierPropertiesListEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDrmFormatModifierPropertiesListEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_DRM_FORMAT_MODIFIER_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceImageDrmFormatModifierInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceImageDrmFormatModifierInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkImageDrmFormatModifierListCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkImageDrmFormatModifierListCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_EXPLICIT_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkImageDrmFormatModifierExplicitCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkImageDrmFormatModifierExplicitCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkShaderModuleValidationCacheCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkShaderModuleValidationCacheCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SHADING_RATE_IMAGE_STATE_CREATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineViewportShadingRateImageStateCreateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineViewportShadingRateImageStateCreateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_FEATURES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShadingRateImageFeaturesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShadingRateImageFeaturesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_PROPERTIES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShadingRateImagePropertiesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShadingRateImagePropertiesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_COARSE_SAMPLE_ORDER_STATE_CREATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkWriteDescriptorSetAccelerationStructureNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkWriteDescriptorSetAccelerationStructureNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PROPERTIES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceRayTracingPropertiesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceRayTracingPropertiesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_REPRESENTATIVE_FRAGMENT_TEST_STATE_CREATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_IMAGE_FORMAT_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_FILTER_CUBIC_IMAGE_VIEW_IMAGE_FORMAT_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_IMPORT_MEMORY_HOST_POINTER_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkImportMemoryHostPointerInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkImportMemoryHostPointerInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceExternalMemoryHostPropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceExternalMemoryHostPropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_COMPILER_CONTROL_CREATE_INFO_AMD:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineCompilerControlCreateInfoAMD>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineCompilerControlCreateInfoAMD>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_AMD:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShaderCorePropertiesAMD>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShaderCorePropertiesAMD>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEVICE_MEMORY_OVERALLOCATION_CREATE_INFO_AMD:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDeviceMemoryOverallocationCreateInfoAMD>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDeviceMemoryOverallocationCreateInfoAMD>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineVertexInputDivisorStateCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineVertexInputDivisorStateCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PRESENT_FRAME_TOKEN_GGP:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPresentFrameTokenGGP>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPresentFrameTokenGGP>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_CREATION_FEEDBACK_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineCreationFeedbackCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineCreationFeedbackCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceMeshShaderFeaturesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceMeshShaderFeaturesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceMeshShaderPropertiesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceMeshShaderPropertiesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShaderImageFootprintFeaturesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShaderImageFootprintFeaturesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_EXCLUSIVE_SCISSOR_STATE_CREATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineViewportExclusiveScissorStateCreateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineViewportExclusiveScissorStateCreateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceExclusiveScissorFeaturesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceExclusiveScissorFeaturesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkQueueFamilyCheckpointPropertiesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkQueueFamilyCheckpointPropertiesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_QUERY_CREATE_INFO_INTEL:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkQueryPoolPerformanceQueryCreateInfoINTEL>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkQueryPoolPerformanceQueryCreateInfoINTEL>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDevicePCIBusInfoPropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDevicePCIBusInfoPropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DISPLAY_NATIVE_HDR_SURFACE_CAPABILITIES_AMD:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDisplayNativeHdrSurfaceCapabilitiesAMD>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDisplayNativeHdrSurfaceCapabilitiesAMD>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_SWAPCHAIN_DISPLAY_NATIVE_HDR_CREATE_INFO_AMD:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkSwapchainDisplayNativeHdrCreateInfoAMD>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkSwapchainDisplayNativeHdrCreateInfoAMD>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceSubgroupSizeControlFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceSubgroupSizeControlFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceSubgroupSizeControlPropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceSubgroupSizeControlPropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_2_AMD:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShaderCoreProperties2AMD>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShaderCoreProperties2AMD>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceCoherentMemoryFeaturesAMD>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceCoherentMemoryFeaturesAMD>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceMemoryBudgetPropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceMemoryBudgetPropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceMemoryPriorityFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceMemoryPriorityFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkMemoryPriorityAllocateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkMemoryPriorityAllocateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceBufferDeviceAddressFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceBufferDeviceAddressFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkBufferDeviceAddressCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkBufferDeviceAddressCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkValidationFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkValidationFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceCoverageReductionModeFeaturesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceCoverageReductionModeFeaturesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_REDUCTION_STATE_CREATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineCoverageReductionStateCreateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineCoverageReductionStateCreateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkSurfaceFullScreenExclusiveInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkSurfaceFullScreenExclusiveInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_FULL_SCREEN_EXCLUSIVE_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkSurfaceCapabilitiesFullScreenExclusiveEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkSurfaceCapabilitiesFullScreenExclusiveEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkSurfaceFullScreenExclusiveWin32InfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkSurfaceFullScreenExclusiveWin32InfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceLineRasterizationFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceLineRasterizationFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceLineRasterizationPropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceLineRasterizationPropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineRasterizationLineStateCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineRasterizationLineStateCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceIndexTypeUint8FeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceIndexTypeUint8FeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_SHADER_GROUPS_CREATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkGraphicsPipelineShaderGroupsCreateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkGraphicsPipelineShaderGroupsCreateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_RENDER_PASS_TRANSFORM_BEGIN_INFO_QCOM:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkRenderPassTransformBeginInfoQCOM>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkRenderPassTransformBeginInfoQCOM>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_RENDER_PASS_TRANSFORM_INFO_QCOM:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkCommandBufferInheritanceRenderPassTransformInfoQCOM>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkCommandBufferInheritanceRenderPassTransformInfoQCOM>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_MEMORY_REPORT_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEVICE_DEVICE_MEMORY_REPORT_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDeviceDeviceMemoryReportCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDeviceDeviceMemoryReportCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceRobustness2FeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceRobustness2FeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceRobustness2PropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceRobustness2PropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkSamplerCustomBorderColorCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkSamplerCustomBorderColorCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceCustomBorderColorPropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceCustomBorderColorPropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceCustomBorderColorFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceCustomBorderColorFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDevicePrivateDataFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDevicePrivateDataFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEVICE_PRIVATE_DATA_CREATE_INFO_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDevicePrivateDataCreateInfoEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDevicePrivateDataCreateInfoEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DIAGNOSTICS_CONFIG_FEATURES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceDiagnosticsConfigFeaturesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceDiagnosticsConfigFeaturesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_DEVICE_DIAGNOSTICS_CONFIG_CREATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkDeviceDiagnosticsConfigCreateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkDeviceDiagnosticsConfigCreateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_FEATURES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_PROPERTIES_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_SHADING_RATE_ENUM_STATE_CREATE_INFO_NV:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPipelineFragmentShadingRateEnumStateCreateInfoNV>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPipelineFragmentShadingRateEnumStateCreateInfoNV>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentDensityMap2FeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentDensityMap2FeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_PROPERTIES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentDensityMap2PropertiesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceFragmentDensityMap2PropertiesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_COPY_COMMAND_TRANSFORM_INFO_QCOM:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkCopyCommandTransformInfoQCOM>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkCopyCommandTransformInfoQCOM>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceImageRobustnessFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceImageRobustnessFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDevice4444FormatsFeaturesEXT>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDevice4444FormatsFeaturesEXT>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkWriteDescriptorSetAccelerationStructureKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkWriteDescriptorSetAccelerationStructureKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceAccelerationStructureFeaturesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceAccelerationStructureFeaturesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceAccelerationStructurePropertiesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceAccelerationStructurePropertiesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceRayTracingPipelineFeaturesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceRayTracingPipelineFeaturesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceRayTracingPipelinePropertiesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceRayTracingPipelinePropertiesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR:
-                (*pNext) = std::make_unique<PNextTypedNode<Decoded_VkPhysicalDeviceRayQueryFeaturesKHR>>();
+                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_VkPhysicalDeviceRayQueryFeaturesKHR>>();
                 bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);
                 break;
             }

--- a/framework/generated/generated_vulkan_struct_decoders.cpp
+++ b/framework/generated/generated_vulkan_struct_decoders.cpp
@@ -29,6 +29,7 @@
 #include "generated/generated_vulkan_struct_decoders.h"
 
 #include "decode/custom_vulkan_struct_decoders.h"
+#include "decode/decode_allocator.h"
 
 #include <cassert>
 
@@ -98,12 +99,12 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRect2D*
     size_t bytes_read = 0;
     VkRect2D* value = wrapper->decoded_value;
 
-    wrapper->offset = std::make_unique<Decoded_VkOffset2D>();
+    wrapper->offset = DecodeAllocator::Allocate<Decoded_VkOffset2D>();
     wrapper->offset->decoded_value = &(value->offset);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->offset.get());
-    wrapper->extent = std::make_unique<Decoded_VkExtent2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->offset);
+    wrapper->extent = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->extent->decoded_value = &(value->extent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->extent.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->extent);
 
     return bytes_read;
 }
@@ -209,9 +210,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageMe
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->dstQueueFamilyIndex));
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->image));
     value->image = VK_NULL_HANDLE;
-    wrapper->subresourceRange = std::make_unique<Decoded_VkImageSubresourceRange>();
+    wrapper->subresourceRange = DecodeAllocator::Allocate<Decoded_VkImageSubresourceRange>();
     wrapper->subresourceRange->decoded_value = &(value->subresourceRange);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->subresourceRange.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->subresourceRange);
 
     return bytes_read;
 }
@@ -297,9 +298,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageFo
     size_t bytes_read = 0;
     VkImageFormatProperties* value = wrapper->decoded_value;
 
-    wrapper->maxExtent = std::make_unique<Decoded_VkExtent3D>();
+    wrapper->maxExtent = DecodeAllocator::Allocate<Decoded_VkExtent3D>();
     wrapper->maxExtent->decoded_value = &(value->maxExtent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxExtent.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxExtent);
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxMipLevels));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxArrayLayers));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleCounts));
@@ -319,7 +320,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkInstanc
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
-    wrapper->pApplicationInfo = std::make_unique<StructPointerDecoder<Decoded_VkApplicationInfo>>();
+    wrapper->pApplicationInfo = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkApplicationInfo>>();
     bytes_read += wrapper->pApplicationInfo->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pApplicationInfo = wrapper->pApplicationInfo->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->enabledLayerCount));
@@ -555,11 +556,11 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysica
     VkPhysicalDeviceMemoryProperties* value = wrapper->decoded_value;
 
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->memoryTypeCount));
-    wrapper->memoryTypes = std::make_unique<StructPointerDecoder<Decoded_VkMemoryType>>();
+    wrapper->memoryTypes = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkMemoryType>>();
     wrapper->memoryTypes->SetExternalMemory(value->memoryTypes, VK_MAX_MEMORY_TYPES);
     bytes_read += wrapper->memoryTypes->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->memoryHeapCount));
-    wrapper->memoryHeaps = std::make_unique<StructPointerDecoder<Decoded_VkMemoryHeap>>();
+    wrapper->memoryHeaps = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkMemoryHeap>>();
     wrapper->memoryHeaps->SetExternalMemory(value->memoryHeaps, VK_MAX_MEMORY_HEAPS);
     bytes_read += wrapper->memoryHeaps->Decode((buffer + bytes_read), (buffer_size - bytes_read));
 
@@ -598,12 +599,12 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysica
     bytes_read += wrapper->deviceName.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     wrapper->pipelineCacheUUID.SetExternalMemory(value->pipelineCacheUUID, VK_UUID_SIZE);
     bytes_read += wrapper->pipelineCacheUUID.DecodeUInt8((buffer + bytes_read), (buffer_size - bytes_read));
-    wrapper->limits = std::make_unique<Decoded_VkPhysicalDeviceLimits>();
+    wrapper->limits = DecodeAllocator::Allocate<Decoded_VkPhysicalDeviceLimits>();
     wrapper->limits->decoded_value = &(value->limits);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->limits.get());
-    wrapper->sparseProperties = std::make_unique<Decoded_VkPhysicalDeviceSparseProperties>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->limits);
+    wrapper->sparseProperties = DecodeAllocator::Allocate<Decoded_VkPhysicalDeviceSparseProperties>();
     wrapper->sparseProperties->decoded_value = &(value->sparseProperties);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->sparseProperties.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->sparseProperties);
 
     return bytes_read;
 }
@@ -618,9 +619,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkQueueFa
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->queueFlags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->queueCount));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->timestampValidBits));
-    wrapper->minImageTransferGranularity = std::make_unique<Decoded_VkExtent3D>();
+    wrapper->minImageTransferGranularity = DecodeAllocator::Allocate<Decoded_VkExtent3D>();
     wrapper->minImageTransferGranularity->decoded_value = &(value->minImageTransferGranularity);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minImageTransferGranularity.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minImageTransferGranularity);
 
     return bytes_read;
 }
@@ -656,7 +657,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceC
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->queueCreateInfoCount));
-    wrapper->pQueueCreateInfos = std::make_unique<StructPointerDecoder<Decoded_VkDeviceQueueCreateInfo>>();
+    wrapper->pQueueCreateInfos = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkDeviceQueueCreateInfo>>();
     bytes_read += wrapper->pQueueCreateInfos->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pQueueCreateInfos = wrapper->pQueueCreateInfos->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->enabledLayerCount));
@@ -665,7 +666,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceC
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->enabledExtensionCount));
     bytes_read += wrapper->ppEnabledExtensionNames.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->ppEnabledExtensionNames = wrapper->ppEnabledExtensionNames.GetPointer();
-    wrapper->pEnabledFeatures = std::make_unique<StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures>>();
+    wrapper->pEnabledFeatures = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures>>();
     bytes_read += wrapper->pEnabledFeatures->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pEnabledFeatures = wrapper->pEnabledFeatures->GetPointer();
 
@@ -803,7 +804,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseB
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->buffer));
     value->buffer = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->bindCount));
-    wrapper->pBinds = std::make_unique<StructPointerDecoder<Decoded_VkSparseMemoryBind>>();
+    wrapper->pBinds = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkSparseMemoryBind>>();
     bytes_read += wrapper->pBinds->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pBinds = wrapper->pBinds->GetPointer();
 
@@ -820,7 +821,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseI
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->image));
     value->image = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->bindCount));
-    wrapper->pBinds = std::make_unique<StructPointerDecoder<Decoded_VkSparseMemoryBind>>();
+    wrapper->pBinds = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkSparseMemoryBind>>();
     bytes_read += wrapper->pBinds->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pBinds = wrapper->pBinds->GetPointer();
 
@@ -848,15 +849,15 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseI
     size_t bytes_read = 0;
     VkSparseImageMemoryBind* value = wrapper->decoded_value;
 
-    wrapper->subresource = std::make_unique<Decoded_VkImageSubresource>();
+    wrapper->subresource = DecodeAllocator::Allocate<Decoded_VkImageSubresource>();
     wrapper->subresource->decoded_value = &(value->subresource);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->subresource.get());
-    wrapper->offset = std::make_unique<Decoded_VkOffset3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->subresource);
+    wrapper->offset = DecodeAllocator::Allocate<Decoded_VkOffset3D>();
     wrapper->offset->decoded_value = &(value->offset);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->offset.get());
-    wrapper->extent = std::make_unique<Decoded_VkExtent3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->offset);
+    wrapper->extent = DecodeAllocator::Allocate<Decoded_VkExtent3D>();
     wrapper->extent->decoded_value = &(value->extent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->extent.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->extent);
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->memory));
     value->memory = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->memoryOffset));
@@ -875,7 +876,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseI
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->image));
     value->image = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->bindCount));
-    wrapper->pBinds = std::make_unique<StructPointerDecoder<Decoded_VkSparseImageMemoryBind>>();
+    wrapper->pBinds = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkSparseImageMemoryBind>>();
     bytes_read += wrapper->pBinds->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pBinds = wrapper->pBinds->GetPointer();
 
@@ -896,15 +897,15 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindSpa
     bytes_read += wrapper->pWaitSemaphores.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pWaitSemaphores = nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->bufferBindCount));
-    wrapper->pBufferBinds = std::make_unique<StructPointerDecoder<Decoded_VkSparseBufferMemoryBindInfo>>();
+    wrapper->pBufferBinds = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkSparseBufferMemoryBindInfo>>();
     bytes_read += wrapper->pBufferBinds->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pBufferBinds = wrapper->pBufferBinds->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageOpaqueBindCount));
-    wrapper->pImageOpaqueBinds = std::make_unique<StructPointerDecoder<Decoded_VkSparseImageOpaqueMemoryBindInfo>>();
+    wrapper->pImageOpaqueBinds = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkSparseImageOpaqueMemoryBindInfo>>();
     bytes_read += wrapper->pImageOpaqueBinds->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pImageOpaqueBinds = wrapper->pImageOpaqueBinds->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageBindCount));
-    wrapper->pImageBinds = std::make_unique<StructPointerDecoder<Decoded_VkSparseImageMemoryBindInfo>>();
+    wrapper->pImageBinds = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkSparseImageMemoryBindInfo>>();
     bytes_read += wrapper->pImageBinds->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pImageBinds = wrapper->pImageBinds->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->signalSemaphoreCount));
@@ -922,9 +923,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseI
     VkSparseImageFormatProperties* value = wrapper->decoded_value;
 
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->aspectMask));
-    wrapper->imageGranularity = std::make_unique<Decoded_VkExtent3D>();
+    wrapper->imageGranularity = DecodeAllocator::Allocate<Decoded_VkExtent3D>();
     wrapper->imageGranularity->decoded_value = &(value->imageGranularity);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageGranularity.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageGranularity);
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
 
     return bytes_read;
@@ -937,9 +938,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseI
     size_t bytes_read = 0;
     VkSparseImageMemoryRequirements* value = wrapper->decoded_value;
 
-    wrapper->formatProperties = std::make_unique<Decoded_VkSparseImageFormatProperties>();
+    wrapper->formatProperties = DecodeAllocator::Allocate<Decoded_VkSparseImageFormatProperties>();
     wrapper->formatProperties->decoded_value = &(value->formatProperties);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->formatProperties.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->formatProperties);
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageMipTailFirstLod));
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageMipTailSize));
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageMipTailOffset));
@@ -1065,9 +1066,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageCr
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageType));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->format));
-    wrapper->extent = std::make_unique<Decoded_VkExtent3D>();
+    wrapper->extent = DecodeAllocator::Allocate<Decoded_VkExtent3D>();
     wrapper->extent->decoded_value = &(value->extent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->extent.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->extent);
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->mipLevels));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->arrayLayers));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->samples));
@@ -1128,12 +1129,12 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageVi
     value->image = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->viewType));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->format));
-    wrapper->components = std::make_unique<Decoded_VkComponentMapping>();
+    wrapper->components = DecodeAllocator::Allocate<Decoded_VkComponentMapping>();
     wrapper->components->decoded_value = &(value->components);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->components.get());
-    wrapper->subresourceRange = std::make_unique<Decoded_VkImageSubresourceRange>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->components);
+    wrapper->subresourceRange = DecodeAllocator::Allocate<Decoded_VkImageSubresourceRange>();
     wrapper->subresourceRange->decoded_value = &(value->subresourceRange);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->subresourceRange.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->subresourceRange);
 
     return bytes_read;
 }
@@ -1196,7 +1197,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSpecial
     VkSpecializationInfo* value = wrapper->decoded_value;
 
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->mapEntryCount));
-    wrapper->pMapEntries = std::make_unique<StructPointerDecoder<Decoded_VkSpecializationMapEntry>>();
+    wrapper->pMapEntries = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkSpecializationMapEntry>>();
     bytes_read += wrapper->pMapEntries->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pMapEntries = wrapper->pMapEntries->GetPointer();
     bytes_read += ValueDecoder::DecodeSizeTValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->dataSize));
@@ -1222,7 +1223,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     value->module = VK_NULL_HANDLE;
     bytes_read += wrapper->pName.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pName = wrapper->pName.GetPointer();
-    wrapper->pSpecializationInfo = std::make_unique<StructPointerDecoder<Decoded_VkSpecializationInfo>>();
+    wrapper->pSpecializationInfo = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkSpecializationInfo>>();
     bytes_read += wrapper->pSpecializationInfo->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pSpecializationInfo = wrapper->pSpecializationInfo->GetPointer();
 
@@ -1240,9 +1241,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCompute
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
-    wrapper->stage = std::make_unique<Decoded_VkPipelineShaderStageCreateInfo>();
+    wrapper->stage = DecodeAllocator::Allocate<Decoded_VkPipelineShaderStageCreateInfo>();
     wrapper->stage->decoded_value = &(value->stage);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->stage.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->stage);
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->layout));
     value->layout = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->basePipelineHandle));
@@ -1293,11 +1294,11 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->vertexBindingDescriptionCount));
-    wrapper->pVertexBindingDescriptions = std::make_unique<StructPointerDecoder<Decoded_VkVertexInputBindingDescription>>();
+    wrapper->pVertexBindingDescriptions = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkVertexInputBindingDescription>>();
     bytes_read += wrapper->pVertexBindingDescriptions->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pVertexBindingDescriptions = wrapper->pVertexBindingDescriptions->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->vertexAttributeDescriptionCount));
-    wrapper->pVertexAttributeDescriptions = std::make_unique<StructPointerDecoder<Decoded_VkVertexInputAttributeDescription>>();
+    wrapper->pVertexAttributeDescriptions = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkVertexInputAttributeDescription>>();
     bytes_read += wrapper->pVertexAttributeDescriptions->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pVertexAttributeDescriptions = wrapper->pVertexAttributeDescriptions->GetPointer();
 
@@ -1366,11 +1367,11 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->viewportCount));
-    wrapper->pViewports = std::make_unique<StructPointerDecoder<Decoded_VkViewport>>();
+    wrapper->pViewports = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkViewport>>();
     bytes_read += wrapper->pViewports->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pViewports = wrapper->pViewports->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->scissorCount));
-    wrapper->pScissors = std::make_unique<StructPointerDecoder<Decoded_VkRect2D>>();
+    wrapper->pScissors = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkRect2D>>();
     bytes_read += wrapper->pScissors->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pScissors = wrapper->pScissors->GetPointer();
 
@@ -1458,12 +1459,12 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->depthCompareOp));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->depthBoundsTestEnable));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->stencilTestEnable));
-    wrapper->front = std::make_unique<Decoded_VkStencilOpState>();
+    wrapper->front = DecodeAllocator::Allocate<Decoded_VkStencilOpState>();
     wrapper->front->decoded_value = &(value->front);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->front.get());
-    wrapper->back = std::make_unique<Decoded_VkStencilOpState>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->front);
+    wrapper->back = DecodeAllocator::Allocate<Decoded_VkStencilOpState>();
     wrapper->back->decoded_value = &(value->back);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->back.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->back);
     bytes_read += ValueDecoder::DecodeFloatValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->minDepthBounds));
     bytes_read += ValueDecoder::DecodeFloatValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxDepthBounds));
 
@@ -1503,7 +1504,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->logicOpEnable));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->logicOp));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->attachmentCount));
-    wrapper->pAttachments = std::make_unique<StructPointerDecoder<Decoded_VkPipelineColorBlendAttachmentState>>();
+    wrapper->pAttachments = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineColorBlendAttachmentState>>();
     bytes_read += wrapper->pAttachments->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAttachments = wrapper->pAttachments->GetPointer();
     wrapper->blendConstants.SetExternalMemory(value->blendConstants, 4);
@@ -1542,34 +1543,34 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGraphic
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->stageCount));
-    wrapper->pStages = std::make_unique<StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>>();
+    wrapper->pStages = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>>();
     bytes_read += wrapper->pStages->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pStages = wrapper->pStages->GetPointer();
-    wrapper->pVertexInputState = std::make_unique<StructPointerDecoder<Decoded_VkPipelineVertexInputStateCreateInfo>>();
+    wrapper->pVertexInputState = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineVertexInputStateCreateInfo>>();
     bytes_read += wrapper->pVertexInputState->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pVertexInputState = wrapper->pVertexInputState->GetPointer();
-    wrapper->pInputAssemblyState = std::make_unique<StructPointerDecoder<Decoded_VkPipelineInputAssemblyStateCreateInfo>>();
+    wrapper->pInputAssemblyState = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineInputAssemblyStateCreateInfo>>();
     bytes_read += wrapper->pInputAssemblyState->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pInputAssemblyState = wrapper->pInputAssemblyState->GetPointer();
-    wrapper->pTessellationState = std::make_unique<StructPointerDecoder<Decoded_VkPipelineTessellationStateCreateInfo>>();
+    wrapper->pTessellationState = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineTessellationStateCreateInfo>>();
     bytes_read += wrapper->pTessellationState->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pTessellationState = wrapper->pTessellationState->GetPointer();
-    wrapper->pViewportState = std::make_unique<StructPointerDecoder<Decoded_VkPipelineViewportStateCreateInfo>>();
+    wrapper->pViewportState = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineViewportStateCreateInfo>>();
     bytes_read += wrapper->pViewportState->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pViewportState = wrapper->pViewportState->GetPointer();
-    wrapper->pRasterizationState = std::make_unique<StructPointerDecoder<Decoded_VkPipelineRasterizationStateCreateInfo>>();
+    wrapper->pRasterizationState = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineRasterizationStateCreateInfo>>();
     bytes_read += wrapper->pRasterizationState->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pRasterizationState = wrapper->pRasterizationState->GetPointer();
-    wrapper->pMultisampleState = std::make_unique<StructPointerDecoder<Decoded_VkPipelineMultisampleStateCreateInfo>>();
+    wrapper->pMultisampleState = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineMultisampleStateCreateInfo>>();
     bytes_read += wrapper->pMultisampleState->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pMultisampleState = wrapper->pMultisampleState->GetPointer();
-    wrapper->pDepthStencilState = std::make_unique<StructPointerDecoder<Decoded_VkPipelineDepthStencilStateCreateInfo>>();
+    wrapper->pDepthStencilState = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineDepthStencilStateCreateInfo>>();
     bytes_read += wrapper->pDepthStencilState->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pDepthStencilState = wrapper->pDepthStencilState->GetPointer();
-    wrapper->pColorBlendState = std::make_unique<StructPointerDecoder<Decoded_VkPipelineColorBlendStateCreateInfo>>();
+    wrapper->pColorBlendState = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineColorBlendStateCreateInfo>>();
     bytes_read += wrapper->pColorBlendState->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pColorBlendState = wrapper->pColorBlendState->GetPointer();
-    wrapper->pDynamicState = std::make_unique<StructPointerDecoder<Decoded_VkPipelineDynamicStateCreateInfo>>();
+    wrapper->pDynamicState = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineDynamicStateCreateInfo>>();
     bytes_read += wrapper->pDynamicState->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pDynamicState = wrapper->pDynamicState->GetPointer();
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->layout));
@@ -1613,7 +1614,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     bytes_read += wrapper->pSetLayouts.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pSetLayouts = nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->pushConstantRangeCount));
-    wrapper->pPushConstantRanges = std::make_unique<StructPointerDecoder<Decoded_VkPushConstantRange>>();
+    wrapper->pPushConstantRanges = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPushConstantRange>>();
     bytes_read += wrapper->pPushConstantRanges->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pPushConstantRanges = wrapper->pPushConstantRanges->GetPointer();
 
@@ -1714,7 +1715,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescrip
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxSets));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->poolSizeCount));
-    wrapper->pPoolSizes = std::make_unique<StructPointerDecoder<Decoded_VkDescriptorPoolSize>>();
+    wrapper->pPoolSizes = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkDescriptorPoolSize>>();
     bytes_read += wrapper->pPoolSizes->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pPoolSizes = wrapper->pPoolSizes->GetPointer();
 
@@ -1769,7 +1770,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescrip
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->bindingCount));
-    wrapper->pBindings = std::make_unique<StructPointerDecoder<Decoded_VkDescriptorSetLayoutBinding>>();
+    wrapper->pBindings = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkDescriptorSetLayoutBinding>>();
     bytes_read += wrapper->pBindings->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pBindings = wrapper->pBindings->GetPointer();
 
@@ -1842,17 +1843,17 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpass
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->pipelineBindPoint));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->inputAttachmentCount));
-    wrapper->pInputAttachments = std::make_unique<StructPointerDecoder<Decoded_VkAttachmentReference>>();
+    wrapper->pInputAttachments = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkAttachmentReference>>();
     bytes_read += wrapper->pInputAttachments->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pInputAttachments = wrapper->pInputAttachments->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->colorAttachmentCount));
-    wrapper->pColorAttachments = std::make_unique<StructPointerDecoder<Decoded_VkAttachmentReference>>();
+    wrapper->pColorAttachments = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkAttachmentReference>>();
     bytes_read += wrapper->pColorAttachments->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pColorAttachments = wrapper->pColorAttachments->GetPointer();
-    wrapper->pResolveAttachments = std::make_unique<StructPointerDecoder<Decoded_VkAttachmentReference>>();
+    wrapper->pResolveAttachments = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkAttachmentReference>>();
     bytes_read += wrapper->pResolveAttachments->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pResolveAttachments = wrapper->pResolveAttachments->GetPointer();
-    wrapper->pDepthStencilAttachment = std::make_unique<StructPointerDecoder<Decoded_VkAttachmentReference>>();
+    wrapper->pDepthStencilAttachment = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkAttachmentReference>>();
     bytes_read += wrapper->pDepthStencilAttachment->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pDepthStencilAttachment = wrapper->pDepthStencilAttachment->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->preserveAttachmentCount));
@@ -1892,15 +1893,15 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderP
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->attachmentCount));
-    wrapper->pAttachments = std::make_unique<StructPointerDecoder<Decoded_VkAttachmentDescription>>();
+    wrapper->pAttachments = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkAttachmentDescription>>();
     bytes_read += wrapper->pAttachments->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAttachments = wrapper->pAttachments->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->subpassCount));
-    wrapper->pSubpasses = std::make_unique<StructPointerDecoder<Decoded_VkSubpassDescription>>();
+    wrapper->pSubpasses = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkSubpassDescription>>();
     bytes_read += wrapper->pSubpasses->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pSubpasses = wrapper->pSubpasses->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->dependencyCount));
-    wrapper->pDependencies = std::make_unique<StructPointerDecoder<Decoded_VkSubpassDependency>>();
+    wrapper->pDependencies = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkSubpassDependency>>();
     bytes_read += wrapper->pDependencies->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pDependencies = wrapper->pDependencies->GetPointer();
 
@@ -1974,7 +1975,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCommand
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
-    wrapper->pInheritanceInfo = std::make_unique<StructPointerDecoder<Decoded_VkCommandBufferInheritanceInfo>>();
+    wrapper->pInheritanceInfo = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkCommandBufferInheritanceInfo>>();
     bytes_read += wrapper->pInheritanceInfo->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pInheritanceInfo = wrapper->pInheritanceInfo->GetPointer();
 
@@ -2020,15 +2021,15 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferI
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->bufferOffset));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->bufferRowLength));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->bufferImageHeight));
-    wrapper->imageSubresource = std::make_unique<Decoded_VkImageSubresourceLayers>();
+    wrapper->imageSubresource = DecodeAllocator::Allocate<Decoded_VkImageSubresourceLayers>();
     wrapper->imageSubresource->decoded_value = &(value->imageSubresource);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageSubresource.get());
-    wrapper->imageOffset = std::make_unique<Decoded_VkOffset3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageSubresource);
+    wrapper->imageOffset = DecodeAllocator::Allocate<Decoded_VkOffset3D>();
     wrapper->imageOffset->decoded_value = &(value->imageOffset);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageOffset.get());
-    wrapper->imageExtent = std::make_unique<Decoded_VkExtent3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageOffset);
+    wrapper->imageExtent = DecodeAllocator::Allocate<Decoded_VkExtent3D>();
     wrapper->imageExtent->decoded_value = &(value->imageExtent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageExtent.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageExtent);
 
     return bytes_read;
 }
@@ -2055,9 +2056,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearAt
 
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->aspectMask));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->colorAttachment));
-    wrapper->clearValue = std::make_unique<Decoded_VkClearValue>();
+    wrapper->clearValue = DecodeAllocator::Allocate<Decoded_VkClearValue>();
     wrapper->clearValue->decoded_value = &(value->clearValue);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->clearValue.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->clearValue);
 
     return bytes_read;
 }
@@ -2069,9 +2070,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkClearRe
     size_t bytes_read = 0;
     VkClearRect* value = wrapper->decoded_value;
 
-    wrapper->rect = std::make_unique<Decoded_VkRect2D>();
+    wrapper->rect = DecodeAllocator::Allocate<Decoded_VkRect2D>();
     wrapper->rect->decoded_value = &(value->rect);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->rect.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->rect);
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->baseArrayLayer));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->layerCount));
 
@@ -2085,16 +2086,16 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageBl
     size_t bytes_read = 0;
     VkImageBlit* value = wrapper->decoded_value;
 
-    wrapper->srcSubresource = std::make_unique<Decoded_VkImageSubresourceLayers>();
+    wrapper->srcSubresource = DecodeAllocator::Allocate<Decoded_VkImageSubresourceLayers>();
     wrapper->srcSubresource->decoded_value = &(value->srcSubresource);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcSubresource.get());
-    wrapper->srcOffsets = std::make_unique<StructPointerDecoder<Decoded_VkOffset3D>>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcSubresource);
+    wrapper->srcOffsets = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkOffset3D>>();
     wrapper->srcOffsets->SetExternalMemory(value->srcOffsets, 2);
     bytes_read += wrapper->srcOffsets->Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    wrapper->dstSubresource = std::make_unique<Decoded_VkImageSubresourceLayers>();
+    wrapper->dstSubresource = DecodeAllocator::Allocate<Decoded_VkImageSubresourceLayers>();
     wrapper->dstSubresource->decoded_value = &(value->dstSubresource);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstSubresource.get());
-    wrapper->dstOffsets = std::make_unique<StructPointerDecoder<Decoded_VkOffset3D>>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstSubresource);
+    wrapper->dstOffsets = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkOffset3D>>();
     wrapper->dstOffsets->SetExternalMemory(value->dstOffsets, 2);
     bytes_read += wrapper->dstOffsets->Decode((buffer + bytes_read), (buffer_size - bytes_read));
 
@@ -2108,21 +2109,21 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageCo
     size_t bytes_read = 0;
     VkImageCopy* value = wrapper->decoded_value;
 
-    wrapper->srcSubresource = std::make_unique<Decoded_VkImageSubresourceLayers>();
+    wrapper->srcSubresource = DecodeAllocator::Allocate<Decoded_VkImageSubresourceLayers>();
     wrapper->srcSubresource->decoded_value = &(value->srcSubresource);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcSubresource.get());
-    wrapper->srcOffset = std::make_unique<Decoded_VkOffset3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcSubresource);
+    wrapper->srcOffset = DecodeAllocator::Allocate<Decoded_VkOffset3D>();
     wrapper->srcOffset->decoded_value = &(value->srcOffset);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcOffset.get());
-    wrapper->dstSubresource = std::make_unique<Decoded_VkImageSubresourceLayers>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcOffset);
+    wrapper->dstSubresource = DecodeAllocator::Allocate<Decoded_VkImageSubresourceLayers>();
     wrapper->dstSubresource->decoded_value = &(value->dstSubresource);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstSubresource.get());
-    wrapper->dstOffset = std::make_unique<Decoded_VkOffset3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstSubresource);
+    wrapper->dstOffset = DecodeAllocator::Allocate<Decoded_VkOffset3D>();
     wrapper->dstOffset->decoded_value = &(value->dstOffset);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstOffset.get());
-    wrapper->extent = std::make_unique<Decoded_VkExtent3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstOffset);
+    wrapper->extent = DecodeAllocator::Allocate<Decoded_VkExtent3D>();
     wrapper->extent->decoded_value = &(value->extent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->extent.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->extent);
 
     return bytes_read;
 }
@@ -2134,21 +2135,21 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageRe
     size_t bytes_read = 0;
     VkImageResolve* value = wrapper->decoded_value;
 
-    wrapper->srcSubresource = std::make_unique<Decoded_VkImageSubresourceLayers>();
+    wrapper->srcSubresource = DecodeAllocator::Allocate<Decoded_VkImageSubresourceLayers>();
     wrapper->srcSubresource->decoded_value = &(value->srcSubresource);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcSubresource.get());
-    wrapper->srcOffset = std::make_unique<Decoded_VkOffset3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcSubresource);
+    wrapper->srcOffset = DecodeAllocator::Allocate<Decoded_VkOffset3D>();
     wrapper->srcOffset->decoded_value = &(value->srcOffset);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcOffset.get());
-    wrapper->dstSubresource = std::make_unique<Decoded_VkImageSubresourceLayers>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcOffset);
+    wrapper->dstSubresource = DecodeAllocator::Allocate<Decoded_VkImageSubresourceLayers>();
     wrapper->dstSubresource->decoded_value = &(value->dstSubresource);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstSubresource.get());
-    wrapper->dstOffset = std::make_unique<Decoded_VkOffset3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstSubresource);
+    wrapper->dstOffset = DecodeAllocator::Allocate<Decoded_VkOffset3D>();
     wrapper->dstOffset->decoded_value = &(value->dstOffset);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstOffset.get());
-    wrapper->extent = std::make_unique<Decoded_VkExtent3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstOffset);
+    wrapper->extent = DecodeAllocator::Allocate<Decoded_VkExtent3D>();
     wrapper->extent->decoded_value = &(value->extent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->extent.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->extent);
 
     return bytes_read;
 }
@@ -2167,11 +2168,11 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderP
     value->renderPass = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->framebuffer));
     value->framebuffer = VK_NULL_HANDLE;
-    wrapper->renderArea = std::make_unique<Decoded_VkRect2D>();
+    wrapper->renderArea = DecodeAllocator::Allocate<Decoded_VkRect2D>();
     wrapper->renderArea->decoded_value = &(value->renderArea);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->renderArea.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->renderArea);
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->clearValueCount));
-    wrapper->pClearValues = std::make_unique<StructPointerDecoder<Decoded_VkClearValue>>();
+    wrapper->pClearValues = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkClearValue>>();
     bytes_read += wrapper->pClearValues->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pClearValues = wrapper->pClearValues->GetPointer();
 
@@ -2314,7 +2315,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDeviceG
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->deviceMask));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->deviceRenderAreaCount));
-    wrapper->pDeviceRenderAreas = std::make_unique<StructPointerDecoder<Decoded_VkRect2D>>();
+    wrapper->pDeviceRenderAreas = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkRect2D>>();
     bytes_read += wrapper->pDeviceRenderAreas->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pDeviceRenderAreas = wrapper->pDeviceRenderAreas->GetPointer();
 
@@ -2406,7 +2407,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBindIma
     bytes_read += wrapper->pDeviceIndices.DecodeUInt32((buffer + bytes_read), (buffer_size - bytes_read));
     value->pDeviceIndices = wrapper->pDeviceIndices.GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->splitInstanceBindRegionCount));
-    wrapper->pSplitInstanceBindRegions = std::make_unique<StructPointerDecoder<Decoded_VkRect2D>>();
+    wrapper->pSplitInstanceBindRegions = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkRect2D>>();
     bytes_read += wrapper->pSplitInstanceBindRegions->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pSplitInstanceBindRegions = wrapper->pSplitInstanceBindRegions->GetPointer();
 
@@ -2506,9 +2507,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMemoryR
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->memoryRequirements = std::make_unique<Decoded_VkMemoryRequirements>();
+    wrapper->memoryRequirements = DecodeAllocator::Allocate<Decoded_VkMemoryRequirements>();
     wrapper->memoryRequirements->decoded_value = &(value->memoryRequirements);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->memoryRequirements.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->memoryRequirements);
 
     return bytes_read;
 }
@@ -2523,9 +2524,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseI
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->memoryRequirements = std::make_unique<Decoded_VkSparseImageMemoryRequirements>();
+    wrapper->memoryRequirements = DecodeAllocator::Allocate<Decoded_VkSparseImageMemoryRequirements>();
     wrapper->memoryRequirements->decoded_value = &(value->memoryRequirements);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->memoryRequirements.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->memoryRequirements);
 
     return bytes_read;
 }
@@ -2540,9 +2541,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysica
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->features = std::make_unique<Decoded_VkPhysicalDeviceFeatures>();
+    wrapper->features = DecodeAllocator::Allocate<Decoded_VkPhysicalDeviceFeatures>();
     wrapper->features->decoded_value = &(value->features);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->features.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->features);
 
     return bytes_read;
 }
@@ -2557,9 +2558,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysica
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->properties = std::make_unique<Decoded_VkPhysicalDeviceProperties>();
+    wrapper->properties = DecodeAllocator::Allocate<Decoded_VkPhysicalDeviceProperties>();
     wrapper->properties->decoded_value = &(value->properties);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->properties.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->properties);
 
     return bytes_read;
 }
@@ -2574,9 +2575,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFormatP
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->formatProperties = std::make_unique<Decoded_VkFormatProperties>();
+    wrapper->formatProperties = DecodeAllocator::Allocate<Decoded_VkFormatProperties>();
     wrapper->formatProperties->decoded_value = &(value->formatProperties);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->formatProperties.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->formatProperties);
 
     return bytes_read;
 }
@@ -2591,9 +2592,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageFo
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->imageFormatProperties = std::make_unique<Decoded_VkImageFormatProperties>();
+    wrapper->imageFormatProperties = DecodeAllocator::Allocate<Decoded_VkImageFormatProperties>();
     wrapper->imageFormatProperties->decoded_value = &(value->imageFormatProperties);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageFormatProperties.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageFormatProperties);
 
     return bytes_read;
 }
@@ -2627,9 +2628,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkQueueFa
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->queueFamilyProperties = std::make_unique<Decoded_VkQueueFamilyProperties>();
+    wrapper->queueFamilyProperties = DecodeAllocator::Allocate<Decoded_VkQueueFamilyProperties>();
     wrapper->queueFamilyProperties->decoded_value = &(value->queueFamilyProperties);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->queueFamilyProperties.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->queueFamilyProperties);
 
     return bytes_read;
 }
@@ -2644,9 +2645,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysica
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->memoryProperties = std::make_unique<Decoded_VkPhysicalDeviceMemoryProperties>();
+    wrapper->memoryProperties = DecodeAllocator::Allocate<Decoded_VkPhysicalDeviceMemoryProperties>();
     wrapper->memoryProperties->decoded_value = &(value->memoryProperties);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->memoryProperties.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->memoryProperties);
 
     return bytes_read;
 }
@@ -2661,9 +2662,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSparseI
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->properties = std::make_unique<Decoded_VkSparseImageFormatProperties>();
+    wrapper->properties = DecodeAllocator::Allocate<Decoded_VkSparseImageFormatProperties>();
     wrapper->properties->decoded_value = &(value->properties);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->properties.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->properties);
 
     return bytes_read;
 }
@@ -2727,7 +2728,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderP
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->aspectReferenceCount));
-    wrapper->pAspectReferences = std::make_unique<StructPointerDecoder<Decoded_VkInputAttachmentAspectReference>>();
+    wrapper->pAspectReferences = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkInputAttachmentAspectReference>>();
     bytes_read += wrapper->pAspectReferences->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAspectReferences = wrapper->pAspectReferences->GetPointer();
 
@@ -2911,9 +2912,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSampler
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->format));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->ycbcrModel));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->ycbcrRange));
-    wrapper->components = std::make_unique<Decoded_VkComponentMapping>();
+    wrapper->components = DecodeAllocator::Allocate<Decoded_VkComponentMapping>();
     wrapper->components->decoded_value = &(value->components);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->components.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->components);
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->xChromaOffset));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->yChromaOffset));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->chromaFilter));
@@ -3027,7 +3028,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDescrip
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->descriptorUpdateEntryCount));
-    wrapper->pDescriptorUpdateEntries = std::make_unique<StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateEntry>>();
+    wrapper->pDescriptorUpdateEntries = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateEntry>>();
     bytes_read += wrapper->pDescriptorUpdateEntries->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pDescriptorUpdateEntries = wrapper->pDescriptorUpdateEntries->GetPointer();
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->templateType));
@@ -3080,9 +3081,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExterna
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->externalMemoryProperties = std::make_unique<Decoded_VkExternalMemoryProperties>();
+    wrapper->externalMemoryProperties = DecodeAllocator::Allocate<Decoded_VkExternalMemoryProperties>();
     wrapper->externalMemoryProperties->decoded_value = &(value->externalMemoryProperties);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->externalMemoryProperties.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->externalMemoryProperties);
 
     return bytes_read;
 }
@@ -3114,9 +3115,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExterna
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->externalMemoryProperties = std::make_unique<Decoded_VkExternalMemoryProperties>();
+    wrapper->externalMemoryProperties = DecodeAllocator::Allocate<Decoded_VkExternalMemoryProperties>();
     wrapper->externalMemoryProperties->decoded_value = &(value->externalMemoryProperties);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->externalMemoryProperties.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->externalMemoryProperties);
 
     return bytes_read;
 }
@@ -3477,9 +3478,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysica
     bytes_read += wrapper->driverName.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     wrapper->driverInfo.SetExternalMemory(value->driverInfo, VK_MAX_DRIVER_INFO_SIZE);
     bytes_read += wrapper->driverInfo.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    wrapper->conformanceVersion = std::make_unique<Decoded_VkConformanceVersion>();
+    wrapper->conformanceVersion = DecodeAllocator::Allocate<Decoded_VkConformanceVersion>();
     wrapper->conformanceVersion->decoded_value = &(value->conformanceVersion);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->conformanceVersion.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->conformanceVersion);
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->denormBehaviorIndependence));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->roundingModeIndependence));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shaderSignedZeroInfNanPreserveFloat16));
@@ -3603,17 +3604,17 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpass
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->pipelineBindPoint));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->viewMask));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->inputAttachmentCount));
-    wrapper->pInputAttachments = std::make_unique<StructPointerDecoder<Decoded_VkAttachmentReference2>>();
+    wrapper->pInputAttachments = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkAttachmentReference2>>();
     bytes_read += wrapper->pInputAttachments->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pInputAttachments = wrapper->pInputAttachments->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->colorAttachmentCount));
-    wrapper->pColorAttachments = std::make_unique<StructPointerDecoder<Decoded_VkAttachmentReference2>>();
+    wrapper->pColorAttachments = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkAttachmentReference2>>();
     bytes_read += wrapper->pColorAttachments->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pColorAttachments = wrapper->pColorAttachments->GetPointer();
-    wrapper->pResolveAttachments = std::make_unique<StructPointerDecoder<Decoded_VkAttachmentReference2>>();
+    wrapper->pResolveAttachments = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkAttachmentReference2>>();
     bytes_read += wrapper->pResolveAttachments->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pResolveAttachments = wrapper->pResolveAttachments->GetPointer();
-    wrapper->pDepthStencilAttachment = std::make_unique<StructPointerDecoder<Decoded_VkAttachmentReference2>>();
+    wrapper->pDepthStencilAttachment = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkAttachmentReference2>>();
     bytes_read += wrapper->pDepthStencilAttachment->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pDepthStencilAttachment = wrapper->pDepthStencilAttachment->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->preserveAttachmentCount));
@@ -3657,15 +3658,15 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderP
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->attachmentCount));
-    wrapper->pAttachments = std::make_unique<StructPointerDecoder<Decoded_VkAttachmentDescription2>>();
+    wrapper->pAttachments = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkAttachmentDescription2>>();
     bytes_read += wrapper->pAttachments->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAttachments = wrapper->pAttachments->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->subpassCount));
-    wrapper->pSubpasses = std::make_unique<StructPointerDecoder<Decoded_VkSubpassDescription2>>();
+    wrapper->pSubpasses = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkSubpassDescription2>>();
     bytes_read += wrapper->pSubpasses->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pSubpasses = wrapper->pSubpasses->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->dependencyCount));
-    wrapper->pDependencies = std::make_unique<StructPointerDecoder<Decoded_VkSubpassDependency2>>();
+    wrapper->pDependencies = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkSubpassDependency2>>();
     bytes_read += wrapper->pDependencies->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pDependencies = wrapper->pDependencies->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->correlatedViewMaskCount));
@@ -3736,9 +3737,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysica
     bytes_read += wrapper->driverName.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     wrapper->driverInfo.SetExternalMemory(value->driverInfo, VK_MAX_DRIVER_INFO_SIZE);
     bytes_read += wrapper->driverInfo.Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    wrapper->conformanceVersion = std::make_unique<Decoded_VkConformanceVersion>();
+    wrapper->conformanceVersion = DecodeAllocator::Allocate<Decoded_VkConformanceVersion>();
     wrapper->conformanceVersion->decoded_value = &(value->conformanceVersion);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->conformanceVersion.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->conformanceVersion);
 
     return bytes_read;
 }
@@ -3938,7 +3939,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpass
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->depthResolveMode));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->stencilResolveMode));
-    wrapper->pDepthStencilResolveAttachment = std::make_unique<StructPointerDecoder<Decoded_VkAttachmentReference2>>();
+    wrapper->pDepthStencilResolveAttachment = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkAttachmentReference2>>();
     bytes_read += wrapper->pDepthStencilResolveAttachment->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pDepthStencilResolveAttachment = wrapper->pDepthStencilResolveAttachment->GetPointer();
 
@@ -4089,7 +4090,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFramebu
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->attachmentImageInfoCount));
-    wrapper->pAttachmentImageInfos = std::make_unique<StructPointerDecoder<Decoded_VkFramebufferAttachmentImageInfo>>();
+    wrapper->pAttachmentImageInfos = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkFramebufferAttachmentImageInfo>>();
     bytes_read += wrapper->pAttachmentImageInfos->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAttachmentImageInfos = wrapper->pAttachmentImageInfos->GetPointer();
 
@@ -4395,15 +4396,15 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurface
 
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->minImageCount));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxImageCount));
-    wrapper->currentExtent = std::make_unique<Decoded_VkExtent2D>();
+    wrapper->currentExtent = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->currentExtent->decoded_value = &(value->currentExtent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->currentExtent.get());
-    wrapper->minImageExtent = std::make_unique<Decoded_VkExtent2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->currentExtent);
+    wrapper->minImageExtent = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->minImageExtent->decoded_value = &(value->minImageExtent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minImageExtent.get());
-    wrapper->maxImageExtent = std::make_unique<Decoded_VkExtent2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minImageExtent);
+    wrapper->maxImageExtent = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->maxImageExtent->decoded_value = &(value->maxImageExtent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxImageExtent.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxImageExtent);
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxImageArrayLayers));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->supportedTransforms));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->currentTransform));
@@ -4442,9 +4443,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSwapcha
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->minImageCount));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageFormat));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageColorSpace));
-    wrapper->imageExtent = std::make_unique<Decoded_VkExtent2D>();
+    wrapper->imageExtent = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->imageExtent->decoded_value = &(value->imageExtent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageExtent.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageExtent);
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageArrayLayers));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageUsage));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->imageSharingMode));
@@ -4597,9 +4598,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplay
     size_t bytes_read = 0;
     VkDisplayModeParametersKHR* value = wrapper->decoded_value;
 
-    wrapper->visibleRegion = std::make_unique<Decoded_VkExtent2D>();
+    wrapper->visibleRegion = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->visibleRegion->decoded_value = &(value->visibleRegion);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->visibleRegion.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->visibleRegion);
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->refreshRate));
 
     return bytes_read;
@@ -4616,9 +4617,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplay
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
-    wrapper->parameters = std::make_unique<Decoded_VkDisplayModeParametersKHR>();
+    wrapper->parameters = DecodeAllocator::Allocate<Decoded_VkDisplayModeParametersKHR>();
     wrapper->parameters->decoded_value = &(value->parameters);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->parameters.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->parameters);
 
     return bytes_read;
 }
@@ -4632,9 +4633,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplay
 
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->displayMode));
     value->displayMode = VK_NULL_HANDLE;
-    wrapper->parameters = std::make_unique<Decoded_VkDisplayModeParametersKHR>();
+    wrapper->parameters = DecodeAllocator::Allocate<Decoded_VkDisplayModeParametersKHR>();
     wrapper->parameters->decoded_value = &(value->parameters);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->parameters.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->parameters);
 
     return bytes_read;
 }
@@ -4647,30 +4648,30 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplay
     VkDisplayPlaneCapabilitiesKHR* value = wrapper->decoded_value;
 
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->supportedAlpha));
-    wrapper->minSrcPosition = std::make_unique<Decoded_VkOffset2D>();
+    wrapper->minSrcPosition = DecodeAllocator::Allocate<Decoded_VkOffset2D>();
     wrapper->minSrcPosition->decoded_value = &(value->minSrcPosition);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minSrcPosition.get());
-    wrapper->maxSrcPosition = std::make_unique<Decoded_VkOffset2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minSrcPosition);
+    wrapper->maxSrcPosition = DecodeAllocator::Allocate<Decoded_VkOffset2D>();
     wrapper->maxSrcPosition->decoded_value = &(value->maxSrcPosition);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxSrcPosition.get());
-    wrapper->minSrcExtent = std::make_unique<Decoded_VkExtent2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxSrcPosition);
+    wrapper->minSrcExtent = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->minSrcExtent->decoded_value = &(value->minSrcExtent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minSrcExtent.get());
-    wrapper->maxSrcExtent = std::make_unique<Decoded_VkExtent2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minSrcExtent);
+    wrapper->maxSrcExtent = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->maxSrcExtent->decoded_value = &(value->maxSrcExtent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxSrcExtent.get());
-    wrapper->minDstPosition = std::make_unique<Decoded_VkOffset2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxSrcExtent);
+    wrapper->minDstPosition = DecodeAllocator::Allocate<Decoded_VkOffset2D>();
     wrapper->minDstPosition->decoded_value = &(value->minDstPosition);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minDstPosition.get());
-    wrapper->maxDstPosition = std::make_unique<Decoded_VkOffset2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minDstPosition);
+    wrapper->maxDstPosition = DecodeAllocator::Allocate<Decoded_VkOffset2D>();
     wrapper->maxDstPosition->decoded_value = &(value->maxDstPosition);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxDstPosition.get());
-    wrapper->minDstExtent = std::make_unique<Decoded_VkExtent2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxDstPosition);
+    wrapper->minDstExtent = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->minDstExtent->decoded_value = &(value->minDstExtent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minDstExtent.get());
-    wrapper->maxDstExtent = std::make_unique<Decoded_VkExtent2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minDstExtent);
+    wrapper->maxDstExtent = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->maxDstExtent->decoded_value = &(value->maxDstExtent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxDstExtent.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxDstExtent);
 
     return bytes_read;
 }
@@ -4700,12 +4701,12 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplay
     value->display = VK_NULL_HANDLE;
     bytes_read += wrapper->displayName.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->displayName = wrapper->displayName.GetPointer();
-    wrapper->physicalDimensions = std::make_unique<Decoded_VkExtent2D>();
+    wrapper->physicalDimensions = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->physicalDimensions->decoded_value = &(value->physicalDimensions);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->physicalDimensions.get());
-    wrapper->physicalResolution = std::make_unique<Decoded_VkExtent2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->physicalDimensions);
+    wrapper->physicalResolution = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->physicalResolution->decoded_value = &(value->physicalResolution);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->physicalResolution.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->physicalResolution);
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->supportedTransforms));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->planeReorderPossible));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->persistentContent));
@@ -4731,9 +4732,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplay
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->transform));
     bytes_read += ValueDecoder::DecodeFloatValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->globalAlpha));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->alphaMode));
-    wrapper->imageExtent = std::make_unique<Decoded_VkExtent2D>();
+    wrapper->imageExtent = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->imageExtent->decoded_value = &(value->imageExtent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageExtent.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageExtent);
 
     return bytes_read;
 }
@@ -4748,12 +4749,12 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplay
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->srcRect = std::make_unique<Decoded_VkRect2D>();
+    wrapper->srcRect = DecodeAllocator::Allocate<Decoded_VkRect2D>();
     wrapper->srcRect->decoded_value = &(value->srcRect);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcRect.get());
-    wrapper->dstRect = std::make_unique<Decoded_VkRect2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcRect);
+    wrapper->dstRect = DecodeAllocator::Allocate<Decoded_VkRect2D>();
     wrapper->dstRect->decoded_value = &(value->dstRect);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstRect.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstRect);
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->persistent));
 
     return bytes_read;
@@ -4879,7 +4880,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportM
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->pAttributes = std::make_unique<StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>>();
+    wrapper->pAttributes = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>>();
     bytes_read += wrapper->pAttributes->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAttributes = wrapper->pAttributes->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->dwAccess));
@@ -5027,7 +5028,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportS
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->pAttributes = std::make_unique<StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>>();
+    wrapper->pAttributes = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>>();
     bytes_read += wrapper->pAttributes->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAttributes = wrapper->pAttributes->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->dwAccess));
@@ -5132,12 +5133,12 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRectLay
     size_t bytes_read = 0;
     VkRectLayerKHR* value = wrapper->decoded_value;
 
-    wrapper->offset = std::make_unique<Decoded_VkOffset2D>();
+    wrapper->offset = DecodeAllocator::Allocate<Decoded_VkOffset2D>();
     wrapper->offset->decoded_value = &(value->offset);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->offset.get());
-    wrapper->extent = std::make_unique<Decoded_VkExtent2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->offset);
+    wrapper->extent = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->extent->decoded_value = &(value->extent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->extent.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->extent);
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->layer));
 
     return bytes_read;
@@ -5151,7 +5152,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresent
     VkPresentRegionKHR* value = wrapper->decoded_value;
 
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->rectangleCount));
-    wrapper->pRectangles = std::make_unique<StructPointerDecoder<Decoded_VkRectLayerKHR>>();
+    wrapper->pRectangles = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkRectLayerKHR>>();
     bytes_read += wrapper->pRectangles->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pRectangles = wrapper->pRectangles->GetPointer();
 
@@ -5169,7 +5170,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresent
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->swapchainCount));
-    wrapper->pRegions = std::make_unique<StructPointerDecoder<Decoded_VkPresentRegionKHR>>();
+    wrapper->pRegions = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPresentRegionKHR>>();
     bytes_read += wrapper->pRegions->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pRegions = wrapper->pRegions->GetPointer();
 
@@ -5223,7 +5224,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportF
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->pAttributes = std::make_unique<StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>>();
+    wrapper->pAttributes = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>>();
     bytes_read += wrapper->pAttributes->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAttributes = wrapper->pAttributes->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->dwAccess));
@@ -5432,9 +5433,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurface
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->surfaceCapabilities = std::make_unique<Decoded_VkSurfaceCapabilitiesKHR>();
+    wrapper->surfaceCapabilities = DecodeAllocator::Allocate<Decoded_VkSurfaceCapabilitiesKHR>();
     wrapper->surfaceCapabilities->decoded_value = &(value->surfaceCapabilities);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->surfaceCapabilities.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->surfaceCapabilities);
 
     return bytes_read;
 }
@@ -5449,9 +5450,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurface
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->surfaceFormat = std::make_unique<Decoded_VkSurfaceFormatKHR>();
+    wrapper->surfaceFormat = DecodeAllocator::Allocate<Decoded_VkSurfaceFormatKHR>();
     wrapper->surfaceFormat->decoded_value = &(value->surfaceFormat);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->surfaceFormat.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->surfaceFormat);
 
     return bytes_read;
 }
@@ -5466,9 +5467,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplay
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->displayProperties = std::make_unique<Decoded_VkDisplayPropertiesKHR>();
+    wrapper->displayProperties = DecodeAllocator::Allocate<Decoded_VkDisplayPropertiesKHR>();
     wrapper->displayProperties->decoded_value = &(value->displayProperties);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->displayProperties.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->displayProperties);
 
     return bytes_read;
 }
@@ -5483,9 +5484,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplay
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->displayPlaneProperties = std::make_unique<Decoded_VkDisplayPlanePropertiesKHR>();
+    wrapper->displayPlaneProperties = DecodeAllocator::Allocate<Decoded_VkDisplayPlanePropertiesKHR>();
     wrapper->displayPlaneProperties->decoded_value = &(value->displayPlaneProperties);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->displayPlaneProperties.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->displayPlaneProperties);
 
     return bytes_read;
 }
@@ -5500,9 +5501,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplay
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->displayModeProperties = std::make_unique<Decoded_VkDisplayModePropertiesKHR>();
+    wrapper->displayModeProperties = DecodeAllocator::Allocate<Decoded_VkDisplayModePropertiesKHR>();
     wrapper->displayModeProperties->decoded_value = &(value->displayModeProperties);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->displayModeProperties.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->displayModeProperties);
 
     return bytes_read;
 }
@@ -5534,9 +5535,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDisplay
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->capabilities = std::make_unique<Decoded_VkDisplayPlaneCapabilitiesKHR>();
+    wrapper->capabilities = DecodeAllocator::Allocate<Decoded_VkDisplayPlaneCapabilitiesKHR>();
     wrapper->capabilities->decoded_value = &(value->capabilities);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->capabilities.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->capabilities);
 
     return bytes_read;
 }
@@ -5626,12 +5627,12 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkFragmen
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->pFragmentShadingRateAttachment = std::make_unique<StructPointerDecoder<Decoded_VkAttachmentReference2>>();
+    wrapper->pFragmentShadingRateAttachment = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkAttachmentReference2>>();
     bytes_read += wrapper->pFragmentShadingRateAttachment->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pFragmentShadingRateAttachment = wrapper->pFragmentShadingRateAttachment->GetPointer();
-    wrapper->shadingRateAttachmentTexelSize = std::make_unique<Decoded_VkExtent2D>();
+    wrapper->shadingRateAttachmentTexelSize = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->shadingRateAttachmentTexelSize->decoded_value = &(value->shadingRateAttachmentTexelSize);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->shadingRateAttachmentTexelSize.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->shadingRateAttachmentTexelSize);
 
     return bytes_read;
 }
@@ -5646,9 +5647,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->fragmentSize = std::make_unique<Decoded_VkExtent2D>();
+    wrapper->fragmentSize = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->fragmentSize->decoded_value = &(value->fragmentSize);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->fragmentSize.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->fragmentSize);
     wrapper->combinerOps.SetExternalMemory(value->combinerOps, 2);
     bytes_read += wrapper->combinerOps.DecodeEnum((buffer + bytes_read), (buffer_size - bytes_read));
 
@@ -5682,19 +5683,19 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysica
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->minFragmentShadingRateAttachmentTexelSize = std::make_unique<Decoded_VkExtent2D>();
+    wrapper->minFragmentShadingRateAttachmentTexelSize = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->minFragmentShadingRateAttachmentTexelSize->decoded_value = &(value->minFragmentShadingRateAttachmentTexelSize);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minFragmentShadingRateAttachmentTexelSize.get());
-    wrapper->maxFragmentShadingRateAttachmentTexelSize = std::make_unique<Decoded_VkExtent2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minFragmentShadingRateAttachmentTexelSize);
+    wrapper->maxFragmentShadingRateAttachmentTexelSize = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->maxFragmentShadingRateAttachmentTexelSize->decoded_value = &(value->maxFragmentShadingRateAttachmentTexelSize);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxFragmentShadingRateAttachmentTexelSize.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxFragmentShadingRateAttachmentTexelSize);
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxFragmentShadingRateAttachmentTexelSizeAspectRatio));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->primitiveFragmentShadingRateWithMultipleViewports));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->layeredShadingRateAttachments));
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->fragmentShadingRateNonTrivialCombinerOps));
-    wrapper->maxFragmentSize = std::make_unique<Decoded_VkExtent2D>();
+    wrapper->maxFragmentSize = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->maxFragmentSize->decoded_value = &(value->maxFragmentSize);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxFragmentSize.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxFragmentSize);
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxFragmentSizeAspectRatio));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxFragmentShadingRateCoverageSamples));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxFragmentShadingRateRasterizationSamples));
@@ -5720,9 +5721,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysica
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleCounts));
-    wrapper->fragmentSize = std::make_unique<Decoded_VkExtent2D>();
+    wrapper->fragmentSize = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->fragmentSize->decoded_value = &(value->fragmentSize);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->fragmentSize.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->fragmentSize);
 
     return bytes_read;
 }
@@ -5825,9 +5826,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     wrapper->description.SetExternalMemory(value->description, VK_MAX_DESCRIPTION_SIZE);
     bytes_read += wrapper->description.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->format));
-    wrapper->value = std::make_unique<Decoded_VkPipelineExecutableStatisticValueKHR>();
+    wrapper->value = DecodeAllocator::Allocate<Decoded_VkPipelineExecutableStatisticValueKHR>();
     wrapper->value->decoded_value = &(value->value);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->value.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->value);
 
     return bytes_read;
 }
@@ -5903,7 +5904,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCopyBuf
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dstBuffer));
     value->dstBuffer = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->regionCount));
-    wrapper->pRegions = std::make_unique<StructPointerDecoder<Decoded_VkBufferCopy2KHR>>();
+    wrapper->pRegions = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkBufferCopy2KHR>>();
     bytes_read += wrapper->pRegions->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pRegions = wrapper->pRegions->GetPointer();
 
@@ -5920,21 +5921,21 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageCo
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->srcSubresource = std::make_unique<Decoded_VkImageSubresourceLayers>();
+    wrapper->srcSubresource = DecodeAllocator::Allocate<Decoded_VkImageSubresourceLayers>();
     wrapper->srcSubresource->decoded_value = &(value->srcSubresource);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcSubresource.get());
-    wrapper->srcOffset = std::make_unique<Decoded_VkOffset3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcSubresource);
+    wrapper->srcOffset = DecodeAllocator::Allocate<Decoded_VkOffset3D>();
     wrapper->srcOffset->decoded_value = &(value->srcOffset);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcOffset.get());
-    wrapper->dstSubresource = std::make_unique<Decoded_VkImageSubresourceLayers>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcOffset);
+    wrapper->dstSubresource = DecodeAllocator::Allocate<Decoded_VkImageSubresourceLayers>();
     wrapper->dstSubresource->decoded_value = &(value->dstSubresource);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstSubresource.get());
-    wrapper->dstOffset = std::make_unique<Decoded_VkOffset3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstSubresource);
+    wrapper->dstOffset = DecodeAllocator::Allocate<Decoded_VkOffset3D>();
     wrapper->dstOffset->decoded_value = &(value->dstOffset);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstOffset.get());
-    wrapper->extent = std::make_unique<Decoded_VkExtent3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstOffset);
+    wrapper->extent = DecodeAllocator::Allocate<Decoded_VkExtent3D>();
     wrapper->extent->decoded_value = &(value->extent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->extent.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->extent);
 
     return bytes_read;
 }
@@ -5956,7 +5957,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCopyIma
     value->dstImage = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->dstImageLayout));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->regionCount));
-    wrapper->pRegions = std::make_unique<StructPointerDecoder<Decoded_VkImageCopy2KHR>>();
+    wrapper->pRegions = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkImageCopy2KHR>>();
     bytes_read += wrapper->pRegions->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pRegions = wrapper->pRegions->GetPointer();
 
@@ -5976,15 +5977,15 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBufferI
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->bufferOffset));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->bufferRowLength));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->bufferImageHeight));
-    wrapper->imageSubresource = std::make_unique<Decoded_VkImageSubresourceLayers>();
+    wrapper->imageSubresource = DecodeAllocator::Allocate<Decoded_VkImageSubresourceLayers>();
     wrapper->imageSubresource->decoded_value = &(value->imageSubresource);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageSubresource.get());
-    wrapper->imageOffset = std::make_unique<Decoded_VkOffset3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageSubresource);
+    wrapper->imageOffset = DecodeAllocator::Allocate<Decoded_VkOffset3D>();
     wrapper->imageOffset->decoded_value = &(value->imageOffset);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageOffset.get());
-    wrapper->imageExtent = std::make_unique<Decoded_VkExtent3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageOffset);
+    wrapper->imageExtent = DecodeAllocator::Allocate<Decoded_VkExtent3D>();
     wrapper->imageExtent->decoded_value = &(value->imageExtent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageExtent.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageExtent);
 
     return bytes_read;
 }
@@ -6005,7 +6006,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCopyBuf
     value->dstImage = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->dstImageLayout));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->regionCount));
-    wrapper->pRegions = std::make_unique<StructPointerDecoder<Decoded_VkBufferImageCopy2KHR>>();
+    wrapper->pRegions = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkBufferImageCopy2KHR>>();
     bytes_read += wrapper->pRegions->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pRegions = wrapper->pRegions->GetPointer();
 
@@ -6028,7 +6029,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCopyIma
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dstBuffer));
     value->dstBuffer = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->regionCount));
-    wrapper->pRegions = std::make_unique<StructPointerDecoder<Decoded_VkBufferImageCopy2KHR>>();
+    wrapper->pRegions = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkBufferImageCopy2KHR>>();
     bytes_read += wrapper->pRegions->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pRegions = wrapper->pRegions->GetPointer();
 
@@ -6045,16 +6046,16 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageBl
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->srcSubresource = std::make_unique<Decoded_VkImageSubresourceLayers>();
+    wrapper->srcSubresource = DecodeAllocator::Allocate<Decoded_VkImageSubresourceLayers>();
     wrapper->srcSubresource->decoded_value = &(value->srcSubresource);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcSubresource.get());
-    wrapper->srcOffsets = std::make_unique<StructPointerDecoder<Decoded_VkOffset3D>>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcSubresource);
+    wrapper->srcOffsets = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkOffset3D>>();
     wrapper->srcOffsets->SetExternalMemory(value->srcOffsets, 2);
     bytes_read += wrapper->srcOffsets->Decode((buffer + bytes_read), (buffer_size - bytes_read));
-    wrapper->dstSubresource = std::make_unique<Decoded_VkImageSubresourceLayers>();
+    wrapper->dstSubresource = DecodeAllocator::Allocate<Decoded_VkImageSubresourceLayers>();
     wrapper->dstSubresource->decoded_value = &(value->dstSubresource);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstSubresource.get());
-    wrapper->dstOffsets = std::make_unique<StructPointerDecoder<Decoded_VkOffset3D>>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstSubresource);
+    wrapper->dstOffsets = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkOffset3D>>();
     wrapper->dstOffsets->SetExternalMemory(value->dstOffsets, 2);
     bytes_read += wrapper->dstOffsets->Decode((buffer + bytes_read), (buffer_size - bytes_read));
 
@@ -6078,7 +6079,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkBlitIma
     value->dstImage = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->dstImageLayout));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->regionCount));
-    wrapper->pRegions = std::make_unique<StructPointerDecoder<Decoded_VkImageBlit2KHR>>();
+    wrapper->pRegions = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkImageBlit2KHR>>();
     bytes_read += wrapper->pRegions->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pRegions = wrapper->pRegions->GetPointer();
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->filter));
@@ -6096,21 +6097,21 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageRe
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->srcSubresource = std::make_unique<Decoded_VkImageSubresourceLayers>();
+    wrapper->srcSubresource = DecodeAllocator::Allocate<Decoded_VkImageSubresourceLayers>();
     wrapper->srcSubresource->decoded_value = &(value->srcSubresource);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcSubresource.get());
-    wrapper->srcOffset = std::make_unique<Decoded_VkOffset3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcSubresource);
+    wrapper->srcOffset = DecodeAllocator::Allocate<Decoded_VkOffset3D>();
     wrapper->srcOffset->decoded_value = &(value->srcOffset);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcOffset.get());
-    wrapper->dstSubresource = std::make_unique<Decoded_VkImageSubresourceLayers>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->srcOffset);
+    wrapper->dstSubresource = DecodeAllocator::Allocate<Decoded_VkImageSubresourceLayers>();
     wrapper->dstSubresource->decoded_value = &(value->dstSubresource);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstSubresource.get());
-    wrapper->dstOffset = std::make_unique<Decoded_VkOffset3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstSubresource);
+    wrapper->dstOffset = DecodeAllocator::Allocate<Decoded_VkOffset3D>();
     wrapper->dstOffset->decoded_value = &(value->dstOffset);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstOffset.get());
-    wrapper->extent = std::make_unique<Decoded_VkExtent3D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dstOffset);
+    wrapper->extent = DecodeAllocator::Allocate<Decoded_VkExtent3D>();
     wrapper->extent->decoded_value = &(value->extent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->extent.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->extent);
 
     return bytes_read;
 }
@@ -6132,7 +6133,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkResolve
     value->dstImage = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->dstImageLayout));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->regionCount));
-    wrapper->pRegions = std::make_unique<StructPointerDecoder<Decoded_VkImageResolve2KHR>>();
+    wrapper->pRegions = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkImageResolve2KHR>>();
     bytes_read += wrapper->pRegions->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pRegions = wrapper->pRegions->GetPointer();
 
@@ -6409,9 +6410,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkShaderS
     VkShaderStatisticsInfoAMD* value = wrapper->decoded_value;
 
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->shaderStageMask));
-    wrapper->resourceUsage = std::make_unique<Decoded_VkShaderResourceUsageAMD>();
+    wrapper->resourceUsage = DecodeAllocator::Allocate<Decoded_VkShaderResourceUsageAMD>();
     wrapper->resourceUsage->decoded_value = &(value->resourceUsage);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->resourceUsage.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->resourceUsage);
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->numPhysicalVgprs));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->numPhysicalSgprs));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->numAvailableVgprs));
@@ -6460,9 +6461,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExterna
     size_t bytes_read = 0;
     VkExternalImageFormatPropertiesNV* value = wrapper->decoded_value;
 
-    wrapper->imageFormatProperties = std::make_unique<Decoded_VkImageFormatProperties>();
+    wrapper->imageFormatProperties = DecodeAllocator::Allocate<Decoded_VkImageFormatProperties>();
     wrapper->imageFormatProperties->decoded_value = &(value->imageFormatProperties);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageFormatProperties.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->imageFormatProperties);
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->externalMemoryFeatures));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->exportFromImportedHandleTypes));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->compatibleHandleTypes));
@@ -6527,7 +6528,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExportM
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->pAttributes = std::make_unique<StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>>();
+    wrapper->pAttributes = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>>();
     bytes_read += wrapper->pAttributes->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAttributes = wrapper->pAttributes->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->dwAccess));
@@ -6714,7 +6715,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->viewportWScalingEnable));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->viewportCount));
-    wrapper->pViewportWScalings = std::make_unique<StructPointerDecoder<Decoded_VkViewportWScalingNV>>();
+    wrapper->pViewportWScalings = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkViewportWScalingNV>>();
     bytes_read += wrapper->pViewportWScalings->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pViewportWScalings = wrapper->pViewportWScalings->GetPointer();
 
@@ -6733,15 +6734,15 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSurface
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->minImageCount));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxImageCount));
-    wrapper->currentExtent = std::make_unique<Decoded_VkExtent2D>();
+    wrapper->currentExtent = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->currentExtent->decoded_value = &(value->currentExtent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->currentExtent.get());
-    wrapper->minImageExtent = std::make_unique<Decoded_VkExtent2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->currentExtent);
+    wrapper->minImageExtent = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->minImageExtent->decoded_value = &(value->minImageExtent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minImageExtent.get());
-    wrapper->maxImageExtent = std::make_unique<Decoded_VkExtent2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minImageExtent);
+    wrapper->maxImageExtent = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->maxImageExtent->decoded_value = &(value->maxImageExtent);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxImageExtent.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxImageExtent);
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxImageArrayLayers));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->supportedTransforms));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->currentTransform));
@@ -6864,7 +6865,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPresent
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->swapchainCount));
-    wrapper->pTimes = std::make_unique<StructPointerDecoder<Decoded_VkPresentTimeGOOGLE>>();
+    wrapper->pTimes = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPresentTimeGOOGLE>>();
     bytes_read += wrapper->pTimes->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pTimes = wrapper->pTimes->GetPointer();
 
@@ -6913,7 +6914,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->viewportCount));
-    wrapper->pViewportSwizzles = std::make_unique<StructPointerDecoder<Decoded_VkViewportSwizzleNV>>();
+    wrapper->pViewportSwizzles = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkViewportSwizzleNV>>();
     bytes_read += wrapper->pViewportSwizzles->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pViewportSwizzles = wrapper->pViewportSwizzles->GetPointer();
 
@@ -6948,7 +6949,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->discardRectangleMode));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->discardRectangleCount));
-    wrapper->pDiscardRectangles = std::make_unique<StructPointerDecoder<Decoded_VkRect2D>>();
+    wrapper->pDiscardRectangles = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkRect2D>>();
     bytes_read += wrapper->pDiscardRectangles->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pDiscardRectangles = wrapper->pDiscardRectangles->GetPointer();
 
@@ -7049,18 +7050,18 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkHdrMeta
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->displayPrimaryRed = std::make_unique<Decoded_VkXYColorEXT>();
+    wrapper->displayPrimaryRed = DecodeAllocator::Allocate<Decoded_VkXYColorEXT>();
     wrapper->displayPrimaryRed->decoded_value = &(value->displayPrimaryRed);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->displayPrimaryRed.get());
-    wrapper->displayPrimaryGreen = std::make_unique<Decoded_VkXYColorEXT>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->displayPrimaryRed);
+    wrapper->displayPrimaryGreen = DecodeAllocator::Allocate<Decoded_VkXYColorEXT>();
     wrapper->displayPrimaryGreen->decoded_value = &(value->displayPrimaryGreen);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->displayPrimaryGreen.get());
-    wrapper->displayPrimaryBlue = std::make_unique<Decoded_VkXYColorEXT>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->displayPrimaryGreen);
+    wrapper->displayPrimaryBlue = DecodeAllocator::Allocate<Decoded_VkXYColorEXT>();
     wrapper->displayPrimaryBlue->decoded_value = &(value->displayPrimaryBlue);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->displayPrimaryBlue.get());
-    wrapper->whitePoint = std::make_unique<Decoded_VkXYColorEXT>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->displayPrimaryBlue);
+    wrapper->whitePoint = DecodeAllocator::Allocate<Decoded_VkXYColorEXT>();
     wrapper->whitePoint->decoded_value = &(value->whitePoint);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->whitePoint.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->whitePoint);
     bytes_read += ValueDecoder::DecodeFloatValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxLuminance));
     bytes_read += ValueDecoder::DecodeFloatValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->minLuminance));
     bytes_read += ValueDecoder::DecodeFloatValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxContentLightLevel));
@@ -7157,15 +7158,15 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDebugUt
     bytes_read += wrapper->pMessage.Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pMessage = wrapper->pMessage.GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->queueLabelCount));
-    wrapper->pQueueLabels = std::make_unique<StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>>();
+    wrapper->pQueueLabels = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>>();
     bytes_read += wrapper->pQueueLabels->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pQueueLabels = wrapper->pQueueLabels->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->cmdBufLabelCount));
-    wrapper->pCmdBufLabels = std::make_unique<StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>>();
+    wrapper->pCmdBufLabels = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>>();
     bytes_read += wrapper->pCmdBufLabels->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pCmdBufLabels = wrapper->pCmdBufLabels->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->objectCount));
-    wrapper->pObjects = std::make_unique<StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>>();
+    wrapper->pObjects = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>>();
     bytes_read += wrapper->pObjects->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pObjects = wrapper->pObjects->GetPointer();
 
@@ -7258,9 +7259,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAndroid
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->format));
     bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->externalFormat));
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->formatFeatures));
-    wrapper->samplerYcbcrConversionComponents = std::make_unique<Decoded_VkComponentMapping>();
+    wrapper->samplerYcbcrConversionComponents = DecodeAllocator::Allocate<Decoded_VkComponentMapping>();
     wrapper->samplerYcbcrConversionComponents->decoded_value = &(value->samplerYcbcrConversionComponents);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->samplerYcbcrConversionComponents.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->samplerYcbcrConversionComponents);
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->suggestedYcbcrModel));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->suggestedYcbcrRange));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->suggestedXChromaOffset));
@@ -7407,11 +7408,11 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSampleL
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleLocationsPerPixel));
-    wrapper->sampleLocationGridSize = std::make_unique<Decoded_VkExtent2D>();
+    wrapper->sampleLocationGridSize = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->sampleLocationGridSize->decoded_value = &(value->sampleLocationGridSize);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->sampleLocationGridSize.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->sampleLocationGridSize);
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleLocationsCount));
-    wrapper->pSampleLocations = std::make_unique<StructPointerDecoder<Decoded_VkSampleLocationEXT>>();
+    wrapper->pSampleLocations = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkSampleLocationEXT>>();
     bytes_read += wrapper->pSampleLocations->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pSampleLocations = wrapper->pSampleLocations->GetPointer();
 
@@ -7426,9 +7427,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAttachm
     VkAttachmentSampleLocationsEXT* value = wrapper->decoded_value;
 
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->attachmentIndex));
-    wrapper->sampleLocationsInfo = std::make_unique<Decoded_VkSampleLocationsInfoEXT>();
+    wrapper->sampleLocationsInfo = DecodeAllocator::Allocate<Decoded_VkSampleLocationsInfoEXT>();
     wrapper->sampleLocationsInfo->decoded_value = &(value->sampleLocationsInfo);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->sampleLocationsInfo.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->sampleLocationsInfo);
 
     return bytes_read;
 }
@@ -7441,9 +7442,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSubpass
     VkSubpassSampleLocationsEXT* value = wrapper->decoded_value;
 
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->subpassIndex));
-    wrapper->sampleLocationsInfo = std::make_unique<Decoded_VkSampleLocationsInfoEXT>();
+    wrapper->sampleLocationsInfo = DecodeAllocator::Allocate<Decoded_VkSampleLocationsInfoEXT>();
     wrapper->sampleLocationsInfo->decoded_value = &(value->sampleLocationsInfo);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->sampleLocationsInfo.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->sampleLocationsInfo);
 
     return bytes_read;
 }
@@ -7459,11 +7460,11 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderP
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->attachmentInitialSampleLocationsCount));
-    wrapper->pAttachmentInitialSampleLocations = std::make_unique<StructPointerDecoder<Decoded_VkAttachmentSampleLocationsEXT>>();
+    wrapper->pAttachmentInitialSampleLocations = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkAttachmentSampleLocationsEXT>>();
     bytes_read += wrapper->pAttachmentInitialSampleLocations->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pAttachmentInitialSampleLocations = wrapper->pAttachmentInitialSampleLocations->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->postSubpassSampleLocationsCount));
-    wrapper->pPostSubpassSampleLocations = std::make_unique<StructPointerDecoder<Decoded_VkSubpassSampleLocationsEXT>>();
+    wrapper->pPostSubpassSampleLocations = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkSubpassSampleLocationsEXT>>();
     bytes_read += wrapper->pPostSubpassSampleLocations->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pPostSubpassSampleLocations = wrapper->pPostSubpassSampleLocations->GetPointer();
 
@@ -7481,9 +7482,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleLocationsEnable));
-    wrapper->sampleLocationsInfo = std::make_unique<Decoded_VkSampleLocationsInfoEXT>();
+    wrapper->sampleLocationsInfo = DecodeAllocator::Allocate<Decoded_VkSampleLocationsInfoEXT>();
     wrapper->sampleLocationsInfo->decoded_value = &(value->sampleLocationsInfo);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->sampleLocationsInfo.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->sampleLocationsInfo);
 
     return bytes_read;
 }
@@ -7499,9 +7500,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysica
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleLocationSampleCounts));
-    wrapper->maxSampleLocationGridSize = std::make_unique<Decoded_VkExtent2D>();
+    wrapper->maxSampleLocationGridSize = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->maxSampleLocationGridSize->decoded_value = &(value->maxSampleLocationGridSize);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxSampleLocationGridSize.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxSampleLocationGridSize);
     wrapper->sampleLocationCoordinateRange.SetExternalMemory(value->sampleLocationCoordinateRange, 2);
     bytes_read += wrapper->sampleLocationCoordinateRange.DecodeFloat((buffer + bytes_read), (buffer_size - bytes_read));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleLocationSubPixelBits));
@@ -7520,9 +7521,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkMultisa
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->maxSampleLocationGridSize = std::make_unique<Decoded_VkExtent2D>();
+    wrapper->maxSampleLocationGridSize = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->maxSampleLocationGridSize->decoded_value = &(value->maxSampleLocationGridSize);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxSampleLocationGridSize.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxSampleLocationGridSize);
 
     return bytes_read;
 }
@@ -7672,7 +7673,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkDrmForm
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->drmFormatModifierCount));
-    wrapper->pDrmFormatModifierProperties = std::make_unique<StructPointerDecoder<Decoded_VkDrmFormatModifierPropertiesEXT>>();
+    wrapper->pDrmFormatModifierProperties = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkDrmFormatModifierPropertiesEXT>>();
     bytes_read += wrapper->pDrmFormatModifierProperties->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pDrmFormatModifierProperties = wrapper->pDrmFormatModifierProperties->GetPointer();
 
@@ -7727,7 +7728,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkImageDr
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt64Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->drmFormatModifier));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->drmFormatModifierPlaneCount));
-    wrapper->pPlaneLayouts = std::make_unique<StructPointerDecoder<Decoded_VkSubresourceLayout>>();
+    wrapper->pPlaneLayouts = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkSubresourceLayout>>();
     bytes_read += wrapper->pPlaneLayouts->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pPlaneLayouts = wrapper->pPlaneLayouts->GetPointer();
 
@@ -7809,7 +7810,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shadingRateImageEnable));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->viewportCount));
-    wrapper->pShadingRatePalettes = std::make_unique<StructPointerDecoder<Decoded_VkShadingRatePaletteNV>>();
+    wrapper->pShadingRatePalettes = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkShadingRatePaletteNV>>();
     bytes_read += wrapper->pShadingRatePalettes->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pShadingRatePalettes = wrapper->pShadingRatePalettes->GetPointer();
 
@@ -7842,9 +7843,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysica
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->shadingRateTexelSize = std::make_unique<Decoded_VkExtent2D>();
+    wrapper->shadingRateTexelSize = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->shadingRateTexelSize->decoded_value = &(value->shadingRateTexelSize);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->shadingRateTexelSize.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->shadingRateTexelSize);
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shadingRatePaletteSize));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->shadingRateMaxCoarseSamples));
 
@@ -7875,7 +7876,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCoarseS
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->shadingRate));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleCount));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleLocationCount));
-    wrapper->pSampleLocations = std::make_unique<StructPointerDecoder<Decoded_VkCoarseSampleLocationNV>>();
+    wrapper->pSampleLocations = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkCoarseSampleLocationNV>>();
     bytes_read += wrapper->pSampleLocations->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pSampleLocations = wrapper->pSampleLocations->GetPointer();
 
@@ -7894,7 +7895,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sampleOrderType));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->customSampleOrderCount));
-    wrapper->pCustomSampleOrders = std::make_unique<StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>>();
+    wrapper->pCustomSampleOrders = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>>();
     bytes_read += wrapper->pCustomSampleOrders->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pCustomSampleOrders = wrapper->pCustomSampleOrders->GetPointer();
 
@@ -7932,11 +7933,11 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRayTrac
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->stageCount));
-    wrapper->pStages = std::make_unique<StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>>();
+    wrapper->pStages = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>>();
     bytes_read += wrapper->pStages->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pStages = wrapper->pStages->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->groupCount));
-    wrapper->pGroups = std::make_unique<StructPointerDecoder<Decoded_VkRayTracingShaderGroupCreateInfoNV>>();
+    wrapper->pGroups = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkRayTracingShaderGroupCreateInfoNV>>();
     bytes_read += wrapper->pGroups->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pGroups = wrapper->pGroups->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxRecursionDepth));
@@ -8003,12 +8004,12 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGeometr
     size_t bytes_read = 0;
     VkGeometryDataNV* value = wrapper->decoded_value;
 
-    wrapper->triangles = std::make_unique<Decoded_VkGeometryTrianglesNV>();
+    wrapper->triangles = DecodeAllocator::Allocate<Decoded_VkGeometryTrianglesNV>();
     wrapper->triangles->decoded_value = &(value->triangles);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->triangles.get());
-    wrapper->aabbs = std::make_unique<Decoded_VkGeometryAABBNV>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->triangles);
+    wrapper->aabbs = DecodeAllocator::Allocate<Decoded_VkGeometryAABBNV>();
     wrapper->aabbs->decoded_value = &(value->aabbs);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->aabbs.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->aabbs);
 
     return bytes_read;
 }
@@ -8024,9 +8025,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGeometr
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->geometryType));
-    wrapper->geometry = std::make_unique<Decoded_VkGeometryDataNV>();
+    wrapper->geometry = DecodeAllocator::Allocate<Decoded_VkGeometryDataNV>();
     wrapper->geometry->decoded_value = &(value->geometry);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->geometry.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->geometry);
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
 
     return bytes_read;
@@ -8046,7 +8047,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAcceler
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->instanceCount));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->geometryCount));
-    wrapper->pGeometries = std::make_unique<StructPointerDecoder<Decoded_VkGeometryNV>>();
+    wrapper->pGeometries = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkGeometryNV>>();
     bytes_read += wrapper->pGeometries->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pGeometries = wrapper->pGeometries->GetPointer();
 
@@ -8064,9 +8065,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAcceler
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->compactedSize));
-    wrapper->info = std::make_unique<Decoded_VkAccelerationStructureInfoNV>();
+    wrapper->info = DecodeAllocator::Allocate<Decoded_VkAccelerationStructureInfoNV>();
     wrapper->info->decoded_value = &(value->info);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->info.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->info);
 
     return bytes_read;
 }
@@ -8186,9 +8187,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAcceler
     size_t bytes_read = 0;
     VkAccelerationStructureInstanceKHR* value = wrapper->decoded_value;
 
-    wrapper->transform = std::make_unique<Decoded_VkTransformMatrixKHR>();
+    wrapper->transform = DecodeAllocator::Allocate<Decoded_VkTransformMatrixKHR>();
     wrapper->transform->decoded_value = &(value->transform);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->transform.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->transform);
     uint32_t temp_instanceCustomIndex;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &temp_instanceCustomIndex);
     value->instanceCustomIndex = temp_instanceCustomIndex;
@@ -8441,7 +8442,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->vertexBindingDivisorCount));
-    wrapper->pVertexBindingDivisors = std::make_unique<StructPointerDecoder<Decoded_VkVertexInputBindingDivisorDescriptionEXT>>();
+    wrapper->pVertexBindingDivisors = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkVertexInputBindingDivisorDescriptionEXT>>();
     bytes_read += wrapper->pVertexBindingDivisors->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pVertexBindingDivisors = wrapper->pVertexBindingDivisors->GetPointer();
 
@@ -8502,11 +8503,11 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->pPipelineCreationFeedback = std::make_unique<StructPointerDecoder<Decoded_VkPipelineCreationFeedbackEXT>>();
+    wrapper->pPipelineCreationFeedback = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineCreationFeedbackEXT>>();
     bytes_read += wrapper->pPipelineCreationFeedback->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pPipelineCreationFeedback = wrapper->pPipelineCreationFeedback->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->pipelineStageCreationFeedbackCount));
-    wrapper->pPipelineStageCreationFeedbacks = std::make_unique<StructPointerDecoder<Decoded_VkPipelineCreationFeedbackEXT>>();
+    wrapper->pPipelineStageCreationFeedbacks = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineCreationFeedbackEXT>>();
     bytes_read += wrapper->pPipelineStageCreationFeedbacks->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pPipelineStageCreationFeedbacks = wrapper->pPipelineStageCreationFeedbacks->GetPointer();
 
@@ -8628,7 +8629,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPipelin
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->exclusiveScissorCount));
-    wrapper->pExclusiveScissors = std::make_unique<StructPointerDecoder<Decoded_VkRect2D>>();
+    wrapper->pExclusiveScissors = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkRect2D>>();
     bytes_read += wrapper->pExclusiveScissors->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pExclusiveScissors = wrapper->pExclusiveScissors->GetPointer();
 
@@ -8898,12 +8899,12 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkPhysica
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->minFragmentDensityTexelSize = std::make_unique<Decoded_VkExtent2D>();
+    wrapper->minFragmentDensityTexelSize = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->minFragmentDensityTexelSize->decoded_value = &(value->minFragmentDensityTexelSize);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minFragmentDensityTexelSize.get());
-    wrapper->maxFragmentDensityTexelSize = std::make_unique<Decoded_VkExtent2D>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->minFragmentDensityTexelSize);
+    wrapper->maxFragmentDensityTexelSize = DecodeAllocator::Allocate<Decoded_VkExtent2D>();
     wrapper->maxFragmentDensityTexelSize->decoded_value = &(value->maxFragmentDensityTexelSize);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxFragmentDensityTexelSize.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->maxFragmentDensityTexelSize);
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->fragmentDensityInvocations));
 
     return bytes_read;
@@ -8919,9 +8920,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRenderP
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->fragmentDensityMapAttachment = std::make_unique<Decoded_VkAttachmentReference>();
+    wrapper->fragmentDensityMapAttachment = DecodeAllocator::Allocate<Decoded_VkAttachmentReference>();
     wrapper->fragmentDensityMapAttachment->decoded_value = &(value->fragmentDensityMapAttachment);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->fragmentDensityMapAttachment.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->fragmentDensityMapAttachment);
 
     return bytes_read;
 }
@@ -9528,13 +9529,13 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGraphic
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->stageCount));
-    wrapper->pStages = std::make_unique<StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>>();
+    wrapper->pStages = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>>();
     bytes_read += wrapper->pStages->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pStages = wrapper->pStages->GetPointer();
-    wrapper->pVertexInputState = std::make_unique<StructPointerDecoder<Decoded_VkPipelineVertexInputStateCreateInfo>>();
+    wrapper->pVertexInputState = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineVertexInputStateCreateInfo>>();
     bytes_read += wrapper->pVertexInputState->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pVertexInputState = wrapper->pVertexInputState->GetPointer();
-    wrapper->pTessellationState = std::make_unique<StructPointerDecoder<Decoded_VkPipelineTessellationStateCreateInfo>>();
+    wrapper->pTessellationState = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineTessellationStateCreateInfo>>();
     bytes_read += wrapper->pTessellationState->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pTessellationState = wrapper->pTessellationState->GetPointer();
 
@@ -9552,7 +9553,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGraphic
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->groupCount));
-    wrapper->pGroups = std::make_unique<StructPointerDecoder<Decoded_VkGraphicsShaderGroupCreateInfoNV>>();
+    wrapper->pGroups = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkGraphicsShaderGroupCreateInfoNV>>();
     bytes_read += wrapper->pGroups->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pGroups = wrapper->pGroups->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->pipelineCount));
@@ -9671,7 +9672,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkIndirec
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->pipelineBindPoint));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->tokenCount));
-    wrapper->pTokens = std::make_unique<StructPointerDecoder<Decoded_VkIndirectCommandsLayoutTokenNV>>();
+    wrapper->pTokens = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkIndirectCommandsLayoutTokenNV>>();
     bytes_read += wrapper->pTokens->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pTokens = wrapper->pTokens->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->streamCount));
@@ -9697,7 +9698,7 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkGenerat
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->indirectCommandsLayout));
     value->indirectCommandsLayout = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->streamCount));
-    wrapper->pStreams = std::make_unique<StructPointerDecoder<Decoded_VkIndirectCommandsStreamNV>>();
+    wrapper->pStreams = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkIndirectCommandsStreamNV>>();
     bytes_read += wrapper->pStreams->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pStreams = wrapper->pStreams->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->sequencesCount));
@@ -9794,9 +9795,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCommand
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->transform));
-    wrapper->renderArea = std::make_unique<Decoded_VkRect2D>();
+    wrapper->renderArea = DecodeAllocator::Allocate<Decoded_VkRect2D>();
     wrapper->renderArea->decoded_value = &(value->renderArea);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->renderArea.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->renderArea);
 
     return bytes_read;
 }
@@ -9899,9 +9900,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkSampler
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->customBorderColor = std::make_unique<Decoded_VkClearColorValue>();
+    wrapper->customBorderColor = DecodeAllocator::Allocate<Decoded_VkClearColorValue>();
     wrapper->customBorderColor->decoded_value = &(value->customBorderColor);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->customBorderColor.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->customBorderColor);
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->format));
 
     return bytes_read;
@@ -10202,18 +10203,18 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAcceler
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->vertexFormat));
-    wrapper->vertexData = std::make_unique<Decoded_VkDeviceOrHostAddressConstKHR>();
+    wrapper->vertexData = DecodeAllocator::Allocate<Decoded_VkDeviceOrHostAddressConstKHR>();
     wrapper->vertexData->decoded_value = &(value->vertexData);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->vertexData.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->vertexData);
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->vertexStride));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxVertex));
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->indexType));
-    wrapper->indexData = std::make_unique<Decoded_VkDeviceOrHostAddressConstKHR>();
+    wrapper->indexData = DecodeAllocator::Allocate<Decoded_VkDeviceOrHostAddressConstKHR>();
     wrapper->indexData->decoded_value = &(value->indexData);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->indexData.get());
-    wrapper->transformData = std::make_unique<Decoded_VkDeviceOrHostAddressConstKHR>();
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->indexData);
+    wrapper->transformData = DecodeAllocator::Allocate<Decoded_VkDeviceOrHostAddressConstKHR>();
     wrapper->transformData->decoded_value = &(value->transformData);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->transformData.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->transformData);
 
     return bytes_read;
 }
@@ -10228,9 +10229,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAcceler
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->data = std::make_unique<Decoded_VkDeviceOrHostAddressConstKHR>();
+    wrapper->data = DecodeAllocator::Allocate<Decoded_VkDeviceOrHostAddressConstKHR>();
     wrapper->data->decoded_value = &(value->data);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->data.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->data);
     bytes_read += ValueDecoder::DecodeVkDeviceSizeValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->stride));
 
     return bytes_read;
@@ -10247,9 +10248,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAcceler
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeVkBool32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->arrayOfPointers));
-    wrapper->data = std::make_unique<Decoded_VkDeviceOrHostAddressConstKHR>();
+    wrapper->data = DecodeAllocator::Allocate<Decoded_VkDeviceOrHostAddressConstKHR>();
     wrapper->data->decoded_value = &(value->data);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->data.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->data);
 
     return bytes_read;
 }
@@ -10272,15 +10273,15 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAcceler
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dstAccelerationStructure));
     value->dstAccelerationStructure = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->geometryCount));
-    wrapper->pGeometries = std::make_unique<StructPointerDecoder<Decoded_VkAccelerationStructureGeometryKHR>>();
+    wrapper->pGeometries = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkAccelerationStructureGeometryKHR>>();
     bytes_read += wrapper->pGeometries->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pGeometries = wrapper->pGeometries->GetPointer();
-    wrapper->ppGeometries = std::make_unique<StructPointerDecoder<Decoded_VkAccelerationStructureGeometryKHR*>>();
+    wrapper->ppGeometries = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkAccelerationStructureGeometryKHR*>>();
     bytes_read += wrapper->ppGeometries->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->ppGeometries = wrapper->ppGeometries->GetPointer();
-    wrapper->scratchData = std::make_unique<Decoded_VkDeviceOrHostAddressKHR>();
+    wrapper->scratchData = DecodeAllocator::Allocate<Decoded_VkDeviceOrHostAddressKHR>();
     wrapper->scratchData->decoded_value = &(value->scratchData);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->scratchData.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->scratchData);
 
     return bytes_read;
 }
@@ -10408,9 +10409,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCopyAcc
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->src));
     value->src = VK_NULL_HANDLE;
-    wrapper->dst = std::make_unique<Decoded_VkDeviceOrHostAddressKHR>();
+    wrapper->dst = DecodeAllocator::Allocate<Decoded_VkDeviceOrHostAddressKHR>();
     wrapper->dst->decoded_value = &(value->dst);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dst.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->dst);
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->mode));
 
     return bytes_read;
@@ -10426,9 +10427,9 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkCopyMem
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->sType));
     bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->pNext));
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
-    wrapper->src = std::make_unique<Decoded_VkDeviceOrHostAddressConstKHR>();
+    wrapper->src = DecodeAllocator::Allocate<Decoded_VkDeviceOrHostAddressConstKHR>();
     wrapper->src->decoded_value = &(value->src);
-    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->src.get());
+    bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->src);
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->dst));
     value->dst = VK_NULL_HANDLE;
     bytes_read += ValueDecoder::DecodeEnumValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->mode));
@@ -10521,21 +10522,21 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkRayTrac
     value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->stageCount));
-    wrapper->pStages = std::make_unique<StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>>();
+    wrapper->pStages = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>>();
     bytes_read += wrapper->pStages->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pStages = wrapper->pStages->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->groupCount));
-    wrapper->pGroups = std::make_unique<StructPointerDecoder<Decoded_VkRayTracingShaderGroupCreateInfoKHR>>();
+    wrapper->pGroups = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkRayTracingShaderGroupCreateInfoKHR>>();
     bytes_read += wrapper->pGroups->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pGroups = wrapper->pGroups->GetPointer();
     bytes_read += ValueDecoder::DecodeUInt32Value((buffer + bytes_read), (buffer_size - bytes_read), &(value->maxPipelineRayRecursionDepth));
-    wrapper->pLibraryInfo = std::make_unique<StructPointerDecoder<Decoded_VkPipelineLibraryCreateInfoKHR>>();
+    wrapper->pLibraryInfo = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineLibraryCreateInfoKHR>>();
     bytes_read += wrapper->pLibraryInfo->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pLibraryInfo = wrapper->pLibraryInfo->GetPointer();
-    wrapper->pLibraryInterface = std::make_unique<StructPointerDecoder<Decoded_VkRayTracingPipelineInterfaceCreateInfoKHR>>();
+    wrapper->pLibraryInterface = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkRayTracingPipelineInterfaceCreateInfoKHR>>();
     bytes_read += wrapper->pLibraryInterface->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pLibraryInterface = wrapper->pLibraryInterface->GetPointer();
-    wrapper->pDynamicState = std::make_unique<StructPointerDecoder<Decoded_VkPipelineDynamicStateCreateInfo>>();
+    wrapper->pDynamicState = DecodeAllocator::Allocate<StructPointerDecoder<Decoded_VkPipelineDynamicStateCreateInfo>>();
     bytes_read += wrapper->pDynamicState->Decode((buffer + bytes_read), (buffer_size - bytes_read));
     value->pDynamicState = wrapper->pDynamicState->GetPointer();
     bytes_read += ValueDecoder::DecodeHandleIdValue((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->layout));

--- a/framework/generated/generated_vulkan_struct_decoders.cpp
+++ b/framework/generated/generated_vulkan_struct_decoders.cpp
@@ -36,7 +36,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-size_t DecodePNextStruct(const uint8_t* buffer, size_t buffer_size, std::unique_ptr<PNextNode>* pNext);
+size_t DecodePNextStruct(const uint8_t* buffer, size_t buffer_size, PNextNode** pNext);
 
 size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkExtent2D* wrapper)
 {

--- a/framework/generated/generated_vulkan_struct_decoders.h
+++ b/framework/generated/generated_vulkan_struct_decoders.h
@@ -92,7 +92,7 @@ struct Decoded_VkBufferMemoryBarrier
 
     VkBufferMemoryBarrier* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId buffer{ format::kNullHandleId };
 };
 
@@ -130,7 +130,7 @@ struct Decoded_VkImageMemoryBarrier
 
     VkImageMemoryBarrier* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId image{ format::kNullHandleId };
     Decoded_VkImageSubresourceRange* subresourceRange{ nullptr };
 };
@@ -141,7 +141,7 @@ struct Decoded_VkMemoryBarrier
 
     VkMemoryBarrier* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkAllocationCallbacks
@@ -164,7 +164,7 @@ struct Decoded_VkApplicationInfo
 
     VkApplicationInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StringDecoder pApplicationName;
     StringDecoder pEngineName;
 };
@@ -191,7 +191,7 @@ struct Decoded_VkInstanceCreateInfo
 
     VkInstanceCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkApplicationInfo>* pApplicationInfo{ nullptr };
     StringArrayDecoder ppEnabledLayerNames;
     StringArrayDecoder ppEnabledExtensionNames;
@@ -276,7 +276,7 @@ struct Decoded_VkDeviceQueueCreateInfo
 
     VkDeviceQueueCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<float> pQueuePriorities;
 };
 
@@ -286,7 +286,7 @@ struct Decoded_VkDeviceCreateInfo
 
     VkDeviceCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkDeviceQueueCreateInfo>* pQueueCreateInfos{ nullptr };
     StringArrayDecoder ppEnabledLayerNames;
     StringArrayDecoder ppEnabledExtensionNames;
@@ -318,7 +318,7 @@ struct Decoded_VkSubmitInfo
 
     VkSubmitInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     HandlePointerDecoder<VkSemaphore> pWaitSemaphores;
     PointerDecoder<VkPipelineStageFlags> pWaitDstStageMask;
     HandlePointerDecoder<VkCommandBuffer> pCommandBuffers;
@@ -331,7 +331,7 @@ struct Decoded_VkMappedMemoryRange
 
     VkMappedMemoryRange* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId memory{ format::kNullHandleId };
 };
 
@@ -341,7 +341,7 @@ struct Decoded_VkMemoryAllocateInfo
 
     VkMemoryAllocateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkMemoryRequirements
@@ -415,7 +415,7 @@ struct Decoded_VkBindSparseInfo
 
     VkBindSparseInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     HandlePointerDecoder<VkSemaphore> pWaitSemaphores;
     StructPointerDecoder<Decoded_VkSparseBufferMemoryBindInfo>* pBufferBinds{ nullptr };
     StructPointerDecoder<Decoded_VkSparseImageOpaqueMemoryBindInfo>* pImageOpaqueBinds{ nullptr };
@@ -447,7 +447,7 @@ struct Decoded_VkFenceCreateInfo
 
     VkFenceCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkSemaphoreCreateInfo
@@ -456,7 +456,7 @@ struct Decoded_VkSemaphoreCreateInfo
 
     VkSemaphoreCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkEventCreateInfo
@@ -465,7 +465,7 @@ struct Decoded_VkEventCreateInfo
 
     VkEventCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkQueryPoolCreateInfo
@@ -474,7 +474,7 @@ struct Decoded_VkQueryPoolCreateInfo
 
     VkQueryPoolCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkBufferCreateInfo
@@ -483,7 +483,7 @@ struct Decoded_VkBufferCreateInfo
 
     VkBufferCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint32_t> pQueueFamilyIndices;
 };
 
@@ -493,7 +493,7 @@ struct Decoded_VkBufferViewCreateInfo
 
     VkBufferViewCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId buffer{ format::kNullHandleId };
 };
 
@@ -503,7 +503,7 @@ struct Decoded_VkImageCreateInfo
 
     VkImageCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkExtent3D* extent{ nullptr };
     PointerDecoder<uint32_t> pQueueFamilyIndices;
 };
@@ -528,7 +528,7 @@ struct Decoded_VkImageViewCreateInfo
 
     VkImageViewCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId image{ format::kNullHandleId };
     Decoded_VkComponentMapping* components{ nullptr };
     Decoded_VkImageSubresourceRange* subresourceRange{ nullptr };
@@ -540,7 +540,7 @@ struct Decoded_VkShaderModuleCreateInfo
 
     VkShaderModuleCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint32_t> pCode;
 };
 
@@ -550,7 +550,7 @@ struct Decoded_VkPipelineCacheCreateInfo
 
     VkPipelineCacheCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint8_t> pInitialData;
 };
 
@@ -577,7 +577,7 @@ struct Decoded_VkPipelineShaderStageCreateInfo
 
     VkPipelineShaderStageCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId module{ format::kNullHandleId };
     StringDecoder pName;
     StructPointerDecoder<Decoded_VkSpecializationInfo>* pSpecializationInfo{ nullptr };
@@ -589,7 +589,7 @@ struct Decoded_VkComputePipelineCreateInfo
 
     VkComputePipelineCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkPipelineShaderStageCreateInfo* stage{ nullptr };
     format::HandleId layout{ format::kNullHandleId };
     format::HandleId basePipelineHandle{ format::kNullHandleId };
@@ -615,7 +615,7 @@ struct Decoded_VkPipelineVertexInputStateCreateInfo
 
     VkPipelineVertexInputStateCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkVertexInputBindingDescription>* pVertexBindingDescriptions{ nullptr };
     StructPointerDecoder<Decoded_VkVertexInputAttributeDescription>* pVertexAttributeDescriptions{ nullptr };
 };
@@ -626,7 +626,7 @@ struct Decoded_VkPipelineInputAssemblyStateCreateInfo
 
     VkPipelineInputAssemblyStateCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineTessellationStateCreateInfo
@@ -635,7 +635,7 @@ struct Decoded_VkPipelineTessellationStateCreateInfo
 
     VkPipelineTessellationStateCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkViewport
@@ -651,7 +651,7 @@ struct Decoded_VkPipelineViewportStateCreateInfo
 
     VkPipelineViewportStateCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkViewport>* pViewports{ nullptr };
     StructPointerDecoder<Decoded_VkRect2D>* pScissors{ nullptr };
 };
@@ -662,7 +662,7 @@ struct Decoded_VkPipelineRasterizationStateCreateInfo
 
     VkPipelineRasterizationStateCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineMultisampleStateCreateInfo
@@ -671,7 +671,7 @@ struct Decoded_VkPipelineMultisampleStateCreateInfo
 
     VkPipelineMultisampleStateCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<VkSampleMask> pSampleMask;
 };
 
@@ -688,7 +688,7 @@ struct Decoded_VkPipelineDepthStencilStateCreateInfo
 
     VkPipelineDepthStencilStateCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkStencilOpState* front{ nullptr };
     Decoded_VkStencilOpState* back{ nullptr };
 };
@@ -706,7 +706,7 @@ struct Decoded_VkPipelineColorBlendStateCreateInfo
 
     VkPipelineColorBlendStateCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkPipelineColorBlendAttachmentState>* pAttachments{ nullptr };
     PointerDecoder<float> blendConstants;
 };
@@ -717,7 +717,7 @@ struct Decoded_VkPipelineDynamicStateCreateInfo
 
     VkPipelineDynamicStateCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<VkDynamicState> pDynamicStates;
 };
 
@@ -727,7 +727,7 @@ struct Decoded_VkGraphicsPipelineCreateInfo
 
     VkGraphicsPipelineCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>* pStages{ nullptr };
     StructPointerDecoder<Decoded_VkPipelineVertexInputStateCreateInfo>* pVertexInputState{ nullptr };
     StructPointerDecoder<Decoded_VkPipelineInputAssemblyStateCreateInfo>* pInputAssemblyState{ nullptr };
@@ -756,7 +756,7 @@ struct Decoded_VkPipelineLayoutCreateInfo
 
     VkPipelineLayoutCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     HandlePointerDecoder<VkDescriptorSetLayout> pSetLayouts;
     StructPointerDecoder<Decoded_VkPushConstantRange>* pPushConstantRanges{ nullptr };
 };
@@ -767,7 +767,7 @@ struct Decoded_VkSamplerCreateInfo
 
     VkSamplerCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkCopyDescriptorSet
@@ -776,7 +776,7 @@ struct Decoded_VkCopyDescriptorSet
 
     VkCopyDescriptorSet* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId srcSet{ format::kNullHandleId };
     format::HandleId dstSet{ format::kNullHandleId };
 };
@@ -803,7 +803,7 @@ struct Decoded_VkDescriptorPoolCreateInfo
 
     VkDescriptorPoolCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkDescriptorPoolSize>* pPoolSizes{ nullptr };
 };
 
@@ -813,7 +813,7 @@ struct Decoded_VkDescriptorSetAllocateInfo
 
     VkDescriptorSetAllocateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId descriptorPool{ format::kNullHandleId };
     HandlePointerDecoder<VkDescriptorSetLayout> pSetLayouts;
 };
@@ -833,7 +833,7 @@ struct Decoded_VkDescriptorSetLayoutCreateInfo
 
     VkDescriptorSetLayoutCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutBinding>* pBindings{ nullptr };
 };
 
@@ -857,7 +857,7 @@ struct Decoded_VkFramebufferCreateInfo
 
     VkFramebufferCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId renderPass{ format::kNullHandleId };
     HandlePointerDecoder<VkImageView> pAttachments;
 };
@@ -888,7 +888,7 @@ struct Decoded_VkRenderPassCreateInfo
 
     VkRenderPassCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkAttachmentDescription>* pAttachments{ nullptr };
     StructPointerDecoder<Decoded_VkSubpassDescription>* pSubpasses{ nullptr };
     StructPointerDecoder<Decoded_VkSubpassDependency>* pDependencies{ nullptr };
@@ -900,7 +900,7 @@ struct Decoded_VkCommandPoolCreateInfo
 
     VkCommandPoolCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkCommandBufferAllocateInfo
@@ -909,7 +909,7 @@ struct Decoded_VkCommandBufferAllocateInfo
 
     VkCommandBufferAllocateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId commandPool{ format::kNullHandleId };
 };
 
@@ -919,7 +919,7 @@ struct Decoded_VkCommandBufferInheritanceInfo
 
     VkCommandBufferInheritanceInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId renderPass{ format::kNullHandleId };
     format::HandleId framebuffer{ format::kNullHandleId };
 };
@@ -930,7 +930,7 @@ struct Decoded_VkCommandBufferBeginInfo
 
     VkCommandBufferBeginInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkCommandBufferInheritanceInfo>* pInheritanceInfo{ nullptr };
 };
 
@@ -1028,7 +1028,7 @@ struct Decoded_VkRenderPassBeginInfo
 
     VkRenderPassBeginInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId renderPass{ format::kNullHandleId };
     format::HandleId framebuffer{ format::kNullHandleId };
     Decoded_VkRect2D* renderArea{ nullptr };
@@ -1041,7 +1041,7 @@ struct Decoded_VkPhysicalDeviceSubgroupProperties
 
     VkPhysicalDeviceSubgroupProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkBindBufferMemoryInfo
@@ -1050,7 +1050,7 @@ struct Decoded_VkBindBufferMemoryInfo
 
     VkBindBufferMemoryInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId buffer{ format::kNullHandleId };
     format::HandleId memory{ format::kNullHandleId };
 };
@@ -1061,7 +1061,7 @@ struct Decoded_VkBindImageMemoryInfo
 
     VkBindImageMemoryInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId image{ format::kNullHandleId };
     format::HandleId memory{ format::kNullHandleId };
 };
@@ -1072,7 +1072,7 @@ struct Decoded_VkPhysicalDevice16BitStorageFeatures
 
     VkPhysicalDevice16BitStorageFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkMemoryDedicatedRequirements
@@ -1081,7 +1081,7 @@ struct Decoded_VkMemoryDedicatedRequirements
 
     VkMemoryDedicatedRequirements* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkMemoryDedicatedAllocateInfo
@@ -1090,7 +1090,7 @@ struct Decoded_VkMemoryDedicatedAllocateInfo
 
     VkMemoryDedicatedAllocateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId image{ format::kNullHandleId };
     format::HandleId buffer{ format::kNullHandleId };
 };
@@ -1101,7 +1101,7 @@ struct Decoded_VkMemoryAllocateFlagsInfo
 
     VkMemoryAllocateFlagsInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDeviceGroupRenderPassBeginInfo
@@ -1110,7 +1110,7 @@ struct Decoded_VkDeviceGroupRenderPassBeginInfo
 
     VkDeviceGroupRenderPassBeginInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkRect2D>* pDeviceRenderAreas{ nullptr };
 };
 
@@ -1120,7 +1120,7 @@ struct Decoded_VkDeviceGroupCommandBufferBeginInfo
 
     VkDeviceGroupCommandBufferBeginInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDeviceGroupSubmitInfo
@@ -1129,7 +1129,7 @@ struct Decoded_VkDeviceGroupSubmitInfo
 
     VkDeviceGroupSubmitInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint32_t> pWaitSemaphoreDeviceIndices;
     PointerDecoder<uint32_t> pCommandBufferDeviceMasks;
     PointerDecoder<uint32_t> pSignalSemaphoreDeviceIndices;
@@ -1141,7 +1141,7 @@ struct Decoded_VkDeviceGroupBindSparseInfo
 
     VkDeviceGroupBindSparseInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkBindBufferMemoryDeviceGroupInfo
@@ -1150,7 +1150,7 @@ struct Decoded_VkBindBufferMemoryDeviceGroupInfo
 
     VkBindBufferMemoryDeviceGroupInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint32_t> pDeviceIndices;
 };
 
@@ -1160,7 +1160,7 @@ struct Decoded_VkBindImageMemoryDeviceGroupInfo
 
     VkBindImageMemoryDeviceGroupInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint32_t> pDeviceIndices;
     StructPointerDecoder<Decoded_VkRect2D>* pSplitInstanceBindRegions{ nullptr };
 };
@@ -1171,7 +1171,7 @@ struct Decoded_VkPhysicalDeviceGroupProperties
 
     VkPhysicalDeviceGroupProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     HandlePointerDecoder<VkPhysicalDevice> physicalDevices;
 };
 
@@ -1181,7 +1181,7 @@ struct Decoded_VkDeviceGroupDeviceCreateInfo
 
     VkDeviceGroupDeviceCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     HandlePointerDecoder<VkPhysicalDevice> pPhysicalDevices;
 };
 
@@ -1191,7 +1191,7 @@ struct Decoded_VkBufferMemoryRequirementsInfo2
 
     VkBufferMemoryRequirementsInfo2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId buffer{ format::kNullHandleId };
 };
 
@@ -1201,7 +1201,7 @@ struct Decoded_VkImageMemoryRequirementsInfo2
 
     VkImageMemoryRequirementsInfo2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId image{ format::kNullHandleId };
 };
 
@@ -1211,7 +1211,7 @@ struct Decoded_VkImageSparseMemoryRequirementsInfo2
 
     VkImageSparseMemoryRequirementsInfo2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId image{ format::kNullHandleId };
 };
 
@@ -1221,7 +1221,7 @@ struct Decoded_VkMemoryRequirements2
 
     VkMemoryRequirements2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkMemoryRequirements* memoryRequirements{ nullptr };
 };
 
@@ -1231,7 +1231,7 @@ struct Decoded_VkSparseImageMemoryRequirements2
 
     VkSparseImageMemoryRequirements2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkSparseImageMemoryRequirements* memoryRequirements{ nullptr };
 };
 
@@ -1241,7 +1241,7 @@ struct Decoded_VkPhysicalDeviceFeatures2
 
     VkPhysicalDeviceFeatures2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkPhysicalDeviceFeatures* features{ nullptr };
 };
 
@@ -1251,7 +1251,7 @@ struct Decoded_VkPhysicalDeviceProperties2
 
     VkPhysicalDeviceProperties2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkPhysicalDeviceProperties* properties{ nullptr };
 };
 
@@ -1261,7 +1261,7 @@ struct Decoded_VkFormatProperties2
 
     VkFormatProperties2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkFormatProperties* formatProperties{ nullptr };
 };
 
@@ -1271,7 +1271,7 @@ struct Decoded_VkImageFormatProperties2
 
     VkImageFormatProperties2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkImageFormatProperties* imageFormatProperties{ nullptr };
 };
 
@@ -1281,7 +1281,7 @@ struct Decoded_VkPhysicalDeviceImageFormatInfo2
 
     VkPhysicalDeviceImageFormatInfo2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkQueueFamilyProperties2
@@ -1290,7 +1290,7 @@ struct Decoded_VkQueueFamilyProperties2
 
     VkQueueFamilyProperties2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkQueueFamilyProperties* queueFamilyProperties{ nullptr };
 };
 
@@ -1300,7 +1300,7 @@ struct Decoded_VkPhysicalDeviceMemoryProperties2
 
     VkPhysicalDeviceMemoryProperties2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkPhysicalDeviceMemoryProperties* memoryProperties{ nullptr };
 };
 
@@ -1310,7 +1310,7 @@ struct Decoded_VkSparseImageFormatProperties2
 
     VkSparseImageFormatProperties2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkSparseImageFormatProperties* properties{ nullptr };
 };
 
@@ -1320,7 +1320,7 @@ struct Decoded_VkPhysicalDeviceSparseImageFormatInfo2
 
     VkPhysicalDeviceSparseImageFormatInfo2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDevicePointClippingProperties
@@ -1329,7 +1329,7 @@ struct Decoded_VkPhysicalDevicePointClippingProperties
 
     VkPhysicalDevicePointClippingProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkInputAttachmentAspectReference
@@ -1345,7 +1345,7 @@ struct Decoded_VkRenderPassInputAttachmentAspectCreateInfo
 
     VkRenderPassInputAttachmentAspectCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkInputAttachmentAspectReference>* pAspectReferences{ nullptr };
 };
 
@@ -1355,7 +1355,7 @@ struct Decoded_VkImageViewUsageCreateInfo
 
     VkImageViewUsageCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineTessellationDomainOriginStateCreateInfo
@@ -1364,7 +1364,7 @@ struct Decoded_VkPipelineTessellationDomainOriginStateCreateInfo
 
     VkPipelineTessellationDomainOriginStateCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkRenderPassMultiviewCreateInfo
@@ -1373,7 +1373,7 @@ struct Decoded_VkRenderPassMultiviewCreateInfo
 
     VkRenderPassMultiviewCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint32_t> pViewMasks;
     PointerDecoder<int32_t> pViewOffsets;
     PointerDecoder<uint32_t> pCorrelationMasks;
@@ -1385,7 +1385,7 @@ struct Decoded_VkPhysicalDeviceMultiviewFeatures
 
     VkPhysicalDeviceMultiviewFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceMultiviewProperties
@@ -1394,7 +1394,7 @@ struct Decoded_VkPhysicalDeviceMultiviewProperties
 
     VkPhysicalDeviceMultiviewProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceVariablePointersFeatures
@@ -1403,7 +1403,7 @@ struct Decoded_VkPhysicalDeviceVariablePointersFeatures
 
     VkPhysicalDeviceVariablePointersFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceProtectedMemoryFeatures
@@ -1412,7 +1412,7 @@ struct Decoded_VkPhysicalDeviceProtectedMemoryFeatures
 
     VkPhysicalDeviceProtectedMemoryFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceProtectedMemoryProperties
@@ -1421,7 +1421,7 @@ struct Decoded_VkPhysicalDeviceProtectedMemoryProperties
 
     VkPhysicalDeviceProtectedMemoryProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDeviceQueueInfo2
@@ -1430,7 +1430,7 @@ struct Decoded_VkDeviceQueueInfo2
 
     VkDeviceQueueInfo2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkProtectedSubmitInfo
@@ -1439,7 +1439,7 @@ struct Decoded_VkProtectedSubmitInfo
 
     VkProtectedSubmitInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkSamplerYcbcrConversionCreateInfo
@@ -1448,7 +1448,7 @@ struct Decoded_VkSamplerYcbcrConversionCreateInfo
 
     VkSamplerYcbcrConversionCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkComponentMapping* components{ nullptr };
 };
 
@@ -1458,7 +1458,7 @@ struct Decoded_VkSamplerYcbcrConversionInfo
 
     VkSamplerYcbcrConversionInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId conversion{ format::kNullHandleId };
 };
 
@@ -1468,7 +1468,7 @@ struct Decoded_VkBindImagePlaneMemoryInfo
 
     VkBindImagePlaneMemoryInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkImagePlaneMemoryRequirementsInfo
@@ -1477,7 +1477,7 @@ struct Decoded_VkImagePlaneMemoryRequirementsInfo
 
     VkImagePlaneMemoryRequirementsInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceSamplerYcbcrConversionFeatures
@@ -1486,7 +1486,7 @@ struct Decoded_VkPhysicalDeviceSamplerYcbcrConversionFeatures
 
     VkPhysicalDeviceSamplerYcbcrConversionFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkSamplerYcbcrConversionImageFormatProperties
@@ -1495,7 +1495,7 @@ struct Decoded_VkSamplerYcbcrConversionImageFormatProperties
 
     VkSamplerYcbcrConversionImageFormatProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDescriptorUpdateTemplateEntry
@@ -1511,7 +1511,7 @@ struct Decoded_VkDescriptorUpdateTemplateCreateInfo
 
     VkDescriptorUpdateTemplateCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateEntry>* pDescriptorUpdateEntries{ nullptr };
     format::HandleId descriptorSetLayout{ format::kNullHandleId };
     format::HandleId pipelineLayout{ format::kNullHandleId };
@@ -1530,7 +1530,7 @@ struct Decoded_VkPhysicalDeviceExternalImageFormatInfo
 
     VkPhysicalDeviceExternalImageFormatInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkExternalImageFormatProperties
@@ -1539,7 +1539,7 @@ struct Decoded_VkExternalImageFormatProperties
 
     VkExternalImageFormatProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkExternalMemoryProperties* externalMemoryProperties{ nullptr };
 };
 
@@ -1549,7 +1549,7 @@ struct Decoded_VkPhysicalDeviceExternalBufferInfo
 
     VkPhysicalDeviceExternalBufferInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkExternalBufferProperties
@@ -1558,7 +1558,7 @@ struct Decoded_VkExternalBufferProperties
 
     VkExternalBufferProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkExternalMemoryProperties* externalMemoryProperties{ nullptr };
 };
 
@@ -1568,7 +1568,7 @@ struct Decoded_VkPhysicalDeviceIDProperties
 
     VkPhysicalDeviceIDProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint8_t> deviceUUID;
     PointerDecoder<uint8_t> driverUUID;
     PointerDecoder<uint8_t> deviceLUID;
@@ -1580,7 +1580,7 @@ struct Decoded_VkExternalMemoryImageCreateInfo
 
     VkExternalMemoryImageCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkExternalMemoryBufferCreateInfo
@@ -1589,7 +1589,7 @@ struct Decoded_VkExternalMemoryBufferCreateInfo
 
     VkExternalMemoryBufferCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkExportMemoryAllocateInfo
@@ -1598,7 +1598,7 @@ struct Decoded_VkExportMemoryAllocateInfo
 
     VkExportMemoryAllocateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceExternalFenceInfo
@@ -1607,7 +1607,7 @@ struct Decoded_VkPhysicalDeviceExternalFenceInfo
 
     VkPhysicalDeviceExternalFenceInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkExternalFenceProperties
@@ -1616,7 +1616,7 @@ struct Decoded_VkExternalFenceProperties
 
     VkExternalFenceProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkExportFenceCreateInfo
@@ -1625,7 +1625,7 @@ struct Decoded_VkExportFenceCreateInfo
 
     VkExportFenceCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkExportSemaphoreCreateInfo
@@ -1634,7 +1634,7 @@ struct Decoded_VkExportSemaphoreCreateInfo
 
     VkExportSemaphoreCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceExternalSemaphoreInfo
@@ -1643,7 +1643,7 @@ struct Decoded_VkPhysicalDeviceExternalSemaphoreInfo
 
     VkPhysicalDeviceExternalSemaphoreInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkExternalSemaphoreProperties
@@ -1652,7 +1652,7 @@ struct Decoded_VkExternalSemaphoreProperties
 
     VkExternalSemaphoreProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceMaintenance3Properties
@@ -1661,7 +1661,7 @@ struct Decoded_VkPhysicalDeviceMaintenance3Properties
 
     VkPhysicalDeviceMaintenance3Properties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDescriptorSetLayoutSupport
@@ -1670,7 +1670,7 @@ struct Decoded_VkDescriptorSetLayoutSupport
 
     VkDescriptorSetLayoutSupport* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceShaderDrawParametersFeatures
@@ -1679,7 +1679,7 @@ struct Decoded_VkPhysicalDeviceShaderDrawParametersFeatures
 
     VkPhysicalDeviceShaderDrawParametersFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 typedef Decoded_VkPhysicalDeviceVariablePointersFeatures Decoded_VkPhysicalDeviceVariablePointerFeatures;
@@ -1692,7 +1692,7 @@ struct Decoded_VkPhysicalDeviceVulkan11Features
 
     VkPhysicalDeviceVulkan11Features* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceVulkan11Properties
@@ -1701,7 +1701,7 @@ struct Decoded_VkPhysicalDeviceVulkan11Properties
 
     VkPhysicalDeviceVulkan11Properties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint8_t> deviceUUID;
     PointerDecoder<uint8_t> driverUUID;
     PointerDecoder<uint8_t> deviceLUID;
@@ -1713,7 +1713,7 @@ struct Decoded_VkPhysicalDeviceVulkan12Features
 
     VkPhysicalDeviceVulkan12Features* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkConformanceVersion
@@ -1729,7 +1729,7 @@ struct Decoded_VkPhysicalDeviceVulkan12Properties
 
     VkPhysicalDeviceVulkan12Properties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StringDecoder driverName;
     StringDecoder driverInfo;
     Decoded_VkConformanceVersion* conformanceVersion{ nullptr };
@@ -1741,7 +1741,7 @@ struct Decoded_VkImageFormatListCreateInfo
 
     VkImageFormatListCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<VkFormat> pViewFormats;
 };
 
@@ -1751,7 +1751,7 @@ struct Decoded_VkAttachmentDescription2
 
     VkAttachmentDescription2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkAttachmentReference2
@@ -1760,7 +1760,7 @@ struct Decoded_VkAttachmentReference2
 
     VkAttachmentReference2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkSubpassDescription2
@@ -1769,7 +1769,7 @@ struct Decoded_VkSubpassDescription2
 
     VkSubpassDescription2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkAttachmentReference2>* pInputAttachments{ nullptr };
     StructPointerDecoder<Decoded_VkAttachmentReference2>* pColorAttachments{ nullptr };
     StructPointerDecoder<Decoded_VkAttachmentReference2>* pResolveAttachments{ nullptr };
@@ -1783,7 +1783,7 @@ struct Decoded_VkSubpassDependency2
 
     VkSubpassDependency2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkRenderPassCreateInfo2
@@ -1792,7 +1792,7 @@ struct Decoded_VkRenderPassCreateInfo2
 
     VkRenderPassCreateInfo2* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkAttachmentDescription2>* pAttachments{ nullptr };
     StructPointerDecoder<Decoded_VkSubpassDescription2>* pSubpasses{ nullptr };
     StructPointerDecoder<Decoded_VkSubpassDependency2>* pDependencies{ nullptr };
@@ -1805,7 +1805,7 @@ struct Decoded_VkSubpassBeginInfo
 
     VkSubpassBeginInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkSubpassEndInfo
@@ -1814,7 +1814,7 @@ struct Decoded_VkSubpassEndInfo
 
     VkSubpassEndInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDevice8BitStorageFeatures
@@ -1823,7 +1823,7 @@ struct Decoded_VkPhysicalDevice8BitStorageFeatures
 
     VkPhysicalDevice8BitStorageFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceDriverProperties
@@ -1832,7 +1832,7 @@ struct Decoded_VkPhysicalDeviceDriverProperties
 
     VkPhysicalDeviceDriverProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StringDecoder driverName;
     StringDecoder driverInfo;
     Decoded_VkConformanceVersion* conformanceVersion{ nullptr };
@@ -1844,7 +1844,7 @@ struct Decoded_VkPhysicalDeviceShaderAtomicInt64Features
 
     VkPhysicalDeviceShaderAtomicInt64Features* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceShaderFloat16Int8Features
@@ -1853,7 +1853,7 @@ struct Decoded_VkPhysicalDeviceShaderFloat16Int8Features
 
     VkPhysicalDeviceShaderFloat16Int8Features* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceFloatControlsProperties
@@ -1862,7 +1862,7 @@ struct Decoded_VkPhysicalDeviceFloatControlsProperties
 
     VkPhysicalDeviceFloatControlsProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDescriptorSetLayoutBindingFlagsCreateInfo
@@ -1871,7 +1871,7 @@ struct Decoded_VkDescriptorSetLayoutBindingFlagsCreateInfo
 
     VkDescriptorSetLayoutBindingFlagsCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<VkDescriptorBindingFlags> pBindingFlags;
 };
 
@@ -1881,7 +1881,7 @@ struct Decoded_VkPhysicalDeviceDescriptorIndexingFeatures
 
     VkPhysicalDeviceDescriptorIndexingFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceDescriptorIndexingProperties
@@ -1890,7 +1890,7 @@ struct Decoded_VkPhysicalDeviceDescriptorIndexingProperties
 
     VkPhysicalDeviceDescriptorIndexingProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDescriptorSetVariableDescriptorCountAllocateInfo
@@ -1899,7 +1899,7 @@ struct Decoded_VkDescriptorSetVariableDescriptorCountAllocateInfo
 
     VkDescriptorSetVariableDescriptorCountAllocateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint32_t> pDescriptorCounts;
 };
 
@@ -1909,7 +1909,7 @@ struct Decoded_VkDescriptorSetVariableDescriptorCountLayoutSupport
 
     VkDescriptorSetVariableDescriptorCountLayoutSupport* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkSubpassDescriptionDepthStencilResolve
@@ -1918,7 +1918,7 @@ struct Decoded_VkSubpassDescriptionDepthStencilResolve
 
     VkSubpassDescriptionDepthStencilResolve* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkAttachmentReference2>* pDepthStencilResolveAttachment{ nullptr };
 };
 
@@ -1928,7 +1928,7 @@ struct Decoded_VkPhysicalDeviceDepthStencilResolveProperties
 
     VkPhysicalDeviceDepthStencilResolveProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceScalarBlockLayoutFeatures
@@ -1937,7 +1937,7 @@ struct Decoded_VkPhysicalDeviceScalarBlockLayoutFeatures
 
     VkPhysicalDeviceScalarBlockLayoutFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkImageStencilUsageCreateInfo
@@ -1946,7 +1946,7 @@ struct Decoded_VkImageStencilUsageCreateInfo
 
     VkImageStencilUsageCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkSamplerReductionModeCreateInfo
@@ -1955,7 +1955,7 @@ struct Decoded_VkSamplerReductionModeCreateInfo
 
     VkSamplerReductionModeCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceSamplerFilterMinmaxProperties
@@ -1964,7 +1964,7 @@ struct Decoded_VkPhysicalDeviceSamplerFilterMinmaxProperties
 
     VkPhysicalDeviceSamplerFilterMinmaxProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceVulkanMemoryModelFeatures
@@ -1973,7 +1973,7 @@ struct Decoded_VkPhysicalDeviceVulkanMemoryModelFeatures
 
     VkPhysicalDeviceVulkanMemoryModelFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceImagelessFramebufferFeatures
@@ -1982,7 +1982,7 @@ struct Decoded_VkPhysicalDeviceImagelessFramebufferFeatures
 
     VkPhysicalDeviceImagelessFramebufferFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkFramebufferAttachmentImageInfo
@@ -1991,7 +1991,7 @@ struct Decoded_VkFramebufferAttachmentImageInfo
 
     VkFramebufferAttachmentImageInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<VkFormat> pViewFormats;
 };
 
@@ -2001,7 +2001,7 @@ struct Decoded_VkFramebufferAttachmentsCreateInfo
 
     VkFramebufferAttachmentsCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkFramebufferAttachmentImageInfo>* pAttachmentImageInfos{ nullptr };
 };
 
@@ -2011,7 +2011,7 @@ struct Decoded_VkRenderPassAttachmentBeginInfo
 
     VkRenderPassAttachmentBeginInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     HandlePointerDecoder<VkImageView> pAttachments;
 };
 
@@ -2021,7 +2021,7 @@ struct Decoded_VkPhysicalDeviceUniformBufferStandardLayoutFeatures
 
     VkPhysicalDeviceUniformBufferStandardLayoutFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
@@ -2030,7 +2030,7 @@ struct Decoded_VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures
 
     VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures
@@ -2039,7 +2039,7 @@ struct Decoded_VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures
 
     VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkAttachmentReferenceStencilLayout
@@ -2048,7 +2048,7 @@ struct Decoded_VkAttachmentReferenceStencilLayout
 
     VkAttachmentReferenceStencilLayout* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkAttachmentDescriptionStencilLayout
@@ -2057,7 +2057,7 @@ struct Decoded_VkAttachmentDescriptionStencilLayout
 
     VkAttachmentDescriptionStencilLayout* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceHostQueryResetFeatures
@@ -2066,7 +2066,7 @@ struct Decoded_VkPhysicalDeviceHostQueryResetFeatures
 
     VkPhysicalDeviceHostQueryResetFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceTimelineSemaphoreFeatures
@@ -2075,7 +2075,7 @@ struct Decoded_VkPhysicalDeviceTimelineSemaphoreFeatures
 
     VkPhysicalDeviceTimelineSemaphoreFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceTimelineSemaphoreProperties
@@ -2084,7 +2084,7 @@ struct Decoded_VkPhysicalDeviceTimelineSemaphoreProperties
 
     VkPhysicalDeviceTimelineSemaphoreProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkSemaphoreTypeCreateInfo
@@ -2093,7 +2093,7 @@ struct Decoded_VkSemaphoreTypeCreateInfo
 
     VkSemaphoreTypeCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkTimelineSemaphoreSubmitInfo
@@ -2102,7 +2102,7 @@ struct Decoded_VkTimelineSemaphoreSubmitInfo
 
     VkTimelineSemaphoreSubmitInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint64_t> pWaitSemaphoreValues;
     PointerDecoder<uint64_t> pSignalSemaphoreValues;
 };
@@ -2113,7 +2113,7 @@ struct Decoded_VkSemaphoreWaitInfo
 
     VkSemaphoreWaitInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     HandlePointerDecoder<VkSemaphore> pSemaphores;
     PointerDecoder<uint64_t> pValues;
 };
@@ -2124,7 +2124,7 @@ struct Decoded_VkSemaphoreSignalInfo
 
     VkSemaphoreSignalInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId semaphore{ format::kNullHandleId };
 };
 
@@ -2134,7 +2134,7 @@ struct Decoded_VkPhysicalDeviceBufferDeviceAddressFeatures
 
     VkPhysicalDeviceBufferDeviceAddressFeatures* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkBufferDeviceAddressInfo
@@ -2143,7 +2143,7 @@ struct Decoded_VkBufferDeviceAddressInfo
 
     VkBufferDeviceAddressInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId buffer{ format::kNullHandleId };
 };
 
@@ -2153,7 +2153,7 @@ struct Decoded_VkBufferOpaqueCaptureAddressCreateInfo
 
     VkBufferOpaqueCaptureAddressCreateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkMemoryOpaqueCaptureAddressAllocateInfo
@@ -2162,7 +2162,7 @@ struct Decoded_VkMemoryOpaqueCaptureAddressAllocateInfo
 
     VkMemoryOpaqueCaptureAddressAllocateInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo
@@ -2171,7 +2171,7 @@ struct Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo
 
     VkDeviceMemoryOpaqueCaptureAddressInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId memory{ format::kNullHandleId };
 };
 
@@ -2199,7 +2199,7 @@ struct Decoded_VkSwapchainCreateInfoKHR
 
     VkSwapchainCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId surface{ format::kNullHandleId };
     Decoded_VkExtent2D* imageExtent{ nullptr };
     PointerDecoder<uint32_t> pQueueFamilyIndices;
@@ -2212,7 +2212,7 @@ struct Decoded_VkPresentInfoKHR
 
     VkPresentInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     HandlePointerDecoder<VkSemaphore> pWaitSemaphores;
     HandlePointerDecoder<VkSwapchainKHR> pSwapchains;
     PointerDecoder<uint32_t> pImageIndices;
@@ -2225,7 +2225,7 @@ struct Decoded_VkImageSwapchainCreateInfoKHR
 
     VkImageSwapchainCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId swapchain{ format::kNullHandleId };
 };
 
@@ -2235,7 +2235,7 @@ struct Decoded_VkBindImageMemorySwapchainInfoKHR
 
     VkBindImageMemorySwapchainInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId swapchain{ format::kNullHandleId };
 };
 
@@ -2245,7 +2245,7 @@ struct Decoded_VkAcquireNextImageInfoKHR
 
     VkAcquireNextImageInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId swapchain{ format::kNullHandleId };
     format::HandleId semaphore{ format::kNullHandleId };
     format::HandleId fence{ format::kNullHandleId };
@@ -2257,7 +2257,7 @@ struct Decoded_VkDeviceGroupPresentCapabilitiesKHR
 
     VkDeviceGroupPresentCapabilitiesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint32_t> presentMask;
 };
 
@@ -2267,7 +2267,7 @@ struct Decoded_VkDeviceGroupPresentInfoKHR
 
     VkDeviceGroupPresentInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint32_t> pDeviceMasks;
 };
 
@@ -2277,7 +2277,7 @@ struct Decoded_VkDeviceGroupSwapchainCreateInfoKHR
 
     VkDeviceGroupSwapchainCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDisplayModeParametersKHR
@@ -2295,7 +2295,7 @@ struct Decoded_VkDisplayModeCreateInfoKHR
 
     VkDisplayModeCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkDisplayModeParametersKHR* parameters{ nullptr };
 };
 
@@ -2352,7 +2352,7 @@ struct Decoded_VkDisplaySurfaceCreateInfoKHR
 
     VkDisplaySurfaceCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId displayMode{ format::kNullHandleId };
     Decoded_VkExtent2D* imageExtent{ nullptr };
 };
@@ -2363,7 +2363,7 @@ struct Decoded_VkDisplayPresentInfoKHR
 
     VkDisplayPresentInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkRect2D* srcRect{ nullptr };
     Decoded_VkRect2D* dstRect{ nullptr };
 };
@@ -2374,7 +2374,7 @@ struct Decoded_VkXlibSurfaceCreateInfoKHR
 
     VkXlibSurfaceCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t dpy{ 0 };
 };
 
@@ -2384,7 +2384,7 @@ struct Decoded_VkXcbSurfaceCreateInfoKHR
 
     VkXcbSurfaceCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t connection{ 0 };
 };
 
@@ -2394,7 +2394,7 @@ struct Decoded_VkWaylandSurfaceCreateInfoKHR
 
     VkWaylandSurfaceCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t display{ 0 };
     uint64_t surface{ 0 };
 };
@@ -2405,7 +2405,7 @@ struct Decoded_VkAndroidSurfaceCreateInfoKHR
 
     VkAndroidSurfaceCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t window{ 0 };
 };
 
@@ -2415,7 +2415,7 @@ struct Decoded_VkWin32SurfaceCreateInfoKHR
 
     VkWin32SurfaceCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t hinstance{ 0 };
     uint64_t hwnd{ 0 };
 };
@@ -2486,7 +2486,7 @@ struct Decoded_VkImportMemoryWin32HandleInfoKHR
 
     VkImportMemoryWin32HandleInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t handle{ 0 };
     WStringDecoder name;
 };
@@ -2497,7 +2497,7 @@ struct Decoded_VkExportMemoryWin32HandleInfoKHR
 
     VkExportMemoryWin32HandleInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>* pAttributes{ nullptr };
     WStringDecoder name;
 };
@@ -2508,7 +2508,7 @@ struct Decoded_VkMemoryWin32HandlePropertiesKHR
 
     VkMemoryWin32HandlePropertiesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkMemoryGetWin32HandleInfoKHR
@@ -2517,7 +2517,7 @@ struct Decoded_VkMemoryGetWin32HandleInfoKHR
 
     VkMemoryGetWin32HandleInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId memory{ format::kNullHandleId };
 };
 
@@ -2527,7 +2527,7 @@ struct Decoded_VkImportMemoryFdInfoKHR
 
     VkImportMemoryFdInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkMemoryFdPropertiesKHR
@@ -2536,7 +2536,7 @@ struct Decoded_VkMemoryFdPropertiesKHR
 
     VkMemoryFdPropertiesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkMemoryGetFdInfoKHR
@@ -2545,7 +2545,7 @@ struct Decoded_VkMemoryGetFdInfoKHR
 
     VkMemoryGetFdInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId memory{ format::kNullHandleId };
 };
 
@@ -2555,7 +2555,7 @@ struct Decoded_VkWin32KeyedMutexAcquireReleaseInfoKHR
 
     VkWin32KeyedMutexAcquireReleaseInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     HandlePointerDecoder<VkDeviceMemory> pAcquireSyncs;
     PointerDecoder<uint64_t> pAcquireKeys;
     PointerDecoder<uint32_t> pAcquireTimeouts;
@@ -2575,7 +2575,7 @@ struct Decoded_VkImportSemaphoreWin32HandleInfoKHR
 
     VkImportSemaphoreWin32HandleInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId semaphore{ format::kNullHandleId };
     uint64_t handle{ 0 };
     WStringDecoder name;
@@ -2587,7 +2587,7 @@ struct Decoded_VkExportSemaphoreWin32HandleInfoKHR
 
     VkExportSemaphoreWin32HandleInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>* pAttributes{ nullptr };
     WStringDecoder name;
 };
@@ -2598,7 +2598,7 @@ struct Decoded_VkD3D12FenceSubmitInfoKHR
 
     VkD3D12FenceSubmitInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint64_t> pWaitSemaphoreValues;
     PointerDecoder<uint64_t> pSignalSemaphoreValues;
 };
@@ -2609,7 +2609,7 @@ struct Decoded_VkSemaphoreGetWin32HandleInfoKHR
 
     VkSemaphoreGetWin32HandleInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId semaphore{ format::kNullHandleId };
 };
 
@@ -2619,7 +2619,7 @@ struct Decoded_VkImportSemaphoreFdInfoKHR
 
     VkImportSemaphoreFdInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId semaphore{ format::kNullHandleId };
 };
 
@@ -2629,7 +2629,7 @@ struct Decoded_VkSemaphoreGetFdInfoKHR
 
     VkSemaphoreGetFdInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId semaphore{ format::kNullHandleId };
 };
 
@@ -2639,7 +2639,7 @@ struct Decoded_VkPhysicalDevicePushDescriptorPropertiesKHR
 
     VkPhysicalDevicePushDescriptorPropertiesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 typedef Decoded_VkPhysicalDeviceShaderFloat16Int8Features Decoded_VkPhysicalDeviceShaderFloat16Int8FeaturesKHR;
@@ -2673,7 +2673,7 @@ struct Decoded_VkPresentRegionsKHR
 
     VkPresentRegionsKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkPresentRegionKHR>* pRegions{ nullptr };
 };
 
@@ -2709,7 +2709,7 @@ struct Decoded_VkSharedPresentSurfaceCapabilitiesKHR
 
     VkSharedPresentSurfaceCapabilitiesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 typedef Decoded_VkPhysicalDeviceExternalFenceInfo Decoded_VkPhysicalDeviceExternalFenceInfoKHR;
@@ -2724,7 +2724,7 @@ struct Decoded_VkImportFenceWin32HandleInfoKHR
 
     VkImportFenceWin32HandleInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId fence{ format::kNullHandleId };
     uint64_t handle{ 0 };
     WStringDecoder name;
@@ -2736,7 +2736,7 @@ struct Decoded_VkExportFenceWin32HandleInfoKHR
 
     VkExportFenceWin32HandleInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>* pAttributes{ nullptr };
     WStringDecoder name;
 };
@@ -2747,7 +2747,7 @@ struct Decoded_VkFenceGetWin32HandleInfoKHR
 
     VkFenceGetWin32HandleInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId fence{ format::kNullHandleId };
 };
 
@@ -2757,7 +2757,7 @@ struct Decoded_VkImportFenceFdInfoKHR
 
     VkImportFenceFdInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId fence{ format::kNullHandleId };
 };
 
@@ -2767,7 +2767,7 @@ struct Decoded_VkFenceGetFdInfoKHR
 
     VkFenceGetFdInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId fence{ format::kNullHandleId };
 };
 
@@ -2777,7 +2777,7 @@ struct Decoded_VkPhysicalDevicePerformanceQueryFeaturesKHR
 
     VkPhysicalDevicePerformanceQueryFeaturesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDevicePerformanceQueryPropertiesKHR
@@ -2786,7 +2786,7 @@ struct Decoded_VkPhysicalDevicePerformanceQueryPropertiesKHR
 
     VkPhysicalDevicePerformanceQueryPropertiesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPerformanceCounterKHR
@@ -2795,7 +2795,7 @@ struct Decoded_VkPerformanceCounterKHR
 
     VkPerformanceCounterKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint8_t> uuid;
 };
 
@@ -2805,7 +2805,7 @@ struct Decoded_VkPerformanceCounterDescriptionKHR
 
     VkPerformanceCounterDescriptionKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StringDecoder name;
     StringDecoder category;
     StringDecoder description;
@@ -2817,7 +2817,7 @@ struct Decoded_VkQueryPoolPerformanceCreateInfoKHR
 
     VkQueryPoolPerformanceCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint32_t> pCounterIndices;
 };
 
@@ -2827,7 +2827,7 @@ struct Decoded_VkAcquireProfilingLockInfoKHR
 
     VkAcquireProfilingLockInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPerformanceQuerySubmitInfoKHR
@@ -2836,7 +2836,7 @@ struct Decoded_VkPerformanceQuerySubmitInfoKHR
 
     VkPerformanceQuerySubmitInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 typedef Decoded_VkPhysicalDevicePointClippingProperties Decoded_VkPhysicalDevicePointClippingPropertiesKHR;
@@ -2855,7 +2855,7 @@ struct Decoded_VkPhysicalDeviceSurfaceInfo2KHR
 
     VkPhysicalDeviceSurfaceInfo2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId surface{ format::kNullHandleId };
 };
 
@@ -2865,7 +2865,7 @@ struct Decoded_VkSurfaceCapabilities2KHR
 
     VkSurfaceCapabilities2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkSurfaceCapabilitiesKHR* surfaceCapabilities{ nullptr };
 };
 
@@ -2875,7 +2875,7 @@ struct Decoded_VkSurfaceFormat2KHR
 
     VkSurfaceFormat2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkSurfaceFormatKHR* surfaceFormat{ nullptr };
 };
 
@@ -2889,7 +2889,7 @@ struct Decoded_VkDisplayProperties2KHR
 
     VkDisplayProperties2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkDisplayPropertiesKHR* displayProperties{ nullptr };
 };
 
@@ -2899,7 +2899,7 @@ struct Decoded_VkDisplayPlaneProperties2KHR
 
     VkDisplayPlaneProperties2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkDisplayPlanePropertiesKHR* displayPlaneProperties{ nullptr };
 };
 
@@ -2909,7 +2909,7 @@ struct Decoded_VkDisplayModeProperties2KHR
 
     VkDisplayModeProperties2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkDisplayModePropertiesKHR* displayModeProperties{ nullptr };
 };
 
@@ -2919,7 +2919,7 @@ struct Decoded_VkDisplayPlaneInfo2KHR
 
     VkDisplayPlaneInfo2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId mode{ format::kNullHandleId };
 };
 
@@ -2929,7 +2929,7 @@ struct Decoded_VkDisplayPlaneCapabilities2KHR
 
     VkDisplayPlaneCapabilities2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkDisplayPlaneCapabilitiesKHR* capabilities{ nullptr };
 };
 
@@ -2971,7 +2971,7 @@ struct Decoded_VkPhysicalDevicePortabilitySubsetFeaturesKHR
 
     VkPhysicalDevicePortabilitySubsetFeaturesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDevicePortabilitySubsetPropertiesKHR
@@ -2980,7 +2980,7 @@ struct Decoded_VkPhysicalDevicePortabilitySubsetPropertiesKHR
 
     VkPhysicalDevicePortabilitySubsetPropertiesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 typedef Decoded_VkPhysicalDeviceMaintenance3Properties Decoded_VkPhysicalDeviceMaintenance3PropertiesKHR;
@@ -2999,7 +2999,7 @@ struct Decoded_VkPhysicalDeviceShaderClockFeaturesKHR
 
     VkPhysicalDeviceShaderClockFeaturesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 typedef Decoded_VkConformanceVersion Decoded_VkConformanceVersionKHR;
@@ -3032,7 +3032,7 @@ struct Decoded_VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR
 
     VkPhysicalDeviceShaderTerminateInvocationFeaturesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkFragmentShadingRateAttachmentInfoKHR
@@ -3041,7 +3041,7 @@ struct Decoded_VkFragmentShadingRateAttachmentInfoKHR
 
     VkFragmentShadingRateAttachmentInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkAttachmentReference2>* pFragmentShadingRateAttachment{ nullptr };
     Decoded_VkExtent2D* shadingRateAttachmentTexelSize{ nullptr };
 };
@@ -3052,7 +3052,7 @@ struct Decoded_VkPipelineFragmentShadingRateStateCreateInfoKHR
 
     VkPipelineFragmentShadingRateStateCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkExtent2D* fragmentSize{ nullptr };
     PointerDecoder<VkFragmentShadingRateCombinerOpKHR> combinerOps;
 };
@@ -3063,7 +3063,7 @@ struct Decoded_VkPhysicalDeviceFragmentShadingRateFeaturesKHR
 
     VkPhysicalDeviceFragmentShadingRateFeaturesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceFragmentShadingRatePropertiesKHR
@@ -3072,7 +3072,7 @@ struct Decoded_VkPhysicalDeviceFragmentShadingRatePropertiesKHR
 
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkExtent2D* minFragmentShadingRateAttachmentTexelSize{ nullptr };
     Decoded_VkExtent2D* maxFragmentShadingRateAttachmentTexelSize{ nullptr };
     Decoded_VkExtent2D* maxFragmentSize{ nullptr };
@@ -3084,7 +3084,7 @@ struct Decoded_VkPhysicalDeviceFragmentShadingRateKHR
 
     VkPhysicalDeviceFragmentShadingRateKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkExtent2D* fragmentSize{ nullptr };
 };
 
@@ -3094,7 +3094,7 @@ struct Decoded_VkSurfaceProtectedCapabilitiesKHR
 
     VkSurfaceProtectedCapabilitiesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 typedef Decoded_VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures Decoded_VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR;
@@ -3121,7 +3121,7 @@ struct Decoded_VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR
 
     VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineInfoKHR
@@ -3130,7 +3130,7 @@ struct Decoded_VkPipelineInfoKHR
 
     VkPipelineInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId pipeline{ format::kNullHandleId };
 };
 
@@ -3140,7 +3140,7 @@ struct Decoded_VkPipelineExecutablePropertiesKHR
 
     VkPipelineExecutablePropertiesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StringDecoder name;
     StringDecoder description;
 };
@@ -3151,7 +3151,7 @@ struct Decoded_VkPipelineExecutableInfoKHR
 
     VkPipelineExecutableInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId pipeline{ format::kNullHandleId };
 };
 
@@ -3161,7 +3161,7 @@ struct Decoded_VkPipelineExecutableStatisticKHR
 
     VkPipelineExecutableStatisticKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StringDecoder name;
     StringDecoder description;
     Decoded_VkPipelineExecutableStatisticValueKHR* value{ nullptr };
@@ -3173,7 +3173,7 @@ struct Decoded_VkPipelineExecutableInternalRepresentationKHR
 
     VkPipelineExecutableInternalRepresentationKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StringDecoder name;
     StringDecoder description;
     PointerDecoder<uint8_t> pData;
@@ -3185,7 +3185,7 @@ struct Decoded_VkPipelineLibraryCreateInfoKHR
 
     VkPipelineLibraryCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     HandlePointerDecoder<VkPipeline> pLibraries;
 };
 
@@ -3195,7 +3195,7 @@ struct Decoded_VkBufferCopy2KHR
 
     VkBufferCopy2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkCopyBufferInfo2KHR
@@ -3204,7 +3204,7 @@ struct Decoded_VkCopyBufferInfo2KHR
 
     VkCopyBufferInfo2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId srcBuffer{ format::kNullHandleId };
     format::HandleId dstBuffer{ format::kNullHandleId };
     StructPointerDecoder<Decoded_VkBufferCopy2KHR>* pRegions{ nullptr };
@@ -3216,7 +3216,7 @@ struct Decoded_VkImageCopy2KHR
 
     VkImageCopy2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkImageSubresourceLayers* srcSubresource{ nullptr };
     Decoded_VkOffset3D* srcOffset{ nullptr };
     Decoded_VkImageSubresourceLayers* dstSubresource{ nullptr };
@@ -3230,7 +3230,7 @@ struct Decoded_VkCopyImageInfo2KHR
 
     VkCopyImageInfo2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId srcImage{ format::kNullHandleId };
     format::HandleId dstImage{ format::kNullHandleId };
     StructPointerDecoder<Decoded_VkImageCopy2KHR>* pRegions{ nullptr };
@@ -3242,7 +3242,7 @@ struct Decoded_VkBufferImageCopy2KHR
 
     VkBufferImageCopy2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkImageSubresourceLayers* imageSubresource{ nullptr };
     Decoded_VkOffset3D* imageOffset{ nullptr };
     Decoded_VkExtent3D* imageExtent{ nullptr };
@@ -3254,7 +3254,7 @@ struct Decoded_VkCopyBufferToImageInfo2KHR
 
     VkCopyBufferToImageInfo2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId srcBuffer{ format::kNullHandleId };
     format::HandleId dstImage{ format::kNullHandleId };
     StructPointerDecoder<Decoded_VkBufferImageCopy2KHR>* pRegions{ nullptr };
@@ -3266,7 +3266,7 @@ struct Decoded_VkCopyImageToBufferInfo2KHR
 
     VkCopyImageToBufferInfo2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId srcImage{ format::kNullHandleId };
     format::HandleId dstBuffer{ format::kNullHandleId };
     StructPointerDecoder<Decoded_VkBufferImageCopy2KHR>* pRegions{ nullptr };
@@ -3278,7 +3278,7 @@ struct Decoded_VkImageBlit2KHR
 
     VkImageBlit2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkImageSubresourceLayers* srcSubresource{ nullptr };
     StructPointerDecoder<Decoded_VkOffset3D>* srcOffsets{ nullptr };
     Decoded_VkImageSubresourceLayers* dstSubresource{ nullptr };
@@ -3291,7 +3291,7 @@ struct Decoded_VkBlitImageInfo2KHR
 
     VkBlitImageInfo2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId srcImage{ format::kNullHandleId };
     format::HandleId dstImage{ format::kNullHandleId };
     StructPointerDecoder<Decoded_VkImageBlit2KHR>* pRegions{ nullptr };
@@ -3303,7 +3303,7 @@ struct Decoded_VkImageResolve2KHR
 
     VkImageResolve2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkImageSubresourceLayers* srcSubresource{ nullptr };
     Decoded_VkOffset3D* srcOffset{ nullptr };
     Decoded_VkImageSubresourceLayers* dstSubresource{ nullptr };
@@ -3317,7 +3317,7 @@ struct Decoded_VkResolveImageInfo2KHR
 
     VkResolveImageInfo2KHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId srcImage{ format::kNullHandleId };
     format::HandleId dstImage{ format::kNullHandleId };
     StructPointerDecoder<Decoded_VkImageResolve2KHR>* pRegions{ nullptr };
@@ -3329,7 +3329,7 @@ struct Decoded_VkDebugReportCallbackCreateInfoEXT
 
     VkDebugReportCallbackCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t pfnCallback{ 0 };
     uint64_t pUserData{ 0 };
 };
@@ -3340,7 +3340,7 @@ struct Decoded_VkPipelineRasterizationStateRasterizationOrderAMD
 
     VkPipelineRasterizationStateRasterizationOrderAMD* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDebugMarkerObjectNameInfoEXT
@@ -3349,7 +3349,7 @@ struct Decoded_VkDebugMarkerObjectNameInfoEXT
 
     VkDebugMarkerObjectNameInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t object{ 0 };
     StringDecoder pObjectName;
 };
@@ -3360,7 +3360,7 @@ struct Decoded_VkDebugMarkerObjectTagInfoEXT
 
     VkDebugMarkerObjectTagInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t object{ 0 };
     PointerDecoder<uint8_t> pTag;
 };
@@ -3371,7 +3371,7 @@ struct Decoded_VkDebugMarkerMarkerInfoEXT
 
     VkDebugMarkerMarkerInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StringDecoder pMarkerName;
     PointerDecoder<float> color;
 };
@@ -3382,7 +3382,7 @@ struct Decoded_VkDedicatedAllocationImageCreateInfoNV
 
     VkDedicatedAllocationImageCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDedicatedAllocationBufferCreateInfoNV
@@ -3391,7 +3391,7 @@ struct Decoded_VkDedicatedAllocationBufferCreateInfoNV
 
     VkDedicatedAllocationBufferCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDedicatedAllocationMemoryAllocateInfoNV
@@ -3400,7 +3400,7 @@ struct Decoded_VkDedicatedAllocationMemoryAllocateInfoNV
 
     VkDedicatedAllocationMemoryAllocateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId image{ format::kNullHandleId };
     format::HandleId buffer{ format::kNullHandleId };
 };
@@ -3411,7 +3411,7 @@ struct Decoded_VkPhysicalDeviceTransformFeedbackFeaturesEXT
 
     VkPhysicalDeviceTransformFeedbackFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT
@@ -3420,7 +3420,7 @@ struct Decoded_VkPhysicalDeviceTransformFeedbackPropertiesEXT
 
     VkPhysicalDeviceTransformFeedbackPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT
@@ -3429,7 +3429,7 @@ struct Decoded_VkPipelineRasterizationStateStreamCreateInfoEXT
 
     VkPipelineRasterizationStateStreamCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkImageViewHandleInfoNVX
@@ -3438,7 +3438,7 @@ struct Decoded_VkImageViewHandleInfoNVX
 
     VkImageViewHandleInfoNVX* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId imageView{ format::kNullHandleId };
     format::HandleId sampler{ format::kNullHandleId };
 };
@@ -3449,7 +3449,7 @@ struct Decoded_VkImageViewAddressPropertiesNVX
 
     VkImageViewAddressPropertiesNVX* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkTextureLODGatherFormatPropertiesAMD
@@ -3458,7 +3458,7 @@ struct Decoded_VkTextureLODGatherFormatPropertiesAMD
 
     VkTextureLODGatherFormatPropertiesAMD* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkShaderResourceUsageAMD
@@ -3484,7 +3484,7 @@ struct Decoded_VkStreamDescriptorSurfaceCreateInfoGGP
 
     VkStreamDescriptorSurfaceCreateInfoGGP* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceCornerSampledImageFeaturesNV
@@ -3493,7 +3493,7 @@ struct Decoded_VkPhysicalDeviceCornerSampledImageFeaturesNV
 
     VkPhysicalDeviceCornerSampledImageFeaturesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkExternalImageFormatPropertiesNV
@@ -3511,7 +3511,7 @@ struct Decoded_VkExternalMemoryImageCreateInfoNV
 
     VkExternalMemoryImageCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkExportMemoryAllocateInfoNV
@@ -3520,7 +3520,7 @@ struct Decoded_VkExportMemoryAllocateInfoNV
 
     VkExportMemoryAllocateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkImportMemoryWin32HandleInfoNV
@@ -3529,7 +3529,7 @@ struct Decoded_VkImportMemoryWin32HandleInfoNV
 
     VkImportMemoryWin32HandleInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t handle{ 0 };
 };
 
@@ -3539,7 +3539,7 @@ struct Decoded_VkExportMemoryWin32HandleInfoNV
 
     VkExportMemoryWin32HandleInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>* pAttributes{ nullptr };
 };
 
@@ -3549,7 +3549,7 @@ struct Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV
 
     VkWin32KeyedMutexAcquireReleaseInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     HandlePointerDecoder<VkDeviceMemory> pAcquireSyncs;
     PointerDecoder<uint64_t> pAcquireKeys;
     PointerDecoder<uint32_t> pAcquireTimeoutMilliseconds;
@@ -3563,7 +3563,7 @@ struct Decoded_VkValidationFlagsEXT
 
     VkValidationFlagsEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<VkValidationCheckEXT> pDisabledValidationChecks;
 };
 
@@ -3573,7 +3573,7 @@ struct Decoded_VkViSurfaceCreateInfoNN
 
     VkViSurfaceCreateInfoNN* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t window{ 0 };
 };
 
@@ -3583,7 +3583,7 @@ struct Decoded_VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT
 
     VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkImageViewASTCDecodeModeEXT
@@ -3592,7 +3592,7 @@ struct Decoded_VkImageViewASTCDecodeModeEXT
 
     VkImageViewASTCDecodeModeEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceASTCDecodeFeaturesEXT
@@ -3601,7 +3601,7 @@ struct Decoded_VkPhysicalDeviceASTCDecodeFeaturesEXT
 
     VkPhysicalDeviceASTCDecodeFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkConditionalRenderingBeginInfoEXT
@@ -3610,7 +3610,7 @@ struct Decoded_VkConditionalRenderingBeginInfoEXT
 
     VkConditionalRenderingBeginInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId buffer{ format::kNullHandleId };
 };
 
@@ -3620,7 +3620,7 @@ struct Decoded_VkPhysicalDeviceConditionalRenderingFeaturesEXT
 
     VkPhysicalDeviceConditionalRenderingFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkCommandBufferInheritanceConditionalRenderingInfoEXT
@@ -3629,7 +3629,7 @@ struct Decoded_VkCommandBufferInheritanceConditionalRenderingInfoEXT
 
     VkCommandBufferInheritanceConditionalRenderingInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkViewportWScalingNV
@@ -3645,7 +3645,7 @@ struct Decoded_VkPipelineViewportWScalingStateCreateInfoNV
 
     VkPipelineViewportWScalingStateCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkViewportWScalingNV>* pViewportWScalings{ nullptr };
 };
 
@@ -3655,7 +3655,7 @@ struct Decoded_VkSurfaceCapabilities2EXT
 
     VkSurfaceCapabilities2EXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkExtent2D* currentExtent{ nullptr };
     Decoded_VkExtent2D* minImageExtent{ nullptr };
     Decoded_VkExtent2D* maxImageExtent{ nullptr };
@@ -3667,7 +3667,7 @@ struct Decoded_VkDisplayPowerInfoEXT
 
     VkDisplayPowerInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDeviceEventInfoEXT
@@ -3676,7 +3676,7 @@ struct Decoded_VkDeviceEventInfoEXT
 
     VkDeviceEventInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDisplayEventInfoEXT
@@ -3685,7 +3685,7 @@ struct Decoded_VkDisplayEventInfoEXT
 
     VkDisplayEventInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkSwapchainCounterCreateInfoEXT
@@ -3694,7 +3694,7 @@ struct Decoded_VkSwapchainCounterCreateInfoEXT
 
     VkSwapchainCounterCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkRefreshCycleDurationGOOGLE
@@ -3724,7 +3724,7 @@ struct Decoded_VkPresentTimesInfoGOOGLE
 
     VkPresentTimesInfoGOOGLE* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkPresentTimeGOOGLE>* pTimes{ nullptr };
 };
 
@@ -3734,7 +3734,7 @@ struct Decoded_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
 
     VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkViewportSwizzleNV
@@ -3750,7 +3750,7 @@ struct Decoded_VkPipelineViewportSwizzleStateCreateInfoNV
 
     VkPipelineViewportSwizzleStateCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkViewportSwizzleNV>* pViewportSwizzles{ nullptr };
 };
 
@@ -3760,7 +3760,7 @@ struct Decoded_VkPhysicalDeviceDiscardRectanglePropertiesEXT
 
     VkPhysicalDeviceDiscardRectanglePropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT
@@ -3769,7 +3769,7 @@ struct Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT
 
     VkPipelineDiscardRectangleStateCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkRect2D>* pDiscardRectangles{ nullptr };
 };
 
@@ -3779,7 +3779,7 @@ struct Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT
 
     VkPhysicalDeviceConservativeRasterizationPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT
@@ -3788,7 +3788,7 @@ struct Decoded_VkPipelineRasterizationConservativeStateCreateInfoEXT
 
     VkPipelineRasterizationConservativeStateCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT
@@ -3797,7 +3797,7 @@ struct Decoded_VkPhysicalDeviceDepthClipEnableFeaturesEXT
 
     VkPhysicalDeviceDepthClipEnableFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT
@@ -3806,7 +3806,7 @@ struct Decoded_VkPipelineRasterizationDepthClipStateCreateInfoEXT
 
     VkPipelineRasterizationDepthClipStateCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkXYColorEXT
@@ -3822,7 +3822,7 @@ struct Decoded_VkHdrMetadataEXT
 
     VkHdrMetadataEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkXYColorEXT* displayPrimaryRed{ nullptr };
     Decoded_VkXYColorEXT* displayPrimaryGreen{ nullptr };
     Decoded_VkXYColorEXT* displayPrimaryBlue{ nullptr };
@@ -3835,7 +3835,7 @@ struct Decoded_VkIOSSurfaceCreateInfoMVK
 
     VkIOSSurfaceCreateInfoMVK* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t pView{ 0 };
 };
 
@@ -3845,7 +3845,7 @@ struct Decoded_VkMacOSSurfaceCreateInfoMVK
 
     VkMacOSSurfaceCreateInfoMVK* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t pView{ 0 };
 };
 
@@ -3855,7 +3855,7 @@ struct Decoded_VkDebugUtilsLabelEXT
 
     VkDebugUtilsLabelEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StringDecoder pLabelName;
     PointerDecoder<float> color;
 };
@@ -3866,7 +3866,7 @@ struct Decoded_VkDebugUtilsObjectNameInfoEXT
 
     VkDebugUtilsObjectNameInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t objectHandle{ 0 };
     StringDecoder pObjectName;
 };
@@ -3877,7 +3877,7 @@ struct Decoded_VkDebugUtilsMessengerCallbackDataEXT
 
     VkDebugUtilsMessengerCallbackDataEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StringDecoder pMessageIdName;
     StringDecoder pMessage;
     StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pQueueLabels{ nullptr };
@@ -3891,7 +3891,7 @@ struct Decoded_VkDebugUtilsMessengerCreateInfoEXT
 
     VkDebugUtilsMessengerCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t pfnUserCallback{ 0 };
     uint64_t pUserData{ 0 };
 };
@@ -3902,7 +3902,7 @@ struct Decoded_VkDebugUtilsObjectTagInfoEXT
 
     VkDebugUtilsObjectTagInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t objectHandle{ 0 };
     PointerDecoder<uint8_t> pTag;
 };
@@ -3913,7 +3913,7 @@ struct Decoded_VkAndroidHardwareBufferUsageANDROID
 
     VkAndroidHardwareBufferUsageANDROID* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkAndroidHardwareBufferPropertiesANDROID
@@ -3922,7 +3922,7 @@ struct Decoded_VkAndroidHardwareBufferPropertiesANDROID
 
     VkAndroidHardwareBufferPropertiesANDROID* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkAndroidHardwareBufferFormatPropertiesANDROID
@@ -3931,7 +3931,7 @@ struct Decoded_VkAndroidHardwareBufferFormatPropertiesANDROID
 
     VkAndroidHardwareBufferFormatPropertiesANDROID* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkComponentMapping* samplerYcbcrConversionComponents{ nullptr };
 };
 
@@ -3941,7 +3941,7 @@ struct Decoded_VkImportAndroidHardwareBufferInfoANDROID
 
     VkImportAndroidHardwareBufferInfoANDROID* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t buffer{ 0 };
 };
 
@@ -3951,7 +3951,7 @@ struct Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID
 
     VkMemoryGetAndroidHardwareBufferInfoANDROID* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId memory{ format::kNullHandleId };
 };
 
@@ -3961,7 +3961,7 @@ struct Decoded_VkExternalFormatANDROID
 
     VkExternalFormatANDROID* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 typedef Decoded_VkSamplerReductionModeCreateInfo Decoded_VkSamplerReductionModeCreateInfoEXT;
@@ -3974,7 +3974,7 @@ struct Decoded_VkPhysicalDeviceInlineUniformBlockFeaturesEXT
 
     VkPhysicalDeviceInlineUniformBlockFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceInlineUniformBlockPropertiesEXT
@@ -3983,7 +3983,7 @@ struct Decoded_VkPhysicalDeviceInlineUniformBlockPropertiesEXT
 
     VkPhysicalDeviceInlineUniformBlockPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkWriteDescriptorSetInlineUniformBlockEXT
@@ -3992,7 +3992,7 @@ struct Decoded_VkWriteDescriptorSetInlineUniformBlockEXT
 
     VkWriteDescriptorSetInlineUniformBlockEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint8_t> pData;
 };
 
@@ -4002,7 +4002,7 @@ struct Decoded_VkDescriptorPoolInlineUniformBlockCreateInfoEXT
 
     VkDescriptorPoolInlineUniformBlockCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkSampleLocationEXT
@@ -4018,7 +4018,7 @@ struct Decoded_VkSampleLocationsInfoEXT
 
     VkSampleLocationsInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkExtent2D* sampleLocationGridSize{ nullptr };
     StructPointerDecoder<Decoded_VkSampleLocationEXT>* pSampleLocations{ nullptr };
 };
@@ -4047,7 +4047,7 @@ struct Decoded_VkRenderPassSampleLocationsBeginInfoEXT
 
     VkRenderPassSampleLocationsBeginInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkAttachmentSampleLocationsEXT>* pAttachmentInitialSampleLocations{ nullptr };
     StructPointerDecoder<Decoded_VkSubpassSampleLocationsEXT>* pPostSubpassSampleLocations{ nullptr };
 };
@@ -4058,7 +4058,7 @@ struct Decoded_VkPipelineSampleLocationsStateCreateInfoEXT
 
     VkPipelineSampleLocationsStateCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkSampleLocationsInfoEXT* sampleLocationsInfo{ nullptr };
 };
 
@@ -4068,7 +4068,7 @@ struct Decoded_VkPhysicalDeviceSampleLocationsPropertiesEXT
 
     VkPhysicalDeviceSampleLocationsPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkExtent2D* maxSampleLocationGridSize{ nullptr };
     PointerDecoder<float> sampleLocationCoordinateRange;
 };
@@ -4079,7 +4079,7 @@ struct Decoded_VkMultisamplePropertiesEXT
 
     VkMultisamplePropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkExtent2D* maxSampleLocationGridSize{ nullptr };
 };
 
@@ -4089,7 +4089,7 @@ struct Decoded_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT
 
     VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT
@@ -4098,7 +4098,7 @@ struct Decoded_VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT
 
     VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineColorBlendAdvancedStateCreateInfoEXT
@@ -4107,7 +4107,7 @@ struct Decoded_VkPipelineColorBlendAdvancedStateCreateInfoEXT
 
     VkPipelineColorBlendAdvancedStateCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineCoverageToColorStateCreateInfoNV
@@ -4116,7 +4116,7 @@ struct Decoded_VkPipelineCoverageToColorStateCreateInfoNV
 
     VkPipelineCoverageToColorStateCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineCoverageModulationStateCreateInfoNV
@@ -4125,7 +4125,7 @@ struct Decoded_VkPipelineCoverageModulationStateCreateInfoNV
 
     VkPipelineCoverageModulationStateCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<float> pCoverageModulationTable;
 };
 
@@ -4135,7 +4135,7 @@ struct Decoded_VkPhysicalDeviceShaderSMBuiltinsPropertiesNV
 
     VkPhysicalDeviceShaderSMBuiltinsPropertiesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceShaderSMBuiltinsFeaturesNV
@@ -4144,7 +4144,7 @@ struct Decoded_VkPhysicalDeviceShaderSMBuiltinsFeaturesNV
 
     VkPhysicalDeviceShaderSMBuiltinsFeaturesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDrmFormatModifierPropertiesEXT
@@ -4160,7 +4160,7 @@ struct Decoded_VkDrmFormatModifierPropertiesListEXT
 
     VkDrmFormatModifierPropertiesListEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkDrmFormatModifierPropertiesEXT>* pDrmFormatModifierProperties{ nullptr };
 };
 
@@ -4170,7 +4170,7 @@ struct Decoded_VkPhysicalDeviceImageDrmFormatModifierInfoEXT
 
     VkPhysicalDeviceImageDrmFormatModifierInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint32_t> pQueueFamilyIndices;
 };
 
@@ -4180,7 +4180,7 @@ struct Decoded_VkImageDrmFormatModifierListCreateInfoEXT
 
     VkImageDrmFormatModifierListCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint64_t> pDrmFormatModifiers;
 };
 
@@ -4190,7 +4190,7 @@ struct Decoded_VkImageDrmFormatModifierExplicitCreateInfoEXT
 
     VkImageDrmFormatModifierExplicitCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkSubresourceLayout>* pPlaneLayouts{ nullptr };
 };
 
@@ -4200,7 +4200,7 @@ struct Decoded_VkImageDrmFormatModifierPropertiesEXT
 
     VkImageDrmFormatModifierPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkValidationCacheCreateInfoEXT
@@ -4209,7 +4209,7 @@ struct Decoded_VkValidationCacheCreateInfoEXT
 
     VkValidationCacheCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint8_t> pInitialData;
 };
 
@@ -4219,7 +4219,7 @@ struct Decoded_VkShaderModuleValidationCacheCreateInfoEXT
 
     VkShaderModuleValidationCacheCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId validationCache{ format::kNullHandleId };
 };
 
@@ -4248,7 +4248,7 @@ struct Decoded_VkPipelineViewportShadingRateImageStateCreateInfoNV
 
     VkPipelineViewportShadingRateImageStateCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkShadingRatePaletteNV>* pShadingRatePalettes{ nullptr };
 };
 
@@ -4258,7 +4258,7 @@ struct Decoded_VkPhysicalDeviceShadingRateImageFeaturesNV
 
     VkPhysicalDeviceShadingRateImageFeaturesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceShadingRateImagePropertiesNV
@@ -4267,7 +4267,7 @@ struct Decoded_VkPhysicalDeviceShadingRateImagePropertiesNV
 
     VkPhysicalDeviceShadingRateImagePropertiesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkExtent2D* shadingRateTexelSize{ nullptr };
 };
 
@@ -4293,7 +4293,7 @@ struct Decoded_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV
 
     VkPipelineViewportCoarseSampleOrderStateCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>* pCustomSampleOrders{ nullptr };
 };
 
@@ -4303,7 +4303,7 @@ struct Decoded_VkRayTracingShaderGroupCreateInfoNV
 
     VkRayTracingShaderGroupCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkRayTracingPipelineCreateInfoNV
@@ -4312,7 +4312,7 @@ struct Decoded_VkRayTracingPipelineCreateInfoNV
 
     VkRayTracingPipelineCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>* pStages{ nullptr };
     StructPointerDecoder<Decoded_VkRayTracingShaderGroupCreateInfoNV>* pGroups{ nullptr };
     format::HandleId layout{ format::kNullHandleId };
@@ -4325,7 +4325,7 @@ struct Decoded_VkGeometryTrianglesNV
 
     VkGeometryTrianglesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId vertexData{ format::kNullHandleId };
     format::HandleId indexData{ format::kNullHandleId };
     format::HandleId transformData{ format::kNullHandleId };
@@ -4337,7 +4337,7 @@ struct Decoded_VkGeometryAABBNV
 
     VkGeometryAABBNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId aabbData{ format::kNullHandleId };
 };
 
@@ -4357,7 +4357,7 @@ struct Decoded_VkGeometryNV
 
     VkGeometryNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkGeometryDataNV* geometry{ nullptr };
 };
 
@@ -4367,7 +4367,7 @@ struct Decoded_VkAccelerationStructureInfoNV
 
     VkAccelerationStructureInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkGeometryNV>* pGeometries{ nullptr };
 };
 
@@ -4377,7 +4377,7 @@ struct Decoded_VkAccelerationStructureCreateInfoNV
 
     VkAccelerationStructureCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkAccelerationStructureInfoNV* info{ nullptr };
 };
 
@@ -4387,7 +4387,7 @@ struct Decoded_VkBindAccelerationStructureMemoryInfoNV
 
     VkBindAccelerationStructureMemoryInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId accelerationStructure{ format::kNullHandleId };
     format::HandleId memory{ format::kNullHandleId };
     PointerDecoder<uint32_t> pDeviceIndices;
@@ -4399,7 +4399,7 @@ struct Decoded_VkWriteDescriptorSetAccelerationStructureNV
 
     VkWriteDescriptorSetAccelerationStructureNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     HandlePointerDecoder<VkAccelerationStructureNV> pAccelerationStructures;
 };
 
@@ -4409,7 +4409,7 @@ struct Decoded_VkAccelerationStructureMemoryRequirementsInfoNV
 
     VkAccelerationStructureMemoryRequirementsInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId accelerationStructure{ format::kNullHandleId };
 };
 
@@ -4419,7 +4419,7 @@ struct Decoded_VkPhysicalDeviceRayTracingPropertiesNV
 
     VkPhysicalDeviceRayTracingPropertiesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkTransformMatrixKHR
@@ -4459,7 +4459,7 @@ struct Decoded_VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV
 
     VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV
@@ -4468,7 +4468,7 @@ struct Decoded_VkPipelineRepresentativeFragmentTestStateCreateInfoNV
 
     VkPipelineRepresentativeFragmentTestStateCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT
@@ -4477,7 +4477,7 @@ struct Decoded_VkPhysicalDeviceImageViewImageFormatInfoEXT
 
     VkPhysicalDeviceImageViewImageFormatInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT
@@ -4486,7 +4486,7 @@ struct Decoded_VkFilterCubicImageViewImageFormatPropertiesEXT
 
     VkFilterCubicImageViewImageFormatPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT
@@ -4495,7 +4495,7 @@ struct Decoded_VkDeviceQueueGlobalPriorityCreateInfoEXT
 
     VkDeviceQueueGlobalPriorityCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkImportMemoryHostPointerInfoEXT
@@ -4504,7 +4504,7 @@ struct Decoded_VkImportMemoryHostPointerInfoEXT
 
     VkImportMemoryHostPointerInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t pHostPointer{ 0 };
 };
 
@@ -4514,7 +4514,7 @@ struct Decoded_VkMemoryHostPointerPropertiesEXT
 
     VkMemoryHostPointerPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceExternalMemoryHostPropertiesEXT
@@ -4523,7 +4523,7 @@ struct Decoded_VkPhysicalDeviceExternalMemoryHostPropertiesEXT
 
     VkPhysicalDeviceExternalMemoryHostPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineCompilerControlCreateInfoAMD
@@ -4532,7 +4532,7 @@ struct Decoded_VkPipelineCompilerControlCreateInfoAMD
 
     VkPipelineCompilerControlCreateInfoAMD* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkCalibratedTimestampInfoEXT
@@ -4541,7 +4541,7 @@ struct Decoded_VkCalibratedTimestampInfoEXT
 
     VkCalibratedTimestampInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceShaderCorePropertiesAMD
@@ -4550,7 +4550,7 @@ struct Decoded_VkPhysicalDeviceShaderCorePropertiesAMD
 
     VkPhysicalDeviceShaderCorePropertiesAMD* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDeviceMemoryOverallocationCreateInfoAMD
@@ -4559,7 +4559,7 @@ struct Decoded_VkDeviceMemoryOverallocationCreateInfoAMD
 
     VkDeviceMemoryOverallocationCreateInfoAMD* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT
@@ -4568,7 +4568,7 @@ struct Decoded_VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT
 
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkVertexInputBindingDivisorDescriptionEXT
@@ -4584,7 +4584,7 @@ struct Decoded_VkPipelineVertexInputDivisorStateCreateInfoEXT
 
     VkPipelineVertexInputDivisorStateCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkVertexInputBindingDivisorDescriptionEXT>* pVertexBindingDivisors{ nullptr };
 };
 
@@ -4594,7 +4594,7 @@ struct Decoded_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT
 
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPresentFrameTokenGGP
@@ -4603,7 +4603,7 @@ struct Decoded_VkPresentFrameTokenGGP
 
     VkPresentFrameTokenGGP* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineCreationFeedbackEXT
@@ -4619,7 +4619,7 @@ struct Decoded_VkPipelineCreationFeedbackCreateInfoEXT
 
     VkPipelineCreationFeedbackCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkPipelineCreationFeedbackEXT>* pPipelineCreationFeedback{ nullptr };
     StructPointerDecoder<Decoded_VkPipelineCreationFeedbackEXT>* pPipelineStageCreationFeedbacks{ nullptr };
 };
@@ -4630,7 +4630,7 @@ struct Decoded_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV
 
     VkPhysicalDeviceComputeShaderDerivativesFeaturesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceMeshShaderFeaturesNV
@@ -4639,7 +4639,7 @@ struct Decoded_VkPhysicalDeviceMeshShaderFeaturesNV
 
     VkPhysicalDeviceMeshShaderFeaturesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceMeshShaderPropertiesNV
@@ -4648,7 +4648,7 @@ struct Decoded_VkPhysicalDeviceMeshShaderPropertiesNV
 
     VkPhysicalDeviceMeshShaderPropertiesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint32_t> maxTaskWorkGroupSize;
     PointerDecoder<uint32_t> maxMeshWorkGroupSize;
 };
@@ -4666,7 +4666,7 @@ struct Decoded_VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV
 
     VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceShaderImageFootprintFeaturesNV
@@ -4675,7 +4675,7 @@ struct Decoded_VkPhysicalDeviceShaderImageFootprintFeaturesNV
 
     VkPhysicalDeviceShaderImageFootprintFeaturesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineViewportExclusiveScissorStateCreateInfoNV
@@ -4684,7 +4684,7 @@ struct Decoded_VkPipelineViewportExclusiveScissorStateCreateInfoNV
 
     VkPipelineViewportExclusiveScissorStateCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkRect2D>* pExclusiveScissors{ nullptr };
 };
 
@@ -4694,7 +4694,7 @@ struct Decoded_VkPhysicalDeviceExclusiveScissorFeaturesNV
 
     VkPhysicalDeviceExclusiveScissorFeaturesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkQueueFamilyCheckpointPropertiesNV
@@ -4703,7 +4703,7 @@ struct Decoded_VkQueueFamilyCheckpointPropertiesNV
 
     VkQueueFamilyCheckpointPropertiesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkCheckpointDataNV
@@ -4712,7 +4712,7 @@ struct Decoded_VkCheckpointDataNV
 
     VkCheckpointDataNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t pCheckpointMarker{ 0 };
 };
 
@@ -4722,7 +4722,7 @@ struct Decoded_VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL
 
     VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkInitializePerformanceApiInfoINTEL
@@ -4731,7 +4731,7 @@ struct Decoded_VkInitializePerformanceApiInfoINTEL
 
     VkInitializePerformanceApiInfoINTEL* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t pUserData{ 0 };
 };
 
@@ -4741,7 +4741,7 @@ struct Decoded_VkQueryPoolPerformanceQueryCreateInfoINTEL
 
     VkQueryPoolPerformanceQueryCreateInfoINTEL* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPerformanceMarkerInfoINTEL
@@ -4750,7 +4750,7 @@ struct Decoded_VkPerformanceMarkerInfoINTEL
 
     VkPerformanceMarkerInfoINTEL* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPerformanceStreamMarkerInfoINTEL
@@ -4759,7 +4759,7 @@ struct Decoded_VkPerformanceStreamMarkerInfoINTEL
 
     VkPerformanceStreamMarkerInfoINTEL* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPerformanceOverrideInfoINTEL
@@ -4768,7 +4768,7 @@ struct Decoded_VkPerformanceOverrideInfoINTEL
 
     VkPerformanceOverrideInfoINTEL* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPerformanceConfigurationAcquireInfoINTEL
@@ -4777,7 +4777,7 @@ struct Decoded_VkPerformanceConfigurationAcquireInfoINTEL
 
     VkPerformanceConfigurationAcquireInfoINTEL* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 typedef Decoded_VkQueryPoolPerformanceQueryCreateInfoINTEL Decoded_VkQueryPoolCreateInfoINTEL;
@@ -4788,7 +4788,7 @@ struct Decoded_VkPhysicalDevicePCIBusInfoPropertiesEXT
 
     VkPhysicalDevicePCIBusInfoPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDisplayNativeHdrSurfaceCapabilitiesAMD
@@ -4797,7 +4797,7 @@ struct Decoded_VkDisplayNativeHdrSurfaceCapabilitiesAMD
 
     VkDisplayNativeHdrSurfaceCapabilitiesAMD* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkSwapchainDisplayNativeHdrCreateInfoAMD
@@ -4806,7 +4806,7 @@ struct Decoded_VkSwapchainDisplayNativeHdrCreateInfoAMD
 
     VkSwapchainDisplayNativeHdrCreateInfoAMD* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA
@@ -4815,7 +4815,7 @@ struct Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA
 
     VkImagePipeSurfaceCreateInfoFUCHSIA* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkMetalSurfaceCreateInfoEXT
@@ -4824,7 +4824,7 @@ struct Decoded_VkMetalSurfaceCreateInfoEXT
 
     VkMetalSurfaceCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t pLayer{ 0 };
 };
 
@@ -4834,7 +4834,7 @@ struct Decoded_VkPhysicalDeviceFragmentDensityMapFeaturesEXT
 
     VkPhysicalDeviceFragmentDensityMapFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT
@@ -4843,7 +4843,7 @@ struct Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT
 
     VkPhysicalDeviceFragmentDensityMapPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkExtent2D* minFragmentDensityTexelSize{ nullptr };
     Decoded_VkExtent2D* maxFragmentDensityTexelSize{ nullptr };
 };
@@ -4854,7 +4854,7 @@ struct Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT
 
     VkRenderPassFragmentDensityMapCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkAttachmentReference* fragmentDensityMapAttachment{ nullptr };
 };
 
@@ -4866,7 +4866,7 @@ struct Decoded_VkPhysicalDeviceSubgroupSizeControlFeaturesEXT
 
     VkPhysicalDeviceSubgroupSizeControlFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceSubgroupSizeControlPropertiesEXT
@@ -4875,7 +4875,7 @@ struct Decoded_VkPhysicalDeviceSubgroupSizeControlPropertiesEXT
 
     VkPhysicalDeviceSubgroupSizeControlPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT
@@ -4884,7 +4884,7 @@ struct Decoded_VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT
 
     VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceShaderCoreProperties2AMD
@@ -4893,7 +4893,7 @@ struct Decoded_VkPhysicalDeviceShaderCoreProperties2AMD
 
     VkPhysicalDeviceShaderCoreProperties2AMD* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceCoherentMemoryFeaturesAMD
@@ -4902,7 +4902,7 @@ struct Decoded_VkPhysicalDeviceCoherentMemoryFeaturesAMD
 
     VkPhysicalDeviceCoherentMemoryFeaturesAMD* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT
@@ -4911,7 +4911,7 @@ struct Decoded_VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT
 
     VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceMemoryBudgetPropertiesEXT
@@ -4920,7 +4920,7 @@ struct Decoded_VkPhysicalDeviceMemoryBudgetPropertiesEXT
 
     VkPhysicalDeviceMemoryBudgetPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<VkDeviceSize> heapBudget;
     PointerDecoder<VkDeviceSize> heapUsage;
 };
@@ -4931,7 +4931,7 @@ struct Decoded_VkPhysicalDeviceMemoryPriorityFeaturesEXT
 
     VkPhysicalDeviceMemoryPriorityFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkMemoryPriorityAllocateInfoEXT
@@ -4940,7 +4940,7 @@ struct Decoded_VkMemoryPriorityAllocateInfoEXT
 
     VkMemoryPriorityAllocateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV
@@ -4949,7 +4949,7 @@ struct Decoded_VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV
 
     VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceBufferDeviceAddressFeaturesEXT
@@ -4958,7 +4958,7 @@ struct Decoded_VkPhysicalDeviceBufferDeviceAddressFeaturesEXT
 
     VkPhysicalDeviceBufferDeviceAddressFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkBufferDeviceAddressCreateInfoEXT
@@ -4967,7 +4967,7 @@ struct Decoded_VkBufferDeviceAddressCreateInfoEXT
 
     VkBufferDeviceAddressCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 typedef Decoded_VkPhysicalDeviceBufferDeviceAddressFeaturesEXT Decoded_VkPhysicalDeviceBufferAddressFeaturesEXT;
@@ -4980,7 +4980,7 @@ struct Decoded_VkPhysicalDeviceToolPropertiesEXT
 
     VkPhysicalDeviceToolPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StringDecoder name;
     StringDecoder version;
     StringDecoder description;
@@ -4995,7 +4995,7 @@ struct Decoded_VkValidationFeaturesEXT
 
     VkValidationFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<VkValidationFeatureEnableEXT> pEnabledValidationFeatures;
     PointerDecoder<VkValidationFeatureDisableEXT> pDisabledValidationFeatures;
 };
@@ -5006,7 +5006,7 @@ struct Decoded_VkCooperativeMatrixPropertiesNV
 
     VkCooperativeMatrixPropertiesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV
@@ -5015,7 +5015,7 @@ struct Decoded_VkPhysicalDeviceCooperativeMatrixFeaturesNV
 
     VkPhysicalDeviceCooperativeMatrixFeaturesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV
@@ -5024,7 +5024,7 @@ struct Decoded_VkPhysicalDeviceCooperativeMatrixPropertiesNV
 
     VkPhysicalDeviceCooperativeMatrixPropertiesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceCoverageReductionModeFeaturesNV
@@ -5033,7 +5033,7 @@ struct Decoded_VkPhysicalDeviceCoverageReductionModeFeaturesNV
 
     VkPhysicalDeviceCoverageReductionModeFeaturesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineCoverageReductionStateCreateInfoNV
@@ -5042,7 +5042,7 @@ struct Decoded_VkPipelineCoverageReductionStateCreateInfoNV
 
     VkPipelineCoverageReductionStateCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkFramebufferMixedSamplesCombinationNV
@@ -5051,7 +5051,7 @@ struct Decoded_VkFramebufferMixedSamplesCombinationNV
 
     VkFramebufferMixedSamplesCombinationNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
@@ -5060,7 +5060,7 @@ struct Decoded_VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
 
     VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT
@@ -5069,7 +5069,7 @@ struct Decoded_VkPhysicalDeviceYcbcrImageArraysFeaturesEXT
 
     VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkSurfaceFullScreenExclusiveInfoEXT
@@ -5078,7 +5078,7 @@ struct Decoded_VkSurfaceFullScreenExclusiveInfoEXT
 
     VkSurfaceFullScreenExclusiveInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkSurfaceCapabilitiesFullScreenExclusiveEXT
@@ -5087,7 +5087,7 @@ struct Decoded_VkSurfaceCapabilitiesFullScreenExclusiveEXT
 
     VkSurfaceCapabilitiesFullScreenExclusiveEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkSurfaceFullScreenExclusiveWin32InfoEXT
@@ -5096,7 +5096,7 @@ struct Decoded_VkSurfaceFullScreenExclusiveWin32InfoEXT
 
     VkSurfaceFullScreenExclusiveWin32InfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t hmonitor{ 0 };
 };
 
@@ -5106,7 +5106,7 @@ struct Decoded_VkHeadlessSurfaceCreateInfoEXT
 
     VkHeadlessSurfaceCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceLineRasterizationFeaturesEXT
@@ -5115,7 +5115,7 @@ struct Decoded_VkPhysicalDeviceLineRasterizationFeaturesEXT
 
     VkPhysicalDeviceLineRasterizationFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceLineRasterizationPropertiesEXT
@@ -5124,7 +5124,7 @@ struct Decoded_VkPhysicalDeviceLineRasterizationPropertiesEXT
 
     VkPhysicalDeviceLineRasterizationPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineRasterizationLineStateCreateInfoEXT
@@ -5133,7 +5133,7 @@ struct Decoded_VkPipelineRasterizationLineStateCreateInfoEXT
 
     VkPipelineRasterizationLineStateCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
@@ -5142,7 +5142,7 @@ struct Decoded_VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
 
     VkPhysicalDeviceShaderAtomicFloatFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 typedef Decoded_VkPhysicalDeviceHostQueryResetFeatures Decoded_VkPhysicalDeviceHostQueryResetFeaturesEXT;
@@ -5153,7 +5153,7 @@ struct Decoded_VkPhysicalDeviceIndexTypeUint8FeaturesEXT
 
     VkPhysicalDeviceIndexTypeUint8FeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceExtendedDynamicStateFeaturesEXT
@@ -5162,7 +5162,7 @@ struct Decoded_VkPhysicalDeviceExtendedDynamicStateFeaturesEXT
 
     VkPhysicalDeviceExtendedDynamicStateFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
@@ -5171,7 +5171,7 @@ struct Decoded_VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT
 
     VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV
@@ -5180,7 +5180,7 @@ struct Decoded_VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV
 
     VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV
@@ -5189,7 +5189,7 @@ struct Decoded_VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV
 
     VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkGraphicsShaderGroupCreateInfoNV
@@ -5198,7 +5198,7 @@ struct Decoded_VkGraphicsShaderGroupCreateInfoNV
 
     VkGraphicsShaderGroupCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>* pStages{ nullptr };
     StructPointerDecoder<Decoded_VkPipelineVertexInputStateCreateInfo>* pVertexInputState{ nullptr };
     StructPointerDecoder<Decoded_VkPipelineTessellationStateCreateInfo>* pTessellationState{ nullptr };
@@ -5210,7 +5210,7 @@ struct Decoded_VkGraphicsPipelineShaderGroupsCreateInfoNV
 
     VkGraphicsPipelineShaderGroupsCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkGraphicsShaderGroupCreateInfoNV>* pGroups{ nullptr };
     HandlePointerDecoder<VkPipeline> pPipelines;
 };
@@ -5258,7 +5258,7 @@ struct Decoded_VkIndirectCommandsLayoutTokenNV
 
     VkIndirectCommandsLayoutTokenNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId pushconstantPipelineLayout{ format::kNullHandleId };
     PointerDecoder<VkIndexType> pIndexTypes;
     PointerDecoder<uint32_t> pIndexTypeValues;
@@ -5270,7 +5270,7 @@ struct Decoded_VkIndirectCommandsLayoutCreateInfoNV
 
     VkIndirectCommandsLayoutCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkIndirectCommandsLayoutTokenNV>* pTokens{ nullptr };
     PointerDecoder<uint32_t> pStreamStrides;
 };
@@ -5281,7 +5281,7 @@ struct Decoded_VkGeneratedCommandsInfoNV
 
     VkGeneratedCommandsInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId pipeline{ format::kNullHandleId };
     format::HandleId indirectCommandsLayout{ format::kNullHandleId };
     StructPointerDecoder<Decoded_VkIndirectCommandsStreamNV>* pStreams{ nullptr };
@@ -5296,7 +5296,7 @@ struct Decoded_VkGeneratedCommandsMemoryRequirementsInfoNV
 
     VkGeneratedCommandsMemoryRequirementsInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId pipeline{ format::kNullHandleId };
     format::HandleId indirectCommandsLayout{ format::kNullHandleId };
 };
@@ -5307,7 +5307,7 @@ struct Decoded_VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT
 
     VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT
@@ -5316,7 +5316,7 @@ struct Decoded_VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT
 
     VkPhysicalDeviceTexelBufferAlignmentPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkRenderPassTransformBeginInfoQCOM
@@ -5325,7 +5325,7 @@ struct Decoded_VkRenderPassTransformBeginInfoQCOM
 
     VkRenderPassTransformBeginInfoQCOM* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkCommandBufferInheritanceRenderPassTransformInfoQCOM
@@ -5334,7 +5334,7 @@ struct Decoded_VkCommandBufferInheritanceRenderPassTransformInfoQCOM
 
     VkCommandBufferInheritanceRenderPassTransformInfoQCOM* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkRect2D* renderArea{ nullptr };
 };
 
@@ -5344,7 +5344,7 @@ struct Decoded_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT
 
     VkPhysicalDeviceDeviceMemoryReportFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDeviceMemoryReportCallbackDataEXT
@@ -5353,7 +5353,7 @@ struct Decoded_VkDeviceMemoryReportCallbackDataEXT
 
     VkDeviceMemoryReportCallbackDataEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDeviceDeviceMemoryReportCreateInfoEXT
@@ -5362,7 +5362,7 @@ struct Decoded_VkDeviceDeviceMemoryReportCreateInfoEXT
 
     VkDeviceDeviceMemoryReportCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t pfnUserCallback{ 0 };
     uint64_t pUserData{ 0 };
 };
@@ -5373,7 +5373,7 @@ struct Decoded_VkPhysicalDeviceRobustness2FeaturesEXT
 
     VkPhysicalDeviceRobustness2FeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceRobustness2PropertiesEXT
@@ -5382,7 +5382,7 @@ struct Decoded_VkPhysicalDeviceRobustness2PropertiesEXT
 
     VkPhysicalDeviceRobustness2PropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkSamplerCustomBorderColorCreateInfoEXT
@@ -5391,7 +5391,7 @@ struct Decoded_VkSamplerCustomBorderColorCreateInfoEXT
 
     VkSamplerCustomBorderColorCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkClearColorValue* customBorderColor{ nullptr };
 };
 
@@ -5401,7 +5401,7 @@ struct Decoded_VkPhysicalDeviceCustomBorderColorPropertiesEXT
 
     VkPhysicalDeviceCustomBorderColorPropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceCustomBorderColorFeaturesEXT
@@ -5410,7 +5410,7 @@ struct Decoded_VkPhysicalDeviceCustomBorderColorFeaturesEXT
 
     VkPhysicalDeviceCustomBorderColorFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDevicePrivateDataFeaturesEXT
@@ -5419,7 +5419,7 @@ struct Decoded_VkPhysicalDevicePrivateDataFeaturesEXT
 
     VkPhysicalDevicePrivateDataFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDevicePrivateDataCreateInfoEXT
@@ -5428,7 +5428,7 @@ struct Decoded_VkDevicePrivateDataCreateInfoEXT
 
     VkDevicePrivateDataCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPrivateDataSlotCreateInfoEXT
@@ -5437,7 +5437,7 @@ struct Decoded_VkPrivateDataSlotCreateInfoEXT
 
     VkPrivateDataSlotCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT
@@ -5446,7 +5446,7 @@ struct Decoded_VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT
 
     VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceDiagnosticsConfigFeaturesNV
@@ -5455,7 +5455,7 @@ struct Decoded_VkPhysicalDeviceDiagnosticsConfigFeaturesNV
 
     VkPhysicalDeviceDiagnosticsConfigFeaturesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDeviceDiagnosticsConfigCreateInfoNV
@@ -5464,7 +5464,7 @@ struct Decoded_VkDeviceDiagnosticsConfigCreateInfoNV
 
     VkDeviceDiagnosticsConfigCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV
@@ -5473,7 +5473,7 @@ struct Decoded_VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV
 
     VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV
@@ -5482,7 +5482,7 @@ struct Decoded_VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV
 
     VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPipelineFragmentShadingRateEnumStateCreateInfoNV
@@ -5491,7 +5491,7 @@ struct Decoded_VkPipelineFragmentShadingRateEnumStateCreateInfoNV
 
     VkPipelineFragmentShadingRateEnumStateCreateInfoNV* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<VkFragmentShadingRateCombinerOpKHR> combinerOps;
 };
 
@@ -5501,7 +5501,7 @@ struct Decoded_VkPhysicalDeviceFragmentDensityMap2FeaturesEXT
 
     VkPhysicalDeviceFragmentDensityMap2FeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceFragmentDensityMap2PropertiesEXT
@@ -5510,7 +5510,7 @@ struct Decoded_VkPhysicalDeviceFragmentDensityMap2PropertiesEXT
 
     VkPhysicalDeviceFragmentDensityMap2PropertiesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkCopyCommandTransformInfoQCOM
@@ -5519,7 +5519,7 @@ struct Decoded_VkCopyCommandTransformInfoQCOM
 
     VkCopyCommandTransformInfoQCOM* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceImageRobustnessFeaturesEXT
@@ -5528,7 +5528,7 @@ struct Decoded_VkPhysicalDeviceImageRobustnessFeaturesEXT
 
     VkPhysicalDeviceImageRobustnessFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDevice4444FormatsFeaturesEXT
@@ -5537,7 +5537,7 @@ struct Decoded_VkPhysicalDevice4444FormatsFeaturesEXT
 
     VkPhysicalDevice4444FormatsFeaturesEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkDirectFBSurfaceCreateInfoEXT
@@ -5546,7 +5546,7 @@ struct Decoded_VkDirectFBSurfaceCreateInfoEXT
 
     VkDirectFBSurfaceCreateInfoEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t dfb{ 0 };
     uint64_t surface{ 0 };
 };
@@ -5564,7 +5564,7 @@ struct Decoded_VkAccelerationStructureGeometryTrianglesDataKHR
 
     VkAccelerationStructureGeometryTrianglesDataKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkDeviceOrHostAddressConstKHR* vertexData{ nullptr };
     Decoded_VkDeviceOrHostAddressConstKHR* indexData{ nullptr };
     Decoded_VkDeviceOrHostAddressConstKHR* transformData{ nullptr };
@@ -5576,7 +5576,7 @@ struct Decoded_VkAccelerationStructureGeometryAabbsDataKHR
 
     VkAccelerationStructureGeometryAabbsDataKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkDeviceOrHostAddressConstKHR* data{ nullptr };
 };
 
@@ -5586,7 +5586,7 @@ struct Decoded_VkAccelerationStructureGeometryInstancesDataKHR
 
     VkAccelerationStructureGeometryInstancesDataKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkDeviceOrHostAddressConstKHR* data{ nullptr };
 };
 
@@ -5596,7 +5596,7 @@ struct Decoded_VkAccelerationStructureBuildGeometryInfoKHR
 
     VkAccelerationStructureBuildGeometryInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId srcAccelerationStructure{ format::kNullHandleId };
     format::HandleId dstAccelerationStructure{ format::kNullHandleId };
     StructPointerDecoder<Decoded_VkAccelerationStructureGeometryKHR>* pGeometries{ nullptr };
@@ -5610,7 +5610,7 @@ struct Decoded_VkAccelerationStructureCreateInfoKHR
 
     VkAccelerationStructureCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId buffer{ format::kNullHandleId };
 };
 
@@ -5620,7 +5620,7 @@ struct Decoded_VkWriteDescriptorSetAccelerationStructureKHR
 
     VkWriteDescriptorSetAccelerationStructureKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     HandlePointerDecoder<VkAccelerationStructureKHR> pAccelerationStructures;
 };
 
@@ -5630,7 +5630,7 @@ struct Decoded_VkPhysicalDeviceAccelerationStructureFeaturesKHR
 
     VkPhysicalDeviceAccelerationStructureFeaturesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceAccelerationStructurePropertiesKHR
@@ -5639,7 +5639,7 @@ struct Decoded_VkPhysicalDeviceAccelerationStructurePropertiesKHR
 
     VkPhysicalDeviceAccelerationStructurePropertiesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkAccelerationStructureDeviceAddressInfoKHR
@@ -5648,7 +5648,7 @@ struct Decoded_VkAccelerationStructureDeviceAddressInfoKHR
 
     VkAccelerationStructureDeviceAddressInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId accelerationStructure{ format::kNullHandleId };
 };
 
@@ -5658,7 +5658,7 @@ struct Decoded_VkAccelerationStructureVersionInfoKHR
 
     VkAccelerationStructureVersionInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     PointerDecoder<uint8_t> pVersionData;
 };
 
@@ -5668,7 +5668,7 @@ struct Decoded_VkCopyAccelerationStructureToMemoryInfoKHR
 
     VkCopyAccelerationStructureToMemoryInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId src{ format::kNullHandleId };
     Decoded_VkDeviceOrHostAddressKHR* dst{ nullptr };
 };
@@ -5679,7 +5679,7 @@ struct Decoded_VkCopyMemoryToAccelerationStructureInfoKHR
 
     VkCopyMemoryToAccelerationStructureInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     Decoded_VkDeviceOrHostAddressConstKHR* src{ nullptr };
     format::HandleId dst{ format::kNullHandleId };
 };
@@ -5690,7 +5690,7 @@ struct Decoded_VkCopyAccelerationStructureInfoKHR
 
     VkCopyAccelerationStructureInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     format::HandleId src{ format::kNullHandleId };
     format::HandleId dst{ format::kNullHandleId };
 };
@@ -5701,7 +5701,7 @@ struct Decoded_VkAccelerationStructureBuildSizesInfoKHR
 
     VkAccelerationStructureBuildSizesInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkRayTracingShaderGroupCreateInfoKHR
@@ -5710,7 +5710,7 @@ struct Decoded_VkRayTracingShaderGroupCreateInfoKHR
 
     VkRayTracingShaderGroupCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     uint64_t pShaderGroupCaptureReplayHandle{ 0 };
 };
 
@@ -5720,7 +5720,7 @@ struct Decoded_VkRayTracingPipelineInterfaceCreateInfoKHR
 
     VkRayTracingPipelineInterfaceCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkRayTracingPipelineCreateInfoKHR
@@ -5729,7 +5729,7 @@ struct Decoded_VkRayTracingPipelineCreateInfoKHR
 
     VkRayTracingPipelineCreateInfoKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
     StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>* pStages{ nullptr };
     StructPointerDecoder<Decoded_VkRayTracingShaderGroupCreateInfoKHR>* pGroups{ nullptr };
     StructPointerDecoder<Decoded_VkPipelineLibraryCreateInfoKHR>* pLibraryInfo{ nullptr };
@@ -5745,7 +5745,7 @@ struct Decoded_VkPhysicalDeviceRayTracingPipelineFeaturesKHR
 
     VkPhysicalDeviceRayTracingPipelineFeaturesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceRayTracingPipelinePropertiesKHR
@@ -5754,7 +5754,7 @@ struct Decoded_VkPhysicalDeviceRayTracingPipelinePropertiesKHR
 
     VkPhysicalDeviceRayTracingPipelinePropertiesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 struct Decoded_VkStridedDeviceAddressRegionKHR
@@ -5777,7 +5777,7 @@ struct Decoded_VkPhysicalDeviceRayQueryFeaturesKHR
 
     VkPhysicalDeviceRayQueryFeaturesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<PNextNode> pNext;
+    PNextNode* pNext{ nullptr };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/generated_vulkan_struct_decoders.h
+++ b/framework/generated/generated_vulkan_struct_decoders.h
@@ -82,8 +82,8 @@ struct Decoded_VkRect2D
 
     VkRect2D* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkOffset2D> offset;
-    std::unique_ptr<Decoded_VkExtent2D> extent;
+    Decoded_VkOffset2D* offset{ nullptr };
+    Decoded_VkExtent2D* extent{ nullptr };
 };
 
 struct Decoded_VkBufferMemoryBarrier
@@ -132,7 +132,7 @@ struct Decoded_VkImageMemoryBarrier
 
     std::unique_ptr<PNextNode> pNext;
     format::HandleId image{ format::kNullHandleId };
-    std::unique_ptr<Decoded_VkImageSubresourceRange> subresourceRange;
+    Decoded_VkImageSubresourceRange* subresourceRange{ nullptr };
 };
 
 struct Decoded_VkMemoryBarrier
@@ -182,7 +182,7 @@ struct Decoded_VkImageFormatProperties
 
     VkImageFormatProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkExtent3D> maxExtent;
+    Decoded_VkExtent3D* maxExtent{ nullptr };
 };
 
 struct Decoded_VkInstanceCreateInfo
@@ -192,7 +192,7 @@ struct Decoded_VkInstanceCreateInfo
     VkInstanceCreateInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkApplicationInfo>> pApplicationInfo;
+    StructPointerDecoder<Decoded_VkApplicationInfo>* pApplicationInfo{ nullptr };
     StringArrayDecoder ppEnabledLayerNames;
     StringArrayDecoder ppEnabledExtensionNames;
 };
@@ -238,8 +238,8 @@ struct Decoded_VkPhysicalDeviceMemoryProperties
 
     VkPhysicalDeviceMemoryProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<StructPointerDecoder<Decoded_VkMemoryType>> memoryTypes;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkMemoryHeap>> memoryHeaps;
+    StructPointerDecoder<Decoded_VkMemoryType>* memoryTypes{ nullptr };
+    StructPointerDecoder<Decoded_VkMemoryHeap>* memoryHeaps{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceSparseProperties
@@ -257,8 +257,8 @@ struct Decoded_VkPhysicalDeviceProperties
 
     StringDecoder deviceName;
     PointerDecoder<uint8_t> pipelineCacheUUID;
-    std::unique_ptr<Decoded_VkPhysicalDeviceLimits> limits;
-    std::unique_ptr<Decoded_VkPhysicalDeviceSparseProperties> sparseProperties;
+    Decoded_VkPhysicalDeviceLimits* limits{ nullptr };
+    Decoded_VkPhysicalDeviceSparseProperties* sparseProperties{ nullptr };
 };
 
 struct Decoded_VkQueueFamilyProperties
@@ -267,7 +267,7 @@ struct Decoded_VkQueueFamilyProperties
 
     VkQueueFamilyProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkExtent3D> minImageTransferGranularity;
+    Decoded_VkExtent3D* minImageTransferGranularity{ nullptr };
 };
 
 struct Decoded_VkDeviceQueueCreateInfo
@@ -287,10 +287,10 @@ struct Decoded_VkDeviceCreateInfo
     VkDeviceCreateInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkDeviceQueueCreateInfo>> pQueueCreateInfos;
+    StructPointerDecoder<Decoded_VkDeviceQueueCreateInfo>* pQueueCreateInfos{ nullptr };
     StringArrayDecoder ppEnabledLayerNames;
     StringArrayDecoder ppEnabledExtensionNames;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures>> pEnabledFeatures;
+    StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures>* pEnabledFeatures{ nullptr };
 };
 
 struct Decoded_VkExtensionProperties
@@ -367,7 +367,7 @@ struct Decoded_VkSparseBufferMemoryBindInfo
     VkSparseBufferMemoryBindInfo* decoded_value{ nullptr };
 
     format::HandleId buffer{ format::kNullHandleId };
-    std::unique_ptr<StructPointerDecoder<Decoded_VkSparseMemoryBind>> pBinds;
+    StructPointerDecoder<Decoded_VkSparseMemoryBind>* pBinds{ nullptr };
 };
 
 struct Decoded_VkSparseImageOpaqueMemoryBindInfo
@@ -377,7 +377,7 @@ struct Decoded_VkSparseImageOpaqueMemoryBindInfo
     VkSparseImageOpaqueMemoryBindInfo* decoded_value{ nullptr };
 
     format::HandleId image{ format::kNullHandleId };
-    std::unique_ptr<StructPointerDecoder<Decoded_VkSparseMemoryBind>> pBinds;
+    StructPointerDecoder<Decoded_VkSparseMemoryBind>* pBinds{ nullptr };
 };
 
 struct Decoded_VkImageSubresource
@@ -393,9 +393,9 @@ struct Decoded_VkSparseImageMemoryBind
 
     VkSparseImageMemoryBind* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkImageSubresource> subresource;
-    std::unique_ptr<Decoded_VkOffset3D> offset;
-    std::unique_ptr<Decoded_VkExtent3D> extent;
+    Decoded_VkImageSubresource* subresource{ nullptr };
+    Decoded_VkOffset3D* offset{ nullptr };
+    Decoded_VkExtent3D* extent{ nullptr };
     format::HandleId memory{ format::kNullHandleId };
 };
 
@@ -406,7 +406,7 @@ struct Decoded_VkSparseImageMemoryBindInfo
     VkSparseImageMemoryBindInfo* decoded_value{ nullptr };
 
     format::HandleId image{ format::kNullHandleId };
-    std::unique_ptr<StructPointerDecoder<Decoded_VkSparseImageMemoryBind>> pBinds;
+    StructPointerDecoder<Decoded_VkSparseImageMemoryBind>* pBinds{ nullptr };
 };
 
 struct Decoded_VkBindSparseInfo
@@ -417,9 +417,9 @@ struct Decoded_VkBindSparseInfo
 
     std::unique_ptr<PNextNode> pNext;
     HandlePointerDecoder<VkSemaphore> pWaitSemaphores;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkSparseBufferMemoryBindInfo>> pBufferBinds;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkSparseImageOpaqueMemoryBindInfo>> pImageOpaqueBinds;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkSparseImageMemoryBindInfo>> pImageBinds;
+    StructPointerDecoder<Decoded_VkSparseBufferMemoryBindInfo>* pBufferBinds{ nullptr };
+    StructPointerDecoder<Decoded_VkSparseImageOpaqueMemoryBindInfo>* pImageOpaqueBinds{ nullptr };
+    StructPointerDecoder<Decoded_VkSparseImageMemoryBindInfo>* pImageBinds{ nullptr };
     HandlePointerDecoder<VkSemaphore> pSignalSemaphores;
 };
 
@@ -429,7 +429,7 @@ struct Decoded_VkSparseImageFormatProperties
 
     VkSparseImageFormatProperties* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkExtent3D> imageGranularity;
+    Decoded_VkExtent3D* imageGranularity{ nullptr };
 };
 
 struct Decoded_VkSparseImageMemoryRequirements
@@ -438,7 +438,7 @@ struct Decoded_VkSparseImageMemoryRequirements
 
     VkSparseImageMemoryRequirements* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkSparseImageFormatProperties> formatProperties;
+    Decoded_VkSparseImageFormatProperties* formatProperties{ nullptr };
 };
 
 struct Decoded_VkFenceCreateInfo
@@ -504,7 +504,7 @@ struct Decoded_VkImageCreateInfo
     VkImageCreateInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkExtent3D> extent;
+    Decoded_VkExtent3D* extent{ nullptr };
     PointerDecoder<uint32_t> pQueueFamilyIndices;
 };
 
@@ -530,8 +530,8 @@ struct Decoded_VkImageViewCreateInfo
 
     std::unique_ptr<PNextNode> pNext;
     format::HandleId image{ format::kNullHandleId };
-    std::unique_ptr<Decoded_VkComponentMapping> components;
-    std::unique_ptr<Decoded_VkImageSubresourceRange> subresourceRange;
+    Decoded_VkComponentMapping* components{ nullptr };
+    Decoded_VkImageSubresourceRange* subresourceRange{ nullptr };
 };
 
 struct Decoded_VkShaderModuleCreateInfo
@@ -567,7 +567,7 @@ struct Decoded_VkSpecializationInfo
 
     VkSpecializationInfo* decoded_value{ nullptr };
 
-    std::unique_ptr<StructPointerDecoder<Decoded_VkSpecializationMapEntry>> pMapEntries;
+    StructPointerDecoder<Decoded_VkSpecializationMapEntry>* pMapEntries{ nullptr };
     PointerDecoder<uint8_t> pData;
 };
 
@@ -580,7 +580,7 @@ struct Decoded_VkPipelineShaderStageCreateInfo
     std::unique_ptr<PNextNode> pNext;
     format::HandleId module{ format::kNullHandleId };
     StringDecoder pName;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkSpecializationInfo>> pSpecializationInfo;
+    StructPointerDecoder<Decoded_VkSpecializationInfo>* pSpecializationInfo{ nullptr };
 };
 
 struct Decoded_VkComputePipelineCreateInfo
@@ -590,7 +590,7 @@ struct Decoded_VkComputePipelineCreateInfo
     VkComputePipelineCreateInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkPipelineShaderStageCreateInfo> stage;
+    Decoded_VkPipelineShaderStageCreateInfo* stage{ nullptr };
     format::HandleId layout{ format::kNullHandleId };
     format::HandleId basePipelineHandle{ format::kNullHandleId };
 };
@@ -616,8 +616,8 @@ struct Decoded_VkPipelineVertexInputStateCreateInfo
     VkPipelineVertexInputStateCreateInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkVertexInputBindingDescription>> pVertexBindingDescriptions;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkVertexInputAttributeDescription>> pVertexAttributeDescriptions;
+    StructPointerDecoder<Decoded_VkVertexInputBindingDescription>* pVertexBindingDescriptions{ nullptr };
+    StructPointerDecoder<Decoded_VkVertexInputAttributeDescription>* pVertexAttributeDescriptions{ nullptr };
 };
 
 struct Decoded_VkPipelineInputAssemblyStateCreateInfo
@@ -652,8 +652,8 @@ struct Decoded_VkPipelineViewportStateCreateInfo
     VkPipelineViewportStateCreateInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkViewport>> pViewports;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkRect2D>> pScissors;
+    StructPointerDecoder<Decoded_VkViewport>* pViewports{ nullptr };
+    StructPointerDecoder<Decoded_VkRect2D>* pScissors{ nullptr };
 };
 
 struct Decoded_VkPipelineRasterizationStateCreateInfo
@@ -689,8 +689,8 @@ struct Decoded_VkPipelineDepthStencilStateCreateInfo
     VkPipelineDepthStencilStateCreateInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkStencilOpState> front;
-    std::unique_ptr<Decoded_VkStencilOpState> back;
+    Decoded_VkStencilOpState* front{ nullptr };
+    Decoded_VkStencilOpState* back{ nullptr };
 };
 
 struct Decoded_VkPipelineColorBlendAttachmentState
@@ -707,7 +707,7 @@ struct Decoded_VkPipelineColorBlendStateCreateInfo
     VkPipelineColorBlendStateCreateInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineColorBlendAttachmentState>> pAttachments;
+    StructPointerDecoder<Decoded_VkPipelineColorBlendAttachmentState>* pAttachments{ nullptr };
     PointerDecoder<float> blendConstants;
 };
 
@@ -728,16 +728,16 @@ struct Decoded_VkGraphicsPipelineCreateInfo
     VkGraphicsPipelineCreateInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>> pStages;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineVertexInputStateCreateInfo>> pVertexInputState;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineInputAssemblyStateCreateInfo>> pInputAssemblyState;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineTessellationStateCreateInfo>> pTessellationState;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineViewportStateCreateInfo>> pViewportState;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineRasterizationStateCreateInfo>> pRasterizationState;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineMultisampleStateCreateInfo>> pMultisampleState;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineDepthStencilStateCreateInfo>> pDepthStencilState;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineColorBlendStateCreateInfo>> pColorBlendState;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineDynamicStateCreateInfo>> pDynamicState;
+    StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>* pStages{ nullptr };
+    StructPointerDecoder<Decoded_VkPipelineVertexInputStateCreateInfo>* pVertexInputState{ nullptr };
+    StructPointerDecoder<Decoded_VkPipelineInputAssemblyStateCreateInfo>* pInputAssemblyState{ nullptr };
+    StructPointerDecoder<Decoded_VkPipelineTessellationStateCreateInfo>* pTessellationState{ nullptr };
+    StructPointerDecoder<Decoded_VkPipelineViewportStateCreateInfo>* pViewportState{ nullptr };
+    StructPointerDecoder<Decoded_VkPipelineRasterizationStateCreateInfo>* pRasterizationState{ nullptr };
+    StructPointerDecoder<Decoded_VkPipelineMultisampleStateCreateInfo>* pMultisampleState{ nullptr };
+    StructPointerDecoder<Decoded_VkPipelineDepthStencilStateCreateInfo>* pDepthStencilState{ nullptr };
+    StructPointerDecoder<Decoded_VkPipelineColorBlendStateCreateInfo>* pColorBlendState{ nullptr };
+    StructPointerDecoder<Decoded_VkPipelineDynamicStateCreateInfo>* pDynamicState{ nullptr };
     format::HandleId layout{ format::kNullHandleId };
     format::HandleId renderPass{ format::kNullHandleId };
     format::HandleId basePipelineHandle{ format::kNullHandleId };
@@ -758,7 +758,7 @@ struct Decoded_VkPipelineLayoutCreateInfo
 
     std::unique_ptr<PNextNode> pNext;
     HandlePointerDecoder<VkDescriptorSetLayout> pSetLayouts;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPushConstantRange>> pPushConstantRanges;
+    StructPointerDecoder<Decoded_VkPushConstantRange>* pPushConstantRanges{ nullptr };
 };
 
 struct Decoded_VkSamplerCreateInfo
@@ -804,7 +804,7 @@ struct Decoded_VkDescriptorPoolCreateInfo
     VkDescriptorPoolCreateInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkDescriptorPoolSize>> pPoolSizes;
+    StructPointerDecoder<Decoded_VkDescriptorPoolSize>* pPoolSizes{ nullptr };
 };
 
 struct Decoded_VkDescriptorSetAllocateInfo
@@ -834,7 +834,7 @@ struct Decoded_VkDescriptorSetLayoutCreateInfo
     VkDescriptorSetLayoutCreateInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkDescriptorSetLayoutBinding>> pBindings;
+    StructPointerDecoder<Decoded_VkDescriptorSetLayoutBinding>* pBindings{ nullptr };
 };
 
 struct Decoded_VkAttachmentDescription
@@ -868,10 +868,10 @@ struct Decoded_VkSubpassDescription
 
     VkSubpassDescription* decoded_value{ nullptr };
 
-    std::unique_ptr<StructPointerDecoder<Decoded_VkAttachmentReference>> pInputAttachments;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkAttachmentReference>> pColorAttachments;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkAttachmentReference>> pResolveAttachments;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkAttachmentReference>> pDepthStencilAttachment;
+    StructPointerDecoder<Decoded_VkAttachmentReference>* pInputAttachments{ nullptr };
+    StructPointerDecoder<Decoded_VkAttachmentReference>* pColorAttachments{ nullptr };
+    StructPointerDecoder<Decoded_VkAttachmentReference>* pResolveAttachments{ nullptr };
+    StructPointerDecoder<Decoded_VkAttachmentReference>* pDepthStencilAttachment{ nullptr };
     PointerDecoder<uint32_t> pPreserveAttachments;
 };
 
@@ -889,9 +889,9 @@ struct Decoded_VkRenderPassCreateInfo
     VkRenderPassCreateInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkAttachmentDescription>> pAttachments;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkSubpassDescription>> pSubpasses;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkSubpassDependency>> pDependencies;
+    StructPointerDecoder<Decoded_VkAttachmentDescription>* pAttachments{ nullptr };
+    StructPointerDecoder<Decoded_VkSubpassDescription>* pSubpasses{ nullptr };
+    StructPointerDecoder<Decoded_VkSubpassDependency>* pDependencies{ nullptr };
 };
 
 struct Decoded_VkCommandPoolCreateInfo
@@ -931,7 +931,7 @@ struct Decoded_VkCommandBufferBeginInfo
     VkCommandBufferBeginInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkCommandBufferInheritanceInfo>> pInheritanceInfo;
+    StructPointerDecoder<Decoded_VkCommandBufferInheritanceInfo>* pInheritanceInfo{ nullptr };
 };
 
 struct Decoded_VkBufferCopy
@@ -954,9 +954,9 @@ struct Decoded_VkBufferImageCopy
 
     VkBufferImageCopy* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkImageSubresourceLayers> imageSubresource;
-    std::unique_ptr<Decoded_VkOffset3D> imageOffset;
-    std::unique_ptr<Decoded_VkExtent3D> imageExtent;
+    Decoded_VkImageSubresourceLayers* imageSubresource{ nullptr };
+    Decoded_VkOffset3D* imageOffset{ nullptr };
+    Decoded_VkExtent3D* imageExtent{ nullptr };
 };
 
 struct Decoded_VkClearDepthStencilValue
@@ -972,7 +972,7 @@ struct Decoded_VkClearAttachment
 
     VkClearAttachment* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkClearValue> clearValue;
+    Decoded_VkClearValue* clearValue{ nullptr };
 };
 
 struct Decoded_VkClearRect
@@ -981,7 +981,7 @@ struct Decoded_VkClearRect
 
     VkClearRect* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkRect2D> rect;
+    Decoded_VkRect2D* rect{ nullptr };
 };
 
 struct Decoded_VkImageBlit
@@ -990,10 +990,10 @@ struct Decoded_VkImageBlit
 
     VkImageBlit* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkImageSubresourceLayers> srcSubresource;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkOffset3D>> srcOffsets;
-    std::unique_ptr<Decoded_VkImageSubresourceLayers> dstSubresource;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkOffset3D>> dstOffsets;
+    Decoded_VkImageSubresourceLayers* srcSubresource{ nullptr };
+    StructPointerDecoder<Decoded_VkOffset3D>* srcOffsets{ nullptr };
+    Decoded_VkImageSubresourceLayers* dstSubresource{ nullptr };
+    StructPointerDecoder<Decoded_VkOffset3D>* dstOffsets{ nullptr };
 };
 
 struct Decoded_VkImageCopy
@@ -1002,11 +1002,11 @@ struct Decoded_VkImageCopy
 
     VkImageCopy* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkImageSubresourceLayers> srcSubresource;
-    std::unique_ptr<Decoded_VkOffset3D> srcOffset;
-    std::unique_ptr<Decoded_VkImageSubresourceLayers> dstSubresource;
-    std::unique_ptr<Decoded_VkOffset3D> dstOffset;
-    std::unique_ptr<Decoded_VkExtent3D> extent;
+    Decoded_VkImageSubresourceLayers* srcSubresource{ nullptr };
+    Decoded_VkOffset3D* srcOffset{ nullptr };
+    Decoded_VkImageSubresourceLayers* dstSubresource{ nullptr };
+    Decoded_VkOffset3D* dstOffset{ nullptr };
+    Decoded_VkExtent3D* extent{ nullptr };
 };
 
 struct Decoded_VkImageResolve
@@ -1015,11 +1015,11 @@ struct Decoded_VkImageResolve
 
     VkImageResolve* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkImageSubresourceLayers> srcSubresource;
-    std::unique_ptr<Decoded_VkOffset3D> srcOffset;
-    std::unique_ptr<Decoded_VkImageSubresourceLayers> dstSubresource;
-    std::unique_ptr<Decoded_VkOffset3D> dstOffset;
-    std::unique_ptr<Decoded_VkExtent3D> extent;
+    Decoded_VkImageSubresourceLayers* srcSubresource{ nullptr };
+    Decoded_VkOffset3D* srcOffset{ nullptr };
+    Decoded_VkImageSubresourceLayers* dstSubresource{ nullptr };
+    Decoded_VkOffset3D* dstOffset{ nullptr };
+    Decoded_VkExtent3D* extent{ nullptr };
 };
 
 struct Decoded_VkRenderPassBeginInfo
@@ -1031,8 +1031,8 @@ struct Decoded_VkRenderPassBeginInfo
     std::unique_ptr<PNextNode> pNext;
     format::HandleId renderPass{ format::kNullHandleId };
     format::HandleId framebuffer{ format::kNullHandleId };
-    std::unique_ptr<Decoded_VkRect2D> renderArea;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkClearValue>> pClearValues;
+    Decoded_VkRect2D* renderArea{ nullptr };
+    StructPointerDecoder<Decoded_VkClearValue>* pClearValues{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceSubgroupProperties
@@ -1111,7 +1111,7 @@ struct Decoded_VkDeviceGroupRenderPassBeginInfo
     VkDeviceGroupRenderPassBeginInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkRect2D>> pDeviceRenderAreas;
+    StructPointerDecoder<Decoded_VkRect2D>* pDeviceRenderAreas{ nullptr };
 };
 
 struct Decoded_VkDeviceGroupCommandBufferBeginInfo
@@ -1162,7 +1162,7 @@ struct Decoded_VkBindImageMemoryDeviceGroupInfo
 
     std::unique_ptr<PNextNode> pNext;
     PointerDecoder<uint32_t> pDeviceIndices;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkRect2D>> pSplitInstanceBindRegions;
+    StructPointerDecoder<Decoded_VkRect2D>* pSplitInstanceBindRegions{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceGroupProperties
@@ -1222,7 +1222,7 @@ struct Decoded_VkMemoryRequirements2
     VkMemoryRequirements2* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkMemoryRequirements> memoryRequirements;
+    Decoded_VkMemoryRequirements* memoryRequirements{ nullptr };
 };
 
 struct Decoded_VkSparseImageMemoryRequirements2
@@ -1232,7 +1232,7 @@ struct Decoded_VkSparseImageMemoryRequirements2
     VkSparseImageMemoryRequirements2* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkSparseImageMemoryRequirements> memoryRequirements;
+    Decoded_VkSparseImageMemoryRequirements* memoryRequirements{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceFeatures2
@@ -1242,7 +1242,7 @@ struct Decoded_VkPhysicalDeviceFeatures2
     VkPhysicalDeviceFeatures2* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkPhysicalDeviceFeatures> features;
+    Decoded_VkPhysicalDeviceFeatures* features{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceProperties2
@@ -1252,7 +1252,7 @@ struct Decoded_VkPhysicalDeviceProperties2
     VkPhysicalDeviceProperties2* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkPhysicalDeviceProperties> properties;
+    Decoded_VkPhysicalDeviceProperties* properties{ nullptr };
 };
 
 struct Decoded_VkFormatProperties2
@@ -1262,7 +1262,7 @@ struct Decoded_VkFormatProperties2
     VkFormatProperties2* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkFormatProperties> formatProperties;
+    Decoded_VkFormatProperties* formatProperties{ nullptr };
 };
 
 struct Decoded_VkImageFormatProperties2
@@ -1272,7 +1272,7 @@ struct Decoded_VkImageFormatProperties2
     VkImageFormatProperties2* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkImageFormatProperties> imageFormatProperties;
+    Decoded_VkImageFormatProperties* imageFormatProperties{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceImageFormatInfo2
@@ -1291,7 +1291,7 @@ struct Decoded_VkQueueFamilyProperties2
     VkQueueFamilyProperties2* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkQueueFamilyProperties> queueFamilyProperties;
+    Decoded_VkQueueFamilyProperties* queueFamilyProperties{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceMemoryProperties2
@@ -1301,7 +1301,7 @@ struct Decoded_VkPhysicalDeviceMemoryProperties2
     VkPhysicalDeviceMemoryProperties2* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkPhysicalDeviceMemoryProperties> memoryProperties;
+    Decoded_VkPhysicalDeviceMemoryProperties* memoryProperties{ nullptr };
 };
 
 struct Decoded_VkSparseImageFormatProperties2
@@ -1311,7 +1311,7 @@ struct Decoded_VkSparseImageFormatProperties2
     VkSparseImageFormatProperties2* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkSparseImageFormatProperties> properties;
+    Decoded_VkSparseImageFormatProperties* properties{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceSparseImageFormatInfo2
@@ -1346,7 +1346,7 @@ struct Decoded_VkRenderPassInputAttachmentAspectCreateInfo
     VkRenderPassInputAttachmentAspectCreateInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkInputAttachmentAspectReference>> pAspectReferences;
+    StructPointerDecoder<Decoded_VkInputAttachmentAspectReference>* pAspectReferences{ nullptr };
 };
 
 struct Decoded_VkImageViewUsageCreateInfo
@@ -1449,7 +1449,7 @@ struct Decoded_VkSamplerYcbcrConversionCreateInfo
     VkSamplerYcbcrConversionCreateInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkComponentMapping> components;
+    Decoded_VkComponentMapping* components{ nullptr };
 };
 
 struct Decoded_VkSamplerYcbcrConversionInfo
@@ -1512,7 +1512,7 @@ struct Decoded_VkDescriptorUpdateTemplateCreateInfo
     VkDescriptorUpdateTemplateCreateInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateEntry>> pDescriptorUpdateEntries;
+    StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateEntry>* pDescriptorUpdateEntries{ nullptr };
     format::HandleId descriptorSetLayout{ format::kNullHandleId };
     format::HandleId pipelineLayout{ format::kNullHandleId };
 };
@@ -1540,7 +1540,7 @@ struct Decoded_VkExternalImageFormatProperties
     VkExternalImageFormatProperties* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkExternalMemoryProperties> externalMemoryProperties;
+    Decoded_VkExternalMemoryProperties* externalMemoryProperties{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceExternalBufferInfo
@@ -1559,7 +1559,7 @@ struct Decoded_VkExternalBufferProperties
     VkExternalBufferProperties* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkExternalMemoryProperties> externalMemoryProperties;
+    Decoded_VkExternalMemoryProperties* externalMemoryProperties{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceIDProperties
@@ -1732,7 +1732,7 @@ struct Decoded_VkPhysicalDeviceVulkan12Properties
     std::unique_ptr<PNextNode> pNext;
     StringDecoder driverName;
     StringDecoder driverInfo;
-    std::unique_ptr<Decoded_VkConformanceVersion> conformanceVersion;
+    Decoded_VkConformanceVersion* conformanceVersion{ nullptr };
 };
 
 struct Decoded_VkImageFormatListCreateInfo
@@ -1770,10 +1770,10 @@ struct Decoded_VkSubpassDescription2
     VkSubpassDescription2* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkAttachmentReference2>> pInputAttachments;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkAttachmentReference2>> pColorAttachments;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkAttachmentReference2>> pResolveAttachments;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkAttachmentReference2>> pDepthStencilAttachment;
+    StructPointerDecoder<Decoded_VkAttachmentReference2>* pInputAttachments{ nullptr };
+    StructPointerDecoder<Decoded_VkAttachmentReference2>* pColorAttachments{ nullptr };
+    StructPointerDecoder<Decoded_VkAttachmentReference2>* pResolveAttachments{ nullptr };
+    StructPointerDecoder<Decoded_VkAttachmentReference2>* pDepthStencilAttachment{ nullptr };
     PointerDecoder<uint32_t> pPreserveAttachments;
 };
 
@@ -1793,9 +1793,9 @@ struct Decoded_VkRenderPassCreateInfo2
     VkRenderPassCreateInfo2* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkAttachmentDescription2>> pAttachments;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkSubpassDescription2>> pSubpasses;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkSubpassDependency2>> pDependencies;
+    StructPointerDecoder<Decoded_VkAttachmentDescription2>* pAttachments{ nullptr };
+    StructPointerDecoder<Decoded_VkSubpassDescription2>* pSubpasses{ nullptr };
+    StructPointerDecoder<Decoded_VkSubpassDependency2>* pDependencies{ nullptr };
     PointerDecoder<uint32_t> pCorrelatedViewMasks;
 };
 
@@ -1835,7 +1835,7 @@ struct Decoded_VkPhysicalDeviceDriverProperties
     std::unique_ptr<PNextNode> pNext;
     StringDecoder driverName;
     StringDecoder driverInfo;
-    std::unique_ptr<Decoded_VkConformanceVersion> conformanceVersion;
+    Decoded_VkConformanceVersion* conformanceVersion{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceShaderAtomicInt64Features
@@ -1919,7 +1919,7 @@ struct Decoded_VkSubpassDescriptionDepthStencilResolve
     VkSubpassDescriptionDepthStencilResolve* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkAttachmentReference2>> pDepthStencilResolveAttachment;
+    StructPointerDecoder<Decoded_VkAttachmentReference2>* pDepthStencilResolveAttachment{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceDepthStencilResolveProperties
@@ -2002,7 +2002,7 @@ struct Decoded_VkFramebufferAttachmentsCreateInfo
     VkFramebufferAttachmentsCreateInfo* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkFramebufferAttachmentImageInfo>> pAttachmentImageInfos;
+    StructPointerDecoder<Decoded_VkFramebufferAttachmentImageInfo>* pAttachmentImageInfos{ nullptr };
 };
 
 struct Decoded_VkRenderPassAttachmentBeginInfo
@@ -2181,9 +2181,9 @@ struct Decoded_VkSurfaceCapabilitiesKHR
 
     VkSurfaceCapabilitiesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkExtent2D> currentExtent;
-    std::unique_ptr<Decoded_VkExtent2D> minImageExtent;
-    std::unique_ptr<Decoded_VkExtent2D> maxImageExtent;
+    Decoded_VkExtent2D* currentExtent{ nullptr };
+    Decoded_VkExtent2D* minImageExtent{ nullptr };
+    Decoded_VkExtent2D* maxImageExtent{ nullptr };
 };
 
 struct Decoded_VkSurfaceFormatKHR
@@ -2201,7 +2201,7 @@ struct Decoded_VkSwapchainCreateInfoKHR
 
     std::unique_ptr<PNextNode> pNext;
     format::HandleId surface{ format::kNullHandleId };
-    std::unique_ptr<Decoded_VkExtent2D> imageExtent;
+    Decoded_VkExtent2D* imageExtent{ nullptr };
     PointerDecoder<uint32_t> pQueueFamilyIndices;
     format::HandleId oldSwapchain{ format::kNullHandleId };
 };
@@ -2286,7 +2286,7 @@ struct Decoded_VkDisplayModeParametersKHR
 
     VkDisplayModeParametersKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkExtent2D> visibleRegion;
+    Decoded_VkExtent2D* visibleRegion{ nullptr };
 };
 
 struct Decoded_VkDisplayModeCreateInfoKHR
@@ -2296,7 +2296,7 @@ struct Decoded_VkDisplayModeCreateInfoKHR
     VkDisplayModeCreateInfoKHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkDisplayModeParametersKHR> parameters;
+    Decoded_VkDisplayModeParametersKHR* parameters{ nullptr };
 };
 
 struct Decoded_VkDisplayModePropertiesKHR
@@ -2306,7 +2306,7 @@ struct Decoded_VkDisplayModePropertiesKHR
     VkDisplayModePropertiesKHR* decoded_value{ nullptr };
 
     format::HandleId displayMode{ format::kNullHandleId };
-    std::unique_ptr<Decoded_VkDisplayModeParametersKHR> parameters;
+    Decoded_VkDisplayModeParametersKHR* parameters{ nullptr };
 };
 
 struct Decoded_VkDisplayPlaneCapabilitiesKHR
@@ -2315,14 +2315,14 @@ struct Decoded_VkDisplayPlaneCapabilitiesKHR
 
     VkDisplayPlaneCapabilitiesKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkOffset2D> minSrcPosition;
-    std::unique_ptr<Decoded_VkOffset2D> maxSrcPosition;
-    std::unique_ptr<Decoded_VkExtent2D> minSrcExtent;
-    std::unique_ptr<Decoded_VkExtent2D> maxSrcExtent;
-    std::unique_ptr<Decoded_VkOffset2D> minDstPosition;
-    std::unique_ptr<Decoded_VkOffset2D> maxDstPosition;
-    std::unique_ptr<Decoded_VkExtent2D> minDstExtent;
-    std::unique_ptr<Decoded_VkExtent2D> maxDstExtent;
+    Decoded_VkOffset2D* minSrcPosition{ nullptr };
+    Decoded_VkOffset2D* maxSrcPosition{ nullptr };
+    Decoded_VkExtent2D* minSrcExtent{ nullptr };
+    Decoded_VkExtent2D* maxSrcExtent{ nullptr };
+    Decoded_VkOffset2D* minDstPosition{ nullptr };
+    Decoded_VkOffset2D* maxDstPosition{ nullptr };
+    Decoded_VkExtent2D* minDstExtent{ nullptr };
+    Decoded_VkExtent2D* maxDstExtent{ nullptr };
 };
 
 struct Decoded_VkDisplayPlanePropertiesKHR
@@ -2342,8 +2342,8 @@ struct Decoded_VkDisplayPropertiesKHR
 
     format::HandleId display{ format::kNullHandleId };
     StringDecoder displayName;
-    std::unique_ptr<Decoded_VkExtent2D> physicalDimensions;
-    std::unique_ptr<Decoded_VkExtent2D> physicalResolution;
+    Decoded_VkExtent2D* physicalDimensions{ nullptr };
+    Decoded_VkExtent2D* physicalResolution{ nullptr };
 };
 
 struct Decoded_VkDisplaySurfaceCreateInfoKHR
@@ -2354,7 +2354,7 @@ struct Decoded_VkDisplaySurfaceCreateInfoKHR
 
     std::unique_ptr<PNextNode> pNext;
     format::HandleId displayMode{ format::kNullHandleId };
-    std::unique_ptr<Decoded_VkExtent2D> imageExtent;
+    Decoded_VkExtent2D* imageExtent{ nullptr };
 };
 
 struct Decoded_VkDisplayPresentInfoKHR
@@ -2364,8 +2364,8 @@ struct Decoded_VkDisplayPresentInfoKHR
     VkDisplayPresentInfoKHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkRect2D> srcRect;
-    std::unique_ptr<Decoded_VkRect2D> dstRect;
+    Decoded_VkRect2D* srcRect{ nullptr };
+    Decoded_VkRect2D* dstRect{ nullptr };
 };
 
 struct Decoded_VkXlibSurfaceCreateInfoKHR
@@ -2498,7 +2498,7 @@ struct Decoded_VkExportMemoryWin32HandleInfoKHR
     VkExportMemoryWin32HandleInfoKHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>> pAttributes;
+    StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>* pAttributes{ nullptr };
     WStringDecoder name;
 };
 
@@ -2588,7 +2588,7 @@ struct Decoded_VkExportSemaphoreWin32HandleInfoKHR
     VkExportSemaphoreWin32HandleInfoKHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>> pAttributes;
+    StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>* pAttributes{ nullptr };
     WStringDecoder name;
 };
 
@@ -2654,8 +2654,8 @@ struct Decoded_VkRectLayerKHR
 
     VkRectLayerKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkOffset2D> offset;
-    std::unique_ptr<Decoded_VkExtent2D> extent;
+    Decoded_VkOffset2D* offset{ nullptr };
+    Decoded_VkExtent2D* extent{ nullptr };
 };
 
 struct Decoded_VkPresentRegionKHR
@@ -2664,7 +2664,7 @@ struct Decoded_VkPresentRegionKHR
 
     VkPresentRegionKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<StructPointerDecoder<Decoded_VkRectLayerKHR>> pRectangles;
+    StructPointerDecoder<Decoded_VkRectLayerKHR>* pRectangles{ nullptr };
 };
 
 struct Decoded_VkPresentRegionsKHR
@@ -2674,7 +2674,7 @@ struct Decoded_VkPresentRegionsKHR
     VkPresentRegionsKHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPresentRegionKHR>> pRegions;
+    StructPointerDecoder<Decoded_VkPresentRegionKHR>* pRegions{ nullptr };
 };
 
 typedef Decoded_VkDescriptorUpdateTemplateEntry Decoded_VkDescriptorUpdateTemplateEntryKHR;
@@ -2737,7 +2737,7 @@ struct Decoded_VkExportFenceWin32HandleInfoKHR
     VkExportFenceWin32HandleInfoKHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>> pAttributes;
+    StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>* pAttributes{ nullptr };
     WStringDecoder name;
 };
 
@@ -2866,7 +2866,7 @@ struct Decoded_VkSurfaceCapabilities2KHR
     VkSurfaceCapabilities2KHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkSurfaceCapabilitiesKHR> surfaceCapabilities;
+    Decoded_VkSurfaceCapabilitiesKHR* surfaceCapabilities{ nullptr };
 };
 
 struct Decoded_VkSurfaceFormat2KHR
@@ -2876,7 +2876,7 @@ struct Decoded_VkSurfaceFormat2KHR
     VkSurfaceFormat2KHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkSurfaceFormatKHR> surfaceFormat;
+    Decoded_VkSurfaceFormatKHR* surfaceFormat{ nullptr };
 };
 
 typedef Decoded_VkPhysicalDeviceVariablePointersFeatures Decoded_VkPhysicalDeviceVariablePointerFeaturesKHR;
@@ -2890,7 +2890,7 @@ struct Decoded_VkDisplayProperties2KHR
     VkDisplayProperties2KHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkDisplayPropertiesKHR> displayProperties;
+    Decoded_VkDisplayPropertiesKHR* displayProperties{ nullptr };
 };
 
 struct Decoded_VkDisplayPlaneProperties2KHR
@@ -2900,7 +2900,7 @@ struct Decoded_VkDisplayPlaneProperties2KHR
     VkDisplayPlaneProperties2KHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkDisplayPlanePropertiesKHR> displayPlaneProperties;
+    Decoded_VkDisplayPlanePropertiesKHR* displayPlaneProperties{ nullptr };
 };
 
 struct Decoded_VkDisplayModeProperties2KHR
@@ -2910,7 +2910,7 @@ struct Decoded_VkDisplayModeProperties2KHR
     VkDisplayModeProperties2KHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkDisplayModePropertiesKHR> displayModeProperties;
+    Decoded_VkDisplayModePropertiesKHR* displayModeProperties{ nullptr };
 };
 
 struct Decoded_VkDisplayPlaneInfo2KHR
@@ -2930,7 +2930,7 @@ struct Decoded_VkDisplayPlaneCapabilities2KHR
     VkDisplayPlaneCapabilities2KHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkDisplayPlaneCapabilitiesKHR> capabilities;
+    Decoded_VkDisplayPlaneCapabilitiesKHR* capabilities{ nullptr };
 };
 
 typedef Decoded_VkMemoryDedicatedRequirements Decoded_VkMemoryDedicatedRequirementsKHR;
@@ -3042,8 +3042,8 @@ struct Decoded_VkFragmentShadingRateAttachmentInfoKHR
     VkFragmentShadingRateAttachmentInfoKHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkAttachmentReference2>> pFragmentShadingRateAttachment;
-    std::unique_ptr<Decoded_VkExtent2D> shadingRateAttachmentTexelSize;
+    StructPointerDecoder<Decoded_VkAttachmentReference2>* pFragmentShadingRateAttachment{ nullptr };
+    Decoded_VkExtent2D* shadingRateAttachmentTexelSize{ nullptr };
 };
 
 struct Decoded_VkPipelineFragmentShadingRateStateCreateInfoKHR
@@ -3053,7 +3053,7 @@ struct Decoded_VkPipelineFragmentShadingRateStateCreateInfoKHR
     VkPipelineFragmentShadingRateStateCreateInfoKHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkExtent2D> fragmentSize;
+    Decoded_VkExtent2D* fragmentSize{ nullptr };
     PointerDecoder<VkFragmentShadingRateCombinerOpKHR> combinerOps;
 };
 
@@ -3073,9 +3073,9 @@ struct Decoded_VkPhysicalDeviceFragmentShadingRatePropertiesKHR
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkExtent2D> minFragmentShadingRateAttachmentTexelSize;
-    std::unique_ptr<Decoded_VkExtent2D> maxFragmentShadingRateAttachmentTexelSize;
-    std::unique_ptr<Decoded_VkExtent2D> maxFragmentSize;
+    Decoded_VkExtent2D* minFragmentShadingRateAttachmentTexelSize{ nullptr };
+    Decoded_VkExtent2D* maxFragmentShadingRateAttachmentTexelSize{ nullptr };
+    Decoded_VkExtent2D* maxFragmentSize{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceFragmentShadingRateKHR
@@ -3085,7 +3085,7 @@ struct Decoded_VkPhysicalDeviceFragmentShadingRateKHR
     VkPhysicalDeviceFragmentShadingRateKHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkExtent2D> fragmentSize;
+    Decoded_VkExtent2D* fragmentSize{ nullptr };
 };
 
 struct Decoded_VkSurfaceProtectedCapabilitiesKHR
@@ -3164,7 +3164,7 @@ struct Decoded_VkPipelineExecutableStatisticKHR
     std::unique_ptr<PNextNode> pNext;
     StringDecoder name;
     StringDecoder description;
-    std::unique_ptr<Decoded_VkPipelineExecutableStatisticValueKHR> value;
+    Decoded_VkPipelineExecutableStatisticValueKHR* value{ nullptr };
 };
 
 struct Decoded_VkPipelineExecutableInternalRepresentationKHR
@@ -3207,7 +3207,7 @@ struct Decoded_VkCopyBufferInfo2KHR
     std::unique_ptr<PNextNode> pNext;
     format::HandleId srcBuffer{ format::kNullHandleId };
     format::HandleId dstBuffer{ format::kNullHandleId };
-    std::unique_ptr<StructPointerDecoder<Decoded_VkBufferCopy2KHR>> pRegions;
+    StructPointerDecoder<Decoded_VkBufferCopy2KHR>* pRegions{ nullptr };
 };
 
 struct Decoded_VkImageCopy2KHR
@@ -3217,11 +3217,11 @@ struct Decoded_VkImageCopy2KHR
     VkImageCopy2KHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkImageSubresourceLayers> srcSubresource;
-    std::unique_ptr<Decoded_VkOffset3D> srcOffset;
-    std::unique_ptr<Decoded_VkImageSubresourceLayers> dstSubresource;
-    std::unique_ptr<Decoded_VkOffset3D> dstOffset;
-    std::unique_ptr<Decoded_VkExtent3D> extent;
+    Decoded_VkImageSubresourceLayers* srcSubresource{ nullptr };
+    Decoded_VkOffset3D* srcOffset{ nullptr };
+    Decoded_VkImageSubresourceLayers* dstSubresource{ nullptr };
+    Decoded_VkOffset3D* dstOffset{ nullptr };
+    Decoded_VkExtent3D* extent{ nullptr };
 };
 
 struct Decoded_VkCopyImageInfo2KHR
@@ -3233,7 +3233,7 @@ struct Decoded_VkCopyImageInfo2KHR
     std::unique_ptr<PNextNode> pNext;
     format::HandleId srcImage{ format::kNullHandleId };
     format::HandleId dstImage{ format::kNullHandleId };
-    std::unique_ptr<StructPointerDecoder<Decoded_VkImageCopy2KHR>> pRegions;
+    StructPointerDecoder<Decoded_VkImageCopy2KHR>* pRegions{ nullptr };
 };
 
 struct Decoded_VkBufferImageCopy2KHR
@@ -3243,9 +3243,9 @@ struct Decoded_VkBufferImageCopy2KHR
     VkBufferImageCopy2KHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkImageSubresourceLayers> imageSubresource;
-    std::unique_ptr<Decoded_VkOffset3D> imageOffset;
-    std::unique_ptr<Decoded_VkExtent3D> imageExtent;
+    Decoded_VkImageSubresourceLayers* imageSubresource{ nullptr };
+    Decoded_VkOffset3D* imageOffset{ nullptr };
+    Decoded_VkExtent3D* imageExtent{ nullptr };
 };
 
 struct Decoded_VkCopyBufferToImageInfo2KHR
@@ -3257,7 +3257,7 @@ struct Decoded_VkCopyBufferToImageInfo2KHR
     std::unique_ptr<PNextNode> pNext;
     format::HandleId srcBuffer{ format::kNullHandleId };
     format::HandleId dstImage{ format::kNullHandleId };
-    std::unique_ptr<StructPointerDecoder<Decoded_VkBufferImageCopy2KHR>> pRegions;
+    StructPointerDecoder<Decoded_VkBufferImageCopy2KHR>* pRegions{ nullptr };
 };
 
 struct Decoded_VkCopyImageToBufferInfo2KHR
@@ -3269,7 +3269,7 @@ struct Decoded_VkCopyImageToBufferInfo2KHR
     std::unique_ptr<PNextNode> pNext;
     format::HandleId srcImage{ format::kNullHandleId };
     format::HandleId dstBuffer{ format::kNullHandleId };
-    std::unique_ptr<StructPointerDecoder<Decoded_VkBufferImageCopy2KHR>> pRegions;
+    StructPointerDecoder<Decoded_VkBufferImageCopy2KHR>* pRegions{ nullptr };
 };
 
 struct Decoded_VkImageBlit2KHR
@@ -3279,10 +3279,10 @@ struct Decoded_VkImageBlit2KHR
     VkImageBlit2KHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkImageSubresourceLayers> srcSubresource;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkOffset3D>> srcOffsets;
-    std::unique_ptr<Decoded_VkImageSubresourceLayers> dstSubresource;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkOffset3D>> dstOffsets;
+    Decoded_VkImageSubresourceLayers* srcSubresource{ nullptr };
+    StructPointerDecoder<Decoded_VkOffset3D>* srcOffsets{ nullptr };
+    Decoded_VkImageSubresourceLayers* dstSubresource{ nullptr };
+    StructPointerDecoder<Decoded_VkOffset3D>* dstOffsets{ nullptr };
 };
 
 struct Decoded_VkBlitImageInfo2KHR
@@ -3294,7 +3294,7 @@ struct Decoded_VkBlitImageInfo2KHR
     std::unique_ptr<PNextNode> pNext;
     format::HandleId srcImage{ format::kNullHandleId };
     format::HandleId dstImage{ format::kNullHandleId };
-    std::unique_ptr<StructPointerDecoder<Decoded_VkImageBlit2KHR>> pRegions;
+    StructPointerDecoder<Decoded_VkImageBlit2KHR>* pRegions{ nullptr };
 };
 
 struct Decoded_VkImageResolve2KHR
@@ -3304,11 +3304,11 @@ struct Decoded_VkImageResolve2KHR
     VkImageResolve2KHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkImageSubresourceLayers> srcSubresource;
-    std::unique_ptr<Decoded_VkOffset3D> srcOffset;
-    std::unique_ptr<Decoded_VkImageSubresourceLayers> dstSubresource;
-    std::unique_ptr<Decoded_VkOffset3D> dstOffset;
-    std::unique_ptr<Decoded_VkExtent3D> extent;
+    Decoded_VkImageSubresourceLayers* srcSubresource{ nullptr };
+    Decoded_VkOffset3D* srcOffset{ nullptr };
+    Decoded_VkImageSubresourceLayers* dstSubresource{ nullptr };
+    Decoded_VkOffset3D* dstOffset{ nullptr };
+    Decoded_VkExtent3D* extent{ nullptr };
 };
 
 struct Decoded_VkResolveImageInfo2KHR
@@ -3320,7 +3320,7 @@ struct Decoded_VkResolveImageInfo2KHR
     std::unique_ptr<PNextNode> pNext;
     format::HandleId srcImage{ format::kNullHandleId };
     format::HandleId dstImage{ format::kNullHandleId };
-    std::unique_ptr<StructPointerDecoder<Decoded_VkImageResolve2KHR>> pRegions;
+    StructPointerDecoder<Decoded_VkImageResolve2KHR>* pRegions{ nullptr };
 };
 
 struct Decoded_VkDebugReportCallbackCreateInfoEXT
@@ -3474,7 +3474,7 @@ struct Decoded_VkShaderStatisticsInfoAMD
 
     VkShaderStatisticsInfoAMD* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkShaderResourceUsageAMD> resourceUsage;
+    Decoded_VkShaderResourceUsageAMD* resourceUsage{ nullptr };
     PointerDecoder<uint32_t> computeWorkGroupSize;
 };
 
@@ -3502,7 +3502,7 @@ struct Decoded_VkExternalImageFormatPropertiesNV
 
     VkExternalImageFormatPropertiesNV* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkImageFormatProperties> imageFormatProperties;
+    Decoded_VkImageFormatProperties* imageFormatProperties{ nullptr };
 };
 
 struct Decoded_VkExternalMemoryImageCreateInfoNV
@@ -3540,7 +3540,7 @@ struct Decoded_VkExportMemoryWin32HandleInfoNV
     VkExportMemoryWin32HandleInfoNV* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>> pAttributes;
+    StructPointerDecoder<Decoded_SECURITY_ATTRIBUTES>* pAttributes{ nullptr };
 };
 
 struct Decoded_VkWin32KeyedMutexAcquireReleaseInfoNV
@@ -3646,7 +3646,7 @@ struct Decoded_VkPipelineViewportWScalingStateCreateInfoNV
     VkPipelineViewportWScalingStateCreateInfoNV* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkViewportWScalingNV>> pViewportWScalings;
+    StructPointerDecoder<Decoded_VkViewportWScalingNV>* pViewportWScalings{ nullptr };
 };
 
 struct Decoded_VkSurfaceCapabilities2EXT
@@ -3656,9 +3656,9 @@ struct Decoded_VkSurfaceCapabilities2EXT
     VkSurfaceCapabilities2EXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkExtent2D> currentExtent;
-    std::unique_ptr<Decoded_VkExtent2D> minImageExtent;
-    std::unique_ptr<Decoded_VkExtent2D> maxImageExtent;
+    Decoded_VkExtent2D* currentExtent{ nullptr };
+    Decoded_VkExtent2D* minImageExtent{ nullptr };
+    Decoded_VkExtent2D* maxImageExtent{ nullptr };
 };
 
 struct Decoded_VkDisplayPowerInfoEXT
@@ -3725,7 +3725,7 @@ struct Decoded_VkPresentTimesInfoGOOGLE
     VkPresentTimesInfoGOOGLE* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPresentTimeGOOGLE>> pTimes;
+    StructPointerDecoder<Decoded_VkPresentTimeGOOGLE>* pTimes{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX
@@ -3751,7 +3751,7 @@ struct Decoded_VkPipelineViewportSwizzleStateCreateInfoNV
     VkPipelineViewportSwizzleStateCreateInfoNV* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkViewportSwizzleNV>> pViewportSwizzles;
+    StructPointerDecoder<Decoded_VkViewportSwizzleNV>* pViewportSwizzles{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceDiscardRectanglePropertiesEXT
@@ -3770,7 +3770,7 @@ struct Decoded_VkPipelineDiscardRectangleStateCreateInfoEXT
     VkPipelineDiscardRectangleStateCreateInfoEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkRect2D>> pDiscardRectangles;
+    StructPointerDecoder<Decoded_VkRect2D>* pDiscardRectangles{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceConservativeRasterizationPropertiesEXT
@@ -3823,10 +3823,10 @@ struct Decoded_VkHdrMetadataEXT
     VkHdrMetadataEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkXYColorEXT> displayPrimaryRed;
-    std::unique_ptr<Decoded_VkXYColorEXT> displayPrimaryGreen;
-    std::unique_ptr<Decoded_VkXYColorEXT> displayPrimaryBlue;
-    std::unique_ptr<Decoded_VkXYColorEXT> whitePoint;
+    Decoded_VkXYColorEXT* displayPrimaryRed{ nullptr };
+    Decoded_VkXYColorEXT* displayPrimaryGreen{ nullptr };
+    Decoded_VkXYColorEXT* displayPrimaryBlue{ nullptr };
+    Decoded_VkXYColorEXT* whitePoint{ nullptr };
 };
 
 struct Decoded_VkIOSSurfaceCreateInfoMVK
@@ -3880,9 +3880,9 @@ struct Decoded_VkDebugUtilsMessengerCallbackDataEXT
     std::unique_ptr<PNextNode> pNext;
     StringDecoder pMessageIdName;
     StringDecoder pMessage;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>> pQueueLabels;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>> pCmdBufLabels;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>> pObjects;
+    StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pQueueLabels{ nullptr };
+    StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pCmdBufLabels{ nullptr };
+    StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* pObjects{ nullptr };
 };
 
 struct Decoded_VkDebugUtilsMessengerCreateInfoEXT
@@ -3932,7 +3932,7 @@ struct Decoded_VkAndroidHardwareBufferFormatPropertiesANDROID
     VkAndroidHardwareBufferFormatPropertiesANDROID* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkComponentMapping> samplerYcbcrConversionComponents;
+    Decoded_VkComponentMapping* samplerYcbcrConversionComponents{ nullptr };
 };
 
 struct Decoded_VkImportAndroidHardwareBufferInfoANDROID
@@ -4019,8 +4019,8 @@ struct Decoded_VkSampleLocationsInfoEXT
     VkSampleLocationsInfoEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkExtent2D> sampleLocationGridSize;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkSampleLocationEXT>> pSampleLocations;
+    Decoded_VkExtent2D* sampleLocationGridSize{ nullptr };
+    StructPointerDecoder<Decoded_VkSampleLocationEXT>* pSampleLocations{ nullptr };
 };
 
 struct Decoded_VkAttachmentSampleLocationsEXT
@@ -4029,7 +4029,7 @@ struct Decoded_VkAttachmentSampleLocationsEXT
 
     VkAttachmentSampleLocationsEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkSampleLocationsInfoEXT> sampleLocationsInfo;
+    Decoded_VkSampleLocationsInfoEXT* sampleLocationsInfo{ nullptr };
 };
 
 struct Decoded_VkSubpassSampleLocationsEXT
@@ -4038,7 +4038,7 @@ struct Decoded_VkSubpassSampleLocationsEXT
 
     VkSubpassSampleLocationsEXT* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkSampleLocationsInfoEXT> sampleLocationsInfo;
+    Decoded_VkSampleLocationsInfoEXT* sampleLocationsInfo{ nullptr };
 };
 
 struct Decoded_VkRenderPassSampleLocationsBeginInfoEXT
@@ -4048,8 +4048,8 @@ struct Decoded_VkRenderPassSampleLocationsBeginInfoEXT
     VkRenderPassSampleLocationsBeginInfoEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkAttachmentSampleLocationsEXT>> pAttachmentInitialSampleLocations;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkSubpassSampleLocationsEXT>> pPostSubpassSampleLocations;
+    StructPointerDecoder<Decoded_VkAttachmentSampleLocationsEXT>* pAttachmentInitialSampleLocations{ nullptr };
+    StructPointerDecoder<Decoded_VkSubpassSampleLocationsEXT>* pPostSubpassSampleLocations{ nullptr };
 };
 
 struct Decoded_VkPipelineSampleLocationsStateCreateInfoEXT
@@ -4059,7 +4059,7 @@ struct Decoded_VkPipelineSampleLocationsStateCreateInfoEXT
     VkPipelineSampleLocationsStateCreateInfoEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkSampleLocationsInfoEXT> sampleLocationsInfo;
+    Decoded_VkSampleLocationsInfoEXT* sampleLocationsInfo{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceSampleLocationsPropertiesEXT
@@ -4069,7 +4069,7 @@ struct Decoded_VkPhysicalDeviceSampleLocationsPropertiesEXT
     VkPhysicalDeviceSampleLocationsPropertiesEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkExtent2D> maxSampleLocationGridSize;
+    Decoded_VkExtent2D* maxSampleLocationGridSize{ nullptr };
     PointerDecoder<float> sampleLocationCoordinateRange;
 };
 
@@ -4080,7 +4080,7 @@ struct Decoded_VkMultisamplePropertiesEXT
     VkMultisamplePropertiesEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkExtent2D> maxSampleLocationGridSize;
+    Decoded_VkExtent2D* maxSampleLocationGridSize{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT
@@ -4161,7 +4161,7 @@ struct Decoded_VkDrmFormatModifierPropertiesListEXT
     VkDrmFormatModifierPropertiesListEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkDrmFormatModifierPropertiesEXT>> pDrmFormatModifierProperties;
+    StructPointerDecoder<Decoded_VkDrmFormatModifierPropertiesEXT>* pDrmFormatModifierProperties{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceImageDrmFormatModifierInfoEXT
@@ -4191,7 +4191,7 @@ struct Decoded_VkImageDrmFormatModifierExplicitCreateInfoEXT
     VkImageDrmFormatModifierExplicitCreateInfoEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkSubresourceLayout>> pPlaneLayouts;
+    StructPointerDecoder<Decoded_VkSubresourceLayout>* pPlaneLayouts{ nullptr };
 };
 
 struct Decoded_VkImageDrmFormatModifierPropertiesEXT
@@ -4249,7 +4249,7 @@ struct Decoded_VkPipelineViewportShadingRateImageStateCreateInfoNV
     VkPipelineViewportShadingRateImageStateCreateInfoNV* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkShadingRatePaletteNV>> pShadingRatePalettes;
+    StructPointerDecoder<Decoded_VkShadingRatePaletteNV>* pShadingRatePalettes{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceShadingRateImageFeaturesNV
@@ -4268,7 +4268,7 @@ struct Decoded_VkPhysicalDeviceShadingRateImagePropertiesNV
     VkPhysicalDeviceShadingRateImagePropertiesNV* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkExtent2D> shadingRateTexelSize;
+    Decoded_VkExtent2D* shadingRateTexelSize{ nullptr };
 };
 
 struct Decoded_VkCoarseSampleLocationNV
@@ -4284,7 +4284,7 @@ struct Decoded_VkCoarseSampleOrderCustomNV
 
     VkCoarseSampleOrderCustomNV* decoded_value{ nullptr };
 
-    std::unique_ptr<StructPointerDecoder<Decoded_VkCoarseSampleLocationNV>> pSampleLocations;
+    StructPointerDecoder<Decoded_VkCoarseSampleLocationNV>* pSampleLocations{ nullptr };
 };
 
 struct Decoded_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV
@@ -4294,7 +4294,7 @@ struct Decoded_VkPipelineViewportCoarseSampleOrderStateCreateInfoNV
     VkPipelineViewportCoarseSampleOrderStateCreateInfoNV* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>> pCustomSampleOrders;
+    StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>* pCustomSampleOrders{ nullptr };
 };
 
 struct Decoded_VkRayTracingShaderGroupCreateInfoNV
@@ -4313,8 +4313,8 @@ struct Decoded_VkRayTracingPipelineCreateInfoNV
     VkRayTracingPipelineCreateInfoNV* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>> pStages;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkRayTracingShaderGroupCreateInfoNV>> pGroups;
+    StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>* pStages{ nullptr };
+    StructPointerDecoder<Decoded_VkRayTracingShaderGroupCreateInfoNV>* pGroups{ nullptr };
     format::HandleId layout{ format::kNullHandleId };
     format::HandleId basePipelineHandle{ format::kNullHandleId };
 };
@@ -4347,8 +4347,8 @@ struct Decoded_VkGeometryDataNV
 
     VkGeometryDataNV* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkGeometryTrianglesNV> triangles;
-    std::unique_ptr<Decoded_VkGeometryAABBNV> aabbs;
+    Decoded_VkGeometryTrianglesNV* triangles{ nullptr };
+    Decoded_VkGeometryAABBNV* aabbs{ nullptr };
 };
 
 struct Decoded_VkGeometryNV
@@ -4358,7 +4358,7 @@ struct Decoded_VkGeometryNV
     VkGeometryNV* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkGeometryDataNV> geometry;
+    Decoded_VkGeometryDataNV* geometry{ nullptr };
 };
 
 struct Decoded_VkAccelerationStructureInfoNV
@@ -4368,7 +4368,7 @@ struct Decoded_VkAccelerationStructureInfoNV
     VkAccelerationStructureInfoNV* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkGeometryNV>> pGeometries;
+    StructPointerDecoder<Decoded_VkGeometryNV>* pGeometries{ nullptr };
 };
 
 struct Decoded_VkAccelerationStructureCreateInfoNV
@@ -4378,7 +4378,7 @@ struct Decoded_VkAccelerationStructureCreateInfoNV
     VkAccelerationStructureCreateInfoNV* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkAccelerationStructureInfoNV> info;
+    Decoded_VkAccelerationStructureInfoNV* info{ nullptr };
 };
 
 struct Decoded_VkBindAccelerationStructureMemoryInfoNV
@@ -4444,7 +4444,7 @@ struct Decoded_VkAccelerationStructureInstanceKHR
 
     VkAccelerationStructureInstanceKHR* decoded_value{ nullptr };
 
-    std::unique_ptr<Decoded_VkTransformMatrixKHR> transform;
+    Decoded_VkTransformMatrixKHR* transform{ nullptr };
 };
 
 typedef Decoded_VkTransformMatrixKHR Decoded_VkTransformMatrixNV;
@@ -4585,7 +4585,7 @@ struct Decoded_VkPipelineVertexInputDivisorStateCreateInfoEXT
     VkPipelineVertexInputDivisorStateCreateInfoEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkVertexInputBindingDivisorDescriptionEXT>> pVertexBindingDivisors;
+    StructPointerDecoder<Decoded_VkVertexInputBindingDivisorDescriptionEXT>* pVertexBindingDivisors{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT
@@ -4620,8 +4620,8 @@ struct Decoded_VkPipelineCreationFeedbackCreateInfoEXT
     VkPipelineCreationFeedbackCreateInfoEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineCreationFeedbackEXT>> pPipelineCreationFeedback;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineCreationFeedbackEXT>> pPipelineStageCreationFeedbacks;
+    StructPointerDecoder<Decoded_VkPipelineCreationFeedbackEXT>* pPipelineCreationFeedback{ nullptr };
+    StructPointerDecoder<Decoded_VkPipelineCreationFeedbackEXT>* pPipelineStageCreationFeedbacks{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceComputeShaderDerivativesFeaturesNV
@@ -4685,7 +4685,7 @@ struct Decoded_VkPipelineViewportExclusiveScissorStateCreateInfoNV
     VkPipelineViewportExclusiveScissorStateCreateInfoNV* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkRect2D>> pExclusiveScissors;
+    StructPointerDecoder<Decoded_VkRect2D>* pExclusiveScissors{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceExclusiveScissorFeaturesNV
@@ -4844,8 +4844,8 @@ struct Decoded_VkPhysicalDeviceFragmentDensityMapPropertiesEXT
     VkPhysicalDeviceFragmentDensityMapPropertiesEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkExtent2D> minFragmentDensityTexelSize;
-    std::unique_ptr<Decoded_VkExtent2D> maxFragmentDensityTexelSize;
+    Decoded_VkExtent2D* minFragmentDensityTexelSize{ nullptr };
+    Decoded_VkExtent2D* maxFragmentDensityTexelSize{ nullptr };
 };
 
 struct Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT
@@ -4855,7 +4855,7 @@ struct Decoded_VkRenderPassFragmentDensityMapCreateInfoEXT
     VkRenderPassFragmentDensityMapCreateInfoEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkAttachmentReference> fragmentDensityMapAttachment;
+    Decoded_VkAttachmentReference* fragmentDensityMapAttachment{ nullptr };
 };
 
 typedef Decoded_VkPhysicalDeviceScalarBlockLayoutFeatures Decoded_VkPhysicalDeviceScalarBlockLayoutFeaturesEXT;
@@ -5199,9 +5199,9 @@ struct Decoded_VkGraphicsShaderGroupCreateInfoNV
     VkGraphicsShaderGroupCreateInfoNV* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>> pStages;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineVertexInputStateCreateInfo>> pVertexInputState;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineTessellationStateCreateInfo>> pTessellationState;
+    StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>* pStages{ nullptr };
+    StructPointerDecoder<Decoded_VkPipelineVertexInputStateCreateInfo>* pVertexInputState{ nullptr };
+    StructPointerDecoder<Decoded_VkPipelineTessellationStateCreateInfo>* pTessellationState{ nullptr };
 };
 
 struct Decoded_VkGraphicsPipelineShaderGroupsCreateInfoNV
@@ -5211,7 +5211,7 @@ struct Decoded_VkGraphicsPipelineShaderGroupsCreateInfoNV
     VkGraphicsPipelineShaderGroupsCreateInfoNV* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkGraphicsShaderGroupCreateInfoNV>> pGroups;
+    StructPointerDecoder<Decoded_VkGraphicsShaderGroupCreateInfoNV>* pGroups{ nullptr };
     HandlePointerDecoder<VkPipeline> pPipelines;
 };
 
@@ -5271,7 +5271,7 @@ struct Decoded_VkIndirectCommandsLayoutCreateInfoNV
     VkIndirectCommandsLayoutCreateInfoNV* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkIndirectCommandsLayoutTokenNV>> pTokens;
+    StructPointerDecoder<Decoded_VkIndirectCommandsLayoutTokenNV>* pTokens{ nullptr };
     PointerDecoder<uint32_t> pStreamStrides;
 };
 
@@ -5284,7 +5284,7 @@ struct Decoded_VkGeneratedCommandsInfoNV
     std::unique_ptr<PNextNode> pNext;
     format::HandleId pipeline{ format::kNullHandleId };
     format::HandleId indirectCommandsLayout{ format::kNullHandleId };
-    std::unique_ptr<StructPointerDecoder<Decoded_VkIndirectCommandsStreamNV>> pStreams;
+    StructPointerDecoder<Decoded_VkIndirectCommandsStreamNV>* pStreams{ nullptr };
     format::HandleId preprocessBuffer{ format::kNullHandleId };
     format::HandleId sequencesCountBuffer{ format::kNullHandleId };
     format::HandleId sequencesIndexBuffer{ format::kNullHandleId };
@@ -5335,7 +5335,7 @@ struct Decoded_VkCommandBufferInheritanceRenderPassTransformInfoQCOM
     VkCommandBufferInheritanceRenderPassTransformInfoQCOM* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkRect2D> renderArea;
+    Decoded_VkRect2D* renderArea{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceDeviceMemoryReportFeaturesEXT
@@ -5392,7 +5392,7 @@ struct Decoded_VkSamplerCustomBorderColorCreateInfoEXT
     VkSamplerCustomBorderColorCreateInfoEXT* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkClearColorValue> customBorderColor;
+    Decoded_VkClearColorValue* customBorderColor{ nullptr };
 };
 
 struct Decoded_VkPhysicalDeviceCustomBorderColorPropertiesEXT
@@ -5565,9 +5565,9 @@ struct Decoded_VkAccelerationStructureGeometryTrianglesDataKHR
     VkAccelerationStructureGeometryTrianglesDataKHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkDeviceOrHostAddressConstKHR> vertexData;
-    std::unique_ptr<Decoded_VkDeviceOrHostAddressConstKHR> indexData;
-    std::unique_ptr<Decoded_VkDeviceOrHostAddressConstKHR> transformData;
+    Decoded_VkDeviceOrHostAddressConstKHR* vertexData{ nullptr };
+    Decoded_VkDeviceOrHostAddressConstKHR* indexData{ nullptr };
+    Decoded_VkDeviceOrHostAddressConstKHR* transformData{ nullptr };
 };
 
 struct Decoded_VkAccelerationStructureGeometryAabbsDataKHR
@@ -5577,7 +5577,7 @@ struct Decoded_VkAccelerationStructureGeometryAabbsDataKHR
     VkAccelerationStructureGeometryAabbsDataKHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkDeviceOrHostAddressConstKHR> data;
+    Decoded_VkDeviceOrHostAddressConstKHR* data{ nullptr };
 };
 
 struct Decoded_VkAccelerationStructureGeometryInstancesDataKHR
@@ -5587,7 +5587,7 @@ struct Decoded_VkAccelerationStructureGeometryInstancesDataKHR
     VkAccelerationStructureGeometryInstancesDataKHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkDeviceOrHostAddressConstKHR> data;
+    Decoded_VkDeviceOrHostAddressConstKHR* data{ nullptr };
 };
 
 struct Decoded_VkAccelerationStructureBuildGeometryInfoKHR
@@ -5599,9 +5599,9 @@ struct Decoded_VkAccelerationStructureBuildGeometryInfoKHR
     std::unique_ptr<PNextNode> pNext;
     format::HandleId srcAccelerationStructure{ format::kNullHandleId };
     format::HandleId dstAccelerationStructure{ format::kNullHandleId };
-    std::unique_ptr<StructPointerDecoder<Decoded_VkAccelerationStructureGeometryKHR>> pGeometries;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkAccelerationStructureGeometryKHR*>> ppGeometries;
-    std::unique_ptr<Decoded_VkDeviceOrHostAddressKHR> scratchData;
+    StructPointerDecoder<Decoded_VkAccelerationStructureGeometryKHR>* pGeometries{ nullptr };
+    StructPointerDecoder<Decoded_VkAccelerationStructureGeometryKHR*>* ppGeometries{ nullptr };
+    Decoded_VkDeviceOrHostAddressKHR* scratchData{ nullptr };
 };
 
 struct Decoded_VkAccelerationStructureCreateInfoKHR
@@ -5670,7 +5670,7 @@ struct Decoded_VkCopyAccelerationStructureToMemoryInfoKHR
 
     std::unique_ptr<PNextNode> pNext;
     format::HandleId src{ format::kNullHandleId };
-    std::unique_ptr<Decoded_VkDeviceOrHostAddressKHR> dst;
+    Decoded_VkDeviceOrHostAddressKHR* dst{ nullptr };
 };
 
 struct Decoded_VkCopyMemoryToAccelerationStructureInfoKHR
@@ -5680,7 +5680,7 @@ struct Decoded_VkCopyMemoryToAccelerationStructureInfoKHR
     VkCopyMemoryToAccelerationStructureInfoKHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<Decoded_VkDeviceOrHostAddressConstKHR> src;
+    Decoded_VkDeviceOrHostAddressConstKHR* src{ nullptr };
     format::HandleId dst{ format::kNullHandleId };
 };
 
@@ -5730,11 +5730,11 @@ struct Decoded_VkRayTracingPipelineCreateInfoKHR
     VkRayTracingPipelineCreateInfoKHR* decoded_value{ nullptr };
 
     std::unique_ptr<PNextNode> pNext;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>> pStages;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkRayTracingShaderGroupCreateInfoKHR>> pGroups;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineLibraryCreateInfoKHR>> pLibraryInfo;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkRayTracingPipelineInterfaceCreateInfoKHR>> pLibraryInterface;
-    std::unique_ptr<StructPointerDecoder<Decoded_VkPipelineDynamicStateCreateInfo>> pDynamicState;
+    StructPointerDecoder<Decoded_VkPipelineShaderStageCreateInfo>* pStages{ nullptr };
+    StructPointerDecoder<Decoded_VkRayTracingShaderGroupCreateInfoKHR>* pGroups{ nullptr };
+    StructPointerDecoder<Decoded_VkPipelineLibraryCreateInfoKHR>* pLibraryInfo{ nullptr };
+    StructPointerDecoder<Decoded_VkRayTracingPipelineInterfaceCreateInfoKHR>* pLibraryInterface{ nullptr };
+    StructPointerDecoder<Decoded_VkPipelineDynamicStateCreateInfo>* pDynamicState{ nullptr };
     format::HandleId layout{ format::kNullHandleId };
     format::HandleId basePipelineHandle{ format::kNullHandleId };
 };

--- a/framework/generated/generated_vulkan_struct_handle_mappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.cpp
@@ -247,7 +247,7 @@ void MapStructHandles(Decoded_VkComputePipelineCreateInfo* wrapper, const Vulkan
     {
         VkComputePipelineCreateInfo* value = wrapper->decoded_value;
 
-        MapStructHandles(wrapper->stage.get(), object_info_table);
+        MapStructHandles(wrapper->stage, object_info_table);
 
         value->layout = handle_mapping::MapHandle<PipelineLayoutInfo>(wrapper->layout, object_info_table, &VulkanObjectInfoTable::GetPipelineLayoutInfo);
 
@@ -793,7 +793,7 @@ void MapStructHandles(Decoded_VkDisplayProperties2KHR* wrapper, const VulkanObje
 {
     if (wrapper != nullptr)
     {
-        MapStructHandles(wrapper->displayProperties.get(), object_info_table);
+        MapStructHandles(wrapper->displayProperties, object_info_table);
     }
 }
 
@@ -801,7 +801,7 @@ void MapStructHandles(Decoded_VkDisplayPlaneProperties2KHR* wrapper, const Vulka
 {
     if (wrapper != nullptr)
     {
-        MapStructHandles(wrapper->displayPlaneProperties.get(), object_info_table);
+        MapStructHandles(wrapper->displayPlaneProperties, object_info_table);
     }
 }
 
@@ -809,7 +809,7 @@ void MapStructHandles(Decoded_VkDisplayModeProperties2KHR* wrapper, const Vulkan
 {
     if (wrapper != nullptr)
     {
-        MapStructHandles(wrapper->displayModeProperties.get(), object_info_table);
+        MapStructHandles(wrapper->displayModeProperties, object_info_table);
     }
 }
 
@@ -1073,9 +1073,9 @@ void MapStructHandles(Decoded_VkGeometryDataNV* wrapper, const VulkanObjectInfoT
 {
     if (wrapper != nullptr)
     {
-        MapStructHandles(wrapper->triangles.get(), object_info_table);
+        MapStructHandles(wrapper->triangles, object_info_table);
 
-        MapStructHandles(wrapper->aabbs.get(), object_info_table);
+        MapStructHandles(wrapper->aabbs, object_info_table);
     }
 }
 
@@ -1083,7 +1083,7 @@ void MapStructHandles(Decoded_VkGeometryNV* wrapper, const VulkanObjectInfoTable
 {
     if (wrapper != nullptr)
     {
-        MapStructHandles(wrapper->geometry.get(), object_info_table);
+        MapStructHandles(wrapper->geometry, object_info_table);
     }
 }
 
@@ -1099,7 +1099,7 @@ void MapStructHandles(Decoded_VkAccelerationStructureCreateInfoNV* wrapper, cons
 {
     if (wrapper != nullptr)
     {
-        MapStructHandles(wrapper->info.get(), object_info_table);
+        MapStructHandles(wrapper->info, object_info_table);
     }
 }
 
@@ -1395,7 +1395,7 @@ void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPropert
 {
     if (id_wrapper != nullptr)
     {
-        AddStructHandles(parent_id, id_wrapper->displayProperties.get(), &handle_struct->displayProperties, object_info_table);
+        AddStructHandles(parent_id, id_wrapper->displayProperties, &handle_struct->displayProperties, object_info_table);
     }
 }
 
@@ -1403,7 +1403,7 @@ void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayPlanePr
 {
     if (id_wrapper != nullptr)
     {
-        AddStructHandles(parent_id, id_wrapper->displayPlaneProperties.get(), &handle_struct->displayPlaneProperties, object_info_table);
+        AddStructHandles(parent_id, id_wrapper->displayPlaneProperties, &handle_struct->displayPlaneProperties, object_info_table);
     }
 }
 
@@ -1411,7 +1411,7 @@ void AddStructHandles(format::HandleId parent_id, const Decoded_VkDisplayModePro
 {
     if (id_wrapper != nullptr)
     {
-        AddStructHandles(parent_id, id_wrapper->displayModeProperties.get(), &handle_struct->displayModeProperties, object_info_table);
+        AddStructHandles(parent_id, id_wrapper->displayModeProperties, &handle_struct->displayModeProperties, object_info_table);
     }
 }
 

--- a/framework/generated/vulkan_generators/decode_pnext_struct_generator.py
+++ b/framework/generated/vulkan_generators/decode_pnext_struct_generator.py
@@ -58,6 +58,7 @@ class DecodePNextStructGenerator(BaseGenerator):
         BaseGenerator.beginFile(self, genOpts)
 
         write('#include "decode/custom_vulkan_struct_decoders.h"', file=self.outFile)
+        write('#include "decode/decode_allocator.h"', file=self.outFile)
         write('#include "decode/pnext_node.h"', file=self.outFile)
         write('#include "decode/pnext_typed_node.h"', file=self.outFile)
         write('#include "generated/generated_vulkan_struct_decoders.h"', file=self.outFile)
@@ -68,7 +69,7 @@ class DecodePNextStructGenerator(BaseGenerator):
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)
         self.newline()
-        write('size_t DecodePNextStruct(const uint8_t* parameter_buffer, size_t buffer_size,  std::unique_ptr<PNextNode>* pNext)', file=self.outFile)
+        write('size_t DecodePNextStruct(const uint8_t* parameter_buffer, size_t buffer_size,  PNextNode** pNext)', file=self.outFile)
         write('{', file=self.outFile)
         write('    assert(pNext != nullptr);', file=self.outFile)
         self.newline()
@@ -148,7 +149,7 @@ class DecodePNextStructGenerator(BaseGenerator):
     def generateFeature(self):
         for struct in self.sTypeValues:
             write('            case {}:'.format(self.sTypeValues[struct]), file=self.outFile)
-            write('                (*pNext) = std::make_unique<PNextTypedNode<Decoded_{}>>();'.format(struct), file=self.outFile)
+            write('                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_{}>>();'.format(struct), file=self.outFile)
             write('                bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);'.format(struct), file=self.outFile)
             write('                break;', file=self.outFile)
         self.sTypeValues = dict()

--- a/framework/generated/vulkan_generators/vulkan_struct_decoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_decoders_body_generator.py
@@ -57,6 +57,7 @@ class VulkanStructDecodersBodyGenerator(BaseGenerator):
         write('#include "generated/generated_vulkan_struct_decoders.h"', file=self.outFile)
         self.newline()
         write('#include "decode/custom_vulkan_struct_decoders.h"', file=self.outFile)
+        write('#include "decode/decode_allocator.h"', file=self.outFile)
         self.newline()
         write('#include <cassert>', file=self.outFile)
         self.newline()
@@ -151,7 +152,7 @@ class VulkanStructDecodersBodyGenerator(BaseGenerator):
                 accessOp = '.'
 
                 if isStruct:
-                    body += '    wrapper->{} = std::make_unique<{}>();\n'.format(value.name, self.makeDecodedParamType(value))
+                    body += '    wrapper->{} = DecodeAllocator::Allocate<{}>();\n'.format(value.name, self.makeDecodedParamType(value))
                     accessOp = '->'
 
                 if isStaticArray:
@@ -172,9 +173,9 @@ class VulkanStructDecodersBodyGenerator(BaseGenerator):
                         body += '    value->{name} = wrapper->{name}{}GetPointer();\n'.format(accessOp, name=value.name)
         else:
             if isStruct:
-                body += '    wrapper->{} = std::make_unique<{}>();\n'.format(value.name, self.makeDecodedParamType(value))
+                body += '    wrapper->{} = DecodeAllocator::Allocate<{}>();\n'.format(value.name, self.makeDecodedParamType(value))
                 body += '    wrapper->{name}->decoded_value = &(value->{name});\n'.format(name=value.name)
-                body += '    bytes_read += DecodeStruct({}, wrapper->{}.get());\n'.format(bufferArgs, value.name)
+                body += '    bytes_read += DecodeStruct({}, wrapper->{});\n'.format(bufferArgs, value.name)
             elif isFuncp:
                 body += '    bytes_read += ValueDecoder::DecodeAddress({}, &(wrapper->{}));\n'.format(bufferArgs, value.name)
                 body += '    value->{} = nullptr;\n'.format(value.name)

--- a/framework/generated/vulkan_generators/vulkan_struct_decoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_decoders_body_generator.py
@@ -64,7 +64,7 @@ class VulkanStructDecodersBodyGenerator(BaseGenerator):
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)
         self.newline()
-        write('size_t DecodePNextStruct(const uint8_t* buffer, size_t buffer_size, std::unique_ptr<PNextNode>* pNext);', file=self.outFile)
+        write('size_t DecodePNextStruct(const uint8_t* buffer, size_t buffer_size, PNextNode** pNext);', file=self.outFile)
 
     # Method override
     def endFile(self):

--- a/framework/generated/vulkan_generators/vulkan_struct_decoders_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_decoders_header_generator.py
@@ -152,7 +152,7 @@ class VulkanStructDecodersHeaderGenerator(BaseGenerator):
         for value in values:
             if value.name == 'pNext':
                 # We have a special type to store the pNext chain
-                body += '    std::unique_ptr<PNextNode> pNext;\n'
+                body += '    PNextNode* pNext{ nullptr };\n'
             elif self.needsMemberDeclaration(name, value):
                 typeName = self.makeDecodedParamType(value)
                 if self.isStruct(value.baseType):

--- a/framework/generated/vulkan_generators/vulkan_struct_decoders_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_decoders_header_generator.py
@@ -156,12 +156,15 @@ class VulkanStructDecodersHeaderGenerator(BaseGenerator):
             elif self.needsMemberDeclaration(name, value):
                 typeName = self.makeDecodedParamType(value)
                 if self.isStruct(value.baseType):
-                    typeName = 'std::unique_ptr<{}>'.format(typeName)
+                    typeName = '{}*'.format(typeName)
 
                 defaultValue = self.getDefaultInitValue(typeName)
                 if defaultValue:
                     body += '    {} {}{{ {} }};\n'.format(typeName, value.name, defaultValue)
                 else:
-                    body += '    {} {};\n'.format(typeName, value.name)
+                    if self.isStruct(value.baseType):
+                        body += '    {} {}{{ nullptr }};\n'.format(typeName, value.name)
+                    else:
+                        body += '    {} {};\n'.format(typeName, value.name)
 
         return body

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_body_generator.py
@@ -215,7 +215,7 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
                 elif member.isPointer:
                     body += '        MapStructArrayHandles<Decoded_{}>(wrapper->{}->GetMetaStructPointer(), 1, object_info_table);\n'.format(member.baseType, member.name)
                 else:
-                    body += '        MapStructHandles(wrapper->{}.get(), object_info_table);\n'.format(member.name)
+                    body += '        MapStructHandles(wrapper->{}, object_info_table);\n'.format(member.name)
             else:
                 # If it is an array or pointer, map with the utility function.
                 if (member.isArray or member.isPointer):
@@ -254,7 +254,7 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
                 elif member.isPointer:
                     body += '        AddStructArrayHandles<Decoded_{}>(parent_id, id_wrapper->{name}->GetMetaStructPointer(), 1, handle_struct->{name}, 1, object_info_table);\n'.format(member.baseType, name=member.name)
                 else:
-                    body += '        AddStructHandles(parent_id, id_wrapper->{name}.get(), &handle_struct->{name}, object_info_table);\n'.format(name=member.name)
+                    body += '        AddStructHandles(parent_id, id_wrapper->{name}, &handle_struct->{name}, object_info_table);\n'.format(name=member.name)
             else:
                 # If it is an array or pointer, add with the utility function.
                 if (member.isArray or member.isPointer):
@@ -305,7 +305,7 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
                 elif member.isPointer:
                     body += '        SetStructArrayHandleLengths<Decoded_{}>(wrapper->{name}->GetMetaStructPointer(), 1);\n'.format(member.baseType, name=member.name)
                 else:
-                    body += '        SetStructHandleLengths(wrapper->{name}.get());\n'.format(name=member.name)
+                    body += '        SetStructHandleLengths(wrapper->{name});\n'.format(name=member.name)
             else:
                 # If it is an array or pointer, add with the utility function.
                 if (member.isArray or member.isPointer):

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -55,6 +55,8 @@ target_sources(gfxrecon_util
                     ${CMAKE_CURRENT_LIST_DIR}/zstd_compressor.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/memory_output_stream.h
                     ${CMAKE_CURRENT_LIST_DIR}/memory_output_stream.cpp
+                    ${CMAKE_CURRENT_LIST_DIR}/monotonic_allocator.h
+                    ${CMAKE_CURRENT_LIST_DIR}/monotonic_allocator.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/output_stream.h
                     ${CMAKE_CURRENT_LIST_DIR}/page_guard_manager.h
                     ${CMAKE_CURRENT_LIST_DIR}/page_guard_manager.cpp

--- a/framework/util/monotonic_allocator.cpp
+++ b/framework/util/monotonic_allocator.cpp
@@ -1,0 +1,105 @@
+
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "util/monotonic_allocator.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+void MonotonicAllocator::Clear(bool free_system_memory)
+{
+    // Call destructors of allocated objects
+    for (auto destructor : destructors_)
+    {
+        destructor.destroy(destructor.obj);
+    }
+    destructors_.clear();
+
+    // Free memory blocks
+    if (free_system_memory)
+    {
+        memory_blocks_.clear();
+    }
+
+    // Free oversized allocations
+    oversized_allocations_.clear();
+
+    current_block_            = 0;
+    current_block_free_bytes_ = block_size_;
+}
+
+void* MonotonicAllocator::Allocate(size_t object_bytes, size_t alignment_bytes)
+{
+    void* result = nullptr;
+
+    // Don't allocate 0 bytes
+    assert(object_bytes + alignment_bytes > 0);
+    if (object_bytes + alignment_bytes == 0)
+    {
+        return nullptr;
+    }
+
+    if (object_bytes <= block_size_)
+    {
+        // Try to allocate to an existing block
+        while (current_block_ < memory_blocks_.size() && result == nullptr)
+        {
+            result = AllocateToBlock(object_bytes, alignment_bytes);
+            if (result == nullptr)
+            {
+                // Move to next block
+                ++current_block_;
+                current_block_free_bytes_ = block_size_;
+            }
+        }
+
+        if (result == nullptr)
+        {
+            memory_blocks_.emplace_back(new unsigned char[block_size_]);
+            result = AllocateToBlock(object_bytes, alignment_bytes);
+        }
+    }
+    else
+    {
+        // Custom allocation
+        oversized_allocations_.emplace_back(new unsigned char[object_bytes]);
+        result = oversized_allocations_.back().get();
+    }
+
+    return result;
+}
+
+void* MonotonicAllocator::AllocateToBlock(size_t object_bytes, size_t alignment_bytes)
+{
+    void* block_ptr =
+        reinterpret_cast<void*>(memory_blocks_[current_block_].get() + block_size_ - current_block_free_bytes_);
+    void* result = std::align(alignment_bytes, object_bytes, block_ptr, current_block_free_bytes_);
+    if (result != nullptr)
+    {
+        current_block_free_bytes_ -= object_bytes;
+    }
+    return result;
+}
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/monotonic_allocator.h
+++ b/framework/util/monotonic_allocator.h
@@ -1,0 +1,100 @@
+
+/*
+** Copyright (c) 2020 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_UTIL_MONOTONIC_ALLOCATOR_H
+#define GFXRECON_UTIL_MONOTONIC_ALLOCATOR_H
+
+#include "util/defines.h"
+
+#include <memory>
+#include <vector>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(util)
+
+// An allocator that manages and allocates from a pool of system memory blocks
+class MonotonicAllocator
+{
+  public:
+    // block_size is the size of the individual memory blocks allocated. The number of blocks increases as needed to
+    // fit requested allocations, and blocks are freed using an appropriate call to Clear or upon destruction of this
+    // MonotonicAllocator
+    MonotonicAllocator(size_t block_size) :
+        block_size_(block_size), current_block_(0), current_block_free_bytes_(block_size)
+    {}
+
+    ~MonotonicAllocator() { Clear(true); }
+
+    // Allocates memory for count objects of type T and optionally initializes them with default constructor. Objects
+    // allocated here are valid until the next call to Clear. If the allocation requires greater than block_size
+    // bytes (oversized allocation), a system heap allocation is performed.
+    template <typename T>
+    T* Allocate(size_t count = 1, bool initialize = true)
+    {
+        T* result = reinterpret_cast<T*>(Allocate(sizeof(T) * count, alignof(T)));
+        assert(result != nullptr);
+        if ((result != nullptr) && initialize)
+        {
+            for (size_t i = 0; i < count; ++i)
+            {
+                T* obj = new (result + i) T();
+                if (!std::is_trivially_destructible<T>())
+                {
+                    destructors_.push_back({ obj, [](const void* x) { static_cast<const T*>(x)->~T(); } });
+                }
+            }
+        }
+        assert(!(reinterpret_cast<uintptr_t>(result) % std::alignment_of<T>::value) &&
+               "Allocated memory is not correctly aligned.");
+        return result;
+    }
+
+    // "Frees" all previously allocated objects. Depending on free_system_memory, system memory blocks are either
+    // reused for new calls to Allocate or freed and re-created as needed. Oversized allocations are freed from system
+    // memory
+    void Clear(bool free_system_memory);
+
+  private:
+    void* Allocate(size_t object_bytes, size_t alignment_bytes);
+    void* AllocateToBlock(size_t object_bytes, size_t alignment_bytes);
+
+  private:
+    struct Destructor
+    {
+        void* obj;
+        void (*destroy)(const void*);
+    };
+
+  private:
+    std::vector<std::unique_ptr<unsigned char[]>> memory_blocks_;
+    std::vector<std::unique_ptr<unsigned char[]>> oversized_allocations_;
+    std::vector<Destructor>                       destructors_;
+    const size_t                                  block_size_;
+    size_t                                        current_block_;
+    size_t                                        current_block_free_bytes_;
+};
+
+GFXRECON_END_NAMESPACE(util)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_UTIL_MONOTONIC_ALLOCATOR_H


### PR DESCRIPTION
Add a custom monotonic/bump allocator for use during decoding. The allocator reserves system memory and provides the decoding functions with fast allocations from that memory. After a function call decode has completed, all custom-allocated objects are simultaneously freed and their memory is available for reuse in future allocations.

- Add MonotonicAllocator utility class
- Create class interface for decode allocations
- Use DecodeAllocator when decoding structs
- Use DecodeAllocator when decoding pointer types
- Use DecodeAllocater when decoding pNext structs