### PR TITLE
Warning fix and code clean up

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2476,6 +2476,8 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult            original_resu
                                        VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
                 }
                 break;
+                default:
+                    break;
             }
             current_struct = current_struct->pNext;
         }

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -1276,6 +1276,8 @@ VkResult TraceManager::OverrideCreateDevice(VkPhysicalDevice             physica
                                    VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
             }
             break;
+            default:
+                break;
         }
         current_struct = current_struct->pNext;
     }

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -1005,7 +1005,6 @@ class TraceManager
     std::mutex                                      file_lock_;
     bool                                            timestamp_filename_;
     bool                                            force_file_flush_;
-    uint64_t                                        bytes_written_;
     std::unique_ptr<util::Compressor>               compressor_;
     CaptureSettings::MemoryTrackingMode             memory_tracking_mode_;
     bool                                            page_guard_align_buffer_sizes_;


### PR DESCRIPTION
Fix Android build warning and remove unused var.

- Cleanup: remove unused variable
- Fix unhandled enumeration values warning
