### PR TITLE
Fixes for replaying ray tracing enabled apps

### DIFF
--- a/framework/decode/pointer_decoder_base.h
+++ b/framework/decode/pointer_decoder_base.h
@@ -75,6 +75,7 @@ class PointerDecoderBase
             }
 
             if (((attrib_ & format::PointerAttributes::kIsArray) == format::PointerAttributes::kIsArray) ||
+                ((attrib_ & format::PointerAttributes::kIsArray2D) == format::PointerAttributes::kIsArray2D) ||
                 ((attrib_ & format::PointerAttributes::kIsString) == format::PointerAttributes::kIsString) ||
                 ((attrib_ & format::PointerAttributes::kIsWString) == format::PointerAttributes::kIsWString))
             {

--- a/framework/decode/vulkan_handle_mapping_util.cpp
+++ b/framework/decode/vulkan_handle_mapping_util.cpp
@@ -132,10 +132,9 @@ uint64_t MapHandle(uint64_t object, VkObjectType object_type, const VulkanObject
         case VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT:
             return format::ToHandleId(MapHandle<DebugUtilsMessengerEXTInfo>(
                 object, object_info_table, &VulkanObjectInfoTable::GetDebugUtilsMessengerEXTInfo));
-        // TODO: Handle acceleration structure handles separately.
-        // case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR:
-        //    return format::ToHandleId(MapHandle<AccelerationStructureKHRInfo>(
-        //        object, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo));
+        case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR:
+            return format::ToHandleId(MapHandle<AccelerationStructureKHRInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo));
         case VK_OBJECT_TYPE_VALIDATION_CACHE_EXT:
             return format::ToHandleId(MapHandle<ValidationCacheEXTInfo>(
                 object, object_info_table, &VulkanObjectInfoTable::GetValidationCacheEXTInfo));
@@ -269,10 +268,9 @@ MapHandle(uint64_t object, VkDebugReportObjectTypeEXT object_type, const VulkanO
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT:
             return format::ToHandleId(MapHandle<DescriptorUpdateTemplateInfo>(
                 object, object_info_table, &VulkanObjectInfoTable::GetDescriptorUpdateTemplateInfo));
-        // TODO: Handle acceleration structure handles separately.
-        // case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT:
-        //    return format::ToHandleId(MapHandle<AccelerationStructureKHRInfo>(
-        //        object, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT:
+            return format::ToHandleId(MapHandle<AccelerationStructureKHRInfo>(
+                object, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureKHRInfo));
         case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT:
             return format::ToHandleId(MapHandle<AccelerationStructureNVInfo>(
                 object, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureNVInfo));

--- a/framework/encode/vulkan_handle_wrapper_util.cpp
+++ b/framework/encode/vulkan_handle_wrapper_util.cpp
@@ -95,9 +95,8 @@ uint64_t GetWrappedHandle(uint64_t object, VkObjectType object_type)
             return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDebugReportCallbackEXT>(object)));
         case VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT:
             return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDebugUtilsMessengerEXT>(object)));
-        // TODO: Handle acceleration structure handles separately.
-        // case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR:
-        //    return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkAccelerationStructureKHR>(object)));
+        case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkAccelerationStructureKHR>(object)));
         case VK_OBJECT_TYPE_VALIDATION_CACHE_EXT:
             return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkValidationCacheEXT>(object)));
         case VK_OBJECT_TYPE_PERFORMANCE_CONFIGURATION_INTEL:
@@ -191,9 +190,8 @@ uint64_t GetWrappedHandle(uint64_t object, VkDebugReportObjectTypeEXT object_typ
             return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkSamplerYcbcrConversion>(object)));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT:
             return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkDescriptorUpdateTemplate>(object)));
-        // TODO: Handle acceleration structure handles separately.
-        // case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT:
-        //    return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkAccelerationStructureKHR>(object)));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT:
+            return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkAccelerationStructureKHR>(object)));
         case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT:
             return format::ToHandleId(GetWrappedHandle(format::FromHandleId<VkAccelerationStructureNV>(object)));
         case VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT:
@@ -277,9 +275,8 @@ uint64_t GetWrappedId(uint64_t object, VkObjectType object_type)
             return GetWrappedId(format::FromHandleId<VkDebugReportCallbackEXT>(object));
         case VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT:
             return GetWrappedId(format::FromHandleId<VkDebugUtilsMessengerEXT>(object));
-        // TODO: Handle acceleration structure handles separately.
-        // case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR:
-        //    return GetWrappedId(format::FromHandleId<VkAccelerationStructureKHR>(object));
+        case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR:
+            return GetWrappedId(format::FromHandleId<VkAccelerationStructureKHR>(object));
         case VK_OBJECT_TYPE_VALIDATION_CACHE_EXT:
             return GetWrappedId(format::FromHandleId<VkValidationCacheEXT>(object));
         case VK_OBJECT_TYPE_PERFORMANCE_CONFIGURATION_INTEL:
@@ -373,9 +370,8 @@ uint64_t GetWrappedId(uint64_t object, VkDebugReportObjectTypeEXT object_type)
             return GetWrappedId(format::FromHandleId<VkSamplerYcbcrConversion>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT:
             return GetWrappedId(format::FromHandleId<VkDescriptorUpdateTemplate>(object));
-        // TODO: Handle acceleration structure handles separately.
-        // case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT:
-        //    return GetWrappedId(format::FromHandleId<VkAccelerationStructureKHR>(object));
+        case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT:
+            return GetWrappedId(format::FromHandleId<VkAccelerationStructureKHR>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT:
             return GetWrappedId(format::FromHandleId<VkAccelerationStructureNV>(object));
         case VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT:


### PR DESCRIPTION
These changes fix some issues when replaying ray tracing application captures.

- Enable KHR acceleration structure wrapping
- Read outer array length when decoding 2D arrays
