### PR TITLE
Suppress 'unsupported external object type' messages generated for vkCmdSetCheckpointNV replay

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1539,9 +1539,11 @@ void* VulkanReplayConsumerBase::PreProcessExternalObject(uint64_t          objec
 
     if ((call_id == format::ApiCallId::ApiCall_vkGetPhysicalDeviceXlibPresentationSupportKHR) ||
         (call_id == format::ApiCallId::ApiCall_vkGetPhysicalDeviceXcbPresentationSupportKHR) ||
-        (call_id == format::ApiCallId::ApiCall_vkGetPhysicalDeviceWaylandPresentationSupportKHR))
+        (call_id == format::ApiCallId::ApiCall_vkGetPhysicalDeviceWaylandPresentationSupportKHR) ||
+        (call_id == format::ApiCallId::ApiCall_vkCmdSetCheckpointNV))
     {
         // The window system related handles are ignored by replay.
+        // The checkpoint marker is ignored by replay.
     }
     else
     {


### PR DESCRIPTION
Change replay behavior for vkCmdSetCheckpointNV to silently ignore the pCheckpointMarker value.  Previous behavior was to print a message for each vkCmdSetCheckpointNV call to indicate that the pCheckpointMarker parameter was not an object handle type that replay knew how to map.
