### PR TITLE
Prevent cmd.exe from closing on replay exit

### DIFF
--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -59,6 +59,29 @@
 #endif
 #endif
 
+#if defined(WIN32)
+#include <conio.h>
+void WaitForExit()
+{
+    DWORD process_list[2];
+    DWORD result = GetConsoleProcessList(process_list, ARRAYSIZE(process_list));
+
+    // If the process list contains a single entry, we assume that the console was created when the gfxrecon-replay.exe
+    // process started, and will be destroyed when it exits.  In this case, we will wait on user input before exiting
+    // and closing the console window to give the user a chance to read any console output.
+    if (result <= 1)
+    {
+        GFXRECON_WRITE_CONSOLE("\nPress any key to close this window . . .");
+        while (!_kbhit())
+        {
+            Sleep(250);
+        }
+    }
+}
+#else
+void WaitForExit() {}
+#endif
+
 const char kLayerEnvVar[] = "VK_INSTANCE_LAYERS";
 
 int main(int argc, const char** argv)
@@ -223,6 +246,8 @@ int main(int argc, const char** argv)
         GFXRECON_WRITE_CONSOLE("Replay failed due to an unhandled exception");
         return_code = -1;
     }
+
+    WaitForExit();
 
     gfxrecon::util::Log::Release();
 


### PR DESCRIPTION
For Windows, when a new cmd.exe window is opened at gfxrecon-replay.exe process start, which will close at process termination, wait for user input before exiting the process.  This will keep the cmd.exe window open until a key is pressed, allowing the user to read replay output.

The WIN32 GetConsoleProcessList API call is used to determine if the cmd.exe instance was created when gfxrecon-replay.exe started.  This results in the following scenarios:
- If the user started gfxrecon-replay.exe from an existing cmd.exe instance, the process will exit normally.
- If the user did not start gfxrecon-replay.exe from an existing cmd.exe instance (e.g. the user dragged and dropped a capture file onto the gfxrecon-replay.exe program icon in the file explorer, or launched gfxrecon-replay.exe from RenderDoc), the window for the cmd.exe instance that was created at gfxrecon-replay.exe process start will remain open until closed by the user.
