### PR TITLE
Add logging options to gfxrecon-replay

### DIFF
--- a/USAGE_desktop.md
+++ b/USAGE_desktop.md
@@ -287,8 +287,8 @@ optional arguments:
                         capture file
   --log-level {debug,info,warn,error,fatal}
                         Specify highest level message to log, default is info
-  --log-file logFile    Name of the log file (disable logging with empty
-                        string), default is stdout/stderr
+  --log-file <logFile>  Write log messages to a file at the specified path.
+                        Default is: Empty string (file logging disabled)
   --memory-tracking-mode {page_guard,assisted,unassisted}
                         Method to use to track changes to memory mapped objects:
                            page_guard: use guard pages to track changes (default)
@@ -336,6 +336,7 @@ gfxrecon-replay         [-h | --help] [--version] [--gpu <index>]
                         [--opcd | --omit-pipeline-cache-data] [--wsi <platform>]
                         [--surface-index <N>] [--remove-unsupported]
                         [-m <mode> | --memory-translation <mode>]
+                        [--log-level <level>] [--log-file <file>] [--log-debugview]
                         <file>
 
 Required arguments:
@@ -344,6 +345,11 @@ Required arguments:
 Optional arguments:
   -h                    Print usage information and exit (same as --help).
   --version             Print version information and exit.
+  --log-level <level>   Specify highest level message to log. Options are:
+                        debug, info, warning, error, and fatal. Default is info.
+  --log-file <file>     Write log messages to a file at the specified path.
+                        Default is: Empty string (file logging disabled).
+  --log-debugview       Log messages with OutputDebugStringA. Windows only.
   --gpu <index>         Use the specified device for replay, where index
                         is the zero-based index to the array of physical devices
                         returned by vkEnumeratePhysicalDevices.  Replay may fail

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -36,6 +36,9 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 typedef std::function<VulkanResourceAllocator*()> CreateResourceAllocator;
 
+// Default log level to use prior to loading settings.
+const util::Log::Severity kDefaultLogLevel = util::Log::Severity::kInfoSeverity;
+
 const char kDefaultScreenshotFilePrefix[] = "screenshot";
 
 enum class ScreenshotFormat : uint32_t

--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -480,30 +480,11 @@ format::CompressionType CaptureSettings::ParseCompressionTypeString(const std::s
 util::Log::Severity CaptureSettings::ParseLogLevelString(const std::string&  value_string,
                                                          util::Log::Severity default_value)
 {
-    util::Log::Severity result = default_value;
+    util::Log::Severity result;
 
-    if (util::platform::StringCompareNoCase("debug", value_string.c_str()) == 0)
+    if (!util::Log::StringToSeverity(value_string, result))
     {
-        result = util::Log::Severity::kDebugSeverity;
-    }
-    else if (util::platform::StringCompareNoCase("info", value_string.c_str()) == 0)
-    {
-        result = util::Log::Severity::kInfoSeverity;
-    }
-    else if (util::platform::StringCompareNoCase("warning", value_string.c_str()) == 0)
-    {
-        result = util::Log::Severity::kWarningSeverity;
-    }
-    else if (util::platform::StringCompareNoCase("error", value_string.c_str()) == 0)
-    {
-        result = util::Log::Severity::kErrorSeverity;
-    }
-    else if (util::platform::StringCompareNoCase("fatal", value_string.c_str()) == 0)
-    {
-        result = util::Log::Severity::kFatalSeverity;
-    }
-    else
-    {
+        result = default_value;
         if (!value_string.empty())
         {
             GFXRECON_LOG_WARNING("Settings Loader: Ignoring unrecognized log level option value \"%s\"",

--- a/framework/util/argument_parser.cpp
+++ b/framework/util/argument_parser.cpp
@@ -232,13 +232,16 @@ void ArgumentParser::Init(std::vector<std::string> command_line_args,
                         {
                             // Get the next value and strip off any quotes surrounding the whole string
                             std::string argument_value = command_line_args[++cur_arg];
-                            if (argument_value.front() == '\"')
+                            if (!argument_value.empty())
                             {
-                                argument_value.erase(argument_value.begin());
-                            }
-                            if (argument_value.back() == '\"')
-                            {
-                                argument_value.pop_back();
+                                if (argument_value.front() == '\"')
+                                {
+                                    argument_value.erase(argument_value.begin());
+                                }
+                                if (argument_value.back() == '\"')
+                                {
+                                    argument_value.pop_back();
+                                }
                             }
                             argument_values_[cur_argument.second] = argument_value;
                         }

--- a/framework/util/logging.h
+++ b/framework/util/logging.h
@@ -147,6 +147,40 @@ class Log
         }
     }
 
+    // Returns true if Severity was successfully parsed into parsed_severity. Returns false if the string could not be
+    // parsed as a Severity and parsed_severity is not modified.
+    static bool StringToSeverity(const std::string& value_string, Severity& parsed_severity)
+    {
+        bool parse_success = true;
+
+        if (platform::StringCompareNoCase("debug", value_string.c_str()) == 0)
+        {
+            parsed_severity = Severity::kDebugSeverity;
+        }
+        else if (platform::StringCompareNoCase("info", value_string.c_str()) == 0)
+        {
+            parsed_severity = Severity::kInfoSeverity;
+        }
+        else if (platform::StringCompareNoCase("warning", value_string.c_str()) == 0)
+        {
+            parsed_severity = Severity::kWarningSeverity;
+        }
+        else if (platform::StringCompareNoCase("error", value_string.c_str()) == 0)
+        {
+            parsed_severity = Severity::kErrorSeverity;
+        }
+        else if (util::platform::StringCompareNoCase("fatal", value_string.c_str()) == 0)
+        {
+            parsed_severity = Severity::kFatalSeverity;
+        }
+        else
+        {
+            parse_success = false;
+        }
+
+        return parse_success;
+    }
+
   private:
     static std::string ConvertFormatVaListToString(const std::string& format_string, va_list& var_args);
 

--- a/tools/capture/gfxrecon-capture.py
+++ b/tools/capture/gfxrecon-capture.py
@@ -102,7 +102,7 @@ def ParseArgs():
     parser.add_argument('--compression-type', dest='compressionType', choices=compressionTypeChoices, help='Specify the type of compression to use in the capture file, default is LZ4')
     parser.add_argument('--file-flush', dest='fileFlush', action='store_const', const='true', help='Flush output stream after each packet is written to capture file')
     parser.add_argument('--log-level', dest='logLevel', choices=logLevelChoices, help='Specify highest level message to log, default is info')
-    parser.add_argument('--log-file', dest='logFile', metavar='logFile', help='Name of the log file (disable logging with empty string), default is stdout/stderr')
+    parser.add_argument('--log-file', dest='logFile', metavar='<logFile>', help='Write log messages to a file at the specified path. Default is: Empty string (file logging disabled)')
     parser.add_argument('--log-debugview', dest='logDebugView', action='store_const', const='true', help='Log messages with OutputDebugStringA' if sys.platform=='win32' else argparse.SUPPRESS)
     parser.add_argument('--memory-tracking-mode', dest='memoryTrackingMode', choices=memoryTrackingModeChoices , help=
                         'R|Method to use to track changes to memory mapped objects:' + os.linesep +

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -88,7 +88,8 @@ int main(int argc, const char** argv)
 {
     int return_code = 0;
 
-    gfxrecon::util::Log::Init();
+    // Default initialize logging to report issues while loading settings.
+    gfxrecon::util::Log::Init(gfxrecon::decode::kDefaultLogLevel);
 
     gfxrecon::util::ArgumentParser arg_parser(argc, argv, kOptions, kArguments);
 
@@ -107,6 +108,12 @@ int main(int argc, const char** argv)
     {
         ProcessDisableDebugPopup(arg_parser);
     }
+
+    // Reinitialize logging with values retrieved from command line arguments
+    gfxrecon::util::Log::Settings log_settings;
+    GetLogSettings(arg_parser, log_settings);
+    gfxrecon::util::Log::Release();
+    gfxrecon::util::Log::Init(log_settings);
 
     try
     {


### PR DESCRIPTION
Adds the following command line options to gfxrecon-replay:

--log-level <level> Specify highest level message to log. Options are:
                    debug, info, warning, error, and fatal. Default is
                    info.
--log-file <file>   Write log messages to a file at the specified path.
                    Default is: Empty string (file logging disabled).
--log-debugview     Log messages with OutputDebugStringA (Windows only)

Change-Id: If73a5be5ab1161bf96b7c312313eb6a09381d6f8