### PR TITLE
Add additional support for opaque device addresses

### DIFF
--- a/android/framework/application/CMakeLists.txt
+++ b/android/framework/application/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(gfxrecon_application
 
 target_link_libraries(gfxrecon_application
                       gfxrecon_decode
+                      gfxrecon_graphics
                       gfxrecon_format
                       gfxrecon_util
                       vulkan_registry

--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -94,4 +94,4 @@ target_include_directories(gfxrecon_decode
                            PUBLIC
                                ${GFXRECON_SOURCE_DIR}/framework)
 
-target_link_libraries(gfxrecon_decode gfxrecon_format gfxrecon_util vulkan_registry vulkan_memory_allocator platform_specific)
+target_link_libraries(gfxrecon_decode gfxrecon_graphics gfxrecon_format gfxrecon_util vulkan_registry vulkan_memory_allocator platform_specific)

--- a/android/framework/encode/CMakeLists.txt
+++ b/android/framework/encode/CMakeLists.txt
@@ -43,4 +43,4 @@ target_include_directories(gfxrecon_encode
                                ${CMAKE_BINARY_DIR}
                                ${GFXRECON_SOURCE_DIR}/framework)
 
-target_link_libraries(gfxrecon_encode gfxrecon_format gfxrecon_util vulkan_registry platform_specific android)
+target_link_libraries(gfxrecon_encode gfxrecon_graphics gfxrecon_format gfxrecon_util vulkan_registry platform_specific android)

--- a/android/framework/graphics/CMakeLists.txt
+++ b/android/framework/graphics/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(gfxrecon_graphics STATIC "")
+
+target_sources(gfxrecon_graphics
+               PRIVATE
+                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.h
+                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.cpp
+              )
+
+target_include_directories(gfxrecon_graphics
+                           PUBLIC
+                               ${GFXRECON_SOURCE_DIR}/framework)
+
+target_link_libraries(gfxrecon_graphics gfxrecon_util vulkan_registry platform_specific)

--- a/android/layer/CMakeLists.txt
+++ b/android/layer/CMakeLists.txt
@@ -4,6 +4,7 @@ get_filename_component(GFXRECON_SOURCE_DIR ../.. ABSOLUTE)
 
 include(../framework/cmake-config/PlatformConfig.cmake)
 add_subdirectory(../framework/util ${CMAKE_SOURCE_DIR}/../framework/util/build)
+add_subdirectory(../framework/graphics ${CMAKE_SOURCE_DIR}/../framework/graphics/build)
 add_subdirectory(../framework/format ${CMAKE_SOURCE_DIR}/../framework/format/build)
 add_subdirectory(../framework/encode ${CMAKE_SOURCE_DIR}/../framework/encode/build)
 
@@ -24,6 +25,7 @@ target_include_directories(VkLayer_gfxreconstruct
 
 target_link_libraries(VkLayer_gfxreconstruct
                       gfxrecon_encode
+                      gfxrecon_graphics
                       gfxrecon_format
                       gfxrecon_util
                       vulkan_registry

--- a/android/tools/replay/CMakeLists.txt
+++ b/android/tools/replay/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -u ANativeActivity_o
 
 include(../../framework/cmake-config/PlatformConfig.cmake)
 add_subdirectory(../../framework/util ${CMAKE_SOURCE_DIR}/../../framework/util/build)
+add_subdirectory(../../framework/graphics ${CMAKE_SOURCE_DIR}/../../framework/graphics/build)
 add_subdirectory(../../framework/format ${CMAKE_SOURCE_DIR}/../../framework/format/build)
 add_subdirectory(../../framework/decode ${CMAKE_SOURCE_DIR}/../../framework/decode/build)
 add_subdirectory(../../framework/application ${CMAKE_SOURCE_DIR}/../../framework/application/build)
@@ -32,6 +33,7 @@ target_link_libraries(
         gfxrecon-replay
         gfxrecon_application
         gfxrecon_decode
+        gfxrecon_graphics
         gfxrecon_format
         gfxrecon_util
         platform_specific

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(util)
+add_subdirectory(graphics)
 add_subdirectory(format)
 add_subdirectory(encode)
 add_subdirectory(decode)

--- a/framework/application/CMakeLists.txt
+++ b/framework/application/CMakeLists.txt
@@ -56,6 +56,7 @@ target_include_directories(gfxrecon_application
 
 target_link_libraries(gfxrecon_application
                       gfxrecon_decode
+                      gfxrecon_graphics
                       gfxrecon_format
                       gfxrecon_util
                       vulkan_registry

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -130,7 +130,7 @@ target_include_directories(gfxrecon_decode
                            PUBLIC
                                ${CMAKE_SOURCE_DIR}/framework)
 
-target_link_libraries(gfxrecon_decode gfxrecon_format gfxrecon_util vulkan_registry vulkan_memory_allocator platform_specific)
+target_link_libraries(gfxrecon_decode gfxrecon_graphics gfxrecon_format gfxrecon_util vulkan_registry vulkan_memory_allocator platform_specific)
 
 common_build_directives(gfxrecon_decode)
 

--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -102,7 +102,7 @@ class ApiDecoder
                                              const std::vector<format::DeviceMemoryType>& memory_types,
                                              const std::vector<format::DeviceMemoryHeap>& memory_heaps) = 0;
 
-    virtual void DispatchSetBufferAddressCommand(format::ThreadId thread_id,
+    virtual void DispatchSetOpaqueAddressCommand(format::ThreadId thread_id,
                                                  format::HandleId device_id,
                                                  format::HandleId buffer_id,
                                                  uint64_t         address) = 0;

--- a/framework/decode/custom_vulkan_struct_decoders.cpp
+++ b/framework/decode/custom_vulkan_struct_decoders.cpp
@@ -227,6 +227,8 @@ size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_VkAcceler
             wrapper->geometry->instances->decoded_value = &(value->geometry.instances);
             bytes_read += DecodeStruct((buffer + bytes_read), (buffer_size - bytes_read), wrapper->geometry->instances);
             break;
+        default:
+            break;
     }
 
     bytes_read += ValueDecoder::DecodeFlagsValue((buffer + bytes_read), (buffer_size - bytes_read), &(value->flags));

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -784,24 +784,24 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                                  "Failed to read set device memory properties meta-data block header");
         }
     }
-    else if (meta_type == format::MetaDataType::kSetBufferAddressCommand)
+    else if (meta_type == format::MetaDataType::kSetOpaqueAddressCommand)
     {
         // This command does not support compression.
         assert(block_header.type != format::BlockType::kCompressedMetaDataBlock);
 
-        format::SetBufferAddressCommand header;
+        format::SetOpaqueAddressCommand header;
 
         success = ReadBytes(&header.thread_id, sizeof(header.thread_id));
         success = success && ReadBytes(&header.device_id, sizeof(header.device_id));
-        success = success && ReadBytes(&header.buffer_id, sizeof(header.buffer_id));
+        success = success && ReadBytes(&header.object_id, sizeof(header.object_id));
         success = success && ReadBytes(&header.address, sizeof(header.address));
 
         if (success)
         {
             for (auto decoder : decoders_)
             {
-                decoder->DispatchSetBufferAddressCommand(
-                    header.thread_id, header.device_id, header.buffer_id, header.address);
+                decoder->DispatchSetOpaqueAddressCommand(
+                    header.thread_id, header.device_id, header.object_id, header.address);
             }
         }
         else

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -89,7 +89,7 @@ class VulkanConsumerBase
     {}
 
     virtual void
-    ProcessSetBufferAddressCommand(format::HandleId device_id, format::HandleId buffer_id, uint64_t address)
+    ProcessSetOpaqueAddressCommand(format::HandleId device_id, format::HandleId object_id, uint64_t address)
     {}
 
     virtual void ProcessSetSwapchainImageStateCommand(format::HandleId device_id,

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -161,16 +161,16 @@ void VulkanDecoderBase::DispatchSetDeviceMemoryPropertiesCommand(
     }
 }
 
-void VulkanDecoderBase::DispatchSetBufferAddressCommand(format::ThreadId thread_id,
+void VulkanDecoderBase::DispatchSetOpaqueAddressCommand(format::ThreadId thread_id,
                                                         format::HandleId device_id,
-                                                        format::HandleId buffer_id,
+                                                        format::HandleId object_id,
                                                         uint64_t         address)
 {
     GFXRECON_UNREFERENCED_PARAMETER(thread_id);
 
     for (auto consumer : consumers_)
     {
-        consumer->ProcessSetBufferAddressCommand(device_id, buffer_id, address);
+        consumer->ProcessSetOpaqueAddressCommand(device_id, object_id, address);
     }
 }
 

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -114,9 +114,9 @@ class VulkanDecoderBase : public ApiDecoder
                                              const std::vector<format::DeviceMemoryType>& memory_types,
                                              const std::vector<format::DeviceMemoryHeap>& memory_heaps) override;
 
-    virtual void DispatchSetBufferAddressCommand(format::ThreadId thread_id,
+    virtual void DispatchSetOpaqueAddressCommand(format::ThreadId thread_id,
                                                  format::HandleId device_id,
-                                                 format::HandleId buffer_id,
+                                                 format::HandleId object_id,
                                                  uint64_t         address) override;
 
     virtual void

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -246,6 +246,9 @@ struct DeviceInfo : public VulkanObjectInfo<VkDevice>
     // The following values are only used when loading the initial state for trimmed files.
     std::vector<std::string>                   extensions;
     std::unique_ptr<VulkanResourceInitializer> resource_initializer;
+
+    // Feature state at device creation
+    VkBool32 feature_bufferDeviceAddressCaptureReplay{ VK_FALSE };
 };
 
 struct QueueInfo : public VulkanObjectInfo<VkQueue>

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -241,7 +241,7 @@ struct DeviceInfo : public VulkanObjectInfo<VkDevice>
     std::unique_ptr<VulkanResourceAllocator> allocator;
     std::unordered_map<uint32_t, size_t>     array_counts;
 
-    std::unordered_map<format::HandleId, uint64_t> buffer_addresses;
+    std::unordered_map<format::HandleId, uint64_t> opaque_addresses;
 
     // The following values are only used when loading the initial state for trimmed files.
     std::vector<std::string>                   extensions;

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -249,6 +249,7 @@ struct DeviceInfo : public VulkanObjectInfo<VkDevice>
 
     // Feature state at device creation
     VkBool32 feature_bufferDeviceAddressCaptureReplay{ VK_FALSE };
+    VkBool32 feature_accelerationStructureCaptureReplay{ VK_FALSE };
 };
 
 struct QueueInfo : public VulkanObjectInfo<VkQueue>

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3908,8 +3908,7 @@ VulkanReplayConsumerBase::OverrideCreateBuffer(PFN_vkCreateBuffer               
         address_create_flags |= VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT;
         address_usage_flags |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
     }
-    if (uses_address && (((replay_create_info->flags & address_create_flags) != address_create_flags) ||
-                         ((replay_create_info->usage & address_usage_flags) != address_usage_flags)))
+    if (uses_address)
     {
         // Log error if bufferDeviceAddressCaptureReplay feature was not enabled
         if (!device_info->feature_bufferDeviceAddressCaptureReplay)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -603,7 +603,7 @@ void VulkanReplayConsumerBase::ProcessSetDeviceMemoryPropertiesCommand(
     }
 }
 
-void VulkanReplayConsumerBase::ProcessSetBufferAddressCommand(format::HandleId device_id,
+void VulkanReplayConsumerBase::ProcessSetOpaqueAddressCommand(format::HandleId device_id,
                                                               format::HandleId buffer_id,
                                                               uint64_t         address)
 {
@@ -612,7 +612,7 @@ void VulkanReplayConsumerBase::ProcessSetBufferAddressCommand(format::HandleId d
     if (device_info != nullptr)
     {
         // Store the buffer address to use at device creation.
-        device_info->buffer_addresses[buffer_id] = address;
+        device_info->opaque_addresses[buffer_id] = address;
     }
 }
 
@@ -3859,8 +3859,8 @@ VulkanReplayConsumerBase::OverrideCreateBuffer(PFN_vkCreateBuffer               
             VK_STRUCTURE_TYPE_BUFFER_OPAQUE_CAPTURE_ADDRESS_CREATE_INFO
         };
 
-        auto entry = device_info->buffer_addresses.find(capture_id);
-        if (entry != device_info->buffer_addresses.end())
+        auto entry = device_info->opaque_addresses.find(capture_id);
+        if (entry != device_info->opaque_addresses.end())
         {
             address_info.opaqueCaptureAddress = entry->second;
 
@@ -3874,7 +3874,7 @@ VulkanReplayConsumerBase::OverrideCreateBuffer(PFN_vkCreateBuffer               
         }
         else
         {
-            GFXRECON_LOG_DEBUG("Buffer device address is not available for VkBuffer object (ID = %" PRIu64 ")",
+            GFXRECON_LOG_DEBUG("Opaque device address is not available for VkBuffer object (ID = %" PRIu64 ")",
                                capture_id);
         }
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -789,6 +789,14 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                    const SurfaceKHRInfo*                                      surface_info,
                                    const StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator);
 
+    VkResult OverrideCreateAccelerationStructureKHR(
+        PFN_vkCreateAccelerationStructureKHR                                      func,
+        VkResult                                                                  original_result,
+        const DeviceInfo*                                                         device_info,
+        const StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoKHR>* pCreateInfo,
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>*                pAllocator,
+        HandlePointerDecoder<VkAccelerationStructureKHR>*                         pAccelerationStructureKHR);
+
   private:
     void RaiseFatalError(const char* message) const;
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -115,7 +115,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                             const std::vector<format::DeviceMemoryHeap>& memory_heaps) override;
 
     virtual void
-    ProcessSetBufferAddressCommand(format::HandleId device_id, format::HandleId buffer_id, uint64_t address) override;
+    ProcessSetOpaqueAddressCommand(format::HandleId device_id, format::HandleId object_id, uint64_t address) override;
 
     virtual void
     ProcessSetSwapchainImageStateCommand(format::HandleId                                    device_id,

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -60,7 +60,6 @@ target_sources(gfxrecon_encode
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_api_call_encoders.cpp
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_command_buffer_util.h
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_command_buffer_util.cpp
-                    ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_dispatch_table.h
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_struct_encoders.h
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_struct_encoders.cpp
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_struct_handle_wrappers.h
@@ -77,7 +76,7 @@ target_include_directories(gfxrecon_encode
                                ${CMAKE_BINARY_DIR}
                                ${CMAKE_SOURCE_DIR}/framework)
 
-target_link_libraries(gfxrecon_encode gfxrecon_format gfxrecon_util vulkan_registry platform_specific)
+target_link_libraries(gfxrecon_encode gfxrecon_graphics gfxrecon_format gfxrecon_util vulkan_registry platform_specific)
 
 common_build_directives(gfxrecon_encode)
 

--- a/framework/encode/custom_vulkan_struct_encoders.cpp
+++ b/framework/encode/custom_vulkan_struct_encoders.cpp
@@ -183,6 +183,8 @@ void EncodeStruct(ParameterEncoder* encoder, const VkAccelerationStructureGeomet
         case VK_GEOMETRY_TYPE_INSTANCES_KHR:
             EncodeStruct(encoder, value.geometry.instances);
             break;
+        default:
+            break;
     }
     encoder->EncodeFlagsValue(value.flags);
 }

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -1424,14 +1424,11 @@ VkResult TraceManager::OverrideCreateBuffer(VkDevice                     device,
                 address = device_table->GetBufferOpaqueCaptureAddressKHR(device_unwrapped, &info);
             }
 
-            if (address != 0)
-            {
-                WriteSetOpaqueAddressCommand(device_wrapper->handle_id, buffer_wrapper->handle_id, address);
+            WriteSetOpaqueAddressCommand(device_wrapper->handle_id, buffer_wrapper->handle_id, address);
 
-                if ((capture_mode_ & kModeTrack) == kModeTrack)
-                {
-                    state_tracker_->TrackBufferDeviceAddress(device, *pBuffer, address);
-                }
+            if ((capture_mode_ & kModeTrack) == kModeTrack)
+            {
+                state_tracker_->TrackBufferDeviceAddress(device, *pBuffer, address);
             }
         }
     }
@@ -1481,14 +1478,12 @@ VkResult TraceManager::OverrideCreateAccelerationStructureKHR(VkDevice          
         // save address to use as pCreateInfo->deviceAddress during replay
         VkDeviceAddress address =
             device_table->GetAccelerationStructureDeviceAddressKHR(device_unwrapped, &address_info);
-        if (address != 0)
-        {
-            WriteSetOpaqueAddressCommand(device_wrapper->handle_id, accel_struct_wrapper->handle_id, address);
 
-            if ((capture_mode_ & kModeTrack) == kModeTrack)
-            {
-                state_tracker_->TrackAccelerationStructureKHRDeviceAddress(device, *pAccelerationStructureKHR, address);
-            }
+        WriteSetOpaqueAddressCommand(device_wrapper->handle_id, accel_struct_wrapper->handle_id, address);
+
+        if ((capture_mode_ & kModeTrack) == kModeTrack)
+        {
+            state_tracker_->TrackAccelerationStructureKHRDeviceAddress(device, *pAccelerationStructureKHR, address);
         }
     }
 

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -1011,29 +1011,29 @@ void TraceManager::WriteSetDeviceMemoryPropertiesCommand(format::HandleId       
     }
 }
 
-void TraceManager::WriteSetBufferAddressCommand(format::HandleId device_id,
-                                                format::HandleId buffer_id,
+void TraceManager::WriteSetOpaqueAddressCommand(format::HandleId device_id,
+                                                format::HandleId object_id,
                                                 uint64_t         address)
 {
     if ((capture_mode_ & kModeWrite) == kModeWrite)
     {
-        format::SetBufferAddressCommand buffer_address_cmd;
+        format::SetOpaqueAddressCommand opaque_address_cmd;
 
         auto thread_data = GetThreadData();
         assert(thread_data != nullptr);
 
-        buffer_address_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
-        buffer_address_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(buffer_address_cmd);
-        buffer_address_cmd.meta_header.meta_data_type    = format::MetaDataType::kSetBufferAddressCommand;
-        buffer_address_cmd.thread_id                     = thread_data->thread_id_;
-        buffer_address_cmd.device_id                     = device_id;
-        buffer_address_cmd.buffer_id                     = buffer_id;
-        buffer_address_cmd.address                       = address;
+        opaque_address_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
+        opaque_address_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(opaque_address_cmd);
+        opaque_address_cmd.meta_header.meta_data_type    = format::MetaDataType::kSetOpaqueAddressCommand;
+        opaque_address_cmd.thread_id                     = thread_data->thread_id_;
+        opaque_address_cmd.device_id                     = device_id;
+        opaque_address_cmd.object_id                     = object_id;
+        opaque_address_cmd.address                       = address;
 
         {
             std::lock_guard<std::mutex> lock(file_lock_);
 
-            file_stream_->Write(&buffer_address_cmd, sizeof(buffer_address_cmd));
+            file_stream_->Write(&opaque_address_cmd, sizeof(opaque_address_cmd));
 
             if (force_file_flush_)
             {
@@ -1410,7 +1410,7 @@ VkResult TraceManager::OverrideCreateBuffer(VkDevice                     device,
 
             if (address != 0)
             {
-                WriteSetBufferAddressCommand(device_wrapper->handle_id, buffer_wrapper->handle_id, address);
+                WriteSetOpaqueAddressCommand(device_wrapper->handle_id, buffer_wrapper->handle_id, address);
 
                 if ((capture_mode_ & kModeTrack) == kModeTrack)
                 {

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -980,7 +980,7 @@ class TraceManager
                                          const VkPhysicalDeviceProperties& properties);
     void WriteSetDeviceMemoryPropertiesCommand(format::HandleId                        physical_device_id,
                                                const VkPhysicalDeviceMemoryProperties& memory_properties);
-    void WriteSetBufferAddressCommand(format::HandleId device_id, format::HandleId buffer_id, uint64_t address);
+    void WriteSetOpaqueAddressCommand(format::HandleId device_id, format::HandleId object_id, uint64_t address);
 
     void SetDescriptorUpdateTemplateInfo(VkDescriptorUpdateTemplate                  update_template,
                                          const VkDescriptorUpdateTemplateCreateInfo* create_info);

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -314,6 +314,11 @@ class TraceManager
                                   const VkAllocationCallbacks* pAllocator,
                                   VkBuffer*                    pBuffer);
 
+    VkResult OverrideCreateAccelerationStructureKHR(VkDevice                                    device,
+                                                    const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
+                                                    const VkAllocationCallbacks*                pAllocator,
+                                                    VkAccelerationStructureKHR* pAccelerationStructureKHR);
+
     VkResult OverrideAllocateMemory(VkDevice                     device,
                                     const VkMemoryAllocateInfo*  pAllocateInfo,
                                     const VkAllocationCallbacks* pAllocator,

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -137,6 +137,7 @@ struct DeviceWrapper : public HandleWrapper<VkDevice>
 
     // Feature state at device creation
     VkBool32 feature_bufferDeviceAddressCaptureReplay{ VK_FALSE };
+    VkBool32 feature_accelerationStructureCaptureReplay{ VK_FALSE };
 };
 
 struct FenceWrapper : public HandleWrapper<VkFence>
@@ -372,6 +373,10 @@ struct SwapchainKHRWrapper : public HandleWrapper<VkSwapchainKHR>
 
 struct AccelerationStructureKHRWrapper : public HandleWrapper<VkAccelerationStructureKHR>
 {
+    // State tracking info for buffers with device addresses.
+    format::HandleId device_id{ format::kNullHandleId };
+    VkDeviceAddress  address{ 0 };
+
     // TODO: Determine what additional state tracking is needed.
 };
 

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -166,6 +166,10 @@ struct DeviceMemoryWrapper : public HandleWrapper<VkDeviceMemory>
     uintptr_t        shadow_allocation{ util::PageGuardManager::kNullShadowHandle };
     AHardwareBuffer* hardware_buffer{ nullptr };
     format::HandleId hardware_buffer_memory_id{ format::kNullHandleId };
+
+    // State tracking info for memory with device addresses.
+    format::HandleId device_id{ format::kNullHandleId };
+    VkDeviceAddress  address{ 0 };
 };
 
 struct BufferWrapper : public HandleWrapper<VkBuffer>

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -134,6 +134,9 @@ struct DeviceWrapper : public HandleWrapper<VkDevice>
     DeviceTable                layer_table;
     PhysicalDeviceWrapper*     physical_device{ nullptr };
     std::vector<QueueWrapper*> child_queues;
+
+    // Feature state at device creation
+    VkBool32 feature_bufferDeviceAddressCaptureReplay{ VK_FALSE };
 };
 
 struct FenceWrapper : public HandleWrapper<VkFence>

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -980,6 +980,19 @@ void VulkanStateTracker::TrackPresentedImages(uint32_t              count,
     }
 }
 
+void VulkanStateTracker::TrackAccelerationStructureKHRDeviceAddress(VkDevice                   device,
+                                                                    VkAccelerationStructureKHR accel_struct,
+                                                                    VkDeviceAddress            address)
+{
+    assert((device != VK_NULL_HANDLE) && (accel_struct != VK_NULL_HANDLE));
+
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    auto wrapper       = reinterpret_cast<AccelerationStructureKHRWrapper*>(accel_struct);
+    wrapper->device_id = GetWrappedId(device);
+    wrapper->address   = address;
+}
+
 void VulkanStateTracker::DestroyState(InstanceWrapper* wrapper)
 {
     assert(wrapper != nullptr);

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -993,6 +993,17 @@ void VulkanStateTracker::TrackAccelerationStructureKHRDeviceAddress(VkDevice    
     wrapper->address   = address;
 }
 
+void VulkanStateTracker::TrackDeviceMemoryDeviceAddress(VkDevice device, VkDeviceMemory memory, VkDeviceAddress address)
+{
+    assert((device != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
+
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    auto wrapper       = reinterpret_cast<DeviceMemoryWrapper*>(memory);
+    wrapper->device_id = GetWrappedId(device);
+    wrapper->address   = address;
+}
+
 void VulkanStateTracker::DestroyState(InstanceWrapper* wrapper)
 {
     assert(wrapper != nullptr);

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -363,6 +363,8 @@ class VulkanStateTracker
                                                     VkAccelerationStructureKHR accel_struct,
                                                     VkDeviceAddress            address);
 
+    void TrackDeviceMemoryDeviceAddress(VkDevice device, VkDeviceMemory memory, VkDeviceAddress address);
+
   private:
     template <typename ParentHandle, typename SecondaryHandle, typename Wrapper, typename CreateInfo>
     void AddGroupHandles(ParentHandle                  parent_handle,

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -359,6 +359,10 @@ class VulkanStateTracker
                               const uint32_t*       image_indices,
                               VkQueue               queue);
 
+    void TrackAccelerationStructureKHRDeviceAddress(VkDevice                   device,
+                                                    VkAccelerationStructureKHR accel_struct,
+                                                    VkDeviceAddress            address);
+
   private:
     template <typename ParentHandle, typename SecondaryHandle, typename Wrapper, typename CreateInfo>
     void AddGroupHandles(ParentHandle                  parent_handle,

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -876,10 +876,10 @@ void VulkanStateWriter::WriteBufferState(const VulkanStateTable& state_table)
 
         if ((wrapper->device_id != format::kNullHandleId) && (wrapper->address != 0))
         {
-            // If the buffer has a device address, write the 'set buffer address' command before writing the API call to
+            // If the buffer has a device address, write the 'set opaque address' command before writing the API call to
             // create the buffer.  The address will need to be passed to vkCreateBuffer through the pCreateInfo pNext
             // list.
-            WriteSetBufferAddressCommand(wrapper->device_id, wrapper->handle_id, wrapper->address);
+            WriteSetOpaqueAddressCommand(wrapper->device_id, wrapper->handle_id, wrapper->address);
         }
 
         WriteFunctionCall(wrapper->create_call_id, wrapper->create_parameters.get());
@@ -2618,21 +2618,21 @@ void VulkanStateWriter::WriteSetDeviceMemoryPropertiesCommand(format::HandleId p
     }
 }
 
-void VulkanStateWriter::WriteSetBufferAddressCommand(format::HandleId device_id,
-                                                     format::HandleId buffer_id,
+void VulkanStateWriter::WriteSetOpaqueAddressCommand(format::HandleId device_id,
+                                                     format::HandleId object_id,
                                                      uint64_t         address)
 {
-    format::SetBufferAddressCommand buffer_address_cmd;
+    format::SetOpaqueAddressCommand opaque_address_cmd;
 
-    buffer_address_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
-    buffer_address_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(buffer_address_cmd);
-    buffer_address_cmd.meta_header.meta_data_type    = format::MetaDataType::kSetBufferAddressCommand;
-    buffer_address_cmd.thread_id                     = thread_id_;
-    buffer_address_cmd.device_id                     = device_id;
-    buffer_address_cmd.buffer_id                     = buffer_id;
-    buffer_address_cmd.address                       = address;
+    opaque_address_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
+    opaque_address_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(opaque_address_cmd);
+    opaque_address_cmd.meta_header.meta_data_type    = format::MetaDataType::kSetOpaqueAddressCommand;
+    opaque_address_cmd.thread_id                     = thread_id_;
+    opaque_address_cmd.device_id                     = device_id;
+    opaque_address_cmd.object_id                     = object_id;
+    opaque_address_cmd.address                       = address;
 
-    output_stream_->Write(&buffer_address_cmd, sizeof(buffer_address_cmd));
+    output_stream_->Write(&opaque_address_cmd, sizeof(opaque_address_cmd));
 }
 
 VkMemoryPropertyFlags VulkanStateWriter::GetMemoryProperties(const DeviceWrapper*       device_wrapper,

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -865,6 +865,12 @@ void VulkanStateWriter::WriteDeviceMemoryState(const VulkanStateTable& state_tab
     // Write device memory allocation calls.
     state_table.VisitWrappers([&](const DeviceMemoryWrapper* wrapper) {
         assert(wrapper != nullptr);
+
+        if ((wrapper->device_id != format::kNullHandleId) && (wrapper->address != 0))
+        {
+            WriteSetOpaqueAddressCommand(wrapper->device_id, wrapper->handle_id, wrapper->address);
+        }
+
         WriteFunctionCall(wrapper->create_call_id, wrapper->create_parameters.get());
     });
 }

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -886,6 +886,23 @@ void VulkanStateWriter::WriteBufferState(const VulkanStateTable& state_table)
     });
 }
 
+void VulkanStateWriter::WriteAccelerationStructureKHRState(const VulkanStateTable& state_table)
+{
+    state_table.VisitWrappers([&](const AccelerationStructureKHRWrapper* wrapper) {
+        assert(wrapper != nullptr);
+
+        if ((wrapper->device_id != format::kNullHandleId) && (wrapper->address != 0))
+        {
+            // If the acceleration struct has a device address, write the 'set opaque address' command before writing
+            // the API call to create the acceleration struct.  The address will need to be passed to
+            // vkCreateAccelerationStructKHR through the VkAccelerationStructureCreateInfoKHR::deviceAddress.
+            WriteSetOpaqueAddressCommand(wrapper->device_id, wrapper->handle_id, wrapper->address);
+        }
+
+        WriteFunctionCall(wrapper->create_call_id, wrapper->create_parameters.get());
+    });
+}
+
 void VulkanStateWriter::ProcessHardwareBuffer(format::HandleId memory_id,
                                               AHardwareBuffer* hardware_buffer,
                                               VkDeviceSize     allocation_size)

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -129,6 +129,8 @@ class VulkanStateWriter
 
     void WriteDeviceMemoryState(const VulkanStateTable& state_table);
 
+    void WriteAccelerationStructureKHRState(const VulkanStateTable& state_table);
+
     void
     ProcessHardwareBuffer(format::HandleId memory_id, AHardwareBuffer* hardware_buffer, VkDeviceSize allocation_size);
 

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -267,7 +267,7 @@ class VulkanStateWriter
     void WriteSetDeviceMemoryPropertiesCommand(format::HandleId                        physical_device_id,
                                                const VkPhysicalDeviceMemoryProperties& memory_properties);
 
-    void WriteSetBufferAddressCommand(format::HandleId device_id, format::HandleId buffer_id, VkDeviceAddress address);
+    void WriteSetOpaqueAddressCommand(format::HandleId device_id, format::HandleId object_id, VkDeviceAddress address);
 
     template <typename Wrapper>
     void StandardCreateWrite(const VulkanStateTable& state_table)

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -97,7 +97,7 @@ enum MetaDataType : uint32_t
     kSetDevicePropertiesCommand         = 11,
     kSetDeviceMemoryPropertiesCommand   = 12,
     kResizeWindowCommand2               = 13,
-    kSetBufferAddressCommand            = 14
+    kSetOpaqueAddressCommand            = 14
 };
 
 enum CompressionType : uint32_t
@@ -377,12 +377,12 @@ struct SetDevicePropertiesCommand
     uint32_t         device_name_len;
 };
 
-struct SetBufferAddressCommand
+struct SetOpaqueAddressCommand
 {
     MetaDataHeader   meta_header;
     format::ThreadId thread_id;
     format::HandleId device_id;
-    format::HandleId buffer_id;
+    format::HandleId object_id;
     uint64_t         address;
 };
 

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -12214,17 +12214,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateAccelerationStructureKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateAccelerationStructureKHR>::Dispatch(TraceManager::Get(), device, pCreateInfo, pAllocator, pAccelerationStructure);
 
-    auto handle_unwrap_memory = TraceManager::Get()->GetHandleUnwrapMemory();
-    VkDevice device_unwrapped = GetWrappedHandle<VkDevice>(device);
-    const VkAccelerationStructureCreateInfoKHR* pCreateInfo_unwrapped = UnwrapStructPtrHandles(pCreateInfo, handle_unwrap_memory);
-
-    VkResult result = GetDeviceTable(device)->CreateAccelerationStructureKHR(device_unwrapped, pCreateInfo_unwrapped, pAllocator, pAccelerationStructure);
-
-    if (result >= 0)
-    {
-        CreateWrappedHandle<DeviceWrapper, NoParentWrapper, AccelerationStructureKHRWrapper>(device, NoParentWrapper::kHandleValue, pAccelerationStructure, TraceManager::GetUniqueId);
-    }
-    else
+    VkResult result = TraceManager::Get()->OverrideCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure);
+    if (result < 0)
     {
         omit_output_data = true;
     }

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -5945,17 +5945,17 @@ void VulkanReplayConsumer::Process_vkCreateAccelerationStructureKHR(
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
     HandlePointerDecoder<VkAccelerationStructureKHR>* pAccelerationStructure)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    const VkAccelerationStructureCreateInfoKHR* in_pCreateInfo = pCreateInfo->GetPointer();
-    MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    const VkAllocationCallbacks* in_pAllocator = GetAllocationCallbacks(pAllocator);
-    if (!pAccelerationStructure->IsNull()) { pAccelerationStructure->SetHandleLength(1); }
-    VkAccelerationStructureKHR* out_pAccelerationStructure = pAccelerationStructure->GetHandlePointer();
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
 
-    VkResult replay_result = GetDeviceTable(in_device)->CreateAccelerationStructureKHR(in_device, in_pCreateInfo, in_pAllocator, out_pAccelerationStructure);
+    MapStructHandles(pCreateInfo->GetMetaStructPointer(), GetObjectInfoTable());
+    if (!pAccelerationStructure->IsNull()) { pAccelerationStructure->SetHandleLength(1); }
+    AccelerationStructureKHRInfo handle_info;
+    pAccelerationStructure->SetConsumerData(0, &handle_info);
+
+    VkResult replay_result = OverrideCreateAccelerationStructureKHR(GetDeviceTable(in_device->handle)->CreateAccelerationStructureKHR, returnValue, in_device, pCreateInfo, pAllocator, pAccelerationStructure);
     CheckResult("vkCreateAccelerationStructureKHR", returnValue, replay_result);
 
-    AddHandle<AccelerationStructureKHRInfo>(device, pAccelerationStructure->GetPointer(), out_pAccelerationStructure, &VulkanObjectInfoTable::AddAccelerationStructureKHRInfo);
+    AddHandle<AccelerationStructureKHRInfo>(device, pAccelerationStructure->GetPointer(), pAccelerationStructure->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddAccelerationStructureKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkDestroyAccelerationStructureKHR(

--- a/framework/generated/vulkan_generators/capture_overrides.json
+++ b/framework/generated/vulkan_generators/capture_overrides.json
@@ -4,6 +4,7 @@
     "vkCreateDevice": "TraceManager::Get()->OverrideCreateDevice",
     "vkCreateBuffer": "TraceManager::Get()->OverrideCreateBuffer",
     "vkAllocateMemory": "TraceManager::Get()->OverrideAllocateMemory",
-    "vkGetPhysicalDeviceToolPropertiesEXT": "TraceManager::Get()->OverrideGetPhysicalDeviceToolPropertiesEXT"
+    "vkGetPhysicalDeviceToolPropertiesEXT": "TraceManager::Get()->OverrideGetPhysicalDeviceToolPropertiesEXT",
+    "vkCreateAccelerationStructureKHR": "TraceManager::Get()->OverrideCreateAccelerationStructureKHR"
   }
 }

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -68,6 +68,7 @@
     "vkGetPhysicalDeviceXlibPresentationSupportKHR": "OverrideGetPhysicalDeviceXlibPresentationSupportKHR",
     "vkCreateWaylandSurfaceKHR": "OverrideCreateWaylandSurfaceKHR",
     "vkGetPhysicalDeviceWaylandPresentationSupportKHR": "OverrideGetPhysicalDeviceWaylandPresentationSupportKHR",
-    "vkDestroySurfaceKHR": "OverrideDestroySurfaceKHR"
+    "vkDestroySurfaceKHR": "OverrideDestroySurfaceKHR",
+    "vkCreateAccelerationStructureKHR": "OverrideCreateAccelerationStructureKHR"
   }
 }

--- a/framework/graphics/CMakeLists.txt
+++ b/framework/graphics/CMakeLists.txt
@@ -1,6 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018-2020 LunarG, Inc.
-# Copyright (c) 2020 Advanced Micro Devices, Inc.
+# Copyright (c) 2021 LunarG, Inc.
 # All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -23,22 +22,30 @@
 #
 # Author: LunarG Team
 # Author: AMD Developer Tools Team
-# Description: CMake script for framework util target
+# Description: CMake script for framework graphics target
 ###############################################################################
 
-add_executable(gfxrecon-compress "")
+add_library(gfxrecon_graphics STATIC "")
 
-target_sources(gfxrecon-compress
+target_sources(gfxrecon_graphics
                PRIVATE
-                   ${CMAKE_CURRENT_LIST_DIR}/main.cpp
-                   ${CMAKE_CURRENT_LIST_DIR}/compression_converter.h
-                   ${CMAKE_CURRENT_LIST_DIR}/compression_converter.cpp
-)
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.cpp
+              )
 
-target_include_directories(gfxrecon-compress PUBLIC ${CMAKE_BINARY_DIR})
+target_include_directories(gfxrecon_graphics
+                           PUBLIC
+                               ${CMAKE_SOURCE_DIR}/framework)
 
-target_link_libraries(gfxrecon-compress gfxrecon_decode gfxrecon_graphics gfxrecon_format gfxrecon_util platform_specific)
+target_link_libraries(gfxrecon_graphics gfxrecon_util vulkan_registry platform_specific)
 
-common_build_directives(gfxrecon-compress)
+common_build_directives(gfxrecon_graphics)
 
-install(TARGETS gfxrecon-compress RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+if (${RUN_TESTS})
+    add_executable(gfxrecon_graphics_test "")
+    target_sources(gfxrecon_graphics_test PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/test/main.cpp)
+    target_link_libraries(gfxrecon_graphics_test PRIVATE gfxrecon_graphics)
+    common_build_directives(gfxrecon_graphics_test)
+    common_test_directives(gfxrecon_graphics_test)
+endif()

--- a/framework/graphics/test/main.cpp
+++ b/framework/graphics/test/main.cpp
@@ -1,0 +1,27 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright(c) 2019 Advanced Micro Devices, Inc.All rights reserved
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+/// \author AMD Developer Tools Team
+/// \description gfxrecon_graphics test main entry point
+///////////////////////////////////////////////////////////////////////////////
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/framework/graphics/vulkan_util.cpp
+++ b/framework/graphics/vulkan_util.cpp
@@ -72,12 +72,6 @@ void EnableRequiredPhysicalDeviceFeatures(uint32_t                        instan
                     {
                         buffer_address_features->bufferDeviceAddressCaptureReplay = true;
                     }
-                    else
-                    {
-                        GFXRECON_LOG_ERROR("VkPhysicalDeviceBufferDeviceAddressFeatures::"
-                                           "bufferDeviceAddressCaptureReplay should be enabled to capture and replay "
-                                           "device addresses, but it is not supported by the current device.");
-                    }
                 }
             }
             break;

--- a/framework/graphics/vulkan_util.cpp
+++ b/framework/graphics/vulkan_util.cpp
@@ -1,0 +1,31 @@
+/*
+** Copyright (c) 2021 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "graphics/vulkan_util.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(graphics)
+
+void Placeholder() {}
+
+GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/graphics/vulkan_util.cpp
+++ b/framework/graphics/vulkan_util.cpp
@@ -22,10 +22,86 @@
 
 #include "graphics/vulkan_util.h"
 
+#include "util/logging.h"
+
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
 
-void Placeholder() {}
+void EnableRequiredPhysicalDeviceFeatures(uint32_t                        instance_api_version,
+                                          const encode::InstanceTable*    instance_table,
+                                          const VkPhysicalDevice          physical_device,
+                                          const VkDeviceCreateInfo*       create_info,
+                                          ModifiedPhysicalDeviceFeatures& modified_features)
+{
+    VkBaseOutStructure* current_struct = reinterpret_cast<const VkBaseOutStructure*>(create_info)->pNext;
+    while (current_struct != nullptr)
+    {
+        switch (current_struct->sType)
+        {
+            // Enable bufferDeviceAddressCaptureReplay if bufferDeviceAddress feature is enabled
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES:
+            {
+                VkPhysicalDeviceBufferDeviceAddressFeatures* buffer_address_features =
+                    reinterpret_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(current_struct);
+
+                modified_features.bufferDeviceAddressCaptureReplay_ptr =
+                    (&buffer_address_features->bufferDeviceAddressCaptureReplay);
+                modified_features.bufferDeviceAddressCaptureReplay_original =
+                    buffer_address_features->bufferDeviceAddressCaptureReplay;
+
+                if (buffer_address_features->bufferDeviceAddress &&
+                    !buffer_address_features->bufferDeviceAddressCaptureReplay)
+                {
+                    // Get buffer_address properties
+                    VkPhysicalDeviceFeatures2 features2{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2 };
+                    VkPhysicalDeviceBufferDeviceAddressFeatures supported_features{
+                        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES
+                    };
+                    features2.pNext = &supported_features;
+                    if (instance_api_version >= VK_MAKE_VERSION(1, 1, 0))
+                    {
+                        instance_table->GetPhysicalDeviceFeatures2(physical_device, &features2);
+                    }
+                    else
+                    {
+                        instance_table->GetPhysicalDeviceFeatures2KHR(physical_device, &features2);
+                    }
+
+                    // Enable bufferDeviceAddressCaptureReplay if it is supported
+                    if (supported_features.bufferDeviceAddressCaptureReplay)
+                    {
+                        buffer_address_features->bufferDeviceAddressCaptureReplay = true;
+                    }
+                    else
+                    {
+                        GFXRECON_LOG_ERROR("VkPhysicalDeviceBufferDeviceAddressFeatures::"
+                                           "bufferDeviceAddressCaptureReplay should be enabled to capture and replay "
+                                           "device addresses, but it is not supported by the current device.");
+                    }
+                }
+            }
+            break;
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT:
+            {
+                GFXRECON_LOG_ERROR("Extension %s is not supported by GFXReconstruct.",
+                                   VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+            }
+            break;
+            default:
+                break;
+        }
+        current_struct = current_struct->pNext;
+    }
+}
+
+void RestoreModifiedPhysicalDeviceFeatures(const ModifiedPhysicalDeviceFeatures& modified_features)
+{
+    if (modified_features.bufferDeviceAddressCaptureReplay_ptr != nullptr)
+    {
+        (*modified_features.bufferDeviceAddressCaptureReplay_ptr) =
+            modified_features.bufferDeviceAddressCaptureReplay_original;
+    }
+}
 
 GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/graphics/vulkan_util.h
+++ b/framework/graphics/vulkan_util.h
@@ -36,6 +36,10 @@ struct ModifiedPhysicalDeviceFeatures
     // VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddressCaptureReplay
     VkBool32* bufferDeviceAddressCaptureReplay_ptr{ nullptr };
     VkBool32  bufferDeviceAddressCaptureReplay_original{ VK_FALSE };
+
+    // VkPhysicalDeviceAccelerationStructureFeaturesKHR::accelerationStructureCaptureReplay
+    VkBool32* accelerationStructureCaptureReplay_ptr{ nullptr };
+    VkBool32  accelerationStructureCaptureReplay_original{ VK_FALSE };
 };
 
 // Try to enable the device features required for application capture and replay

--- a/framework/graphics/vulkan_util.h
+++ b/framework/graphics/vulkan_util.h
@@ -1,0 +1,38 @@
+/*
+** Copyright (c) 2021 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_GRAPHICS_VULKAN_UTIL_H
+#define GFXRECON_GRAPHICS_VULKAN_UTIL_H
+
+#include "util/defines.h"
+
+#include "vulkan/vulkan.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(graphics)
+
+static void Placeholder();
+
+GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_GRAPHICS_VULKAN_UTIL_H

--- a/framework/graphics/vulkan_util.h
+++ b/framework/graphics/vulkan_util.h
@@ -23,6 +23,7 @@
 #ifndef GFXRECON_GRAPHICS_VULKAN_UTIL_H
 #define GFXRECON_GRAPHICS_VULKAN_UTIL_H
 
+#include "generated/generated_vulkan_dispatch_table.h"
 #include "util/defines.h"
 
 #include "vulkan/vulkan.h"
@@ -30,7 +31,22 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
 
-static void Placeholder();
+struct ModifiedPhysicalDeviceFeatures
+{
+    // VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddressCaptureReplay
+    VkBool32* bufferDeviceAddressCaptureReplay_ptr{ nullptr };
+    VkBool32  bufferDeviceAddressCaptureReplay_original{ VK_FALSE };
+};
+
+// Try to enable the device features required for application capture and replay
+void EnableRequiredPhysicalDeviceFeatures(uint32_t                        instance_api_version,
+                                          const encode::InstanceTable*    instance_table,
+                                          const VkPhysicalDevice          physical_device,
+                                          const VkDeviceCreateInfo*       create_info,
+                                          ModifiedPhysicalDeviceFeatures& modified_features);
+
+// Restore feature values that may have been modified by EnableRequiredPhysicalDeviceFeatures().
+void RestoreModifiedPhysicalDeviceFeatures(const ModifiedPhysicalDeviceFeatures& modified_features);
 
 GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/util/logging.h
+++ b/framework/util/logging.h
@@ -280,6 +280,25 @@ GFXRECON_END_NAMESPACE(gfxrecon)
                                         ##__VA_ARGS__);                              \
     }
 
+#define GFXRECON_LOG_ONCE(X)         \
+    {                                \
+        static bool log_once = true; \
+        if (log_once)                \
+        {                            \
+            X;                       \
+            log_once = false;        \
+        }                            \
+    }
+
+// clang-format off
+#define GFXRECON_WRITE_CONSOLE_ONCE(message, ...) GFXRECON_LOG_ONCE(GFXRECON_WRITE_CONSOLE(message, ##__VA_ARGS__))
+#define GFXRECON_LOG_FATAL_ONCE(message, ...)     GFXRECON_LOG_ONCE(GFXRECON_LOG_FATAL(message, ##__VA_ARGS__))
+#define GFXRECON_LOG_ERROR_ONCE(message, ...)     GFXRECON_LOG_ONCE(GFXRECON_LOG_ERROR(message, ##__VA_ARGS__))
+#define GFXRECON_LOG_WARNING_ONCE(message, ...)   GFXRECON_LOG_ONCE(GFXRECON_LOG_WARNING(message, ##__VA_ARGS__))
+#define GFXRECON_LOG_INFO_ONCE(message, ...)      GFXRECON_LOG_ONCE(GFXRECON_LOG_INFO(message, ##__VA_ARGS__))
+#define GFXRECON_LOG_DEBUG_ONCE(message, ...)     GFXRECON_LOG_ONCE(GFXRECON_LOG_DEBUG(message, ##__VA_ARGS__))
+// clang-format on
+
 #ifdef GFXRECON_ENABLE_COMMAND_TRACE
 
 #define GFXRECON_LOG_COMMAND() gfxrecon::util::CommandTrace command_trace(__FILE__, __FUNCTION__);

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -42,7 +42,7 @@ target_include_directories(VkLayer_gfxreconstruct
                                ${CMAKE_BINARY_DIR}
                                ${CMAKE_SOURCE_DIR})
 
-target_link_libraries(VkLayer_gfxreconstruct gfxrecon_encode gfxrecon_format gfxrecon_util vulkan_registry platform_specific)
+target_link_libraries(VkLayer_gfxreconstruct gfxrecon_encode gfxrecon_graphics gfxrecon_format gfxrecon_util vulkan_registry platform_specific)
 
 common_build_directives(VkLayer_gfxreconstruct)
 

--- a/tools/extract/CMakeLists.txt
+++ b/tools/extract/CMakeLists.txt
@@ -35,7 +35,7 @@ target_sources(gfxrecon-extract
 
 target_include_directories(gfxrecon-extract PUBLIC ${CMAKE_BINARY_DIR})
 
-target_link_libraries(gfxrecon-extract gfxrecon_decode gfxrecon_format gfxrecon_util platform_specific)
+target_link_libraries(gfxrecon-extract gfxrecon_decode gfxrecon_graphics gfxrecon_format gfxrecon_util platform_specific)
 
 common_build_directives(gfxrecon-extract)
 

--- a/tools/info/CMakeLists.txt
+++ b/tools/info/CMakeLists.txt
@@ -35,7 +35,7 @@ target_sources(gfxrecon-info
 
 target_include_directories(gfxrecon-info PUBLIC ${CMAKE_BINARY_DIR})
 
-target_link_libraries(gfxrecon-info gfxrecon_decode gfxrecon_format gfxrecon_util platform_specific)
+target_link_libraries(gfxrecon-info gfxrecon_decode gfxrecon_graphics gfxrecon_format gfxrecon_util platform_specific)
 
 common_build_directives(gfxrecon-info)
 

--- a/tools/optimize/CMakeLists.txt
+++ b/tools/optimize/CMakeLists.txt
@@ -36,7 +36,7 @@ target_sources(gfxrecon-optimize
 
 target_include_directories(gfxrecon-optimize PUBLIC ${CMAKE_BINARY_DIR})
 
-target_link_libraries(gfxrecon-optimize gfxrecon_decode gfxrecon_format gfxrecon_util platform_specific)
+target_link_libraries(gfxrecon-optimize gfxrecon_decode gfxrecon_graphics gfxrecon_format gfxrecon_util platform_specific)
 
 common_build_directives(gfxrecon-optimize)
 

--- a/tools/replay/CMakeLists.txt
+++ b/tools/replay/CMakeLists.txt
@@ -36,7 +36,7 @@ target_sources(gfxrecon-replay
 
 target_include_directories(gfxrecon-replay PUBLIC ${CMAKE_BINARY_DIR})
 
-target_link_libraries(gfxrecon-replay gfxrecon_application gfxrecon_decode gfxrecon_format gfxrecon_util platform_specific)
+target_link_libraries(gfxrecon-replay gfxrecon_application gfxrecon_decode gfxrecon_graphics gfxrecon_format gfxrecon_util platform_specific)
 
 common_build_directives(gfxrecon-replay)
 

--- a/tools/toascii/CMakeLists.txt
+++ b/tools/toascii/CMakeLists.txt
@@ -35,7 +35,7 @@ target_sources(gfxrecon-toascii
 
 target_include_directories(gfxrecon-toascii PUBLIC ${CMAKE_BINARY_DIR})
 
-target_link_libraries(gfxrecon-toascii gfxrecon_decode gfxrecon_format gfxrecon_util platform_specific)
+target_link_libraries(gfxrecon-toascii gfxrecon_decode gfxrecon_graphics gfxrecon_format gfxrecon_util platform_specific)
 
 common_build_directives(gfxrecon-toascii)
 


### PR DESCRIPTION
Adds or improves support for capturing and replaying device addresses for buffers, device memory, and acceleration structures. If the required features are not present, an error is logged. To facilitate these changes a new library "gfxrecon_graphics" was added to contain Vulkan code common to both capture and replay. Also adds macros to log an error just once and fixes a couple Android build warnings.

- Fix unhandled enum value warning on Android build
- Add logging macros that log messages only once
- Create static lib for common graphics code
- Refactor common device creation code
- Only log feature error when feature is used
- Rename set buffer address for use with other objs
- Save and replay accel struct device addresses
- Save and replay device memory opaque addresses
- Save and replay opaque address even when zero
- Look for device address features in other struct
- Only capture/replay addresses if feature enabled
