### PR TITLE
Fix accel struct wrapper and missing project file

### DIFF
--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -60,6 +60,7 @@ target_sources(gfxrecon_encode
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_api_call_encoders.cpp
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_command_buffer_util.h
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_command_buffer_util.cpp
+                    ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_dispatch_table.h
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_struct_encoders.h
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_struct_encoders.cpp
                     ${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_struct_handle_wrappers.h


### PR DESCRIPTION
Fixes a crash when capturing a ray tracing app with trimming enabled. Also restores a header file to the generated encode project.

- Fix incorrect type used when wrapping accel struct
- Restore header file to project sources