### PR TITLE
Set extractNativeLibs in Android manifest

### DIFF
--- a/android/tools/replay/src/main/AndroidManifest.xml
+++ b/android/tools/replay/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:theme="@style/AppTheme"
         android:supportsRtl="true"
+        android:extractNativeLibs="true"
         android:hasCode="false">
         <activity android:name="android.app.NativeActivity"
                   android:configChanges="orientation|screenSize|keyboard|keyboardHidden"


### PR DESCRIPTION
Add android:extractNativeLibs="true" to the replay tool's Android manifest file.
