### PR TITLE
Fix replay extension tracking for -m rebind

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -2425,6 +2425,9 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
             assert(instance_info != nullptr);
 
             instance_info->api_version = modified_create_info.pApplicationInfo->apiVersion;
+            instance_info->enabled_extensions.assign(modified_create_info.ppEnabledExtensionNames,
+                                                     modified_create_info.ppEnabledExtensionNames +
+                                                         modified_create_info.enabledExtensionCount);
         }
     }
 
@@ -2541,9 +2544,9 @@ VulkanReplayConsumerBase::OverrideCreateDevice(VkResult            original_resu
 
             auto allocator = options_.create_resource_allocator();
 
-            std::vector<std::string> enabled_extensions(replay_create_info->ppEnabledExtensionNames,
-                                                        replay_create_info->ppEnabledExtensionNames +
-                                                            replay_create_info->enabledExtensionCount);
+            std::vector<std::string> enabled_extensions(modified_create_info.ppEnabledExtensionNames,
+                                                        modified_create_info.ppEnabledExtensionNames +
+                                                            modified_create_info.enabledExtensionCount);
             InitializeResourceAllocator(physical_device_info, *replay_device, enabled_extensions, allocator);
 
             device_info->allocator = std::unique_ptr<VulkanResourceAllocator>(allocator);


### PR DESCRIPTION
Fixes for initialization of the rebind memory allocator, related to enabled extensions:
- Fix missing initialization of the enabled instance extension list that is tracked with VkInstance/VkPhysicalDevice handles.  The extension list was not properly initialized when it was added with commit 9773aded.
- For allocator initialization, use the modified device extension list that was specified when replaying vkCreateDevice, instead of the unmodified list that was captured.