### PR TITLE
Use host coherent as fallback when creating a staging buffer

### DIFF
--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2870,6 +2870,16 @@ VkResult VulkanStateWriter::CreateStagingBuffer(const DeviceWrapper*    device_w
                                          &memory_type_index,
                                          memory_property_flags,
                                          state_table);
+        if (!found)
+        {
+            // If we are here it is likely that we lack support for HOST_CACHED, fallback to COHERENT
+            found = FindMemoryTypeIndex(device_wrapper,
+                                        memory_requirements.memoryTypeBits,
+                                        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                                        &memory_type_index,
+                                        memory_property_flags,
+                                        state_table);
+        }
 
         if (found)
         {
@@ -2891,8 +2901,8 @@ VkResult VulkanStateWriter::CreateStagingBuffer(const DeviceWrapper*    device_w
         }
         else
         {
-            GFXRECON_LOG_ERROR("Failed to find a memory type with host visible and host cached properties for resource "
-                               "memory snapshot staging buffer creation");
+            GFXRECON_LOG_ERROR("Failed to find a memory type with host visible and host cached or coherent "
+                               "properties for resource memory snapshot staging buffer creation");
             result = VK_ERROR_INITIALIZATION_FAILED;
         }
     }


### PR DESCRIPTION
By spec only COHERENT is mandatory, so it is possible finding a driver
not supporting CACHED. The current caller for CreateStagingBuffer
already checks if the buffer is coherent or not.

====

As a specific example, right now the v3dv driver (Mesa vulkan driver for V3D Broadcom GPUs, developed specifically for the rpi4) doesn't support CACHED. This change is needed when capturing with a initial frame different to 1 (that is useful when you want to skip intros, menu UI, etc).

The contribution guide recommends to test this change with DOTA, but that seems too much for the embedded device. I have tested it with Quake3e (a vulkan port of quake3 [1]), with vkQuake2 [2], and Unreal 4 Shooter Game demo [3]


[1] https://github.com/ec-/Quake3e
[2] https://github.com/kondrak/vkQuake2/
[3] https://docs.unrealengine.com/en-US/Resources/SampleGames/ShooterGame/index.html