### PR TITLE
Add trimming support for ray tracing

### DIFF
--- a/framework/decode/descriptor_update_template_decoder.cpp
+++ b/framework/decode/descriptor_update_template_decoder.cpp
@@ -56,10 +56,14 @@ size_t DescriptorUpdateTemplateDecoder::Decode(const uint8_t* buffer, size_t buf
             ValueDecoder::DecodeSizeTValue((buffer + bytes_read), (buffer_size - bytes_read), &buffer_info_count_);
         bytes_read += ValueDecoder::DecodeSizeTValue(
             (buffer + bytes_read), (buffer_size - bytes_read), &texel_buffer_view_count_);
+        bytes_read += ValueDecoder::DecodeSizeTValue(
+            (buffer + bytes_read), (buffer_size - bytes_read), &acceleration_structure_khr_count_);
 
         size_t buffer_info_offset       = image_info_count_ * sizeof(VkDescriptorImageInfo);
         size_t texel_buffer_view_offset = buffer_info_offset + (buffer_info_count_ * sizeof(VkDescriptorBufferInfo));
-        size_t total_size               = texel_buffer_view_offset + (texel_buffer_view_count_ * sizeof(VkBufferView));
+        size_t accel_struct_offset      = texel_buffer_view_offset + (texel_buffer_view_count_ * sizeof(VkBufferView));
+        size_t total_size =
+            accel_struct_offset + (acceleration_structure_khr_count_ * sizeof(VkAccelerationStructureKHR));
 
         assert(template_memory_ == nullptr);
         template_memory_ = DecodeAllocator::Allocate<uint8_t>(total_size);
@@ -99,6 +103,19 @@ size_t DescriptorUpdateTemplateDecoder::Decode(const uint8_t* buffer, size_t buf
                                               (buffer_size - bytes_read),
                                               decoded_texel_buffer_view_handle_ids_,
                                               texel_buffer_view_count_);
+        }
+
+        if (acceleration_structure_khr_count_ > 0)
+        {
+            acceleration_structures_khr_ =
+                reinterpret_cast<VkAccelerationStructureKHR*>(template_memory_ + accel_struct_offset);
+            decoded_acceleration_structure_khr_handle_ids_ =
+                DecodeAllocator::Allocate<format::HandleId>(acceleration_structure_khr_count_);
+
+            ValueDecoder::DecodeHandleIdArray((buffer + bytes_read),
+                                              (buffer_size - bytes_read),
+                                              decoded_acceleration_structure_khr_handle_ids_,
+                                              acceleration_structure_khr_count_);
         }
     }
 

--- a/framework/decode/descriptor_update_template_decoder.h
+++ b/framework/decode/descriptor_update_template_decoder.h
@@ -47,22 +47,36 @@ class DescriptorUpdateTemplateDecoder : public PointerDecoderBase
     size_t GetImageInfoCount() const { return image_info_count_; }
     size_t GetBufferInfoCount() const { return buffer_info_count_; }
     size_t GetTexelBufferViewCount() const { return texel_buffer_view_count_; }
+    size_t GetAccelerationStructureKHRCount() const { return acceleration_structure_khr_count_; }
 
     Decoded_VkDescriptorImageInfo*  GetImageInfoMetaStructPointer() { return decoded_image_info_; }
     Decoded_VkDescriptorBufferInfo* GetBufferInfoMetaStructPointer() { return decoded_buffer_info_; }
     format::HandleId* GetTexelBufferViewHandleIdsPointer() { return decoded_texel_buffer_view_handle_ids_; }
+    format::HandleId*               GetAccelerationStructureKHRHandleIdsPointer()
+    {
+        return decoded_acceleration_structure_khr_handle_ids_;
+    }
 
     const Decoded_VkDescriptorImageInfo*  GetImageInfoMetaStructPointer() const { return decoded_image_info_; }
     const Decoded_VkDescriptorBufferInfo* GetBufferInfoMetaStructPointer() const { return decoded_buffer_info_; }
     const format::HandleId* GetTexelBufferViewHandleIdsPointer() const { return decoded_texel_buffer_view_handle_ids_; }
+    const format::HandleId* GetAccelerationStructureKHRHandleIdsPointer() const
+    {
+        return decoded_acceleration_structure_khr_handle_ids_;
+    }
 
-    VkDescriptorImageInfo*  GetImageInfoPointer() { return image_info_; }
-    VkDescriptorBufferInfo* GetBufferInfoPointer() { return buffer_info_; }
-    VkBufferView*           GetTexelBufferViewPointer() { return texel_buffer_views_; }
+    VkDescriptorImageInfo*      GetImageInfoPointer() { return image_info_; }
+    VkDescriptorBufferInfo*     GetBufferInfoPointer() { return buffer_info_; }
+    VkBufferView*               GetTexelBufferViewPointer() { return texel_buffer_views_; }
+    VkAccelerationStructureKHR* GetAccelerationStructureKHRPointer() { return acceleration_structures_khr_; }
 
-    const VkDescriptorImageInfo*  GetImageInfoPointer() const { return image_info_; }
-    const VkDescriptorBufferInfo* GetBufferInfoPointer() const { return buffer_info_; }
-    const VkBufferView*           GetTexelBufferViewPointer() const { return texel_buffer_views_; }
+    const VkDescriptorImageInfo*      GetImageInfoPointer() const { return image_info_; }
+    const VkDescriptorBufferInfo*     GetBufferInfoPointer() const { return buffer_info_; }
+    const VkBufferView*               GetTexelBufferViewPointer() const { return texel_buffer_views_; }
+    const VkAccelerationStructureKHR* GetAccelerationStructureKHRPointer() const
+    {
+        return acceleration_structures_khr_;
+    }
 
     size_t Decode(const uint8_t* buffer, size_t buffer_size);
 
@@ -71,12 +85,15 @@ class DescriptorUpdateTemplateDecoder : public PointerDecoderBase
     Decoded_VkDescriptorImageInfo*  decoded_image_info_{ nullptr };
     Decoded_VkDescriptorBufferInfo* decoded_buffer_info_{ nullptr };
     format::HandleId*               decoded_texel_buffer_view_handle_ids_{ nullptr };
+    format::HandleId*               decoded_acceleration_structure_khr_handle_ids_{ nullptr };
     size_t                          image_info_count_;
     size_t                          buffer_info_count_;
     size_t                          texel_buffer_view_count_;
+    size_t                          acceleration_structure_khr_count_;
     VkDescriptorImageInfo*          image_info_;
     VkDescriptorBufferInfo*         buffer_info_;
     VkBufferView*                   texel_buffer_views_;
+    VkAccelerationStructureKHR*     acceleration_structures_khr_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4140,9 +4140,10 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDescriptorUpdateTemplate(
             (override_create_info.pDescriptorUpdateEntries + override_create_info.descriptorUpdateEntryCount));
 
         // Count the number of values of each type.
-        size_t image_info_count        = 0;
-        size_t buffer_info_count       = 0;
-        size_t texel_buffer_view_count = 0;
+        size_t image_info_count             = 0;
+        size_t buffer_info_count            = 0;
+        size_t texel_buffer_view_count      = 0;
+        size_t acceleration_structure_count = 0;
 
         for (auto entry = entries.begin(); entry != entries.end(); ++entry)
         {
@@ -4165,6 +4166,10 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDescriptorUpdateTemplate(
             {
                 texel_buffer_view_count += entry->descriptorCount;
             }
+            else if (type == VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR)
+            {
+                acceleration_structure_count += entry->descriptorCount;
+            }
             else
             {
                 assert(false);
@@ -4175,6 +4180,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDescriptorUpdateTemplate(
         size_t image_info_offset        = 0;
         size_t buffer_info_offset       = image_info_count * sizeof(VkDescriptorImageInfo);
         size_t texel_buffer_view_offset = buffer_info_offset + (buffer_info_count * sizeof(VkDescriptorBufferInfo));
+        size_t accel_struct_offset      = texel_buffer_view_offset + (texel_buffer_view_count * sizeof(VkBufferView));
 
         // Track descriptor image type.
         std::vector<VkDescriptorType> image_types;
@@ -4207,6 +4213,12 @@ VkResult VulkanReplayConsumerBase::OverrideCreateDescriptorUpdateTemplate(
                 entry->stride = sizeof(VkBufferView);
                 entry->offset = texel_buffer_view_offset;
                 texel_buffer_view_offset += entry->descriptorCount * sizeof(VkBufferView);
+            }
+            else if (type == VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR)
+            {
+                entry->stride = sizeof(VkAccelerationStructureKHR);
+                entry->offset = accel_struct_offset;
+                accel_struct_offset += entry->descriptorCount * sizeof(VkAccelerationStructureKHR);
             }
             else
             {
@@ -5502,6 +5514,7 @@ void VulkanReplayConsumerBase::MapDescriptorUpdateTemplateHandles(
     size_t image_info_count        = decoder->GetImageInfoCount();
     size_t buffer_info_count       = decoder->GetBufferInfoCount();
     size_t texel_buffer_view_count = decoder->GetTexelBufferViewCount();
+    size_t accel_struct_count      = decoder->GetAccelerationStructureKHRCount();
 
     if (image_info_count > 0)
     {
@@ -5549,6 +5562,26 @@ void VulkanReplayConsumerBase::MapDescriptorUpdateTemplateHandles(
             else
             {
                 texel_buffer_view_handles[i] = VK_NULL_HANDLE;
+            }
+        }
+    }
+
+    if (accel_struct_count > 0)
+    {
+        auto accel_struct_ids     = decoder->GetAccelerationStructureKHRHandleIdsPointer();
+        auto accel_struct_handles = decoder->GetAccelerationStructureKHRPointer();
+
+        for (size_t i = 0; i < accel_struct_count; ++i)
+        {
+            auto accel_struct_info = object_info_table_.GetAccelerationStructureKHRInfo(accel_struct_ids[i]);
+
+            if (accel_struct_info != nullptr)
+            {
+                accel_struct_handles[i] = accel_struct_info->handle;
+            }
+            else
+            {
+                accel_struct_handles[i] = VK_NULL_HANDLE;
             }
         }
     }

--- a/framework/encode/custom_vulkan_api_call_encoders.cpp
+++ b/framework/encode/custom_vulkan_api_call_encoders.cpp
@@ -313,5 +313,27 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSetWithTemplateKHR(VkDevice          
         manager, device, descriptorSet, descriptorUpdateTemplate, pData);
 }
 
+VKAPI_ATTR VkResult VKAPI_CALL
+BuildAccelerationStructuresKHR(VkDevice                                               device,
+                               VkDeferredOperationKHR                                 deferredOperation,
+                               uint32_t                                               infoCount,
+                               const VkAccelerationStructureBuildGeometryInfoKHR*     pInfos,
+                               const VkAccelerationStructureBuildRangeInfoKHR* const* ppRangeInfos)
+{
+    // TODO
+    GFXRECON_LOG_ERROR("BuildAccelerationStructuresKHR encoding is not supported");
+    return GetDeviceTable(device)->BuildAccelerationStructuresKHR(
+        device, deferredOperation, infoCount, pInfos, ppRangeInfos);
+}
+
+VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureKHR(VkDevice                                  device,
+                                                            VkDeferredOperationKHR                    deferredOperation,
+                                                            const VkCopyAccelerationStructureInfoKHR* pInfo)
+{
+    // TODO
+    GFXRECON_LOG_ERROR("CopyAccelerationStructureKHR encoding is not supported");
+    return GetDeviceTable(device)->CopyAccelerationStructureKHR(device, deferredOperation, pInfo);
+}
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/custom_vulkan_api_call_encoders.h
+++ b/framework/encode/custom_vulkan_api_call_encoders.h
@@ -47,6 +47,17 @@ VKAPI_ATTR void VKAPI_CALL UpdateDescriptorSetWithTemplateKHR(VkDevice          
                                                               VkDescriptorUpdateTemplate descriptorUpdateTemplate,
                                                               const void*                pData);
 
+VKAPI_ATTR VkResult VKAPI_CALL
+BuildAccelerationStructuresKHR(VkDevice                                               device,
+                               VkDeferredOperationKHR                                 deferredOperation,
+                               uint32_t                                               infoCount,
+                               const VkAccelerationStructureBuildGeometryInfoKHR*     pInfos,
+                               const VkAccelerationStructureBuildRangeInfoKHR* const* ppRangeInfos);
+
+VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureKHR(VkDevice                                  device,
+                                                            VkDeferredOperationKHR                    deferredOperation,
+                                                            const VkCopyAccelerationStructureInfoKHR* pInfo);
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/encode/descriptor_update_template_info.h
+++ b/framework/encode/descriptor_update_template_info.h
@@ -46,16 +46,18 @@ struct UpdateTemplateInfo
 {
     // The counts are the sum of the total descriptorCount for each update template entry type. When written to the
     // capture file, the update template data will be written as tightly packed arrays of VkDescriptorImageInfo,
-    // VkDescriptorBufferInfo, and VkBufferView types.  There will be one array per descriptor update entry, so the
-    // counts are pre-computed for the file encoding process to know the total number of items to encode prior to
-    // processing the individual UpdateTemplateEntry structures.
+    // VkDescriptorBufferInfo, VkBufferView, and VkAccelerationStructureKHR types.  There will be one array per
+    // descriptor update entry, so the counts are pre-computed for the file encoding process to know the total number of
+    // items to encode prior to processing the individual UpdateTemplateEntry structures.
     size_t                               max_size{ 0 };
     size_t                               image_info_count{ 0 };
     size_t                               buffer_info_count{ 0 };
     size_t                               texel_buffer_view_count{ 0 };
+    size_t                               acceleration_structure_khr_count{ 0 };
     std::vector<UpdateTemplateEntryInfo> image_info;
     std::vector<UpdateTemplateEntryInfo> buffer_info;
     std::vector<UpdateTemplateEntryInfo> texel_buffer_view;
+    std::vector<UpdateTemplateEntryInfo> acceleration_structure_khr;
 };
 
 GFXRECON_END_NAMESPACE(encode)

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -1113,6 +1113,21 @@ void TraceManager::SetDescriptorUpdateTemplateInfo(VkDescriptorUpdateTemplate   
 
                 entry_size = sizeof(VkBufferView);
             }
+            else if (type == VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR)
+            {
+                UpdateTemplateEntryInfo accel_struct_info;
+                accel_struct_info.binding       = entry->dstBinding;
+                accel_struct_info.array_element = entry->dstArrayElement;
+                accel_struct_info.count         = entry->descriptorCount;
+                accel_struct_info.offset        = entry->offset;
+                accel_struct_info.stride        = entry->stride;
+                accel_struct_info.type          = type;
+
+                info->acceleration_structure_khr_count += entry->descriptorCount;
+                info->acceleration_structure_khr.emplace_back(accel_struct_info);
+
+                entry_size = sizeof(VkAccelerationStructureKHR);
+            }
             else
             {
                 GFXRECON_LOG_ERROR("Unrecognized/unsupported descriptor type in descriptor update template.");

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -380,8 +380,6 @@ struct AccelerationStructureKHRWrapper : public HandleWrapper<VkAccelerationStru
     // State tracking info for buffers with device addresses.
     format::HandleId device_id{ format::kNullHandleId };
     VkDeviceAddress  address{ 0 };
-
-    // TODO: Determine what additional state tracking is needed.
 };
 
 struct AccelerationStructureNVWrapper : public HandleWrapper<VkAccelerationStructureNV>

--- a/framework/encode/vulkan_state_info.h
+++ b/framework/encode/vulkan_state_info.h
@@ -63,14 +63,15 @@ struct DescriptorBindingInfo
 
 struct DescriptorInfo
 {
-    VkDescriptorType                          type;
-    uint32_t                                  count{ 0 };
-    std::unique_ptr<bool[]>                   written;
-    std::unique_ptr<format::HandleId[]>       handle_ids;  // Image, buffer, or buffer view IDs depending on type.
-    std::unique_ptr<format::HandleId[]>       sampler_ids; // Sampler IDs for image type.
-    std::unique_ptr<VkDescriptorImageInfo[]>  images;
-    std::unique_ptr<VkDescriptorBufferInfo[]> buffers;
-    std::unique_ptr<VkBufferView[]>           texel_buffer_views;
+    VkDescriptorType                              type;
+    uint32_t                                      count{ 0 };
+    std::unique_ptr<bool[]>                       written;
+    std::unique_ptr<format::HandleId[]>           handle_ids;  // Image, buffer, or buffer view IDs depending on type.
+    std::unique_ptr<format::HandleId[]>           sampler_ids; // Sampler IDs for image type.
+    std::unique_ptr<VkDescriptorImageInfo[]>      images;
+    std::unique_ptr<VkDescriptorBufferInfo[]>     buffers;
+    std::unique_ptr<VkBufferView[]>               texel_buffer_views;
+    std::unique_ptr<VkAccelerationStructureKHR[]> acceleration_structures;
 };
 
 struct CreateDependencyInfo

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -541,6 +541,9 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
                     case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
                         // TODO
                         break;
+                    case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+                        // TODO
+                        break;
                     default:
                         GFXRECON_LOG_WARNING("Attempting to track descriptor state for unrecognized descriptor type");
                         break;

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -776,7 +776,8 @@ inline void InitializePoolObjectState(VkDevice                           parent_
                 // TODO
                 break;
             case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
-                // TODO
+                descriptor_info.acceleration_structures =
+                    std::make_unique<VkAccelerationStructureKHR[]>(binding_info.count);
                 break;
             default:
                 GFXRECON_LOG_WARNING("Attempting to initialize descriptor state for unrecognized descriptor type");

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -471,10 +471,12 @@ void VulkanStateWriter::WritePipelineState(const VulkanStateTable& state_table)
     // pipelines than it should, resulting in object leaks or the overwriting of recycled handles.
     std::set<util::MemoryOutputStream*>    processed_graphics_pipelines;
     std::set<util::MemoryOutputStream*>    processed_compute_pipelines;
-    std::set<util::MemoryOutputStream*>    processed_ray_tracing_pipelines;
+    std::set<util::MemoryOutputStream*>    processed_ray_tracing_pipelines_nv;
+    std::set<util::MemoryOutputStream*>    processed_ray_tracing_pipelines_khr;
     std::vector<util::MemoryOutputStream*> graphics_pipelines;
     std::vector<util::MemoryOutputStream*> compute_pipelines;
-    std::vector<util::MemoryOutputStream*> ray_tracing_pipelines;
+    std::vector<util::MemoryOutputStream*> ray_tracing_pipelines_nv;
+    std::vector<util::MemoryOutputStream*> ray_tracing_pipelines_khr;
 
     std::unordered_map<format::HandleId, const util::MemoryOutputStream*> temp_shaders;
     std::unordered_map<format::HandleId, const util::MemoryOutputStream*> temp_render_passes;
@@ -522,11 +524,20 @@ void VulkanStateWriter::WritePipelineState(const VulkanStateTable& state_table)
         }
         else if (wrapper->create_call_id == format::ApiCall_vkCreateRayTracingPipelinesNV)
         {
-            if (processed_ray_tracing_pipelines.find(wrapper->create_parameters.get()) ==
-                processed_ray_tracing_pipelines.end())
+            if (processed_ray_tracing_pipelines_nv.find(wrapper->create_parameters.get()) ==
+                processed_ray_tracing_pipelines_nv.end())
             {
-                ray_tracing_pipelines.push_back(wrapper->create_parameters.get());
-                processed_ray_tracing_pipelines.insert(wrapper->create_parameters.get());
+                ray_tracing_pipelines_nv.push_back(wrapper->create_parameters.get());
+                processed_ray_tracing_pipelines_nv.insert(wrapper->create_parameters.get());
+            }
+        }
+        else if (wrapper->create_call_id == format::ApiCall_vkCreateRayTracingPipelinesKHR)
+        {
+            if (processed_ray_tracing_pipelines_khr.find(wrapper->create_parameters.get()) ==
+                processed_ray_tracing_pipelines_khr.end())
+            {
+                ray_tracing_pipelines_khr.push_back(wrapper->create_parameters.get());
+                processed_ray_tracing_pipelines_khr.insert(wrapper->create_parameters.get());
             }
         }
 
@@ -595,9 +606,14 @@ void VulkanStateWriter::WritePipelineState(const VulkanStateTable& state_table)
         WriteFunctionCall(format::ApiCall_vkCreateComputePipelines, entry);
     }
 
-    for (const auto& entry : ray_tracing_pipelines)
+    for (const auto& entry : ray_tracing_pipelines_nv)
     {
         WriteFunctionCall(format::ApiCall_vkCreateRayTracingPipelinesNV, entry);
+    }
+
+    for (const auto& entry : ray_tracing_pipelines_khr)
+    {
+        WriteFunctionCall(format::ApiCall_vkCreateRayTracingPipelinesKHR, entry);
     }
 
     // Temporary object destruction.
@@ -2177,6 +2193,9 @@ void VulkanStateWriter::WriteDescriptorUpdateCommand(format::HandleId      devic
         case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
             // TODO
             break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+            // TODO
+            break;
         default:
             GFXRECON_LOG_WARNING("Attempting to initialize descriptor state for unrecognized descriptor type");
             break;
@@ -3507,7 +3526,11 @@ bool VulkanStateWriter::CheckDescriptorStatus(const DescriptorInfo*   descriptor
                 break;
             case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
                 // TODO
-                GFXRECON_LOG_WARNING("Descriptor type acceleration structure is not currently supported");
+                GFXRECON_LOG_WARNING("Descriptor type acceleration structure NV is not currently supported");
+                break;
+            case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+                // TODO
+                GFXRECON_LOG_WARNING("Descriptor type acceleration structure KHR is not currently supported");
                 break;
             default:
                 GFXRECON_LOG_WARNING("Attempting to check descriptor write status for unrecognized descriptor type");

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2162,6 +2162,10 @@ void VulkanStateWriter::WriteDescriptorUpdateCommand(format::HandleId      devic
 
     const VkCopyDescriptorSet* copy = nullptr;
 
+    // write_accel_struct may be used in the pNext chain of the VkWriteDescriptorSet and needs to stay in scope until
+    // after VkWriteDescriptorSet is encoded.
+    VkWriteDescriptorSetAccelerationStructureKHR write_accel_struct;
+
     switch (binding->type)
     {
         case VK_DESCRIPTOR_TYPE_SAMPLER:
@@ -2172,6 +2176,7 @@ void VulkanStateWriter::WriteDescriptorUpdateCommand(format::HandleId      devic
             write->pBufferInfo      = nullptr;
             write->pImageInfo       = &binding->images[write->dstArrayElement];
             write->pTexelBufferView = nullptr;
+            write->pNext            = nullptr;
             break;
         case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
         case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
@@ -2180,12 +2185,14 @@ void VulkanStateWriter::WriteDescriptorUpdateCommand(format::HandleId      devic
             write->pBufferInfo      = &binding->buffers[write->dstArrayElement];
             write->pImageInfo       = nullptr;
             write->pTexelBufferView = nullptr;
+            write->pNext            = nullptr;
             break;
         case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
         case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
             write->pBufferInfo      = nullptr;
             write->pImageInfo       = nullptr;
             write->pTexelBufferView = &binding->texel_buffer_views[write->dstArrayElement];
+            write->pNext            = nullptr;
             break;
         case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT:
             // TODO
@@ -2194,8 +2201,18 @@ void VulkanStateWriter::WriteDescriptorUpdateCommand(format::HandleId      devic
             // TODO
             break;
         case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
-            // TODO
-            break;
+        {
+            write_accel_struct.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_KHR;
+            write_accel_struct.pNext = nullptr;
+            write_accel_struct.accelerationStructureCount = write->descriptorCount;
+            write_accel_struct.pAccelerationStructures    = &binding->acceleration_structures[write->dstArrayElement];
+
+            write->pBufferInfo      = nullptr;
+            write->pImageInfo       = nullptr;
+            write->pTexelBufferView = nullptr;
+            write->pNext            = &write_accel_struct;
+        }
+        break;
         default:
             GFXRECON_LOG_WARNING("Attempting to initialize descriptor state for unrecognized descriptor type");
             break;
@@ -2283,6 +2300,14 @@ void VulkanStateWriter::WriteQueryActivation(format::HandleId           device_i
         else if (query_entry.type == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_NV)
         {
             // TODO
+            GFXRECON_LOG_ERROR("Use of VkQueryType::VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_NV is not "
+                               "currently supported when trimming is enabled.");
+        }
+        else if (query_entry.type == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR)
+        {
+            // TODO
+            GFXRECON_LOG_ERROR("Use of VkQueryType::VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR is not "
+                               "currently supported when trimming is enabled.");
         }
         else
         {
@@ -3529,8 +3554,10 @@ bool VulkanStateWriter::CheckDescriptorStatus(const DescriptorInfo*   descriptor
                 GFXRECON_LOG_WARNING("Descriptor type acceleration structure NV is not currently supported");
                 break;
             case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
-                // TODO
-                GFXRECON_LOG_WARNING("Descriptor type acceleration structure KHR is not currently supported");
+                if (state_table.GetAccelerationStructureKHRWrapper(descriptor->handle_ids[index]) != nullptr)
+                {
+                    valid = true;
+                }
                 break;
             default:
                 GFXRECON_LOG_WARNING("Attempting to check descriptor write status for unrecognized descriptor type");

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -12320,68 +12320,6 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresIndirectKHR(
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructuresIndirectKHR>::Dispatch(TraceManager::Get(), commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts);
 }
 
-VKAPI_ATTR VkResult VKAPI_CALL BuildAccelerationStructuresKHR(
-    VkDevice                                    device,
-    VkDeferredOperationKHR                      deferredOperation,
-    uint32_t                                    infoCount,
-    const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
-    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos)
-{
-    CustomEncoderPreCall<format::ApiCallId::ApiCall_vkBuildAccelerationStructuresKHR>::Dispatch(TraceManager::Get(), device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos);
-
-    auto handle_unwrap_memory = TraceManager::Get()->GetHandleUnwrapMemory();
-    VkDevice device_unwrapped = GetWrappedHandle<VkDevice>(device);
-    VkDeferredOperationKHR deferredOperation_unwrapped = GetWrappedHandle<VkDeferredOperationKHR>(deferredOperation);
-    const VkAccelerationStructureBuildGeometryInfoKHR* pInfos_unwrapped = UnwrapStructArrayHandles(pInfos, infoCount, handle_unwrap_memory);
-
-    VkResult result = GetDeviceTable(device)->BuildAccelerationStructuresKHR(device_unwrapped, deferredOperation_unwrapped, infoCount, pInfos_unwrapped, ppBuildRangeInfos);
-
-    auto encoder = TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkBuildAccelerationStructuresKHR);
-    if (encoder)
-    {
-        encoder->EncodeHandleValue(device);
-        encoder->EncodeHandleValue(deferredOperation);
-        encoder->EncodeUInt32Value(infoCount);
-        EncodeStructArray(encoder, pInfos, infoCount);
-        EncodeStructArray2D(encoder, ppBuildRangeInfos, ArraySize2D<VkDevice, VkDeferredOperationKHR, uint32_t, const VkAccelerationStructureBuildGeometryInfoKHR*, const VkAccelerationStructureBuildRangeInfoKHR* const*>(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos));
-        encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndApiCallTrace(encoder);
-    }
-
-    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkBuildAccelerationStructuresKHR>::Dispatch(TraceManager::Get(), result, device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos);
-
-    return result;
-}
-
-VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureKHR(
-    VkDevice                                    device,
-    VkDeferredOperationKHR                      deferredOperation,
-    const VkCopyAccelerationStructureInfoKHR*   pInfo)
-{
-    CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCopyAccelerationStructureKHR>::Dispatch(TraceManager::Get(), device, deferredOperation, pInfo);
-
-    auto handle_unwrap_memory = TraceManager::Get()->GetHandleUnwrapMemory();
-    VkDevice device_unwrapped = GetWrappedHandle<VkDevice>(device);
-    VkDeferredOperationKHR deferredOperation_unwrapped = GetWrappedHandle<VkDeferredOperationKHR>(deferredOperation);
-    const VkCopyAccelerationStructureInfoKHR* pInfo_unwrapped = UnwrapStructPtrHandles(pInfo, handle_unwrap_memory);
-
-    VkResult result = GetDeviceTable(device)->CopyAccelerationStructureKHR(device_unwrapped, deferredOperation_unwrapped, pInfo_unwrapped);
-
-    auto encoder = TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkCopyAccelerationStructureKHR);
-    if (encoder)
-    {
-        encoder->EncodeHandleValue(device);
-        encoder->EncodeHandleValue(deferredOperation);
-        EncodeStructPtr(encoder, pInfo);
-        encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndApiCallTrace(encoder);
-    }
-
-    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCopyAccelerationStructureKHR>::Dispatch(TraceManager::Get(), result, device, deferredOperation, pInfo);
-
-    return result;
-}
-
 VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureToMemoryKHR(
     VkDevice                                    device,
     VkDeferredOperationKHR                      deferredOperation,

--- a/framework/generated/generated_vulkan_api_call_encoders.h
+++ b/framework/generated/generated_vulkan_api_call_encoders.h
@@ -2361,18 +2361,6 @@ VKAPI_ATTR void VKAPI_CALL CmdBuildAccelerationStructuresIndirectKHR(
     const uint32_t*                             pIndirectStrides,
     const uint32_t* const*                      ppMaxPrimitiveCounts);
 
-VKAPI_ATTR VkResult VKAPI_CALL BuildAccelerationStructuresKHR(
-    VkDevice                                    device,
-    VkDeferredOperationKHR                      deferredOperation,
-    uint32_t                                    infoCount,
-    const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
-    const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos);
-
-VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureKHR(
-    VkDevice                                    device,
-    VkDeferredOperationKHR                      deferredOperation,
-    const VkCopyAccelerationStructureInfoKHR*   pInfo);
-
 VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureToMemoryKHR(
     VkDevice                                    device,
     VkDeferredOperationKHR                      deferredOperation,

--- a/framework/generated/generated_vulkan_ascii_consumer.cpp
+++ b/framework/generated/generated_vulkan_ascii_consumer.cpp
@@ -3815,26 +3815,6 @@ void VulkanAsciiConsumer::Process_vkCmdBuildAccelerationStructuresIndirectKHR(
     fprintf(GetFile(), "%s\n", "vkCmdBuildAccelerationStructuresIndirectKHR");
 }
 
-void VulkanAsciiConsumer::Process_vkBuildAccelerationStructuresKHR(
-    VkResult                                    returnValue,
-    format::HandleId                            device,
-    format::HandleId                            deferredOperation,
-    uint32_t                                    infoCount,
-    StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
-    StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>* ppBuildRangeInfos)
-{
-    fprintf(GetFile(), "%s\n", "vkBuildAccelerationStructuresKHR");
-}
-
-void VulkanAsciiConsumer::Process_vkCopyAccelerationStructureKHR(
-    VkResult                                    returnValue,
-    format::HandleId                            device,
-    format::HandleId                            deferredOperation,
-    StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo)
-{
-    fprintf(GetFile(), "%s\n", "vkCopyAccelerationStructureKHR");
-}
-
 void VulkanAsciiConsumer::Process_vkCopyAccelerationStructureToMemoryKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,

--- a/framework/generated/generated_vulkan_ascii_consumer.h
+++ b/framework/generated/generated_vulkan_ascii_consumer.h
@@ -2570,20 +2570,6 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint32_t>*                   pIndirectStrides,
         PointerDecoder<uint32_t*>*                  ppMaxPrimitiveCounts) override;
 
-    virtual void Process_vkBuildAccelerationStructuresKHR(
-        VkResult                                    returnValue,
-        format::HandleId                            device,
-        format::HandleId                            deferredOperation,
-        uint32_t                                    infoCount,
-        StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
-        StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>* ppBuildRangeInfos) override;
-
-    virtual void Process_vkCopyAccelerationStructureKHR(
-        VkResult                                    returnValue,
-        format::HandleId                            device,
-        format::HandleId                            deferredOperation,
-        StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo) override;
-
     virtual void Process_vkCopyAccelerationStructureToMemoryKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,

--- a/framework/generated/generated_vulkan_consumer.h
+++ b/framework/generated/generated_vulkan_consumer.h
@@ -2570,20 +2570,6 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint32_t>*                   pIndirectStrides,
         PointerDecoder<uint32_t*>*                  ppMaxPrimitiveCounts) {}
 
-    virtual void Process_vkBuildAccelerationStructuresKHR(
-        VkResult                                    returnValue,
-        format::HandleId                            device,
-        format::HandleId                            deferredOperation,
-        uint32_t                                    infoCount,
-        StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
-        StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>* ppBuildRangeInfos) {}
-
-    virtual void Process_vkCopyAccelerationStructureKHR(
-        VkResult                                    returnValue,
-        format::HandleId                            device,
-        format::HandleId                            deferredOperation,
-        StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo) {}
-
     virtual void Process_vkCopyAccelerationStructureToMemoryKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,

--- a/framework/generated/generated_vulkan_decoder.cpp
+++ b/framework/generated/generated_vulkan_decoder.cpp
@@ -9276,54 +9276,6 @@ size_t VulkanDecoder::Decode_vkCmdBuildAccelerationStructuresIndirectKHR(const u
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkBuildAccelerationStructuresKHR(const uint8_t* parameter_buffer, size_t buffer_size)
-{
-    size_t bytes_read = 0;
-
-    format::HandleId device;
-    format::HandleId deferredOperation;
-    uint32_t infoCount;
-    StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR> pInfos;
-    StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*> ppBuildRangeInfos;
-    VkResult return_value;
-
-    bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &device);
-    bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &deferredOperation);
-    bytes_read += ValueDecoder::DecodeUInt32Value((parameter_buffer + bytes_read), (buffer_size - bytes_read), &infoCount);
-    bytes_read += pInfos.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));
-    bytes_read += ppBuildRangeInfos.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));
-    bytes_read += ValueDecoder::DecodeEnumValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &return_value);
-
-    for (auto consumer : GetConsumers())
-    {
-        consumer->Process_vkBuildAccelerationStructuresKHR(return_value, device, deferredOperation, infoCount, &pInfos, &ppBuildRangeInfos);
-    }
-
-    return bytes_read;
-}
-
-size_t VulkanDecoder::Decode_vkCopyAccelerationStructureKHR(const uint8_t* parameter_buffer, size_t buffer_size)
-{
-    size_t bytes_read = 0;
-
-    format::HandleId device;
-    format::HandleId deferredOperation;
-    StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR> pInfo;
-    VkResult return_value;
-
-    bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &device);
-    bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &deferredOperation);
-    bytes_read += pInfo.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));
-    bytes_read += ValueDecoder::DecodeEnumValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &return_value);
-
-    for (auto consumer : GetConsumers())
-    {
-        consumer->Process_vkCopyAccelerationStructureKHR(return_value, device, deferredOperation, &pInfo);
-    }
-
-    return bytes_read;
-}
-
 size_t VulkanDecoder::Decode_vkCopyAccelerationStructureToMemoryKHR(const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
@@ -10961,12 +10913,6 @@ void VulkanDecoder::DecodeFunctionCall(format::ApiCallId             call_id,
         break;
     case format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructuresIndirectKHR:
         Decode_vkCmdBuildAccelerationStructuresIndirectKHR(parameter_buffer, buffer_size);
-        break;
-    case format::ApiCallId::ApiCall_vkBuildAccelerationStructuresKHR:
-        Decode_vkBuildAccelerationStructuresKHR(parameter_buffer, buffer_size);
-        break;
-    case format::ApiCallId::ApiCall_vkCopyAccelerationStructureKHR:
-        Decode_vkCopyAccelerationStructureKHR(parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCopyAccelerationStructureToMemoryKHR:
         Decode_vkCopyAccelerationStructureToMemoryKHR(parameter_buffer, buffer_size);

--- a/framework/generated/generated_vulkan_decoder.h
+++ b/framework/generated/generated_vulkan_decoder.h
@@ -886,10 +886,6 @@ class VulkanDecoder : public VulkanDecoderBase
 
     size_t Decode_vkCmdBuildAccelerationStructuresIndirectKHR(const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkBuildAccelerationStructuresKHR(const uint8_t* parameter_buffer, size_t buffer_size);
-
-    size_t Decode_vkCopyAccelerationStructureKHR(const uint8_t* parameter_buffer, size_t buffer_size);
-
     size_t Decode_vkCopyAccelerationStructureToMemoryKHR(const uint8_t* parameter_buffer, size_t buffer_size);
 
     size_t Decode_vkCopyMemoryToAccelerationStructureKHR(const uint8_t* parameter_buffer, size_t buffer_size);

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -6003,39 +6003,6 @@ void VulkanReplayConsumer::Process_vkCmdBuildAccelerationStructuresIndirectKHR(
     GetDeviceTable(in_commandBuffer)->CmdBuildAccelerationStructuresIndirectKHR(in_commandBuffer, infoCount, in_pInfos, in_pIndirectDeviceAddresses, in_pIndirectStrides, in_ppMaxPrimitiveCounts);
 }
 
-void VulkanReplayConsumer::Process_vkBuildAccelerationStructuresKHR(
-    VkResult                                    returnValue,
-    format::HandleId                            device,
-    format::HandleId                            deferredOperation,
-    uint32_t                                    infoCount,
-    StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
-    StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>* ppBuildRangeInfos)
-{
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkDeferredOperationKHR in_deferredOperation = MapHandle<DeferredOperationKHRInfo>(deferredOperation, &VulkanObjectInfoTable::GetDeferredOperationKHRInfo);
-    const VkAccelerationStructureBuildGeometryInfoKHR* in_pInfos = pInfos->GetPointer();
-    MapStructArrayHandles(pInfos->GetMetaStructPointer(), pInfos->GetLength(), GetObjectInfoTable());
-    const VkAccelerationStructureBuildRangeInfoKHR* const* in_ppBuildRangeInfos = ppBuildRangeInfos->GetPointer();
-
-    VkResult replay_result = GetDeviceTable(in_device)->BuildAccelerationStructuresKHR(in_device, in_deferredOperation, infoCount, in_pInfos, in_ppBuildRangeInfos);
-    CheckResult("vkBuildAccelerationStructuresKHR", returnValue, replay_result);
-}
-
-void VulkanReplayConsumer::Process_vkCopyAccelerationStructureKHR(
-    VkResult                                    returnValue,
-    format::HandleId                            device,
-    format::HandleId                            deferredOperation,
-    StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo)
-{
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkDeferredOperationKHR in_deferredOperation = MapHandle<DeferredOperationKHRInfo>(deferredOperation, &VulkanObjectInfoTable::GetDeferredOperationKHRInfo);
-    const VkCopyAccelerationStructureInfoKHR* in_pInfo = pInfo->GetPointer();
-    MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
-
-    VkResult replay_result = GetDeviceTable(in_device)->CopyAccelerationStructureKHR(in_device, in_deferredOperation, in_pInfo);
-    CheckResult("vkCopyAccelerationStructureKHR", returnValue, replay_result);
-}
-
 void VulkanReplayConsumer::Process_vkCopyAccelerationStructureToMemoryKHR(
     VkResult                                    returnValue,
     format::HandleId                            device,

--- a/framework/generated/generated_vulkan_replay_consumer.h
+++ b/framework/generated/generated_vulkan_replay_consumer.h
@@ -2570,20 +2570,6 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint32_t>*                   pIndirectStrides,
         PointerDecoder<uint32_t*>*                  ppMaxPrimitiveCounts) override;
 
-    virtual void Process_vkBuildAccelerationStructuresKHR(
-        VkResult                                    returnValue,
-        format::HandleId                            device,
-        format::HandleId                            deferredOperation,
-        uint32_t                                    infoCount,
-        StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
-        StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>* ppBuildRangeInfos) override;
-
-    virtual void Process_vkCopyAccelerationStructureKHR(
-        VkResult                                    returnValue,
-        format::HandleId                            device,
-        format::HandleId                            deferredOperation,
-        StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo) override;
-
     virtual void Process_vkCopyAccelerationStructureToMemoryKHR(
         VkResult                                    returnValue,
         format::HandleId                            device,

--- a/framework/generated/vulkan_generators/blacklists.json
+++ b/framework/generated/vulkan_generators/blacklists.json
@@ -9,7 +9,9 @@
     "vkEnumerateInstanceVersion",
     "vkUpdateDescriptorSetWithTemplate",
     "vkUpdateDescriptorSetWithTemplateKHR",
-    "vkCmdPushDescriptorSetWithTemplateKHR"
+    "vkCmdPushDescriptorSetWithTemplateKHR",
+    "vkBuildAccelerationStructuresKHR",
+    "vkCopyAccelerationStructureKHR"
   ],
   "structures": [
     "VkBaseOutStructure",

--- a/framework/graphics/vulkan_util.h
+++ b/framework/graphics/vulkan_util.h
@@ -31,6 +31,23 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
 
+// Search through the parent's pNext chain for the first struct with the requested struct_type. parent's struct type is
+// not checked and parent won't be returned as a result. T and Parent_T must be Vulkan struct pointer types. Return
+// nullptr if no matching struct found.
+template <typename T, typename Parent_T>
+static T* GetPNextStruct(const Parent_T* parent, VkStructureType struct_type)
+{
+    VkBaseOutStructure* current_struct = reinterpret_cast<const VkBaseOutStructure*>(parent)->pNext;
+    while (current_struct != nullptr)
+    {
+        if (current_struct->sType == struct_type)
+        {
+            return reinterpret_cast<T*>(current_struct);
+        }
+    }
+    return nullptr;
+}
+
 struct ModifiedPhysicalDeviceFeatures
 {
     // VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddressCaptureReplay


### PR DESCRIPTION
Support trimming for applications that use KHR ray tracing. Also adds support for acceleration structure descriptor updates with template and a warning if unsupported host acceleration structure functions are used.

- Add trimming support for KHR ray tracing pipelines
- Add util to get pNext struct by type
- Add state tracking for accel struct descriptors
- Add support for accel struct descriptor templates
- Warn if unsupported host accel struct is used