### PR TITLE
Improve trim extension support

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1541,6 +1541,7 @@ void* VulkanReplayConsumerBase::PreProcessExternalObject(uint64_t          objec
     if ((call_id == format::ApiCallId::ApiCall_vkGetPhysicalDeviceXlibPresentationSupportKHR) ||
         (call_id == format::ApiCallId::ApiCall_vkGetPhysicalDeviceXcbPresentationSupportKHR) ||
         (call_id == format::ApiCallId::ApiCall_vkGetPhysicalDeviceWaylandPresentationSupportKHR) ||
+        (call_id == format::ApiCallId::ApiCall_vkGetRandROutputDisplayEXT) ||
         (call_id == format::ApiCallId::ApiCall_vkCmdSetCheckpointNV))
     {
         // The window system related handles are ignored by replay.
@@ -5246,6 +5247,21 @@ VkResult VulkanReplayConsumerBase::OverrideGetSemaphoreWin32HandleKHR(
     GFXRECON_UNREFERENCED_PARAMETER(device_info);
     GFXRECON_UNREFERENCED_PARAMETER(pGetWin32HandleInfo);
     GFXRECON_UNREFERENCED_PARAMETER(pHandle);
+    return original_result;
+}
+
+VkResult VulkanReplayConsumerBase::OverrideGetRandROutputDisplayEXT(PFN_vkGetRandROutputDisplayEXT      func,
+                                                                    VkResult                            original_result,
+                                                                    const PhysicalDeviceInfo*           physicalDevice,
+                                                                    Display*                            dpy,
+                                                                    RROutput                            rrOutput,
+                                                                    HandlePointerDecoder<VkDisplayKHR>* pDisplay)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(func);
+    GFXRECON_UNREFERENCED_PARAMETER(physicalDevice);
+    GFXRECON_UNREFERENCED_PARAMETER(dpy);
+    GFXRECON_UNREFERENCED_PARAMETER(rrOutput);
+    GFXRECON_UNREFERENCED_PARAMETER(pDisplay);
     return original_result;
 }
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -722,6 +722,13 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         const StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         const PointerDecoder<uint64_t, void*>*                                pHandle);
 
+    VkResult OverrideGetRandROutputDisplayEXT(PFN_vkGetRandROutputDisplayEXT      func,
+                                              VkResult                            original_result,
+                                              const PhysicalDeviceInfo*           physicalDevice,
+                                              Display*                            dpy,
+                                              RROutput                            rrOutput,
+                                              HandlePointerDecoder<VkDisplayKHR>* pDisplay);
+
     // Window/Surface related overrides, which can transform the window/surface type from the platform
     // specific type found in the trace file to the platform specific type used for replay.
     VkResult

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -231,8 +231,9 @@ struct SemaphoreWrapper : public HandleWrapper<VkSemaphore>
     // AcquireNextImageKHR, or AcquireNextImage2KHR as a signal semaphore. State is not signaled when a semaphore is
     // submitted to QueueSubmit, QueueBindSparse, or QueuePresentKHR as a wait semaphore. Initial state after creation
     // is not signaled.
-    bool           signaled{ false };
-    DeviceWrapper* device{ nullptr };
+    bool            signaled{ false };
+    VkSemaphoreType type{ VK_SEMAPHORE_TYPE_BINARY_KHR };
+    DeviceWrapper*  device{ nullptr };
 };
 
 struct QueryPoolWrapper : public HandleWrapper<VkQueryPool>

--- a/framework/encode/vulkan_state_info.h
+++ b/framework/encode/vulkan_state_info.h
@@ -72,6 +72,7 @@ struct DescriptorInfo
     std::unique_ptr<VkDescriptorBufferInfo[]>     buffers;
     std::unique_ptr<VkBufferView[]>               texel_buffer_views;
     std::unique_ptr<VkAccelerationStructureKHR[]> acceleration_structures;
+    std::unique_ptr<VkDescriptorType[]>           mutable_type;
 };
 
 struct CreateDependencyInfo

--- a/framework/encode/vulkan_state_info.h
+++ b/framework/encode/vulkan_state_info.h
@@ -59,12 +59,14 @@ struct DescriptorBindingInfo
     uint32_t         binding_index{ 0 };
     uint32_t         count{ 0 };
     VkDescriptorType type;
+    bool             immutable_samplers{ 0 };
 };
 
 struct DescriptorInfo
 {
     VkDescriptorType                              type;
     uint32_t                                      count{ 0 };
+    bool                                          immutable_samplers{ 0 };
     std::unique_ptr<bool[]>                       written;
     std::unique_ptr<format::HandleId[]>           handle_ids;  // Image, buffer, or buffer view IDs depending on type.
     std::unique_ptr<format::HandleId[]>           sampler_ids; // Sampler IDs for image type.

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -461,6 +461,12 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
                 bool* written_start = &binding.written[current_dst_array_element];
                 std::fill(written_start, written_start + current_writes, true);
 
+                if (binding.type == VK_DESCRIPTOR_TYPE_MUTABLE_VALVE)
+                {
+                    VkDescriptorType* mutable_type_start = &binding.mutable_type[current_dst_array_element];
+                    std::fill(mutable_type_start, mutable_type_start + current_writes, write->descriptorType);
+                }
+
                 switch (write->descriptorType)
                 {
                     case VK_DESCRIPTOR_TYPE_SAMPLER:
@@ -631,23 +637,29 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
                            &src_binding.images[current_src_array_element],
                            (sizeof(VkDescriptorImageInfo) * current_copies));
                 }
-                else if (src_binding.buffers != nullptr)
+                if (src_binding.buffers != nullptr)
                 {
                     memcpy(&dst_binding.buffers[current_dst_array_element],
                            &src_binding.buffers[current_src_array_element],
                            (sizeof(VkDescriptorBufferInfo) * current_copies));
                 }
-                else if (src_binding.acceleration_structures != nullptr)
+                if (src_binding.acceleration_structures != nullptr)
                 {
                     memcpy(&dst_binding.acceleration_structures[current_dst_array_element],
                            &src_binding.acceleration_structures[current_src_array_element],
                            (sizeof(VkWriteDescriptorSetAccelerationStructureKHR) * current_copies));
                 }
-                else
+                if (src_binding.texel_buffer_views != nullptr)
                 {
                     memcpy(&dst_binding.texel_buffer_views[current_dst_array_element],
                            &src_binding.texel_buffer_views[current_src_array_element],
                            (sizeof(VkBufferView) * current_copies));
+                }
+                if (src_binding.mutable_type != nullptr)
+                {
+                    memcpy(&dst_binding.mutable_type[current_dst_array_element],
+                           &src_binding.mutable_type[current_src_array_element],
+                           (sizeof(VkDescriptorType) * current_copies));
                 }
 
                 // Check for consecutive update.

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -705,6 +705,11 @@ inline void InitializeState<VkDevice, DescriptorSetLayoutWrapper, VkDescriptorSe
             binding_info.count         = binding->descriptorCount;
             binding_info.type          = binding->descriptorType;
 
+            binding_info.immutable_samplers =
+                ((binding->pImmutableSamplers != nullptr) &&
+                 ((binding->descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER) ||
+                  (binding->descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)));
+
             wrapper->binding_info.emplace_back(std::move(binding_info));
         }
     }
@@ -753,9 +758,10 @@ inline void InitializePoolObjectState(VkDevice                           parent_
     for (const auto& binding_info : layout_wrapper->binding_info)
     {
         DescriptorInfo descriptor_info;
-        descriptor_info.type    = binding_info.type;
-        descriptor_info.count   = binding_info.count;
-        descriptor_info.written = std::make_unique<bool[]>(binding_info.count);
+        descriptor_info.type               = binding_info.type;
+        descriptor_info.count              = binding_info.count;
+        descriptor_info.immutable_samplers = binding_info.immutable_samplers;
+        descriptor_info.written            = std::make_unique<bool[]>(binding_info.count);
 
         std::fill(descriptor_info.written.get(), descriptor_info.written.get() + binding_info.count, false);
 

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -779,6 +779,18 @@ inline void InitializePoolObjectState(VkDevice                           parent_
                 descriptor_info.acceleration_structures =
                     std::make_unique<VkAccelerationStructureKHR[]>(binding_info.count);
                 break;
+            case VK_DESCRIPTOR_TYPE_MUTABLE_VALVE:
+                descriptor_info.sampler_ids        = std::make_unique<format::HandleId[]>(binding_info.count);
+                descriptor_info.images             = std::make_unique<VkDescriptorImageInfo[]>(binding_info.count);
+                descriptor_info.buffers            = std::make_unique<VkDescriptorBufferInfo[]>(binding_info.count);
+                descriptor_info.texel_buffer_views = std::make_unique<VkBufferView[]>(binding_info.count);
+                descriptor_info.acceleration_structures =
+                    std::make_unique<VkAccelerationStructureKHR[]>(binding_info.count);
+                descriptor_info.mutable_type = std::make_unique<VkDescriptorType[]>(binding_info.count);
+                std::fill(descriptor_info.mutable_type.get(),
+                          descriptor_info.mutable_type.get() + binding_info.count,
+                          VK_DESCRIPTOR_TYPE_MUTABLE_VALVE);
+                break;
             default:
                 GFXRECON_LOG_WARNING("Attempting to initialize descriptor state for unrecognized descriptor type");
                 break;

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -23,6 +23,7 @@
 #ifndef GFXRECON_ENCODE_VULKAN_STATE_TRACKER_INITIALIZERS_H
 #define GFXRECON_ENCODE_VULKAN_STATE_TRACKER_INITIALIZERS_H
 
+#include "encode/vulkan_handle_wrapper_util.h"
 #include "encode/vulkan_handle_wrappers.h"
 #include "encode/vulkan_state_table.h"
 #include "format/format.h"
@@ -241,6 +242,17 @@ inline void InitializeState<VkDevice, SemaphoreWrapper, VkSemaphoreCreateInfo>(V
     wrapper->create_parameters = std::move(create_parameters);
 
     wrapper->device = reinterpret_cast<DeviceWrapper*>(parent_handle);
+
+    auto next = reinterpret_cast<const VkBaseInStructure*>(create_info->pNext);
+    while (next)
+    {
+        if (next->sType == VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO)
+        {
+            auto semaphore_type = reinterpret_cast<const VkSemaphoreTypeCreateInfo*>(next);
+            wrapper->type       = semaphore_type->semaphoreType;
+        }
+        next = next->pNext;
+    }
 }
 
 template <>

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -3591,9 +3591,8 @@ bool VulkanStateWriter::CheckDescriptorStatus(const DescriptorInfo*   descriptor
                 }
                 break;
             case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-                // TODO: Sampler handle does not need to be valid if descriptor set was allocated from a layout
-                // with immutable samplers.
-                if ((state_table.GetSamplerWrapper(descriptor->sampler_ids[index]) != nullptr) &&
+                if ((descriptor->immutable_samplers ||
+                     (state_table.GetSamplerWrapper(descriptor->sampler_ids[index]) != nullptr)) &&
                     IsImageViewValid(descriptor->handle_ids[index], state_table))
                 {
                     valid = true;

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -239,6 +239,11 @@ class VulkanStateWriter
 
     void WriteSetEvent(format::HandleId device_id, format::HandleId event_id);
 
+    void WriteSignalSemaphoreValue(format::ApiCallId api_call_id,
+                                   format::HandleId  device_id,
+                                   format::HandleId  semaphore,
+                                   uint64_t          value);
+
     void WriteDestroyDeviceObject(format::ApiCallId            call_id,
                                   format::HandleId             device_id,
                                   format::HandleId             object_id,

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -340,7 +340,10 @@ class VulkanStateWriter
     bool
     CheckCommandHandle(CommandHandleType handle_type, format::HandleId handle, const VulkanStateTable& state_table);
 
-    bool CheckDescriptorStatus(const DescriptorInfo* descriptor, uint32_t index, const VulkanStateTable& state_table);
+    bool CheckDescriptorStatus(const DescriptorInfo*   descriptor,
+                               uint32_t                index,
+                               const VulkanStateTable& state_table,
+                               VkDescriptorType*       descriptor_type);
 
     bool IsBufferValid(format::HandleId buffer_id, const VulkanStateTable& state_table);
 

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -4438,15 +4438,16 @@ void VulkanReplayConsumer::Process_vkGetRandROutputDisplayEXT(
     size_t                                      rrOutput,
     HandlePointerDecoder<VkDisplayKHR>*         pDisplay)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
+    auto in_physicalDevice = GetObjectInfoTable().GetPhysicalDeviceInfo(physicalDevice);
     Display* in_dpy = static_cast<Display*>(PreProcessExternalObject(dpy, format::ApiCallId::ApiCall_vkGetRandROutputDisplayEXT, "vkGetRandROutputDisplayEXT"));
     if (!pDisplay->IsNull()) { pDisplay->SetHandleLength(1); }
-    VkDisplayKHR* out_pDisplay = pDisplay->GetHandlePointer();
+    DisplayKHRInfo handle_info;
+    pDisplay->SetConsumerData(0, &handle_info);
 
-    VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetRandROutputDisplayEXT(in_physicalDevice, in_dpy, rrOutput, out_pDisplay);
+    VkResult replay_result = OverrideGetRandROutputDisplayEXT(GetInstanceTable(in_physicalDevice->handle)->GetRandROutputDisplayEXT, returnValue, in_physicalDevice, in_dpy, rrOutput, pDisplay);
     CheckResult("vkGetRandROutputDisplayEXT", returnValue, replay_result);
 
-    AddHandle<DisplayKHRInfo>(physicalDevice, pDisplay->GetPointer(), out_pDisplay, &VulkanObjectInfoTable::AddDisplayKHRInfo);
+    AddHandle<DisplayKHRInfo>(physicalDevice, pDisplay->GetPointer(), pDisplay->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::AddDisplayKHRInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -69,6 +69,7 @@
     "vkCreateWaylandSurfaceKHR": "OverrideCreateWaylandSurfaceKHR",
     "vkGetPhysicalDeviceWaylandPresentationSupportKHR": "OverrideGetPhysicalDeviceWaylandPresentationSupportKHR",
     "vkDestroySurfaceKHR": "OverrideDestroySurfaceKHR",
-    "vkCreateAccelerationStructureKHR": "OverrideCreateAccelerationStructureKHR"
+    "vkCreateAccelerationStructureKHR": "OverrideCreateAccelerationStructureKHR",
+    "vkGetRandROutputDisplayEXT": "OverrideGetRandROutputDisplayEXT"
   }
 }


### PR DESCRIPTION
Add trim support for VK_KHR_timeline_semaphore and VK_VALVE_mutable_descriptor_type as well as miscellaneous bug fixes for trim/replay on vkd3d(proton 5.13)+radv(mesa 21.1)