### PR TITLE
Capture and replay ray tracing shader group handles

### DIFF
--- a/android/framework/graphics/CMakeLists.txt
+++ b/android/framework/graphics/CMakeLists.txt
@@ -2,8 +2,9 @@ add_library(gfxrecon_graphics STATIC "")
 
 target_sources(gfxrecon_graphics
                PRIVATE
+                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_device_util.h
+                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_device_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.h
-                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.cpp
               )
 
 target_include_directories(gfxrecon_graphics

--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -107,6 +107,12 @@ class ApiDecoder
                                                  format::HandleId buffer_id,
                                                  uint64_t         address) = 0;
 
+    virtual void DispatchSetRayTracingShaderGroupHandlesCommand(format::ThreadId thread_id,
+                                                                format::HandleId device_id,
+                                                                format::HandleId buffer_id,
+                                                                size_t           data_size,
+                                                                const uint8_t*   data) = 0;
+
     virtual void
     DispatchSetSwapchainImageStateCommand(format::ThreadId                                    thread_id,
                                           format::HandleId                                    device_id,

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -92,6 +92,12 @@ class VulkanConsumerBase
     ProcessSetOpaqueAddressCommand(format::HandleId device_id, format::HandleId object_id, uint64_t address)
     {}
 
+    virtual void ProcessSetRayTracingShaderGroupHandlesCommand(format::HandleId device_id,
+                                                               format::HandleId pipeline_id,
+                                                               size_t           data_size,
+                                                               const uint8_t*   data)
+    {}
+
     virtual void ProcessSetSwapchainImageStateCommand(format::HandleId device_id,
                                                       format::HandleId swapchain_id,
                                                       uint32_t         last_presented_image,

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -174,6 +174,20 @@ void VulkanDecoderBase::DispatchSetOpaqueAddressCommand(format::ThreadId thread_
     }
 }
 
+void VulkanDecoderBase::DispatchSetRayTracingShaderGroupHandlesCommand(format::ThreadId thread_id,
+                                                                       format::HandleId device_id,
+                                                                       format::HandleId pipeline_id,
+                                                                       size_t           data_size,
+                                                                       const uint8_t*   data)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(thread_id);
+
+    for (auto consumer : consumers_)
+    {
+        consumer->ProcessSetRayTracingShaderGroupHandlesCommand(device_id, pipeline_id, data_size, data);
+    }
+}
+
 void VulkanDecoderBase::DispatchSetSwapchainImageStateCommand(
     format::ThreadId                                    thread_id,
     format::HandleId                                    device_id,

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -119,6 +119,12 @@ class VulkanDecoderBase : public ApiDecoder
                                                  format::HandleId object_id,
                                                  uint64_t         address) override;
 
+    virtual void DispatchSetRayTracingShaderGroupHandlesCommand(format::ThreadId thread_id,
+                                                                format::HandleId device_id,
+                                                                format::HandleId pipeline_id,
+                                                                size_t           data_size,
+                                                                const uint8_t*   data) override;
+
     virtual void
     DispatchSetSwapchainImageStateCommand(format::ThreadId                                    thread_id,
                                           format::HandleId                                    device_id,

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -245,6 +245,9 @@ struct DeviceInfo : public VulkanObjectInfo<VkDevice>
 
     std::unordered_map<format::HandleId, uint64_t> opaque_addresses;
 
+    // Map pipeline ID to ray tracing shader group handle capture replay data.
+    std::unordered_map<format::HandleId, const std::vector<uint8_t>> shader_group_handles;
+
     // The following values are only used when loading the initial state for trimmed files.
     std::vector<std::string>                   extensions;
     std::unique_ptr<VulkanResourceInitializer> resource_initializer;

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -28,6 +28,7 @@
 #include "decode/window.h"
 #include "format/format.h"
 #include "generated/generated_vulkan_dispatch_table.h"
+#include "graphics/vulkan_device_util.h"
 #include "util/defines.h"
 
 #include "vulkan/vulkan.h"
@@ -248,9 +249,8 @@ struct DeviceInfo : public VulkanObjectInfo<VkDevice>
     std::vector<std::string>                   extensions;
     std::unique_ptr<VulkanResourceInitializer> resource_initializer;
 
-    // Feature state at device creation
-    VkBool32 feature_bufferDeviceAddressCaptureReplay{ VK_FALSE };
-    VkBool32 feature_accelerationStructureCaptureReplay{ VK_FALSE };
+    // Physical device property & feature state at device creation
+    graphics::VulkanDevicePropertyFeatureInfo property_feature_info;
 };
 
 struct QueueInfo : public VulkanObjectInfo<VkQueue>

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -5525,6 +5525,43 @@ VkResult VulkanReplayConsumerBase::OverrideCreateAccelerationStructureKHR(
     return result;
 }
 
+VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesKHR(
+    PFN_vkCreateRayTracingPipelinesKHR                                     func,
+    VkResult                                                               original_result,
+    const DeviceInfo*                                                      device_info,
+    const DeferredOperationKHRInfo*                                        deferred_operation_info,
+    const PipelineCacheInfo*                                               pipeline_cache_info,
+    uint32_t                                                               createInfoCount,
+    const StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>* pCreateInfos,
+    const StructPointerDecoder<Decoded_VkAllocationCallbacks>*             pAllocator,
+    HandlePointerDecoder<VkPipeline>*                                      pPipelines)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(original_result);
+
+    assert((device_info != nullptr) && (pCreateInfos != nullptr) && (pAllocator != nullptr) &&
+           (pPipelines != nullptr) && !pPipelines->IsNull() && (pPipelines->GetHandlePointer() != nullptr));
+
+    VkResult                                 result          = VK_SUCCESS;
+    VkDevice                                 device          = device_info->handle;
+    auto                                     device_table    = GetDeviceTable(device);
+    const VkRayTracingPipelineCreateInfoKHR* in_pCreateInfos = pCreateInfos->GetPointer();
+    const VkAllocationCallbacks*             in_pAllocator   = GetAllocationCallbacks(pAllocator);
+    VkPipeline*                              out_pPipelines  = pPipelines->GetHandlePointer();
+    VkDeferredOperationKHR                   in_deferredOperation =
+        (deferred_operation_info != nullptr) ? deferred_operation_info->handle : VK_NULL_HANDLE;
+    VkPipelineCache in_pipelineCache = (pipeline_cache_info != nullptr) ? pipeline_cache_info->handle : VK_NULL_HANDLE;
+
+    result = device_table->CreateRayTracingPipelinesKHR(device,
+                                                        in_deferredOperation,
+                                                        in_pipelineCache,
+                                                        createInfoCount,
+                                                        in_pCreateInfos,
+                                                        in_pAllocator,
+                                                        out_pPipelines);
+
+    return result;
+}
+
 void VulkanReplayConsumerBase::MapDescriptorUpdateTemplateHandles(
     const DescriptorUpdateTemplateInfo* update_template_info, DescriptorUpdateTemplateDecoder* decoder)
 {

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -820,6 +820,25 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>*             pAllocator,
         HandlePointerDecoder<VkPipeline>*                                      pPipelines);
 
+    VkDeviceAddress
+    OverrideGetBufferDeviceAddress(PFN_vkGetBufferDeviceAddress                                   func,
+                                   const DeviceInfo*                                              device_info,
+                                   const StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo);
+
+    void OverrideGetAccelerationStructureDeviceAddressKHR(
+        PFN_vkGetAccelerationStructureDeviceAddressKHR                                   func,
+        const DeviceInfo*                                                                device_info,
+        const StructPointerDecoder<Decoded_VkAccelerationStructureDeviceAddressInfoKHR>* pInfo);
+
+    VkResult OverrideGetRayTracingShaderGroupHandlesKHR(PFN_vkGetRayTracingShaderGroupHandlesKHR func,
+                                                        VkResult                                 original_result,
+                                                        const DeviceInfo*                        device_info,
+                                                        const PipelineInfo*                      pipeline_info,
+                                                        uint32_t                                 firstGroup,
+                                                        uint32_t                                 groupCount,
+                                                        size_t                                   dataSize,
+                                                        PointerDecoder<uint8_t>*                 pData);
+
   private:
     void RaiseFatalError(const char* message) const;
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -804,6 +804,17 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>*                pAllocator,
         HandlePointerDecoder<VkAccelerationStructureKHR>*                         pAccelerationStructureKHR);
 
+    VkResult OverrideCreateRayTracingPipelinesKHR(
+        PFN_vkCreateRayTracingPipelinesKHR                                     func,
+        VkResult                                                               original_result,
+        const DeviceInfo*                                                      device_info,
+        const DeferredOperationKHRInfo*                                        deferred_operation_info,
+        const PipelineCacheInfo*                                               pipeline_cache_info,
+        uint32_t                                                               createInfoCount,
+        const StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>* pCreateInfos,
+        const StructPointerDecoder<Decoded_VkAllocationCallbacks>*             pAllocator,
+        HandlePointerDecoder<VkPipeline>*                                      pPipelines);
+
   private:
     void RaiseFatalError(const char* message) const;
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -117,6 +117,11 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     virtual void
     ProcessSetOpaqueAddressCommand(format::HandleId device_id, format::HandleId object_id, uint64_t address) override;
 
+    virtual void ProcessSetRayTracingShaderGroupHandlesCommand(format::HandleId device_id,
+                                                               format::HandleId pipeline_id,
+                                                               size_t           data_size,
+                                                               const uint8_t*   data) override;
+
     virtual void
     ProcessSetSwapchainImageStateCommand(format::HandleId                                    device_id,
                                          format::HandleId                                    swapchain_id,

--- a/framework/encode/custom_encoder_commands.h
+++ b/framework/encode/custom_encoder_commands.h
@@ -670,6 +670,46 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkResetQueryPoolEXT>
     }
 };
 
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetBufferDeviceAddress>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PreProcess_vkGetBufferDeviceAddress(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetBufferDeviceAddressKHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PreProcess_vkGetBufferDeviceAddress(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetAccelerationStructureDeviceAddressKHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PreProcess_vkGetAccelerationStructureDeviceAddressKHR(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetRayTracingShaderGroupHandlesKHR>
+{
+    template <typename... Args>
+    static void Dispatch(TraceManager* manager, Args... args)
+    {
+        manager->PreProcess_vkGetRayTracingShaderGroupHandlesKHR(args...);
+    }
+};
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -1631,7 +1631,16 @@ VkResult TraceManager::OverrideAllocateMemory(VkDevice                     devic
             VkDeviceMemoryOpaqueCaptureAddressInfo info{ VK_STRUCTURE_TYPE_DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO,
                                                          nullptr,
                                                          memory_wrapper->handle };
-            uint64_t address = GetDeviceTable(device)->GetDeviceMemoryOpaqueCaptureAddress(device_unwrapped, &info);
+
+            uint64_t address = 0;
+            if (device_wrapper->physical_device->instance_api_version >= VK_MAKE_VERSION(1, 2, 0))
+            {
+                address = GetDeviceTable(device)->GetDeviceMemoryOpaqueCaptureAddress(device_unwrapped, &info);
+            }
+            else
+            {
+                address = GetDeviceTable(device)->GetDeviceMemoryOpaqueCaptureAddressKHR(device_unwrapped, &info);
+            }
 
             WriteSetOpaqueAddressCommand(device_wrapper->handle_id, memory_wrapper->handle_id, address);
 

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -1330,7 +1330,7 @@ VkResult TraceManager::OverrideCreateDevice(VkPhysicalDevice             physica
 
         auto wrapper = reinterpret_cast<DeviceWrapper*>(*pDevice);
 
-        // Track whether device address features were enabled
+        // Track whether capture replay features were enabled
         if (modified_features.bufferDeviceAddressCaptureReplay_ptr != nullptr)
         {
             wrapper->feature_bufferDeviceAddressCaptureReplay =
@@ -1340,6 +1340,11 @@ VkResult TraceManager::OverrideCreateDevice(VkPhysicalDevice             physica
         {
             wrapper->feature_accelerationStructureCaptureReplay =
                 (*modified_features.accelerationStructureCaptureReplay_ptr);
+        }
+        if (modified_features.rayTracingPipelineShaderGroupHandleCaptureReplay_ptr != nullptr)
+        {
+            wrapper->feature_rayTracingPipelineShaderGroupHandleCaptureReplay =
+                (*modified_features.rayTracingPipelineShaderGroupHandleCaptureReplay_ptr);
         }
 
         if ((capture_mode_ & kModeTrack) != kModeTrack)

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -907,6 +907,15 @@ class TraceManager
                                                         const VkAllocationCallbacks*                pAllocator,
                                                         VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate);
 
+    void PreProcess_vkGetBufferDeviceAddress(VkDevice device, const VkBufferDeviceAddressInfo* pInfo);
+
+    void
+    PreProcess_vkGetAccelerationStructureDeviceAddressKHR(VkDevice                                           device,
+                                                          const VkAccelerationStructureDeviceAddressInfoKHR* pInfo);
+
+    void PreProcess_vkGetRayTracingShaderGroupHandlesKHR(
+        VkDevice device, VkPipeline pipeline, uint32_t firstGroup, uint32_t groupCount, size_t dataSize, void* pData);
+
 #if defined(__ANDROID__)
     void OverrideGetPhysicalDeviceSurfacePresentModesKHR(uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes);
 #endif

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -1005,6 +1005,11 @@ class TraceManager
                                                const VkPhysicalDeviceMemoryProperties& memory_properties);
     void WriteSetOpaqueAddressCommand(format::HandleId device_id, format::HandleId object_id, uint64_t address);
 
+    void WriteSetRayTracingShaderGroupHandlesCommand(format::HandleId device_id,
+                                                     format::HandleId pipeline_id,
+                                                     size_t           data_size,
+                                                     const void*      data);
+
     void SetDescriptorUpdateTemplateInfo(VkDescriptorUpdateTemplate                  update_template,
                                          const VkDescriptorUpdateTemplateCreateInfo* create_info);
 

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -328,6 +328,14 @@ class TraceManager
                                                         uint32_t*                          pToolCount,
                                                         VkPhysicalDeviceToolPropertiesEXT* pToolProperties);
 
+    VkResult OverrideCreateRayTracingPipelinesKHR(VkDevice                                 device,
+                                                  VkDeferredOperationKHR                   deferredOperation,
+                                                  VkPipelineCache                          pipelineCache,
+                                                  uint32_t                                 createInfoCount,
+                                                  const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,
+                                                  const VkAllocationCallbacks*             pAllocator,
+                                                  VkPipeline*                              pPipelines);
+
     void PostProcess_vkEnumeratePhysicalDevices(VkResult          result,
                                                 VkInstance        instance,
                                                 uint32_t*         pPhysicalDeviceCount,

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -27,6 +27,7 @@
 #include "encode/vulkan_state_info.h"
 #include "format/format.h"
 #include "generated/generated_vulkan_dispatch_table.h"
+#include "graphics/vulkan_device_util.h"
 #include "util/defines.h"
 #include "util/memory_output_stream.h"
 #include "util/page_guard_manager.h"
@@ -135,10 +136,8 @@ struct DeviceWrapper : public HandleWrapper<VkDevice>
     PhysicalDeviceWrapper*     physical_device{ nullptr };
     std::vector<QueueWrapper*> child_queues;
 
-    // Feature state at device creation
-    VkBool32 feature_bufferDeviceAddressCaptureReplay{ VK_FALSE };
-    VkBool32 feature_accelerationStructureCaptureReplay{ VK_FALSE };
-    VkBool32 feature_rayTracingPipelineShaderGroupHandleCaptureReplay{ VK_FALSE };
+    // Physical device property & feature state at device creation
+    graphics::VulkanDevicePropertyFeatureInfo property_feature_info;
 };
 
 struct FenceWrapper : public HandleWrapper<VkFence>

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -297,6 +297,10 @@ struct PipelineWrapper : public HandleWrapper<VkPipeline>
     CreateDependencyInfo                        layout_dependency;
     std::shared_ptr<PipelineLayoutDependencies> layout_dependencies; // Shared with PipelineLayoutWrapper
 
+    // Ray tracing pipeline's shader group handle data
+    format::HandleId     device_id{ format::kNullHandleId };
+    std::vector<uint8_t> shader_group_handle_data;
+
     // TODO: Base pipeline
     // TODO: Pipeline cache
 };

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -138,6 +138,7 @@ struct DeviceWrapper : public HandleWrapper<VkDevice>
     // Feature state at device creation
     VkBool32 feature_bufferDeviceAddressCaptureReplay{ VK_FALSE };
     VkBool32 feature_accelerationStructureCaptureReplay{ VK_FALSE };
+    VkBool32 feature_rayTracingPipelineShaderGroupHandleCaptureReplay{ VK_FALSE };
 };
 
 struct FenceWrapper : public HandleWrapper<VkFence>

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -1114,6 +1114,21 @@ void VulkanStateTracker::TrackDeviceMemoryDeviceAddress(VkDevice device, VkDevic
     wrapper->address   = address;
 }
 
+void VulkanStateTracker::TrackRayTracingShaderGroupHandles(VkDevice    device,
+                                                           VkPipeline  pipeline,
+                                                           size_t      data_size,
+                                                           const void* data)
+{
+    assert((device != VK_NULL_HANDLE) && (pipeline != VK_NULL_HANDLE));
+
+    std::unique_lock<std::mutex> lock(mutex_);
+
+    auto           wrapper   = reinterpret_cast<PipelineWrapper*>(pipeline);
+    const uint8_t* byte_data = reinterpret_cast<const uint8_t*>(data);
+    wrapper->device_id       = GetWrappedId(device);
+    wrapper->shader_group_handle_data.assign(byte_data, byte_data + data_size);
+}
+
 void VulkanStateTracker::DestroyState(InstanceWrapper* wrapper)
 {
     assert(wrapper != nullptr);

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -369,6 +369,8 @@ class VulkanStateTracker
 
     void TrackDeviceMemoryDeviceAddress(VkDevice device, VkDeviceMemory memory, VkDeviceAddress address);
 
+    void TrackRayTracingShaderGroupHandles(VkDevice device, VkPipeline pipeline, size_t data_size, const void* data);
+
   private:
     template <typename ParentHandle, typename SecondaryHandle, typename Wrapper, typename CreateInfo>
     void AddGroupHandles(ParentHandle                  parent_handle,

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -557,7 +557,7 @@ void VulkanStateWriter::WritePipelineState(const VulkanStateTable& state_table)
         }
         else if (wrapper->create_call_id == format::ApiCall_vkCreateRayTracingPipelinesKHR)
         {
-            if ((wrapper->device_id != format::kNullHandleId) && !wrapper->shader_group_handle_data.empty())
+            if (wrapper->device_id != format::kNullHandleId)
             {
                 WriteSetRayTracingShaderGroupHandlesCommand(wrapper->device_id,
                                                             wrapper->handle_id,
@@ -925,7 +925,7 @@ void VulkanStateWriter::WriteDeviceMemoryState(const VulkanStateTable& state_tab
     state_table.VisitWrappers([&](const DeviceMemoryWrapper* wrapper) {
         assert(wrapper != nullptr);
 
-        if ((wrapper->device_id != format::kNullHandleId) && (wrapper->address != 0))
+        if (wrapper->device_id != format::kNullHandleId)
         {
             WriteSetOpaqueAddressCommand(wrapper->device_id, wrapper->handle_id, wrapper->address);
         }

--- a/framework/encode/vulkan_state_writer.h
+++ b/framework/encode/vulkan_state_writer.h
@@ -276,6 +276,11 @@ class VulkanStateWriter
 
     void WriteSetOpaqueAddressCommand(format::HandleId device_id, format::HandleId object_id, VkDeviceAddress address);
 
+    void WriteSetRayTracingShaderGroupHandlesCommand(format::HandleId device_id,
+                                                     format::HandleId pipeline_id,
+                                                     size_t           data_size,
+                                                     const void*      data);
+
     template <typename Wrapper>
     void StandardCreateWrite(const VulkanStateTable& state_table)
     {

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -84,21 +84,22 @@ enum MarkerType : uint32_t
 
 enum MetaDataType : uint32_t
 {
-    kUnknownMetaDataType                = 0,
-    kDisplayMessageCommand              = 1,
-    kFillMemoryCommand                  = 2,
-    kResizeWindowCommand                = 3,
-    kSetSwapchainImageStateCommand      = 4,
-    kBeginResourceInitCommand           = 5,
-    kEndResourceInitCommand             = 6,
-    kInitBufferCommand                  = 7,
-    kInitImageCommand                   = 8,
-    kCreateHardwareBufferCommand        = 9,
-    kDestroyHardwareBufferCommand       = 10,
-    kSetDevicePropertiesCommand         = 11,
-    kSetDeviceMemoryPropertiesCommand   = 12,
-    kResizeWindowCommand2               = 13,
-    kSetOpaqueAddressCommand            = 14
+    kUnknownMetaDataType                    = 0,
+    kDisplayMessageCommand                  = 1,
+    kFillMemoryCommand                      = 2,
+    kResizeWindowCommand                    = 3,
+    kSetSwapchainImageStateCommand          = 4,
+    kBeginResourceInitCommand               = 5,
+    kEndResourceInitCommand                 = 6,
+    kInitBufferCommand                      = 7,
+    kInitImageCommand                       = 8,
+    kCreateHardwareBufferCommand            = 9,
+    kDestroyHardwareBufferCommand           = 10,
+    kSetDevicePropertiesCommand             = 11,
+    kSetDeviceMemoryPropertiesCommand       = 12,
+    kResizeWindowCommand2                   = 13,
+    kSetOpaqueAddressCommand                = 14,
+    kSetRayTracingShaderGroupHandlesCommand = 15
 };
 
 enum CompressionType : uint32_t
@@ -385,6 +386,15 @@ struct SetOpaqueAddressCommand
     format::HandleId device_id;
     format::HandleId object_id;
     uint64_t         address;
+};
+
+struct SetRayTracingShaderGroupHandlesCommandHeader
+{
+    MetaDataHeader   meta_header;
+    format::ThreadId thread_id;
+    format::HandleId device_id;
+    format::HandleId pipeline_id;
+    size_t           data_size;
 };
 
 #pragma pack(pop)

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -12854,19 +12854,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesKHR>::Dispatch(TraceManager::Get(), device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
 
-    auto handle_unwrap_memory = TraceManager::Get()->GetHandleUnwrapMemory();
-    VkDevice device_unwrapped = GetWrappedHandle<VkDevice>(device);
-    VkDeferredOperationKHR deferredOperation_unwrapped = GetWrappedHandle<VkDeferredOperationKHR>(deferredOperation);
-    VkPipelineCache pipelineCache_unwrapped = GetWrappedHandle<VkPipelineCache>(pipelineCache);
-    const VkRayTracingPipelineCreateInfoKHR* pCreateInfos_unwrapped = UnwrapStructArrayHandles(pCreateInfos, createInfoCount, handle_unwrap_memory);
-
-    VkResult result = GetDeviceTable(device)->CreateRayTracingPipelinesKHR(device_unwrapped, deferredOperation_unwrapped, pipelineCache_unwrapped, createInfoCount, pCreateInfos_unwrapped, pAllocator, pPipelines);
-
-    if (result >= 0)
-    {
-        CreateWrappedHandles<DeviceWrapper, DeferredOperationKHRWrapper, PipelineWrapper>(device, deferredOperation, pPipelines, createInfoCount, TraceManager::GetUniqueId);
-    }
-    else
+    VkResult result = TraceManager::Get()->OverrideCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
+    if (result < 0)
     {
         omit_output_data = true;
     }

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -2418,11 +2418,11 @@ void VulkanReplayConsumer::Process_vkGetBufferDeviceAddress(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    const VkBufferDeviceAddressInfo* in_pInfo = pInfo->GetPointer();
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
+
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
-    GetDeviceTable(in_device)->GetBufferDeviceAddress(in_device, in_pInfo);
+    OverrideGetBufferDeviceAddress(GetDeviceTable(in_device->handle)->GetBufferDeviceAddress, in_device, pInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferOpaqueCaptureAddress(
@@ -3817,11 +3817,11 @@ void VulkanReplayConsumer::Process_vkGetBufferDeviceAddressKHR(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    const VkBufferDeviceAddressInfo* in_pInfo = pInfo->GetPointer();
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
+
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
-    GetDeviceTable(in_device)->GetBufferDeviceAddressKHR(in_device, in_pInfo);
+    OverrideGetBufferDeviceAddress(GetDeviceTable(in_device->handle)->GetBufferDeviceAddressKHR, in_device, pInfo);
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferOpaqueCaptureAddressKHR(
@@ -5180,11 +5180,11 @@ void VulkanReplayConsumer::Process_vkGetRayTracingShaderGroupHandlesKHR(
     size_t                                      dataSize,
     PointerDecoder<uint8_t>*                    pData)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkPipeline in_pipeline = MapHandle<PipelineInfo>(pipeline, &VulkanObjectInfoTable::GetPipelineInfo);
-    void* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(dataSize);
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
+    auto in_pipeline = GetObjectInfoTable().GetPipelineInfo(pipeline);
+    if (!pData->IsNull()) { pData->AllocateOutputData(dataSize); }
 
-    VkResult replay_result = GetDeviceTable(in_device)->GetRayTracingShaderGroupHandlesKHR(in_device, in_pipeline, firstGroup, groupCount, dataSize, out_pData);
+    VkResult replay_result = OverrideGetRayTracingShaderGroupHandlesKHR(GetDeviceTable(in_device->handle)->GetRayTracingShaderGroupHandlesKHR, returnValue, in_device, in_pipeline, firstGroup, groupCount, dataSize, pData);
     CheckResult("vkGetRayTracingShaderGroupHandlesKHR", returnValue, replay_result);
 }
 
@@ -6194,11 +6194,11 @@ void VulkanReplayConsumer::Process_vkGetAccelerationStructureDeviceAddressKHR(
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAccelerationStructureDeviceAddressInfoKHR>* pInfo)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    const VkAccelerationStructureDeviceAddressInfoKHR* in_pInfo = pInfo->GetPointer();
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
+
     MapStructHandles(pInfo->GetMetaStructPointer(), GetObjectInfoTable());
 
-    GetDeviceTable(in_device)->GetAccelerationStructureDeviceAddressKHR(in_device, in_pInfo);
+    OverrideGetAccelerationStructureDeviceAddressKHR(GetDeviceTable(in_device->handle)->GetAccelerationStructureDeviceAddressKHR, in_device, pInfo);
 }
 
 void VulkanReplayConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesKHR(

--- a/framework/generated/vulkan_generators/capture_overrides.json
+++ b/framework/generated/vulkan_generators/capture_overrides.json
@@ -5,6 +5,7 @@
     "vkCreateBuffer": "TraceManager::Get()->OverrideCreateBuffer",
     "vkAllocateMemory": "TraceManager::Get()->OverrideAllocateMemory",
     "vkGetPhysicalDeviceToolPropertiesEXT": "TraceManager::Get()->OverrideGetPhysicalDeviceToolPropertiesEXT",
-    "vkCreateAccelerationStructureKHR": "TraceManager::Get()->OverrideCreateAccelerationStructureKHR"
+    "vkCreateAccelerationStructureKHR": "TraceManager::Get()->OverrideCreateAccelerationStructureKHR",
+    "vkCreateRayTracingPipelinesKHR": "TraceManager::Get()->OverrideCreateRayTracingPipelinesKHR"
   }
 }

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -71,6 +71,10 @@
     "vkDestroySurfaceKHR": "OverrideDestroySurfaceKHR",
     "vkCreateAccelerationStructureKHR": "OverrideCreateAccelerationStructureKHR",
     "vkGetRandROutputDisplayEXT": "OverrideGetRandROutputDisplayEXT",
-    "vkCreateRayTracingPipelinesKHR": "OverrideCreateRayTracingPipelinesKHR"
+    "vkCreateRayTracingPipelinesKHR": "OverrideCreateRayTracingPipelinesKHR",
+    "vkGetBufferDeviceAddress": "OverrideGetBufferDeviceAddress",
+    "vkGetBufferDeviceAddressKHR": "OverrideGetBufferDeviceAddress",
+    "vkGetAccelerationStructureDeviceAddressKHR": "OverrideGetAccelerationStructureDeviceAddressKHR",
+    "vkGetRayTracingShaderGroupHandlesKHR": "OverrideGetRayTracingShaderGroupHandlesKHR"
   }
 }

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -70,6 +70,7 @@
     "vkGetPhysicalDeviceWaylandPresentationSupportKHR": "OverrideGetPhysicalDeviceWaylandPresentationSupportKHR",
     "vkDestroySurfaceKHR": "OverrideDestroySurfaceKHR",
     "vkCreateAccelerationStructureKHR": "OverrideCreateAccelerationStructureKHR",
-    "vkGetRandROutputDisplayEXT": "OverrideGetRandROutputDisplayEXT"
+    "vkGetRandROutputDisplayEXT": "OverrideGetRandROutputDisplayEXT",
+    "vkCreateRayTracingPipelinesKHR": "OverrideCreateRayTracingPipelinesKHR"
   }
 }

--- a/framework/graphics/CMakeLists.txt
+++ b/framework/graphics/CMakeLists.txt
@@ -29,8 +29,9 @@ add_library(gfxrecon_graphics STATIC "")
 
 target_sources(gfxrecon_graphics
                PRIVATE
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_device_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_device_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.h
-                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.cpp
               )
 
 target_include_directories(gfxrecon_graphics

--- a/framework/graphics/vulkan_device_util.h
+++ b/framework/graphics/vulkan_device_util.h
@@ -1,0 +1,82 @@
+/*
+** Copyright (c) 2021 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_GRAPHICS_VULKAN_DEVICE_UTIL_H
+#define GFXRECON_GRAPHICS_VULKAN_DEVICE_UTIL_H
+
+#include "generated/generated_vulkan_dispatch_table.h"
+#include "util/defines.h"
+
+#include "vulkan/vulkan.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(graphics)
+
+struct VulkanDevicePropertyFeatureInfo
+{
+    uint32_t property_shaderGroupHandleCaptureReplaySize{ 0 };
+
+    VkBool32 feature_bufferDeviceAddressCaptureReplay{ VK_FALSE };
+    VkBool32 feature_accelerationStructureCaptureReplay{ VK_FALSE };
+    VkBool32 feature_rayTracingPipelineShaderGroupHandleCaptureReplay{ VK_FALSE };
+};
+
+class VulkanDeviceUtil
+{
+  public:
+    // Try to enable the device features required for application capture and replay
+    // Incoming create_info data will be modified. Use RestoreModifiedPhysicalDeviceFeatures
+    // to revert incoming data to original values (e.g., prior to writing to the capture file).
+    // feature_* property_* members store the state of the features/properties after this call.
+    VulkanDevicePropertyFeatureInfo EnableRequiredPhysicalDeviceFeatures(uint32_t instance_api_version,
+                                                                         const encode::InstanceTable* instance_table,
+                                                                         const VkPhysicalDevice       physical_device,
+                                                                         const VkDeviceCreateInfo*    create_info);
+
+    // Restore any incoming values that were modified in EnableRequiredPhysicalDeviceFeatures
+    void RestoreModifiedPhysicalDeviceFeatures();
+
+  private:
+    template <typename T>
+    VkBool32 EnableRequiredBufferDeviceAddressFeatures(uint32_t                     instance_api_version,
+                                                       const encode::InstanceTable* instance_table,
+                                                       const VkPhysicalDevice       physical_device,
+                                                       T*                           feature_struct);
+
+  private:
+    // VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddressCaptureReplay
+    VkBool32* bufferDeviceAddressCaptureReplay_ptr{ nullptr };
+    VkBool32  bufferDeviceAddressCaptureReplay_original{ VK_FALSE };
+
+    // VkPhysicalDeviceAccelerationStructureFeaturesKHR::accelerationStructureCaptureReplay
+    VkBool32* accelerationStructureCaptureReplay_ptr{ nullptr };
+    VkBool32  accelerationStructureCaptureReplay_original{ VK_FALSE };
+
+    // VkPhysicalDeviceRayTracingPipelineFeaturesKHR::rayTracingPipelineShaderGroupHandleCaptureReplay
+    VkBool32* rayTracingPipelineShaderGroupHandleCaptureReplay_ptr{ nullptr };
+    VkBool32  rayTracingPipelineShaderGroupHandleCaptureReplay_original{ VK_FALSE };
+};
+
+GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_GRAPHICS_VULKAN_DEVICE_UTIL_H

--- a/framework/graphics/vulkan_util.cpp
+++ b/framework/graphics/vulkan_util.cpp
@@ -131,7 +131,8 @@ void EnableRequiredPhysicalDeviceFeatures(uint32_t                        instan
                 modified_features.accelerationStructureCaptureReplay_original =
                     accel_struct_features->accelerationStructureCaptureReplay;
 
-                if (!accel_struct_features->accelerationStructureCaptureReplay)
+                if (accel_struct_features->accelerationStructure &&
+                    !accel_struct_features->accelerationStructureCaptureReplay)
                 {
                     // Get acceleration struct properties
                     VkPhysicalDeviceAccelerationStructureFeaturesKHR supported_features{
@@ -144,6 +145,33 @@ void EnableRequiredPhysicalDeviceFeatures(uint32_t                        instan
                     if (supported_features.accelerationStructureCaptureReplay)
                     {
                         accel_struct_features->accelerationStructureCaptureReplay = VK_TRUE;
+                    }
+                }
+            }
+            break;
+            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR:
+            {
+                // Enable rayTracingPipelineShaderGroupHandleCaptureReplay
+                auto rt_pipeline_features =
+                    reinterpret_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(current_struct);
+
+                modified_features.rayTracingPipelineShaderGroupHandleCaptureReplay_ptr =
+                    (&rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay);
+                modified_features.rayTracingPipelineShaderGroupHandleCaptureReplay_original =
+                    rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay;
+
+                if (rt_pipeline_features->rayTracingPipeline &&
+                    !rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay)
+                {
+                    VkPhysicalDeviceRayTracingPipelineFeaturesKHR supported_features{
+                        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR
+                    };
+                    GetSupportedPhysicalDeviceFeatures<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(
+                        instance_api_version, instance_table, physical_device, &supported_features);
+
+                    if (supported_features.rayTracingPipelineShaderGroupHandleCaptureReplay)
+                    {
+                        rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay = VK_TRUE;
                     }
                 }
             }
@@ -166,6 +194,11 @@ void RestoreModifiedPhysicalDeviceFeatures(const ModifiedPhysicalDeviceFeatures&
     {
         (*modified_features.accelerationStructureCaptureReplay_ptr) =
             modified_features.accelerationStructureCaptureReplay_original;
+    }
+    if (modified_features.rayTracingPipelineShaderGroupHandleCaptureReplay_ptr != nullptr)
+    {
+        (*modified_features.rayTracingPipelineShaderGroupHandleCaptureReplay_ptr) =
+            modified_features.rayTracingPipelineShaderGroupHandleCaptureReplay_original;
     }
 }
 

--- a/framework/graphics/vulkan_util.h
+++ b/framework/graphics/vulkan_util.h
@@ -57,6 +57,10 @@ struct ModifiedPhysicalDeviceFeatures
     // VkPhysicalDeviceAccelerationStructureFeaturesKHR::accelerationStructureCaptureReplay
     VkBool32* accelerationStructureCaptureReplay_ptr{ nullptr };
     VkBool32  accelerationStructureCaptureReplay_original{ VK_FALSE };
+
+    // VkPhysicalDeviceRayTracingPipelineFeaturesKHR::rayTracingPipelineShaderGroupHandleCaptureReplay
+    VkBool32* rayTracingPipelineShaderGroupHandleCaptureReplay_ptr{ nullptr };
+    VkBool32  rayTracingPipelineShaderGroupHandleCaptureReplay_original{ VK_FALSE };
 };
 
 // Try to enable the device features required for application capture and replay

--- a/framework/graphics/vulkan_util.h
+++ b/framework/graphics/vulkan_util.h
@@ -61,6 +61,11 @@ struct ModifiedPhysicalDeviceFeatures
     // VkPhysicalDeviceRayTracingPipelineFeaturesKHR::rayTracingPipelineShaderGroupHandleCaptureReplay
     VkBool32* rayTracingPipelineShaderGroupHandleCaptureReplay_ptr{ nullptr };
     VkBool32  rayTracingPipelineShaderGroupHandleCaptureReplay_original{ VK_FALSE };
+
+    // Store associated physical device capture replay properties
+
+    // VkPhysicalDeviceRayTracingPipelinePropertiesKHR::shaderGroupHandleCaptureReplaySize
+    uint32_t shaderGroupHandleCaptureReplaySize{ 0 };
 };
 
 // Try to enable the device features required for application capture and replay

--- a/framework/graphics/vulkan_util.h
+++ b/framework/graphics/vulkan_util.h
@@ -48,36 +48,6 @@ static T* GetPNextStruct(const Parent_T* parent, VkStructureType struct_type)
     return nullptr;
 }
 
-struct ModifiedPhysicalDeviceFeatures
-{
-    // VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddressCaptureReplay
-    VkBool32* bufferDeviceAddressCaptureReplay_ptr{ nullptr };
-    VkBool32  bufferDeviceAddressCaptureReplay_original{ VK_FALSE };
-
-    // VkPhysicalDeviceAccelerationStructureFeaturesKHR::accelerationStructureCaptureReplay
-    VkBool32* accelerationStructureCaptureReplay_ptr{ nullptr };
-    VkBool32  accelerationStructureCaptureReplay_original{ VK_FALSE };
-
-    // VkPhysicalDeviceRayTracingPipelineFeaturesKHR::rayTracingPipelineShaderGroupHandleCaptureReplay
-    VkBool32* rayTracingPipelineShaderGroupHandleCaptureReplay_ptr{ nullptr };
-    VkBool32  rayTracingPipelineShaderGroupHandleCaptureReplay_original{ VK_FALSE };
-
-    // Store associated physical device capture replay properties
-
-    // VkPhysicalDeviceRayTracingPipelinePropertiesKHR::shaderGroupHandleCaptureReplaySize
-    uint32_t shaderGroupHandleCaptureReplaySize{ 0 };
-};
-
-// Try to enable the device features required for application capture and replay
-void EnableRequiredPhysicalDeviceFeatures(uint32_t                        instance_api_version,
-                                          const encode::InstanceTable*    instance_table,
-                                          const VkPhysicalDevice          physical_device,
-                                          const VkDeviceCreateInfo*       create_info,
-                                          ModifiedPhysicalDeviceFeatures& modified_features);
-
-// Restore feature values that may have been modified by EnableRequiredPhysicalDeviceFeatures().
-void RestoreModifiedPhysicalDeviceFeatures(const ModifiedPhysicalDeviceFeatures& modified_features);
-
 GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)
 


### PR DESCRIPTION
If the rayTracingPipelineShaderGroupHandleCaptureReplay feature is supported, attempt to capture and replay ray tracing pipeline's shader group handles. Capture the handles using vkGetRayTracingCaptureReplayShaderGroupHandlesKHR after pipeline creation. Then use the captured handles as pShaderGroupCaptureReplayHandle in VkRayTracingShaderGroupCreateInfoKHRs during replay pipeline creation. Also improve logging for unsupported capture and replay features to reduce false positives and refactor device feature/property setup code.

- Add overrides for vkCreateRayTracingPipelinesKHR
- Enable RT shader grp handle capture replay feature
- Get capture replay rt shader handle size property
- Refactor phys device feature and property util
- Capture ray tracing shader group handle data
- Replay ray tracing pipeline shader grp handle data 
- Improve dev addr/handle capture feature log msg
- Improve dev addr/handle replay feature log msg
- Use vkGetDeviceMemoryOpaqueCaptureAddressKHR