### PR TITLE
Log warning if -m rebind is used with dev addr

### DIFF
--- a/framework/decode/vulkan_default_allocator.h
+++ b/framework/decode/vulkan_default_allocator.h
@@ -249,6 +249,8 @@ class VulkanDefaultAllocator : public VulkanResourceAllocator
         return InvalidateMappedMemoryRanges(memory_range_count, memory_ranges, allocator_datas);
     }
 
+    virtual bool SupportsOpaqueDeviceAddresses() override { return true; }
+
   protected:
     struct ResourceAllocInfo
     {

--- a/framework/decode/vulkan_rebind_allocator.h
+++ b/framework/decode/vulkan_rebind_allocator.h
@@ -253,6 +253,8 @@ class VulkanRebindAllocator : public VulkanResourceAllocator
         return InvalidateMappedMemoryRanges(memory_range_count, memory_ranges, allocator_datas);
     }
 
+    virtual bool SupportsOpaqueDeviceAddresses() override { return false; }
+
   private:
     struct MemoryAllocInfo;
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -5637,6 +5637,13 @@ VkDeviceAddress VulkanReplayConsumerBase::OverrideGetBufferDeviceAddress(
                                 "replay device does not support this feature, so replay may fail.");
     }
 
+    if (!device_info->allocator->SupportsOpaqueDeviceAddresses())
+    {
+        GFXRECON_LOG_WARNING_ONCE(
+            "The captured application used vkGetBufferDeviceAddress. The specified replay option '-m rebind' may not "
+            "support the replay of captured device addresses, so replay may fail.");
+    }
+
     VkDevice                         device       = device_info->handle;
     const VkBufferDeviceAddressInfo* address_info = pInfo->GetPointer();
 
@@ -5655,6 +5662,13 @@ void VulkanReplayConsumerBase::OverrideGetAccelerationStructureDeviceAddressKHR(
         GFXRECON_LOG_WARNING_ONCE("The captured application used vkGetAccelerationStructureDeviceAddressKHR, which may "
                                   "require the accelerationStructureCaptureReplay feature for accurate capture and "
                                   "replay. The replay device does not support this feature, so replay may fail.");
+    }
+
+    if (!device_info->allocator->SupportsOpaqueDeviceAddresses())
+    {
+        GFXRECON_LOG_WARNING_ONCE(
+            "The captured application used vkGetAccelerationStructureDeviceAddressKHR. The specified replay option '-m "
+            "rebind' may not support the replay of captured device addresses, so replay may fail.");
     }
 
     VkDevice                                           device       = device_info->handle;

--- a/framework/decode/vulkan_resource_allocator.h
+++ b/framework/decode/vulkan_resource_allocator.h
@@ -252,6 +252,8 @@ class VulkanResourceAllocator
     virtual VkResult InvalidateMappedMemoryRangesDirect(uint32_t                   memory_range_count,
                                                         const VkMappedMemoryRange* memory_ranges,
                                                         const MemoryData*          allocator_datas) = 0;
+
+    virtual bool SupportsOpaqueDeviceAddresses() = 0;
 };
 
 GFXRECON_END_NAMESPACE(decode)


### PR DESCRIPTION
The rebind allocator may interfere with the replay of device addresses.
Log a warning when trying to replay with the rebind option enabled for
an application that used device addresses.
