### PR TITLE
Suppress stdout if output to console option is off

### DIFF
--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -217,6 +217,18 @@ void CaptureSettings::LoadSettings(CaptureSettings* settings)
     }
 }
 
+void CaptureSettings::LoadLogSettings(CaptureSettings* settings)
+{
+    if (settings != nullptr)
+    {
+        OptionsMap capture_settings;
+
+        LoadOptionsFile(&capture_settings);
+        LoadOptionsEnvVar(&capture_settings);
+        ProcessLogOptions(&capture_settings, settings);
+    }
+}
+
 void CaptureSettings::LoadSingleOptionEnvVar(OptionsMap*        options,
                                              const std::string& environment_variable,
                                              const std::string& option_key)
@@ -345,6 +357,11 @@ void CaptureSettings::ProcessOptions(OptionsMap* options, CaptureSettings* setti
     settings->trace_settings_.page_guard_external_memory = ParseBoolString(
         FindOption(options, kOptionKeyPageGuardExternalMemory), settings->trace_settings_.page_guard_external_memory);
 
+    ProcessLogOptions(options, settings);
+}
+
+void CaptureSettings::ProcessLogOptions(OptionsMap* options, CaptureSettings* settings)
+{
     // Log options
     settings->log_settings_.use_indent =
         ParseBoolString(FindOption(options, kOptionKeyLogAllowIndents), settings->log_settings_.use_indent);

--- a/framework/encode/capture_settings.h
+++ b/framework/encode/capture_settings.h
@@ -92,7 +92,11 @@ class CaptureSettings
 
     const util::Log::Settings& GetLogSettings() const { return log_settings_; }
 
+    // Load all settings.
     static void LoadSettings(CaptureSettings* settings);
+
+    // Load only log settings.
+    static void LoadLogSettings(CaptureSettings* settings);
 
   private:
     typedef std::unordered_map<std::string, std::string> OptionsMap;
@@ -106,6 +110,8 @@ class CaptureSettings
     static void LoadOptionsFile(OptionsMap* options);
 
     static void ProcessOptions(OptionsMap* options, CaptureSettings* settings);
+
+    static void ProcessLogOptions(OptionsMap* options, CaptureSettings* settings);
 
     static std::string FindOption(OptionsMap* options, const std::string& key, const std::string& default_value = "");
 

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -53,9 +53,6 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-// Default log level to use prior to loading settings.
-const util::Log::Severity kDefaultLogLevel = util::Log::Severity::kInfoSeverity;
-
 // One based frame count.
 const uint32_t kFirstFrame = 1;
 
@@ -129,16 +126,22 @@ bool TraceManager::CreateInstance()
     {
         assert(instance_ == nullptr);
 
-        // Default initialize logging to report issues while loading settings.
-        util::Log::Init(kDefaultLogLevel);
+        // Initialize logging to report only errors (to stderr).
+        util::Log::Settings stderr_only_log_settings;
+        stderr_only_log_settings.min_severity            = util::Log::kErrorSeverity;
+        stderr_only_log_settings.output_errors_to_stderr = true;
+        util::Log::Init(stderr_only_log_settings);
 
+        // Load log settings.
         CaptureSettings settings = {};
-        CaptureSettings::LoadSettings(&settings);
+        CaptureSettings::LoadLogSettings(&settings);
 
         // Reinitialize logging with values retrieved from settings.
-        const util::Log::Settings& log_settings = settings.GetLogSettings();
         util::Log::Release();
-        util::Log::Init(log_settings);
+        util::Log::Init(settings.GetLogSettings());
+
+        // Load all settings with final logging settings active.
+        CaptureSettings::LoadSettings(&settings);
 
         GFXRECON_LOG_INFO("Initializing GFXReconstruct capture layer");
         GFXRECON_LOG_INFO("  GFXReconstruct Version %s", GFXRECON_PROJECT_VERSION_STRING);


### PR DESCRIPTION
Prevent settings loading from writing to stdout prior to log
initialization when GFXRECON_LOG_OUTPUT_TO_CONSOLE is false.
