### PR TITLE
Include state load time in post-replay timing info

### DIFF
--- a/android/framework/graphics/CMakeLists.txt
+++ b/android/framework/graphics/CMakeLists.txt
@@ -2,6 +2,8 @@ add_library(gfxrecon_graphics STATIC "")
 
 target_sources(gfxrecon_graphics
                PRIVATE
+                    ${GFXRECON_SOURCE_DIR}/framework/graphics/fps_info.h
+                    ${GFXRECON_SOURCE_DIR}/framework/graphics/fps_info.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_device_util.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_device_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.h

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -145,7 +145,7 @@ static uint32_t GetHardwareBufferFormatBpp(uint32_t format)
 VulkanReplayConsumerBase::VulkanReplayConsumerBase(WindowFactory* window_factory, const ReplayOptions& options) :
     loader_handle_(nullptr), get_instance_proc_addr_(nullptr), create_instance_proc_(nullptr),
     window_factory_(window_factory), options_(options), loading_trim_state_(false), have_imported_semaphores_(false),
-    create_surface_count_(0)
+    create_surface_count_(0), fps_info_(nullptr)
 {
     assert(window_factory != nullptr);
     assert(options.create_resource_allocator != nullptr);
@@ -211,6 +211,10 @@ void VulkanReplayConsumerBase::ProcessStateEndMarker(uint64_t frame_number)
 {
     GFXRECON_LOG_INFO("Finished loading state for captured frame %" PRId64, frame_number);
     loading_trim_state_ = false;
+    if (fps_info_ != nullptr)
+    {
+        fps_info_->ProcessStateEndMarker(frame_number);
+    }
 }
 
 void VulkanReplayConsumerBase::ProcessDisplayMessageCommand(const std::string& message)

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -40,6 +40,7 @@
 #include "format/platform_types.h"
 #include "generated/generated_vulkan_dispatch_table.h"
 #include "generated/generated_vulkan_consumer.h"
+#include "graphics/fps_info.h"
 #include "util/defines.h"
 #include "util/logging.h"
 
@@ -70,6 +71,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     virtual ~VulkanReplayConsumerBase() override;
 
     void SetFatalErrorHandler(std::function<void(const char*)> handler) { fatal_error_handler_ = handler; }
+
+    void SetFpsInfo(graphics::FpsInfo* fps_info) { fps_info_ = fps_info; }
 
     virtual void ProcessStateBeginMarker(uint64_t frame_number) override;
 
@@ -988,6 +991,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::unique_ptr<ScreenshotHandler>                               screenshot_handler_;
     std::string                                                      screenshot_file_prefix_;
     int32_t                                                          create_surface_count_;
+    graphics::FpsInfo*                                               fps_info_;
 
     // Used to track if any shadow sync objects are active to avoid checking if not needed
     std::unordered_set<VkSemaphore> shadow_semaphores_;

--- a/framework/graphics/CMakeLists.txt
+++ b/framework/graphics/CMakeLists.txt
@@ -29,6 +29,8 @@ add_library(gfxrecon_graphics STATIC "")
 
 target_sources(gfxrecon_graphics
                PRIVATE
+                    ${CMAKE_CURRENT_LIST_DIR}/fps_info.h
+                    ${CMAKE_CURRENT_LIST_DIR}/fps_info.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_device_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_device_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.h

--- a/framework/graphics/fps_info.cpp
+++ b/framework/graphics/fps_info.cpp
@@ -1,0 +1,87 @@
+
+/*
+** Copyright (c) 2021 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "graphics/fps_info.h"
+
+#include "util/date_time.h"
+#include "util/logging.h"
+
+#include <inttypes.h>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(graphics)
+
+static double GetElapsedSeconds(uint64_t start_time, uint64_t end_time)
+{
+    return util::datetime::ConvertTimestampToSeconds(util::datetime::DiffTimestamps(start_time, end_time));
+}
+
+static void
+WriteFpsToConsole(const char* prefix, uint64_t start_frame, uint64_t end_frame, int64_t start_time, int64_t end_time)
+{
+    assert(end_frame >= start_frame && end_time >= start_time);
+
+    double   diff_time_sec = GetElapsedSeconds(start_time, end_time);
+    uint64_t total_frames  = (end_frame - start_frame) + 1;
+    double   fps           = (diff_time_sec > 0.0) ? (static_cast<double>(total_frames) / diff_time_sec) : 0.0;
+    GFXRECON_WRITE_CONSOLE("%s %f fps, %f seconds, %" PRIu64 " frame%s, framerange %" PRIu64 "-%" PRIu64,
+                           prefix,
+                           fps,
+                           diff_time_sec,
+                           total_frames,
+                           total_frames > 1 ? "s" : "",
+                           start_frame,
+                           end_frame);
+}
+
+void FpsInfo::Begin(uint64_t start_frame)
+{
+    // Save the start frame/time information for the FPS result.
+    replay_start_frame_ = start_frame;
+    start_time_         = util::datetime::GetTimestamp();
+    replay_start_time_  = start_time_;
+}
+
+void FpsInfo::EndAndLog(uint64_t end_frame)
+{
+    // Get the end frame/time information and calculate FPS.
+    int64_t end_time = util::datetime::GetTimestamp();
+
+    if (replay_start_time_ != start_time_)
+    {
+        GFXRECON_WRITE_CONSOLE("Load time:  %f seconds", GetElapsedSeconds(start_time_, replay_start_time_));
+    }
+    GFXRECON_WRITE_CONSOLE("Total time: %f seconds", GetElapsedSeconds(start_time_, end_time));
+
+    WriteFpsToConsole(
+        "Replay FPS:", replay_start_frame_, end_frame + replay_start_frame_ - 1, replay_start_time_, end_time);
+}
+
+void FpsInfo::ProcessStateEndMarker(uint64_t frame)
+{
+    replay_start_frame_ = frame;
+    replay_start_time_  = util::datetime::GetTimestamp();
+}
+
+GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/graphics/fps_info.h
+++ b/framework/graphics/fps_info.h
@@ -1,0 +1,51 @@
+
+/*
+** Copyright (c) 2021 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_GRAPHICS_FPS_INFO_H
+#define GFXRECON_GRAPHICS_FPS_INFO_H
+
+#include "util/defines.h"
+
+#include <limits>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(graphics)
+
+class FpsInfo
+{
+  public:
+    void Begin(uint64_t start_frame = 1);
+    void EndAndLog(uint64_t current_frame);
+
+    void ProcessStateEndMarker(uint64_t frame);
+
+  private:
+    int64_t  start_time_;
+    uint64_t replay_start_frame_;
+    int64_t  replay_start_time_;
+};
+
+GFXRECON_END_NAMESPACE(graphics)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_GRAPHICS_FPS_INFO_H

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -29,8 +29,8 @@
 #include "decode/vulkan_tracked_object_info_table.h"
 #include "generated/generated_vulkan_decoder.h"
 #include "generated/generated_vulkan_replay_consumer.h"
+#include "graphics/fps_info.h"
 #include "util/argument_parser.h"
-#include "util/date_time.h"
 #include "util/logging.h"
 
 #include <exception>
@@ -193,12 +193,14 @@ int main(int argc, const char** argv)
             }
             else
             {
+                gfxrecon::graphics::FpsInfo                    fps_info;
                 gfxrecon::decode::VulkanTrackedObjectInfoTable tracked_object_info_table;
                 gfxrecon::decode::VulkanReplayConsumer         replay_consumer(
                     window_factory.get(), GetReplayOptions(arg_parser, filename, &tracked_object_info_table));
                 gfxrecon::decode::VulkanDecoder decoder;
 
                 replay_consumer.SetFatalErrorHandler([](const char* message) { throw std::runtime_error(message); });
+                replay_consumer.SetFpsInfo(&fps_info);
 
                 decoder.AddConsumer(&replay_consumer);
                 file_processor.AddDecoder(&decoder);
@@ -207,29 +209,14 @@ int main(int argc, const char** argv)
                 // Warn if the capture layer is active.
                 CheckActiveLayers(gfxrecon::util::platform::GetEnv(kLayerEnvVar));
 
-                // Grab the start frame/time information for the FPS result.
-                uint32_t start_frame = 1;
-                int64_t  start_time  = gfxrecon::util::datetime::GetTimestamp();
+                fps_info.Begin();
 
                 application->Run();
 
                 if ((file_processor.GetCurrentFrameNumber() > 0) &&
                     (file_processor.GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone))
                 {
-                    // Grab the end frame/time information and calculate FPS.
-                    int64_t end_time      = gfxrecon::util::datetime::GetTimestamp();
-                    double  diff_time_sec = gfxrecon::util::datetime::ConvertTimestampToSeconds(
-                        gfxrecon::util::datetime::DiffTimestamps(start_time, end_time));
-                    uint32_t end_frame    = file_processor.GetCurrentFrameNumber();
-                    uint32_t total_frames = (end_frame - start_frame) + 1;
-                    double   fps          = static_cast<double>(total_frames) / diff_time_sec;
-                    GFXRECON_WRITE_CONSOLE("%f fps, %f seconds, %u frame%s, 1 loop, framerange %u-%u",
-                                           fps,
-                                           diff_time_sec,
-                                           total_frames,
-                                           total_frames > 1 ? "s" : "",
-                                           start_frame,
-                                           end_frame);
+                    fps_info.EndAndLog(file_processor.GetCurrentFrameNumber());
                 }
                 else if (file_processor.GetErrorState() != gfxrecon::decode::FileProcessor::kErrorNone)
                 {


### PR DESCRIPTION
Add console output for trimmed file state load time. Also, when computing
FPS, account for trimmed state load time (if any) and report as "Replay
FPS".

Example output with trimmed capture file:

```
Load time:  1.435010 seconds
Total time: 7.576557 seconds
Replay FPS: 285.107319 fps, 6.141547 seconds, 1751 frames, framerange 250-2000
```

Example output with complete (not trimmed) capture file:

```
Total time: 6.758087 seconds
Replay FPS: 254.361922 fps, 6.758087 seconds, 1719 frames, framerange 1-1719
```