### PR TITLE
Track trimmed state acquired image index

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -914,17 +914,15 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     // When processing swapchain image state for the trimming state setup, acquire all swapchain images to transition to
     // the expected layout and keep them acquired until first use.
     void ProcessSetSwapchainImageStatePreAcquire(VkDevice                                            device,
-                                                 VkSwapchainKHR                                      swapchain,
-                                                 uint32_t                                            queue_family_index,
+                                                 SwapchainKHRInfo*                                   swapchain_info,
                                                  const std::vector<format::SwapchainImageStateInfo>& image_info);
 
     // When processing swapchain image state for the trimming state setup, acquire an image, transition it to
     // the expected layout, and then call queue present if the image is not expected to be in the acquired state so that
     // no more than one image is acquired at a time.
-    void ProcessSetSwapchainImageStateQueueSubmit(VkDevice       device,
-                                                  VkSwapchainKHR swapchain,
-                                                  uint32_t       queue_family_index,
-                                                  uint32_t       last_presented_image,
+    void ProcessSetSwapchainImageStateQueueSubmit(VkDevice          device,
+                                                  SwapchainKHRInfo* swapchain_info,
+                                                  uint32_t          last_presented_image,
                                                   const std::vector<format::SwapchainImageStateInfo>& image_info);
 
     void ProcessCreateInstanceDebugCallbackInfo(const Decoded_VkInstanceCreateInfo* instance_info);


### PR DESCRIPTION
Track the acquired image index when initializing from trimmed state.
This fixes an issue where the first presented image could be incorrect
or replay could hang.
