### PR TITLE
VK_EXT_headless_surface support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,14 @@ set(GFXRECONSTRUCT_PROJECT_VERSION_PATCH 7)
 set(GFXRECON_PROJECT_VERSION_DESIGNATION "-unknown")
 set(GFXRECON_PROJECT_VERSION_SHA1 "unknown-build-source")
 
+if (NOT DEFINED NO_XCB)
+    set(NO_XCB FALSE)
+endif()
+
+if (NOT DEFINED HEADLESS)
+    set(HEADLESS TRUE)
+endif()
+
 include(GetGitRevisionDescription)
 get_git_head_revision(GIT_REFSPEC GIT_SHA1)
 git_get_exact_tag(GIT_TAG)
@@ -120,7 +128,11 @@ endif(MSVC)
 find_package(LZ4)
 find_package(ZSTD)
 if(UNIX)
-    find_package(XCB)
+    if (NOT ${NO_XCB})
+        find_package(XCB)
+    else()
+        set(XCB_FOUND FALSE)
+    endif()
     find_package(WAYLAND)
 endif(UNIX)
 
@@ -131,14 +143,16 @@ if(UNIX)
 endif(UNIX)
 
 add_library(windows_specific INTERFACE)
-target_compile_definitions(windows_specific INTERFACE WIN32_LEAN_AND_MEAN NOMINMAX VK_USE_PLATFORM_WIN32_KHR)
+target_compile_definitions(windows_specific INTERFACE WIN32_LEAN_AND_MEAN NOMINMAX VK_USE_PLATFORM_WIN32_KHR
+$<$<BOOL:${HEADLESS}>:VK_USE_PLATFORM_HEADLESS>)
 
 add_library(linux_specific INTERFACE)
 target_compile_definitions(linux_specific INTERFACE _FILE_OFFSET_BITS=64 PAGE_GUARD_ENABLE_UCONTEXT_WRITE_DETECTION
     $<$<BOOL:${X11_FOUND}>:VK_USE_PLATFORM_XLIB_KHR>
     $<$<BOOL:${X11_Xrandr_FOUND}>:VK_USE_PLATFORM_XLIB_XRANDR_EXT>
     $<$<BOOL:${XCB_FOUND}>:VK_USE_PLATFORM_XCB_KHR>
-    $<$<BOOL:${WAYLAND_FOUND}>:VK_USE_PLATFORM_WAYLAND_KHR>)
+    $<$<BOOL:${WAYLAND_FOUND}>:VK_USE_PLATFORM_WAYLAND_KHR>
+    $<$<BOOL:${HEADLESS}>:VK_USE_PLATFORM_HEADLESS>)
 
 add_library(platform_specific INTERFACE)
 target_link_libraries(platform_specific INTERFACE

--- a/framework/application/CMakeLists.txt
+++ b/framework/application/CMakeLists.txt
@@ -32,6 +32,10 @@ target_sources(gfxrecon_application
                PRIVATE
                     ${CMAKE_CURRENT_LIST_DIR}/application.h
                     ${CMAKE_CURRENT_LIST_DIR}/application.cpp
+                    $<$<BOOL:${HEADLESS}>:${CMAKE_CURRENT_LIST_DIR}/headless_application.h>
+                    $<$<BOOL:${HEADLESS}>:${CMAKE_CURRENT_LIST_DIR}/headless_window.h>
+                    $<$<BOOL:${HEADLESS}>:${CMAKE_CURRENT_LIST_DIR}/headless_application.cpp>
+                    $<$<BOOL:${HEADLESS}>:${CMAKE_CURRENT_LIST_DIR}/headless_window.cpp>
                     $<$<BOOL:${XCB_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/xcb_application.h>
                     $<$<BOOL:${XCB_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/xcb_window.h>
                     $<$<BOOL:${XCB_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/xcb_application.cpp>

--- a/framework/application/headless_application.cpp
+++ b/framework/application/headless_application.cpp
@@ -1,0 +1,46 @@
+/*
+** Copyright (c) 2021, Arm Limited.
+** Copyright (c) 2021 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "application/headless_application.h"
+#include "application/headless_window.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(application)
+
+HeadlessApplication::HeadlessApplication(const std::string& name) : Application(name) {}
+
+bool HeadlessApplication::Initialize(decode::FileProcessor* file_processor)
+{
+    // No additional initialization is required for headless.
+    SetFileProcessor(file_processor);
+    return true;
+}
+
+void HeadlessApplication::ProcessEvents(bool wait_for_input)
+{
+    // No winsys events to process for headless.
+    return;
+}
+
+GFXRECON_END_NAMESPACE(application)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/application/headless_application.h
+++ b/framework/application/headless_application.h
@@ -1,0 +1,50 @@
+/*
+** Copyright (c) 2021, Arm Limited.
+** Copyright (c) 2021 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_APPLICATION_HEADLESS_APPLICATION_H
+#define GFXRECON_APPLICATION_HEADLESS_APPLICATION_H
+
+#include "application/application.h"
+#include "util/defines.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(application)
+
+class HeadlessWindow;
+
+class HeadlessApplication : public Application
+{
+  public:
+    HeadlessApplication(const std::string& name);
+
+    virtual ~HeadlessApplication() override{};
+
+    virtual bool Initialize(decode::FileProcessor* file_processor) override;
+
+    virtual void ProcessEvents(bool wait_for_input) override;
+};
+
+GFXRECON_END_NAMESPACE(application)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_APPLICATION_HEADLESS_APPLICATION_H

--- a/framework/application/headless_window.cpp
+++ b/framework/application/headless_window.cpp
@@ -1,0 +1,152 @@
+/*
+** Copyright (c) 2021, Arm Limited.
+** Copyright (c) 2021 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "application/headless_window.h"
+
+#include <cassert>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(application)
+
+HeadlessWindow::HeadlessWindow(HeadlessApplication* application) : headless_application_(application)
+{
+    assert(application != nullptr);
+}
+
+HeadlessWindow::~HeadlessWindow() {}
+
+bool HeadlessWindow::Create(
+    const std::string& title, const int32_t xpos, const int32_t ypos, const uint32_t width, const uint32_t height)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(title);
+    GFXRECON_UNREFERENCED_PARAMETER(xpos);
+    GFXRECON_UNREFERENCED_PARAMETER(ypos);
+    GFXRECON_UNREFERENCED_PARAMETER(width);
+    GFXRECON_UNREFERENCED_PARAMETER(height);
+
+    return true;
+}
+
+bool HeadlessWindow::Destroy()
+{
+    return true;
+}
+
+void HeadlessWindow::SetTitle(const std::string& title)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(title);
+}
+
+void HeadlessWindow::SetPosition(const int32_t x, const int32_t y)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(x);
+    GFXRECON_UNREFERENCED_PARAMETER(y);
+}
+
+void HeadlessWindow::SetSize(const uint32_t width, const uint32_t height)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(width);
+    GFXRECON_UNREFERENCED_PARAMETER(height);
+}
+
+void HeadlessWindow::SetSizePreTransform(const uint32_t width, const uint32_t height, const uint32_t pre_transform)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(width);
+    GFXRECON_UNREFERENCED_PARAMETER(height);
+    GFXRECON_UNREFERENCED_PARAMETER(pre_transform);
+}
+
+void HeadlessWindow::SetVisibility(bool show)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(show);
+}
+
+void HeadlessWindow::SetForeground() {}
+
+bool HeadlessWindow::GetNativeHandle(HandleType type, void** handle)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(type);
+    GFXRECON_UNREFERENCED_PARAMETER(handle);
+    return false;
+}
+
+VkResult HeadlessWindow::CreateSurface(const encode::InstanceTable* table,
+                                       VkInstance                   instance,
+                                       VkFlags                      flags,
+                                       VkSurfaceKHR*                pSurface)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(flags);
+
+    if (table != nullptr)
+    {
+        VkHeadlessSurfaceCreateInfoEXT create_info{ VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT, nullptr, 0 };
+
+        return table->CreateHeadlessSurfaceEXT(instance, &create_info, nullptr, pSurface);
+    }
+
+    return VK_ERROR_INITIALIZATION_FAILED;
+}
+
+void HeadlessWindow::DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface)
+{
+    if (table != nullptr)
+    {
+        table->DestroySurfaceKHR(instance, surface, nullptr);
+    }
+}
+
+HeadlessWindowFactory::HeadlessWindowFactory(HeadlessApplication* application) : headless_application_(application)
+{
+    assert(application != nullptr);
+}
+
+decode::Window*
+HeadlessWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height)
+{
+    auto window = new HeadlessWindow(headless_application_);
+    window->Create(headless_application_->GetName(), x, y, width, height);
+    return window;
+}
+
+void HeadlessWindowFactory::Destroy(decode::Window* window)
+{
+    if (window != nullptr)
+    {
+        window->Destroy();
+        delete window;
+    }
+}
+
+VkBool32 HeadlessWindowFactory::GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
+                                                                     VkPhysicalDevice             physical_device,
+                                                                     uint32_t                     queue_family_index)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(table);
+    GFXRECON_UNREFERENCED_PARAMETER(physical_device);
+    GFXRECON_UNREFERENCED_PARAMETER(queue_family_index);
+
+    return true;
+}
+
+GFXRECON_END_NAMESPACE(application)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/application/headless_window.h
+++ b/framework/application/headless_window.h
@@ -1,0 +1,98 @@
+/*
+** Copyright (c) 2021, Arm Limited.
+** Copyright (c) 2021 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_APPLICATION_HEADLESS_WINDOW_H
+#define GFXRECON_APPLICATION_HEADLESS_WINDOW_H
+
+#include "application/headless_application.h"
+#include "decode/window.h"
+#include "util/defines.h"
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(application)
+
+class HeadlessWindow : public decode::Window
+{
+  public:
+    HeadlessWindow(HeadlessApplication* application);
+
+    virtual ~HeadlessWindow() override;
+
+    virtual bool Create(const std::string& title,
+                        const int32_t      xpos,
+                        const int32_t      ypos,
+                        const uint32_t     width,
+                        const uint32_t     height) override;
+
+    virtual bool Destroy() override;
+
+    virtual void SetTitle(const std::string& title) override;
+
+    virtual void SetPosition(const int32_t x, const int32_t y) override;
+
+    virtual void SetSize(const uint32_t width, const uint32_t height) override;
+
+    virtual void
+    SetSizePreTransform(const uint32_t width, const uint32_t height, const uint32_t pre_transform) override;
+
+    virtual void SetVisibility(bool show) override;
+
+    virtual void SetForeground() override;
+
+    virtual bool GetNativeHandle(HandleType type, void** handle) override;
+
+    virtual VkResult CreateSurface(const encode::InstanceTable* table,
+                                   VkInstance                   instance,
+                                   VkFlags                      flags,
+                                   VkSurfaceKHR*                pSurface) override;
+
+    virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
+
+  private:
+    HeadlessApplication* headless_application_;
+};
+
+class HeadlessWindowFactory : public decode::WindowFactory
+{
+  public:
+    HeadlessWindowFactory(HeadlessApplication* application);
+
+    virtual const char* GetSurfaceExtensionName() const override { return VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME; }
+
+    virtual decode::Window*
+    Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) override;
+
+    void Destroy(decode::Window* window) override;
+
+    virtual VkBool32 GetPhysicalDevicePresentationSupport(const encode::InstanceTable* table,
+                                                          VkPhysicalDevice             physical_device,
+                                                          uint32_t                     queue_family_index) override;
+
+  private:
+    HeadlessApplication* headless_application_;
+};
+
+GFXRECON_END_NAMESPACE(application)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_APPLICATION_HEADLESS_WINDOW_H

--- a/framework/decode/vulkan_feature_util.cpp
+++ b/framework/decode/vulkan_feature_util.cpp
@@ -74,6 +74,21 @@ VkResult GetDeviceExtensions(VkPhysicalDevice                         physical_d
     return result;
 }
 
+bool IsSupportedExtension(const std::vector<VkExtensionProperties>& properties, const char* extension)
+{
+    assert(extension != nullptr);
+
+    for (const auto& property : properties)
+    {
+        if (strcmp(property.extensionName, extension) == 0)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void RemoveUnsupportedExtensions(const std::vector<VkExtensionProperties>& properties,
                                  std::vector<const char*>*                 extensions)
 {
@@ -82,17 +97,7 @@ void RemoveUnsupportedExtensions(const std::vector<VkExtensionProperties>& prope
     auto extensionIter = extensions->begin();
     while (extensionIter != extensions->end())
     {
-        bool found = false;
-        for (const auto& property : properties)
-        {
-            if (strcmp(property.extensionName, *extensionIter) == 0)
-            {
-                found = true;
-                break;
-            }
-        }
-
-        if (found == false)
+        if (!IsSupportedExtension(properties, *extensionIter))
         {
             GFXRECON_LOG_WARNING("Extension %s, which is not supported by the replay device, will not be enabled",
                                  *extensionIter);

--- a/framework/decode/vulkan_feature_util.h
+++ b/framework/decode/vulkan_feature_util.h
@@ -40,6 +40,8 @@ VkResult GetDeviceExtensions(VkPhysicalDevice                         physical_d
                              PFN_vkEnumerateDeviceExtensionProperties device_extension_proc,
                              std::vector<VkExtensionProperties>*      properties);
 
+bool IsSupportedExtension(const std::vector<VkExtensionProperties>& properties, const char* extension);
+
 void RemoveUnsupportedExtensions(const std::vector<VkExtensionProperties>& properties,
                                  std::vector<const char*>*                 extensions);
 

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -1034,7 +1034,8 @@ class BaseGenerator(OutputGenerator):
             'xlib' : 'VK_USE_PLATFORM_XLIB_KHR',
             'xlib_xrandr' : 'VK_USE_PLATFORM_XLIB_XRANDR_EXT',
             'ggp' : 'VK_USE_PLATFORM_GGP',
-            'directfb' : 'VK_USE_PLATFORM_DIRECTFB_EXT'
+            'directfb' : 'VK_USE_PLATFORM_DIRECTFB_EXT',
+            'headless: VK_USE_PLATFORM_HEADLESS'
         }
 
         platform = interface.get('platform')

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -59,6 +59,11 @@
 #endif
 #endif
 
+#if defined(VK_USE_PLATFORM_HEADLESS)
+#include "application/headless_application.h"
+#include "application/headless_window.h"
+#endif
+
 #if defined(WIN32)
 #include <conio.h>
 void WaitForExit()
@@ -182,6 +187,19 @@ int main(int argc, const char** argv)
                 }
             }
 #endif
+#endif
+#if defined(VK_USE_PLATFORM_HEADLESS)
+            if (wsi_platform == WsiPlatform::kHeadless || (wsi_platform == WsiPlatform::kAuto && !application))
+            {
+                auto headless_application =
+                    std::make_unique<gfxrecon::application::HeadlessApplication>(kApplicationName);
+                if (headless_application->Initialize(&file_processor))
+                {
+                    window_factory =
+                        std::make_unique<gfxrecon::application::HeadlessWindowFactory>(headless_application.get());
+                    application = std::move(headless_application);
+                }
+            }
 #endif
 
             if (!window_factory || !application)

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -87,14 +87,16 @@ enum class WsiPlatform
     kWin32,
     kXlib,
     kXcb,
-    kWayland
+    kWayland,
+    kHeadless
 };
 
-const char kWsiPlatformAuto[]    = "auto";
-const char kWsiPlatformWin32[]   = "win32";
-const char kWsiPlatformXlib[]    = "xlib";
-const char kWsiPlatformXcb[]     = "xcb";
-const char kWsiPlatformWayland[] = "wayland";
+const char kWsiPlatformAuto[]     = "auto";
+const char kWsiPlatformWin32[]    = "win32";
+const char kWsiPlatformXlib[]     = "xlib";
+const char kWsiPlatformXcb[]      = "xcb";
+const char kWsiPlatformWayland[]  = "wayland";
+const char kWsiPlatformHeadless[] = "headless";
 
 const char kMemoryTranslationNone[]    = "none";
 const char kMemoryTranslationRemap[]   = "remap";
@@ -269,6 +271,14 @@ static WsiPlatform GetWsiPlatform(const gfxrecon::util::ArgumentParser& arg_pars
             GFXRECON_LOG_WARNING("Ignoring wsi option \"%s\", which is not enabled on this system", value.c_str());
 #endif
         }
+        else if (gfxrecon::util::platform::StringCompareNoCase(kWsiPlatformHeadless, value.c_str()) == 0)
+        {
+#if defined(VK_USE_PLATFORM_HEADLESS)
+            wsi_platform = WsiPlatform::kHeadless;
+#else
+            GFXRECON_LOG_WARNING("Ignoring wsi option \"%s\", which is not enabled on this system", value.c_str());
+#endif
+        }
         else
         {
             GFXRECON_LOG_WARNING("Ignoring unrecognized wsi option \"%s\"", value.c_str());
@@ -296,6 +306,10 @@ static std::string GetWsiArgString()
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
     wsi_args += ',';
     wsi_args += kWsiPlatformWayland;
+#endif
+#if defined(VK_USE_PLATFORM_HEADLESS)
+    wsi_args += ',';
+    wsi_args += kWsiPlatformHeadless;
 #endif
     return wsi_args;
 }


### PR DESCRIPTION
This adds support for the VK_EXT_headless_surface extension to gfxrecon-replay, allowing us to replay on platforms without a windowing system.

This is very useful for testing and performance tracking on development platforms!