### PR TITLE
Handle null swapchain in call to destroy swapchain

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4589,7 +4589,7 @@ void VulkanReplayConsumerBase::OverrideDestroySwapchainKHR(
     }
 
     // Delete backed images of dummy swapchain.
-    if (surface == VK_NULL_HANDLE)
+    if ((swapchain_info != nullptr) && (surface == VK_NULL_HANDLE))
     {
         auto allocator = device_info->allocator.get();
         assert(allocator != nullptr);


### PR DESCRIPTION
vkDestroySwapchainKHR can be called with a null swapchain argument, so
null-check swapchain_info before accessing.
