### PR TITLE
Use host coherent as fallback when creating a screenshot copy resource

### DIFF
--- a/framework/decode/screenshot_handler.cpp
+++ b/framework/decode/screenshot_handler.cpp
@@ -581,6 +581,15 @@ VkResult ScreenshotHandler::CreateCopyResource(VkDevice                         
                                memory_requirements.memoryTypeBits,
                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT);
 
+        if (memory_type_index == std::numeric_limits<uint32_t>::max())
+        {
+            /* fallback to coherent */
+            memory_type_index =
+                GetMemoryTypeIndex(memory_properties,
+                                   memory_requirements.memoryTypeBits,
+                                   VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+        }
+
         assert(memory_type_index != std::numeric_limits<uint32_t>::max());
 
         VkMemoryAllocateInfo allocate_info = { VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO };


### PR DESCRIPTION
By spec only COHERENT is mandatory, so it is possible finding a driver
not supporting CACHED. The current caller for CreateCopyResource
already checks if the buffer is coherent or not.

This is equivalent to #501 but for screenshot handler.