### PR TITLE
Add annotations to capture file format

### DIFF
--- a/android/framework/decode/CMakeLists.txt
+++ b/android/framework/decode/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(gfxrecon_decode STATIC "")
 
 target_sources(gfxrecon_decode
                PRIVATE
+                   ${GFXRECON_SOURCE_DIR}/framework/decode/annotation_handler.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/api_decoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/copy_shaders.h
                    ${GFXRECON_SOURCE_DIR}/framework/decode/custom_vulkan_struct_decoders.h

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(gfxrecon_decode STATIC "")
 
 target_sources(gfxrecon_decode
                PRIVATE
+                    ${CMAKE_CURRENT_LIST_DIR}/annotation_handler.h
                     ${CMAKE_CURRENT_LIST_DIR}/api_decoder.h
                     ${CMAKE_CURRENT_LIST_DIR}/copy_shaders.h
                     ${CMAKE_CURRENT_LIST_DIR}/custom_vulkan_struct_decoders.h

--- a/framework/decode/annotation_handler.h
+++ b/framework/decode/annotation_handler.h
@@ -1,0 +1,45 @@
+/*
+** Copyright (c) 2021 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_ANNOTATION_HANDLER_DECODER_H
+#define GFXRECON_ANNOTATION_HANDLER_DECODER_H
+
+#include "format/format.h"
+#include "util/defines.h"
+
+#include <string>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+class AnnotationHandler
+{
+  public:
+    virtual ~AnnotationHandler() {}
+
+    virtual void ProcessAnnotation(format::AnnotationType type, const std::string& label, const std::string& data) = 0;
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_ANNOTATION_HANDLER_DECODER_H

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -37,7 +37,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 FileProcessor::FileProcessor() :
     file_header_{}, file_descriptor_(nullptr), current_frame_number_(0), bytes_read_(0),
-    error_state_(kErrorInvalidFileDescriptor), compressor_(nullptr)
+    error_state_(kErrorInvalidFileDescriptor), annotation_handler_(nullptr), compressor_(nullptr)
 {}
 
 FileProcessor::~FileProcessor()
@@ -243,6 +243,30 @@ bool FileProcessor::ProcessBlocks()
                 else
                 {
                     HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read state marker header");
+                }
+            }
+            else if (block_header.type == format::BlockType::kAnnotation)
+            {
+                if (annotation_handler_ != nullptr)
+                {
+                    format::AnnotationType annotation_type = format::AnnotationType::kUnknown;
+
+                    success = ReadBytes(&annotation_type, sizeof(annotation_type));
+
+                    if (success)
+                    {
+                        success = ProcessAnnotation(block_header, annotation_type);
+                    }
+                    else
+                    {
+                        HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read annotation block header");
+                    }
+                }
+                else
+                {
+                    // If there is no annotation handler to process the annotation, we can skip the annotation block.
+                    GFXRECON_CHECK_CONVERSION_DATA_LOSS(size_t, block_header.size);
+                    success = SkipBytes(static_cast<size_t>(block_header.size));
                 }
             }
             else
@@ -1096,6 +1120,55 @@ bool FileProcessor::ProcessStateMarker(const format::BlockHeader& block_header, 
     else
     {
         HandleBlockReadError(kErrorReadingBlockData, "Failed to read state marker data");
+    }
+
+    return success;
+}
+
+bool FileProcessor::ProcessAnnotation(const format::BlockHeader& block_header, format::AnnotationType annotation_type)
+{
+    bool     success      = false;
+    uint32_t label_length = 0;
+    uint32_t data_length  = 0;
+
+    success = ReadBytes(&label_length, sizeof(label_length));
+    success = success && ReadBytes(&data_length, sizeof(data_length));
+
+    if (success)
+    {
+        if ((label_length > 0) || (data_length > 0))
+        {
+            std::string label;
+            std::string data;
+            auto        total_length = label_length + data_length;
+
+            success = ReadParameterBuffer(total_length);
+            if (success)
+            {
+                if (label_length > 0)
+                {
+                    auto label_start = parameter_buffer_.begin();
+                    label.assign(label_start, std::next(label_start, label_length));
+                }
+
+                if (data_length > 0)
+                {
+                    auto data_start = std::next(parameter_buffer_.begin(), label_length);
+                    data.assign(data_start, std::next(data_start, data_length));
+                }
+
+                assert(annotation_handler_ != nullptr);
+                annotation_handler_->ProcessAnnotation(annotation_type, label, data);
+            }
+            else
+            {
+                HandleBlockReadError(kErrorReadingBlockData, "Failed to read annotation block");
+            }
+        }
+    }
+    else
+    {
+        HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read annotation block header");
     }
 
     return success;

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -26,6 +26,7 @@
 
 #include "format/api_call_id.h"
 #include "format/format.h"
+#include "decode/annotation_handler.h"
 #include "decode/api_decoder.h"
 #include "util/compressor.h"
 #include "util/defines.h"
@@ -60,6 +61,8 @@ class FileProcessor
     FileProcessor();
 
     ~FileProcessor();
+
+    void SetAnnotationProcessor(AnnotationHandler* handler) { annotation_handler_ = handler; }
 
     void AddDecoder(ApiDecoder* decoder) { decoders_.push_back(decoder); }
 
@@ -112,6 +115,8 @@ class FileProcessor
 
     bool ProcessStateMarker(const format::BlockHeader& block_header, format::MarkerType marker_type);
 
+    bool ProcessAnnotation(const format::BlockHeader& block_header, format::AnnotationType annotation_type);
+
     bool IsFrameDelimiter(format::ApiCallId call_id) const;
 
     bool IsFileHeaderValid() const { return (file_header_.fourcc == GFXRECON_FOURCC); }
@@ -127,6 +132,7 @@ class FileProcessor
     uint32_t                            current_frame_number_;
     uint64_t                            bytes_read_;
     Error                               error_state_;
+    AnnotationHandler*                  annotation_handler_;
     std::vector<ApiDecoder*>            decoders_;
     std::vector<uint8_t>                parameter_buffer_;
     std::vector<uint8_t>                compressed_parameter_buffer_;

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -71,6 +71,7 @@ enum BlockType : uint32_t
     kStateMarkerBlock            = 2, // Marker to denote state snapshot status, such as the start or end of a state snapshot.
     kMetaDataBlock               = 3,
     kFunctionCallBlock           = 4,
+    kAnnotation                  = 5,
     kCompressedMetaDataBlock     = MakeCompressedBlockType(kMetaDataBlock),
     kCompressedFunctionCallBlock = MakeCompressedBlockType(kFunctionCallBlock)
 };
@@ -80,6 +81,14 @@ enum MarkerType : uint32_t
     kUnknownMarker = 0,
     kBeginMarker   = 1,
     kEndMarker     = 2
+};
+
+enum AnnotationType : uint32_t
+{
+    kUnknown = 0,
+    kText    = 1,
+    kJson    = 2,
+    kXml     = 3
 };
 
 enum MetaDataType : uint32_t
@@ -201,6 +210,14 @@ struct MethodCallHeader
     ApiCallId        api_call_id;
     uint64_t         object_id;
     format::ThreadId thread_id;
+};
+
+struct AnnotationHeader
+{
+    BlockHeader    block_header;
+    AnnotationType annotation_type;
+    uint32_t       label_length;
+    uint32_t       data_length;
 };
 
 // Metadata block headers and data types.


### PR DESCRIPTION
- Adds a new annotation block type to the capture file format.  The annotation consists of a string with a name/label for the annotation and a string with the annotation data.  The data can be represented as plain text, XML, and JSON.
- Adds a new AnnotationHandler interface.  Custom handlers can be created for processing annotation data.
- Adds support to the FileProcessor for processing annotation blocks that are read from the capture file, passing the annotation name and data to an AnnotationHandler.
