### PR TITLE
Check for headless support

### DIFF
--- a/android/framework/graphics/CMakeLists.txt
+++ b/android/framework/graphics/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(gfxrecon_graphics
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_device_util.h
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_device_util.cpp
                     ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.h
+                    ${GFXRECON_SOURCE_DIR}/framework/graphics/vulkan_util.cpp
               )
 
 target_include_directories(gfxrecon_graphics

--- a/framework/decode/vulkan_feature_util.cpp
+++ b/framework/decode/vulkan_feature_util.cpp
@@ -21,7 +21,9 @@
 */
 
 #include "decode/vulkan_feature_util.h"
+
 #include "util/logging.h"
+#include "util/platform.h"
 
 #include <cassert>
 
@@ -80,7 +82,7 @@ bool IsSupportedExtension(const std::vector<VkExtensionProperties>& properties, 
 
     for (const auto& property : properties)
     {
-        if (strcmp(property.extensionName, extension) == 0)
+        if (util::platform::StringCompare(property.extensionName, extension) == 0)
         {
             return true;
         }

--- a/framework/graphics/CMakeLists.txt
+++ b/framework/graphics/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(gfxrecon_graphics
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_device_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_device_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.h
+                    ${CMAKE_CURRENT_LIST_DIR}/vulkan_util.cpp
               )
 
 target_include_directories(gfxrecon_graphics

--- a/framework/graphics/vulkan_util.cpp
+++ b/framework/graphics/vulkan_util.cpp
@@ -20,48 +20,25 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#ifndef GFXRECON_GRAPHICS_VULKAN_UTIL_H
-#define GFXRECON_GRAPHICS_VULKAN_UTIL_H
+#include "graphics/vulkan_util.h"
 
-#include "generated/generated_vulkan_dispatch_table.h"
-#include "util/defines.h"
-#include "util/platform.h"
-
-#include "vulkan/vulkan.h"
+#include <vector>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(graphics)
 
-const std::vector<std::string> kLoaderLibNames = {
-#if defined(WIN32)
-    "vulkan-1.dll"
-#else
-    "libvulkan.so.1", "libvulkan.so"
-#endif
-};
-
-util::platform::LibraryHandle InitializeLoader();
-
-void ReleaseLoader(util::platform::LibraryHandle loader_handle);
-
-// Search through the parent's pNext chain for the first struct with the requested struct_type. parent's struct type is
-// not checked and parent won't be returned as a result. T and Parent_T must be Vulkan struct pointer types. Return
-// nullptr if no matching struct found.
-template <typename T, typename Parent_T>
-static T* GetPNextStruct(const Parent_T* parent, VkStructureType struct_type)
+util::platform::LibraryHandle InitializeLoader()
 {
-    VkBaseOutStructure* current_struct = reinterpret_cast<const VkBaseOutStructure*>(parent)->pNext;
-    while (current_struct != nullptr)
+    return util::platform::OpenLibrary(kLoaderLibNames);
+}
+
+void ReleaseLoader(util::platform::LibraryHandle loader_handle)
+{
+    if (loader_handle != nullptr)
     {
-        if (current_struct->sType == struct_type)
-        {
-            return reinterpret_cast<T*>(current_struct);
-        }
+        util::platform::CloseLibrary(loader_handle);
     }
-    return nullptr;
 }
 
 GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)
-
-#endif // GFXRECON_GRAPHICS_VULKAN_UTIL_H


### PR DESCRIPTION
Add a check for VK_EXT_headless_surface before starting replay with a headless surface.  Replay will currently attempt to use a headless surface when the `--wsi headless` option is specified, or when no other WSI platforms are available.  Currently, when VK_EXT_headless_surface is not supported by the replay instance, replay will fail with an error message similar to:
```
[gfxrecon] WARNING - Extension VK_EXT_headless_surface, is not supported by the replay device.
[gfxrecon] FATAL - API call vkCreateInstance returned error value VK_ERROR_EXTENSION_NOT_PRESENT that does not match the result from the capture file: VK_SUCCESS.  Replay cannot continue.
Replay has encountered a fatal error and cannot continue: the specified extension does not exist
```
This change adds a check for VK_EXT_headless_furface prior to starting replay, to generate an error message similar to the following when the extension is not present:
```
Failed to initialize platform specific window system management.
Ensure that the appropriate Vulkan platform extensions have been enabled.
```
This is intended to avoid confusion for the case where headless mode was automatically selected (e.g. if a CI system is in a bad state and other WSI initializations fail) and not explicitly enabled by the user with `--wsi headless`, where the user observes a replay failure for a mode they did not specify.