### PR TITLE
Fix vkconfig built-in variable, SDK 1.2.176 fix

### DIFF
--- a/layer/json/VkLayer_gfxreconstruct.json.in
+++ b/layer/json/VkLayer_gfxreconstruct.json.in
@@ -162,7 +162,7 @@
                 "description": "Path to use when creating the capture file. Default is: gfxrecon_capture.gfxr",
                 "type": "SAVE_FILE",
                 "filter": "*.gfxr",
-                "default": "${LOCAL}/gfxrecon_capture.gfxr",
+                "default": "$[LOCAL]/gfxrecon_capture.gfxr",
                 "settings": [
                     {
                         "key": "capture_file_timestamp",


### PR DESCRIPTION
Vulkan Configurator used to use ${LOCAL} built-in variable but this variable format is erased by the script that processes the .json.in file into .json but this variable is meant to be used by Vulkan Configurator.

Change-Id: I9ba514d03ea80e205360ea595ae4c19ce3dc1478