### PR TITLE
Vulkan layer JSON fixes

### DIFF
--- a/cmake/FindVulkanVersion.cmake
+++ b/cmake/FindVulkanVersion.cmake
@@ -1,7 +1,7 @@
 # Determine the major/minor/patch version from the vulkan header
-set(VULKAN_VERSION_MAJOR "0")
-set(VULKAN_VERSION_MINOR "0")
-set(VULKAN_VERSION_PATCH "0")
+set(VULKAN_VERSION_MAJOR "")
+set(VULKAN_VERSION_MINOR "")
+set(VULKAN_VERSION_PATCH "")
 
 # First, determine which header we need to grab the version information from.
 # Starting with Vulkan 1.1, we should use vulkan_core.h, but prior to that,
@@ -30,18 +30,18 @@ endif()
 file(STRINGS
         ${VulkanHeaders_main_header}
         VulkanHeaders_lines
-        REGEX "^#[ \t]*define[ \t]+(VK_HEADER_VERSION_COMPLETE[ \t]+VK_MAKE_VERSION\\(.*\\)|VK_HEADER_VERSION[ \t]+[0-9]+)$")
+        REGEX "^#[ \t]*define[ \t]+VK_HEADER_VERSION(_COMPLETE)?[ \t]")
 
 foreach(VulkanHeaders_line ${VulkanHeaders_lines})
     # First, handle the case where we have a major/minor version
     #   Format is:
-    #        #define VK_HEADER_VERSION_COMPLETE VK_MAKE_VERSION(X, Y, VK_HEADER_VERSION)
+    #        #define VK_HEADER_VERSION_COMPLETE VK_MAKE_API_VERSION(0, X, Y, VK_HEADER_VERSION)
     #   We grab the major version (X) and minor version (Y) out of the parentheses
-    string(REGEX MATCH "define[ \t]+VK_HEADER_VERSION_COMPLETE[ \t]+VK_MAKE_VERSION\\(.*\\)" VulkanHeaders_make_version ${VulkanHeaders_line})
+    string(REGEX MATCH "define[ \t]+VK_HEADER_VERSION_COMPLETE[ \t]+VK_MAKE_API_VERSION\\(.*\\)" VulkanHeaders_make_version ${VulkanHeaders_line})
     string(REGEX MATCHALL "[0-9]+" VulkanHeaders_MAJOR_MINOR "${VulkanHeaders_make_version}")
     if (VulkanHeaders_MAJOR_MINOR)
-        list (GET VulkanHeaders_MAJOR_MINOR 0 VULKAN_VERSION_MAJOR)
-        list (GET VulkanHeaders_MAJOR_MINOR 1 VULKAN_VERSION_MINOR)
+        list (GET VulkanHeaders_MAJOR_MINOR 1 VULKAN_VERSION_MAJOR)
+        list (GET VulkanHeaders_MAJOR_MINOR 2 VULKAN_VERSION_MINOR)
     endif()
 
     # Second, handle the case where we have the patch version

--- a/cmake/GenerateLayerJson.cmake
+++ b/cmake/GenerateLayerJson.cmake
@@ -3,7 +3,7 @@ function(GENERATE_LAYER_JSON_FILE TARGET RELATIVE_PATH_PREFIX LAYER_BINARY IN_FI
     # Run each .json.in file through the generator
     # We need to create the generator.cmake script so that the generator can be run at compile time, instead of configure time
     # Running at compile time lets us use cmake generator expressions (TARGET_FILE_NAME and TARGET_FILE_DIR, specifically)
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake" "configure_file(\"\${INPUT_FILE}\" \"\${OUTPUT_FILE}\")")
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/generator.cmake" "configure_file(\"\${INPUT_FILE}\" \"\${OUTPUT_FILE}\" @ONLY)")
 
     # Combine major, minor, and patch version values into a single integer.
     math(EXPR GFXRECONSTRUCT_LAYER_JSON_VERSION "${GFXRECONSTRUCT_PROJECT_VERSION_MAJOR} << 22 | ${GFXRECONSTRUCT_PROJECT_VERSION_MINOR} << 12 | ${GFXRECONSTRUCT_PROJECT_VERSION_PATCH}")


### PR DESCRIPTION
2 fixes for the layer json file
- Add `@only` to configure_file so it doesn't do substitution on the
vkconfig `${LOCAL}` variable in VkLayer_gfxreconstruct.json.in
- Update the CMake script that extracts version numbers from vulkan_core.h
to work with the new macros in version 176 of the header.