### PR TITLE
Fix layer settings to match layer manifest schema

### DIFF
--- a/layer/json/VkLayer_gfxreconstruct.json.in
+++ b/layer/json/VkLayer_gfxreconstruct.json.in
@@ -16,388 +16,390 @@
                 "entrypoints": [ "vkGetPhysicalDeviceToolPropertiesEXT" ]
             }
         ],
-        "presets": [
-            {
-                "label": "Initialization",
-                "description": "Capture the applications first two frames.",
-                "platforms": [ "WINDOWS", "LINUX" ],
-                "settings": [
-                    {
-                        "key": "capture_trigger",
-                        "value": ""
-                    },
-                    {
-                        "key": "capture_frames",
-                        "value": "1-2"
-                    },
-                    {
-                        "key": "memory_tracking_mode",
-                        "value": "unassisted"
-                    }
-                ]
-            },
-            {
-                "label": "Range",
-                "description": "Capture a range of frames",
-                "platforms": [ "WINDOWS", "LINUX" ],
-                "settings": [
-                    {
-                        "key": "capture_trigger",
-                        "value": "F5"
-                    },
-                    {
-                        "key": "capture_frames",
-                        "value": ""
-                    },
-                    {
-                        "key": "memory_tracking_mode",
-                        "value": "page_guard"
-                    }
-                ]
-            }
-        ],
-        "settings": [
-            {
-                "key": "capture_trigger",
-                "env": "GFXRECON_CAPTURE_TRIGGER",
-                "label": "Hotkey Capture Trigger",
-                "description": "Specify a hotkey (any one of F1-F12, TAB, CONTROL) that will be used to start/stop capture. Example: F3 will set the capture trigger to F3 hotkey. One capture file will be generated for each pair of start/stop hotkey presses. Default is: Empty string (hotkey capture trigger is disabled).",
-                "type": "ENUM",
-                "flags": [
-                    {
-                        "key": "",
-                        "label": "None",
-                        "description": ""
-                    },
-                    {
-                        "key": "F1",
-                        "label": "F1",
-                        "description": ""
-                    },
-                    {
-                        "key": "F2",
-                        "label": "F2",
-                        "description": ""
-                    },
-                    {
-                        "key": "F3",
-                        "label": "F3",
-                        "description": ""
-                    },
-                    {
-                        "key": "F4",
-                        "label": "F4",
-                        "description": ""
-                    },
-                    {
-                        "key": "F5",
-                        "label": "F5",
-                        "description": ""
-                    },
-                    {
-                        "key": "F6",
-                        "label": "F6",
-                        "description": ""
-                    },
-                    {
-                        "key": "F7",
-                        "label": "F7",
-                        "description": ""
-                    },
-                    {
-                        "key": "F8",
-                        "label": "F8",
-                        "description": ""
-                    },
-                    {
-                        "key": "F9",
-                        "label": "F9",
-                        "description": ""
-                    },
-                    {
-                        "key": "F10",
-                        "label": "F10",
-                        "description": ""
-                    },
-                    {
-                        "key": "F10",
-                        "label": "F10",
-                        "description": ""
-                    },
-                    {
-                        "key": "F11",
-                        "label": "F11",
-                        "description": ""
-                    },
-                    {
-                        "key": "F12",
-                        "label": "F12",
-                        "description": ""
-                    },
-                    {
-                        "key": "TAB",
-                        "label": "TAB",
-                        "description": ""
-                    },
-                    {
-                        "key": "CONTROL",
-                        "label": "CONTROL",
-                        "description": ""
-                    }
-                ],
-                "default": ""
-            },
-            {
-                "key": "capture_frames",
-                "env": "GFXRECON_CAPTURE_FRAMES",
-                "label": "Capture Specific Frames",
-                "description": "Specify one or more comma-separated frame ranges to capture. Each range will be written to its own file. A frame range can be specified as a single value, to specify a single frame to capture, or as two hyphenated values, to specify the first and last frame to capture. Frame ranges should be specified in ascending order and cannot overlap. Note that frame numbering is 1-based (i.e. the first frame is frame 1). Example: 200,301-305 will create two capture files, one containing a single frame and one containing five frames. Default is: Empty string (all frames are captured).",
-                "type": "STRING",
-                "default": ""
-            },
-            {
-                "key": "capture_file",
-                "env": "GFXRECON_CAPTURE_FILE",
-                "label": "Capture File Name",
-                "description": "Path to use when creating the capture file. Default is: gfxrecon_capture.gfxr",
-                "type": "SAVE_FILE",
-                "filter": "*.gfxr",
-                "default": "${LOCAL}/gfxrecon_capture.gfxr",
-                "settings": [
-                    {
-                        "key": "capture_file_timestamp",
-                        "env": "GFXRECON_CAPTURE_FILE_TIMESTAMP",
-                        "label": "Capture File Name with Timestamp",
-                        "description": "Add a timestamp (yyyymmddThhmmss) postfix to the capture file name.",
-                        "type": "BOOL",
-                        "default": true
-                    },
-                    {
-                        "key": "capture_file_flush",
-                        "env": "GFXRECON_CAPTURE_FILE_FLUSH",
-                        "label": "Capture File Flush After Write",
-                        "description": "Flush output stream after each packet is written to the capture file. Default is: false.",
-                        "type": "BOOL",
-                        "default": true
-                    }
-                ]
-            },
-            {
-                "key": "capture_compression_type",
-                "env": "GFXRECON_CAPTURE_COMPRESSION_TYPE",
-                "label": "Compression Format",
-                "description": "Compression format to use with the capture file. Valid values are: LZ4, ZLIB, ZSTD, and NONE. Default is: LZ4",
-                "type": "ENUM",
-                "flags": [
-                    {
-                        "key": "LZ4",
-                        "label": "LZ4",
-                        "description": ""
-                    },
-                    {
-                        "key": "ZLIB",
-                        "label": "ZLIB",
-                        "description": ""
-                    },
-                    {
-                        "key": "ZSTD",
-                        "label": "ZSTD",
-                        "description": ""
-                    },
-                    {
-                        "key": "NONE",
-                        "label": "NONE",
-                        "description": ""
-                    }
-                ],
-                "default": "LZ4"
-            },
-            {
-                "key": "memory_tracking_mode",
-                "env": "GFXRECON_MEMORY_TRACKING_MODE",
-                "label": "Memory Tracking Mode",
-                "description": "Specifies the memory tracking mode to use for detecting modifications to mapped Vulkan memory objects. Available options are: page_guard, assisted, and unassisted.",
-                "type": "ENUM",
-                "flags": [
-                    {
-                        "key": "page_guard",
-                        "label": "page_guard",
-                        "description": "tracks modifications to individual memory pages, which are written to the capture file on calls to vkFlushMappedMemoryRanges, vkUnmapMemory, and vkQueueSubmit. Tracking modifications requires allocating shadow memory for all mapped memory."
-                    },
-                    {
-                        "key": "assisted",
-                        "label": "assisted",
-                        "description": "Expects the application to call vkFlushMappedMemoryRanges after memory is modified; the memory ranges specified to the vkFlushMappedMemoryRanges call will be written to the capture file during the call."
-                    },
-                    {
-                        "key": "unassisted",
-                        "label": "unassisted",
-                        "description": "writes the full content of mapped memory to the capture file on calls to vkUnmapMemory and vkQueueSubmit. It is very inefficient and may be unusable with real-world applications that map large amounts of memory."
-                    }
-                ],
-                "default": "page_guard",
-                "settings": [
-                    {
-                        "key": "page_guard_copy_on_map",
-                        "env": "GFXRECON_PAGE_GUARD_COPY_ON_MAP",
-                        "label": "Page Guard Copy on Map",
-                        "description": "When the page_guard memory tracking mode is enabled, copies the content of the mapped memory to the shadow memory immediately after the memory is mapped.",
-                        "type": "BOOL",
-                        "default": true,
-                        "dependence": {
-                            "mode": "ALL",
-                            "settings": [
-                                {
-                                    "key": "memory_tracking_mode",
-                                    "value": "page_guard"
-                                }
-                            ]
+        "features": {
+            "presets": [
+                {
+                    "label": "Initialization",
+                    "description": "Capture the applications first two frames.",
+                    "platforms": [ "WINDOWS", "LINUX" ],
+                    "settings": [
+                        {
+                            "key": "capture_trigger",
+                            "value": ""
+                        },
+                        {
+                            "key": "capture_frames",
+                            "value": "1-2"
+                        },
+                        {
+                            "key": "memory_tracking_mode",
+                            "value": "unassisted"
                         }
-                    },
-                    {
-                        "key": "page_guard_separate_read",
-                        "env": "GFXRECON_PAGE_GUARD_SEPARATE_READ",
-                        "label": "Page Guard Separate Read Tracking",
-                        "description": "When the page_guard memory tracking mode is enabled, copies the content of pages accessed for read from mapped memory to shadow memory on each read. Can overwrite unprocessed shadow memory content when an application is reading from and writing to the same page.",
-                        "type": "BOOL",
-                        "default": true,
-                        "dependence": {
-                            "mode": "ALL",
-                            "settings": [
-                                {
-                                    "key": "memory_tracking_mode",
-                                    "value": "page_guard"
-                                }
-                            ]
+                    ]
+                },
+                {
+                    "label": "Range",
+                    "description": "Capture a range of frames",
+                    "platforms": [ "WINDOWS", "LINUX" ],
+                    "settings": [
+                        {
+                            "key": "capture_trigger",
+                            "value": "F5"
+                        },
+                        {
+                            "key": "capture_frames",
+                            "value": ""
+                        },
+                        {
+                            "key": "memory_tracking_mode",
+                            "value": "page_guard"
                         }
-                    },
-                    {
-                        "key": "page_guard_external_memory",
-                        "env": "GFXRECON_PAGE_GUARD_EXTERNAL_MEMORY",
-                        "label": "Page Guard External Memory",
-                        "description": "When the page_guard memory tracking mode is enabled, use the VK_EXT_external_memory_host extension to eliminate the need for shadow memory allocations. For each memory allocation from a host visible memory type, the capture layer will create an allocation from system memory, which it can monitor for write access, and provide that allocation to vkAllocateMemory as external memory. Only available on Windows.",
-                        "type": "BOOL",
-                        "default": false,
-                        "dependence": {
-                            "mode": "ALL",
-                            "settings": [
-                                {
-                                    "key": "memory_tracking_mode",
-                                    "value": "page_guard"
-                                }
-                            ]
+                    ]
+                }
+            ],
+            "settings": [
+                {
+                    "key": "capture_trigger",
+                    "env": "GFXRECON_CAPTURE_TRIGGER",
+                    "label": "Hotkey Capture Trigger",
+                    "description": "Specify a hotkey (any one of F1-F12, TAB, CONTROL) that will be used to start/stop capture. Example: F3 will set the capture trigger to F3 hotkey. One capture file will be generated for each pair of start/stop hotkey presses. Default is: Empty string (hotkey capture trigger is disabled).",
+                    "type": "ENUM",
+                    "flags": [
+                        {
+                            "key": "",
+                            "label": "None",
+                            "description": ""
+                        },
+                        {
+                            "key": "F1",
+                            "label": "F1",
+                            "description": ""
+                        },
+                        {
+                            "key": "F2",
+                            "label": "F2",
+                            "description": ""
+                        },
+                        {
+                            "key": "F3",
+                            "label": "F3",
+                            "description": ""
+                        },
+                        {
+                            "key": "F4",
+                            "label": "F4",
+                            "description": ""
+                        },
+                        {
+                            "key": "F5",
+                            "label": "F5",
+                            "description": ""
+                        },
+                        {
+                            "key": "F6",
+                            "label": "F6",
+                            "description": ""
+                        },
+                        {
+                            "key": "F7",
+                            "label": "F7",
+                            "description": ""
+                        },
+                        {
+                            "key": "F8",
+                            "label": "F8",
+                            "description": ""
+                        },
+                        {
+                            "key": "F9",
+                            "label": "F9",
+                            "description": ""
+                        },
+                        {
+                            "key": "F10",
+                            "label": "F10",
+                            "description": ""
+                        },
+                        {
+                            "key": "F10",
+                            "label": "F10",
+                            "description": ""
+                        },
+                        {
+                            "key": "F11",
+                            "label": "F11",
+                            "description": ""
+                        },
+                        {
+                            "key": "F12",
+                            "label": "F12",
+                            "description": ""
+                        },
+                        {
+                            "key": "TAB",
+                            "label": "TAB",
+                            "description": ""
+                        },
+                        {
+                            "key": "CONTROL",
+                            "label": "CONTROL",
+                            "description": ""
                         }
-                    }
-                ]
-            },
-            {
-                "key": "log",
-                "label": "Log",
-                "description": "Control log messages.",
-                "type": "GROUP",
-                "settings": [
-                    {
-                        "key": "log_level",
-                        "env": "GFXRECON_LOG_LEVEL",
-                        "label": "Level",
-                        "description": "Specify the highest level message to log. Options are: debug, info, warning, error, and fatal. The specified level and all levels listed after it will be enabled for logging. For example, choosing the warning level will also enable the error and fatal levels.",
-                        "type": "ENUM",
-                        "flags": [
-                            {
-                                "key": "debug",
-                                "label": "debug, info, warning, error, fatal",
-                                "description": ""
-                            },
-                            {
-                                "key": "info",
-                                "label": "info, warning, error, fatal",
-                                "description": ""
-                            },
-                            {
-                                "key": "warning",
-                                "label": "warning, error, fatal",
-                                "description": ""
-                            },
-                            {
-                                "key": "error",
-                                "label": "error, fatal",
-                                "description": ""
-                            },
-                            {
-                                "key": "fatal",
-                                "label": "fatal",
-                                "description": ""
+                    ],
+                    "default": ""
+                },
+                {
+                    "key": "capture_frames",
+                    "env": "GFXRECON_CAPTURE_FRAMES",
+                    "label": "Capture Specific Frames",
+                    "description": "Specify one or more comma-separated frame ranges to capture. Each range will be written to its own file. A frame range can be specified as a single value, to specify a single frame to capture, or as two hyphenated values, to specify the first and last frame to capture. Frame ranges should be specified in ascending order and cannot overlap. Note that frame numbering is 1-based (i.e. the first frame is frame 1). Example: 200,301-305 will create two capture files, one containing a single frame and one containing five frames. Default is: Empty string (all frames are captured).",
+                    "type": "STRING",
+                    "default": ""
+                },
+                {
+                    "key": "capture_file",
+                    "env": "GFXRECON_CAPTURE_FILE",
+                    "label": "Capture File Name",
+                    "description": "Path to use when creating the capture file. Default is: gfxrecon_capture.gfxr",
+                    "type": "SAVE_FILE",
+                    "filter": "*.gfxr",
+                    "default": "${LOCAL}/gfxrecon_capture.gfxr",
+                    "settings": [
+                        {
+                            "key": "capture_file_timestamp",
+                            "env": "GFXRECON_CAPTURE_FILE_TIMESTAMP",
+                            "label": "Capture File Name with Timestamp",
+                            "description": "Add a timestamp (yyyymmddThhmmss) postfix to the capture file name.",
+                            "type": "BOOL",
+                            "default": true
+                        },
+                        {
+                            "key": "capture_file_flush",
+                            "env": "GFXRECON_CAPTURE_FILE_FLUSH",
+                            "label": "Capture File Flush After Write",
+                            "description": "Flush output stream after each packet is written to the capture file. Default is: false.",
+                            "type": "BOOL",
+                            "default": true
+                        }
+                    ]
+                },
+                {
+                    "key": "capture_compression_type",
+                    "env": "GFXRECON_CAPTURE_COMPRESSION_TYPE",
+                    "label": "Compression Format",
+                    "description": "Compression format to use with the capture file. Valid values are: LZ4, ZLIB, ZSTD, and NONE. Default is: LZ4",
+                    "type": "ENUM",
+                    "flags": [
+                        {
+                            "key": "LZ4",
+                            "label": "LZ4",
+                            "description": ""
+                        },
+                        {
+                            "key": "ZLIB",
+                            "label": "ZLIB",
+                            "description": ""
+                        },
+                        {
+                            "key": "ZSTD",
+                            "label": "ZSTD",
+                            "description": ""
+                        },
+                        {
+                            "key": "NONE",
+                            "label": "NONE",
+                            "description": ""
+                        }
+                    ],
+                    "default": "LZ4"
+                },
+                {
+                    "key": "memory_tracking_mode",
+                    "env": "GFXRECON_MEMORY_TRACKING_MODE",
+                    "label": "Memory Tracking Mode",
+                    "description": "Specifies the memory tracking mode to use for detecting modifications to mapped Vulkan memory objects. Available options are: page_guard, assisted, and unassisted.",
+                    "type": "ENUM",
+                    "flags": [
+                        {
+                            "key": "page_guard",
+                            "label": "page_guard",
+                            "description": "tracks modifications to individual memory pages, which are written to the capture file on calls to vkFlushMappedMemoryRanges, vkUnmapMemory, and vkQueueSubmit. Tracking modifications requires allocating shadow memory for all mapped memory."
+                        },
+                        {
+                            "key": "assisted",
+                            "label": "assisted",
+                            "description": "Expects the application to call vkFlushMappedMemoryRanges after memory is modified; the memory ranges specified to the vkFlushMappedMemoryRanges call will be written to the capture file during the call."
+                        },
+                        {
+                            "key": "unassisted",
+                            "label": "unassisted",
+                            "description": "writes the full content of mapped memory to the capture file on calls to vkUnmapMemory and vkQueueSubmit. It is very inefficient and may be unusable with real-world applications that map large amounts of memory."
+                        }
+                    ],
+                    "default": "page_guard",
+                    "settings": [
+                        {
+                            "key": "page_guard_copy_on_map",
+                            "env": "GFXRECON_PAGE_GUARD_COPY_ON_MAP",
+                            "label": "Page Guard Copy on Map",
+                            "description": "When the page_guard memory tracking mode is enabled, copies the content of the mapped memory to the shadow memory immediately after the memory is mapped.",
+                            "type": "BOOL",
+                            "default": true,
+                            "dependence": {
+                                "mode": "ALL",
+                                "settings": [
+                                    {
+                                        "key": "memory_tracking_mode",
+                                        "value": "page_guard"
+                                    }
+                                ]
                             }
-                        ],
-                        "default": "info"
-                    },
-                    {
-                        "key": "log_detailed",
-                        "env": "GFXRECON_LOG_DETAILED",
-                        "label": "Log Name and Line Number",
-                        "description": "Include name and line number from the file responsible.",
-                        "type": "BOOL",
-                        "default": false
-                    },
-                    {
-                        "key": "log_output_to_console",
-                        "env": "GFXRECON_LOG_OUTPUT_TO_CONSOLE",
-                        "label": "Log Output to Console / stdout",
-                        "description": "Log messages will be written to stdout.",
-                        "type": "BOOL",
-                        "default": true
-                    },
-                    {
-                        "key": "log_break_on_error",
-                        "env": "GFXRECON_LOG_BREAK_ON_ERROR",
-                        "label": "Trigger Debug Break on Error",
-                        "description": "Trigger a debug break when logging an error.",
-                        "type": "BOOL",
-                        "default": false
-                    },
-                    {
-                        "key": "log_output_to_os_debug_string",
-                        "env": "GFXRECON_LOG_OUTPUT_TO_OS_DEBUG_STRING",
-                        "label": "Log Output to Debug Console",
-                        "description": "Windows only option. Log messages will be written to the Debug Console with OutputDebugStringA",
-                        "type": "BOOL",
-                        "default": false
-                    },
-                    {
-                        "key": "log_file",
-                        "env": "GFXRECON_LOG_FILE",
-                        "label": "Log File",
-                        "description": "When set, log messages will be written to a file at the specified path. Default is: Empty string (file logging disabled).",
-                        "type": "SAVE_FILE",
-                        "filter": "*.txt",
-                        "default": ""
-                    },
-                    {
-                        "key": "log_file_flush_after_write",
-                        "env": "GFXRECON_LOG_FILE_FLUSH_AFTER_WRITE",
-                        "label": "Log File Flush After Write",
-                        "description": "Flush the log file to disk after each write when true.",
-                        "type": "BOOL",
-                        "default": false
-                    },
-                    {
-                        "key": "log_file_keep_open",
-                        "env": "GFXRECON_LOG_FILE_KEEP_OPEN",
-                        "label": "Log File Keep Open",
-                        "description": "Keep the log file open between log messages when true, or close and reopen the log file for each message when false.",
-                        "type": "BOOL",
-                        "default": true
-                    },
-                    {
-                        "key": "log_file_create_new",
-                        "env": "GFXRECON_LOG_FILE_CREATE_NEW",
-                        "label": "Log File Overwrite",
-                        "description": "Specifies that log file initialization should overwrite an existing file when true, or append to an existing file when false.",
-                        "type": "BOOL",
-                        "default": true
-                    }
-                ]
-            }
-        ]
+                        },
+                        {
+                            "key": "page_guard_separate_read",
+                            "env": "GFXRECON_PAGE_GUARD_SEPARATE_READ",
+                            "label": "Page Guard Separate Read Tracking",
+                            "description": "When the page_guard memory tracking mode is enabled, copies the content of pages accessed for read from mapped memory to shadow memory on each read. Can overwrite unprocessed shadow memory content when an application is reading from and writing to the same page.",
+                            "type": "BOOL",
+                            "default": true,
+                            "dependence": {
+                                "mode": "ALL",
+                                "settings": [
+                                    {
+                                        "key": "memory_tracking_mode",
+                                        "value": "page_guard"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "key": "page_guard_external_memory",
+                            "env": "GFXRECON_PAGE_GUARD_EXTERNAL_MEMORY",
+                            "label": "Page Guard External Memory",
+                            "description": "When the page_guard memory tracking mode is enabled, use the VK_EXT_external_memory_host extension to eliminate the need for shadow memory allocations. For each memory allocation from a host visible memory type, the capture layer will create an allocation from system memory, which it can monitor for write access, and provide that allocation to vkAllocateMemory as external memory. Only available on Windows.",
+                            "type": "BOOL",
+                            "default": false,
+                            "dependence": {
+                                "mode": "ALL",
+                                "settings": [
+                                    {
+                                        "key": "memory_tracking_mode",
+                                        "value": "page_guard"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "key": "log",
+                    "label": "Log",
+                    "description": "Control log messages.",
+                    "type": "GROUP",
+                    "settings": [
+                        {
+                            "key": "log_level",
+                            "env": "GFXRECON_LOG_LEVEL",
+                            "label": "Level",
+                            "description": "Specify the highest level message to log. Options are: debug, info, warning, error, and fatal. The specified level and all levels listed after it will be enabled for logging. For example, choosing the warning level will also enable the error and fatal levels.",
+                            "type": "ENUM",
+                            "flags": [
+                                {
+                                    "key": "debug",
+                                    "label": "debug, info, warning, error, fatal",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "info",
+                                    "label": "info, warning, error, fatal",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "warning",
+                                    "label": "warning, error, fatal",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "error",
+                                    "label": "error, fatal",
+                                    "description": ""
+                                },
+                                {
+                                    "key": "fatal",
+                                    "label": "fatal",
+                                    "description": ""
+                                }
+                            ],
+                            "default": "info"
+                        },
+                        {
+                            "key": "log_detailed",
+                            "env": "GFXRECON_LOG_DETAILED",
+                            "label": "Log Name and Line Number",
+                            "description": "Include name and line number from the file responsible.",
+                            "type": "BOOL",
+                            "default": false
+                        },
+                        {
+                            "key": "log_output_to_console",
+                            "env": "GFXRECON_LOG_OUTPUT_TO_CONSOLE",
+                            "label": "Log Output to Console / stdout",
+                            "description": "Log messages will be written to stdout.",
+                            "type": "BOOL",
+                            "default": true
+                        },
+                        {
+                            "key": "log_break_on_error",
+                            "env": "GFXRECON_LOG_BREAK_ON_ERROR",
+                            "label": "Trigger Debug Break on Error",
+                            "description": "Trigger a debug break when logging an error.",
+                            "type": "BOOL",
+                            "default": false
+                        },
+                        {
+                            "key": "log_output_to_os_debug_string",
+                            "env": "GFXRECON_LOG_OUTPUT_TO_OS_DEBUG_STRING",
+                            "label": "Log Output to Debug Console",
+                            "description": "Windows only option. Log messages will be written to the Debug Console with OutputDebugStringA",
+                            "type": "BOOL",
+                            "default": false
+                        },
+                        {
+                            "key": "log_file",
+                            "env": "GFXRECON_LOG_FILE",
+                            "label": "Log File",
+                            "description": "When set, log messages will be written to a file at the specified path. Default is: Empty string (file logging disabled).",
+                            "type": "SAVE_FILE",
+                            "filter": "*.txt",
+                            "default": ""
+                        },
+                        {
+                            "key": "log_file_flush_after_write",
+                            "env": "GFXRECON_LOG_FILE_FLUSH_AFTER_WRITE",
+                            "label": "Log File Flush After Write",
+                            "description": "Flush the log file to disk after each write when true.",
+                            "type": "BOOL",
+                            "default": false
+                        },
+                        {
+                            "key": "log_file_keep_open",
+                            "env": "GFXRECON_LOG_FILE_KEEP_OPEN",
+                            "label": "Log File Keep Open",
+                            "description": "Keep the log file open between log messages when true, or close and reopen the log file for each message when false.",
+                            "type": "BOOL",
+                            "default": true
+                        },
+                        {
+                            "key": "log_file_create_new",
+                            "env": "GFXRECON_LOG_FILE_CREATE_NEW",
+                            "label": "Log File Overwrite",
+                            "description": "Specifies that log file initialization should overwrite an existing file when true, or append to an existing file when false.",
+                            "type": "BOOL",
+                            "default": true
+                        }
+                    ]
+                }
+            ]
+        }
     }
 }


### PR DESCRIPTION
A bug caused old versions of vkconfig to crash when loading the layers settings from the layer repository.
To workaround this issue, the layer schema was modified, this change makes the layer manifest to match the updated layer schema.

This change need to be cherry picked to SDK-1.2.176 branch.