### PR TITLE
Remove 'unassisted' memory entry on free

### DIFF
--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -2420,14 +2420,21 @@ void TraceManager::PreProcess_vkFreeMemory(VkDevice                     device,
     {
         auto wrapper = reinterpret_cast<DeviceMemoryWrapper*>(memory);
 
-        if ((memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kPageGuard) &&
-            (wrapper->mapped_data != nullptr))
+        if (wrapper->mapped_data != nullptr)
         {
-            util::PageGuardManager* manager = util::PageGuardManager::Get();
-            assert(manager != nullptr);
+            if (memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kPageGuard)
+            {
+                util::PageGuardManager* manager = util::PageGuardManager::Get();
+                assert(manager != nullptr);
 
-            // Remove memory tracking.
-            manager->RemoveTrackedMemory(wrapper->handle_id);
+                // Remove memory tracking.
+                manager->RemoveTrackedMemory(wrapper->handle_id);
+            }
+            else if (memory_tracking_mode_ == CaptureSettings::MemoryTrackingMode::kUnassisted)
+            {
+                std::lock_guard<std::mutex> lock(mapped_memory_lock_);
+                mapped_memory_.erase(wrapper);
+            }
         }
     }
 }


### PR DESCRIPTION
When the "unassisted" mapped memory tracking mode is active, ensure that memory objects are removed from the mapped memory list if they are freed while mapped.
