### PR TITLE
manifest: some setting are only available on Windows

### DIFF
--- a/layer/json/VkLayer_gfxreconstruct.json.in
+++ b/layer/json/VkLayer_gfxreconstruct.json.in
@@ -7,6 +7,7 @@
         "api_version": "@VK_VERSION@",
         "implementation_version": "@GFXRECONSTRUCT_VERSION@",
         "description": "GFXReconstruct Capture Layer Version @GFXRECONSTRUCT_VERSION_STRING@",
+        "introduction": "A software for capturing and replaying Vulkan API calls on Desktop systems",
         "url": "https://vulkan.lunarg.com/doc/sdk/latest/windows/capture_tools.html",
         "status": "STABLE",
         "device_extensions": [
@@ -277,6 +278,7 @@
                             "env": "GFXRECON_PAGE_GUARD_EXTERNAL_MEMORY",
                             "label": "Page Guard External Memory",
                             "description": "When the page_guard memory tracking mode is enabled, use the VK_EXT_external_memory_host extension to eliminate the need for shadow memory allocations. For each memory allocation from a host visible memory type, the capture layer will create an allocation from system memory, which it can monitor for write access, and provide that allocation to vkAllocateMemory as external memory. Only available on Windows.",
+                            "platforms": [ "WINDOWS" ],
                             "type": "BOOL",
                             "default": false,
                             "dependence": {
@@ -361,6 +363,7 @@
                             "env": "GFXRECON_LOG_OUTPUT_TO_OS_DEBUG_STRING",
                             "label": "Log Output to Debug Console",
                             "description": "Windows only option. Log messages will be written to the Debug Console with OutputDebugStringA",
+                            "platforms": [ "WINDOWS" ],
                             "type": "BOOL",
                             "default": false
                         },


### PR DESCRIPTION
Some gfxreconstruct settings are only available on Windows. The layer manifest schema support this as a result the Windows only settings won't be visible on other OS.