### PR TITLE
Add apt-get update to Linux CI build

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -36,6 +36,7 @@ jobs:
       uses: actions/checkout@v1
     - name: Install build dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y libx11-xcb-dev libxcb-keysyms1-dev libwayland-dev libxrandr-dev liblz4-dev libzstd-dev
     - name: Run build script
       run: |

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -44,6 +44,7 @@ jobs:
       uses: actions/checkout@v1
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y libx11-xcb-dev libxcb-keysyms1-dev libwayland-dev libxrandr-dev liblz4-dev libzstd-dev
     - name: Run build script
       run: |


### PR DESCRIPTION
Add an "apt-get update" command for the Linux builds defined in the ci_build.yml and release_build.yml actions files.
