### PR TITLE
Fix a race condition and crash when done trimming

### DIFF
--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -1002,6 +1002,7 @@ class TraceManager
     std::string CreateTrimFilename(const std::string& base_filename, const CaptureSettings::TrimRange& trim_range);
     bool        CreateCaptureFile(const std::string& base_filename);
     void        ActivateTrimming();
+    void        DeactivateTrimming();
 
     void WriteFileHeader();
     void BuildOptionList(const format::EnabledOptions&        enabled_options,


### PR DESCRIPTION
When an app is done trimming, the file is closed and GFXR sets a state
variable to indicate no additional API calls should be captured to the
file. However there was a race condition around changing the trim state
and the file close, so it was possible for a thread to try and write to file
after it was closed. This is fixed by acquiring the unique state lock
when opening and closing the file.
