### PR TITLE
Deferred operation fix

### DIFF
--- a/android/framework/encode/CMakeLists.txt
+++ b/android/framework/encode/CMakeLists.txt
@@ -1,3 +1,30 @@
+###############################################################################
+# Copyright (c) 2018-2020 LunarG, Inc.
+# Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
+# All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+# Author: LunarG Team
+# Author: AMD Developer Tools Team
+# Description: CMake script for framework util target
+###############################################################################
 add_library(gfxrecon_encode STATIC "")
 
 target_sources(gfxrecon_encode

--- a/android/framework/encode/CMakeLists.txt
+++ b/android/framework/encode/CMakeLists.txt
@@ -16,6 +16,8 @@ target_sources(gfxrecon_encode
                    ${GFXRECON_SOURCE_DIR}/framework/encode/parameter_buffer.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/parameter_encoder.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/struct_pointer_encoder.h
+                   ${GFXRECON_SOURCE_DIR}/framework/encode/deferred_operation.h
+                   ${GFXRECON_SOURCE_DIR}/framework/encode/deferred_operation.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/encode/trace_manager.h
                    ${GFXRECON_SOURCE_DIR}/framework/encode/trace_manager.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/encode/vulkan_handle_wrappers.h

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -79,6 +79,7 @@ target_sources(gfxrecon_decode
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_object_cleanup_util.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_object_cleanup_util.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_object_info.h
+                    ${CMAKE_CURRENT_LIST_DIR}/deferred_operation_info.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_object_info_table.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_realign_allocator.h
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_realign_allocator.cpp

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -1,6 +1,6 @@
 ###############################################################################
 # Copyright (c) 2018-2020 LunarG, Inc.
-# Copyright (c) 2019-2020 Advanced Micro Devices, Inc.
+# Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
 # All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/framework/decode/deferred_operation_info.h
+++ b/framework/decode/deferred_operation_info.h
@@ -1,0 +1,163 @@
+/*
+** Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef GFXRECON_DECODE_DEFERRED_OPERATION_INFO_H
+#define GFXRECON_DECODE_DEFERRED_OPERATION_INFO_H
+
+#include "generated/generated_vulkan_struct_decoders.h"
+#include "decode/vulkan_object_info.h"
+//#include "decode/vulkan_resource_allocator.h"
+//#include "decode/vulkan_resource_initializer.h"
+//#include "decode/window.h"
+//#include "format/format.h"
+//#include "generated/generated_vulkan_dispatch_table.h"
+//#include "graphics/vulkan_device_util.h"
+//#include "util/defines.h"
+
+#include "vulkan/vulkan.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(decode)
+
+class DeferredOperationInfo
+{
+  public:
+    DeferredOperationInfo(format::ApiCallId call_id) : api_call_id_(call_id), process_done_(false) {}
+    ~DeferredOperationInfo() {}
+
+    format::ApiCallId GetApiCallId() { return api_call_id_; }
+    bool              IsProcessDone() { return process_done_; }
+    void              ProcessDone() { process_done_ = true; }
+
+  protected:
+    format::ApiCallId api_call_id_;
+    bool              process_done_;
+};
+
+class DeferredOperationInfoManager
+{
+  public:
+    static std::unique_ptr<DeferredOperationInfoManager>& Get() { return instance_; }
+
+    void add(format::HandleId deferred_operation_handle, std::unique_ptr<DeferredOperationInfo> operation)
+    {
+        if ((deferred_operation_handle != gfxrecon::format::kNullHandleId) && (operation))
+        {
+            deferred_operations_[deferred_operation_handle] = std::move(operation);
+        }
+    }
+
+    std::unique_ptr<DeferredOperationInfo>& find(format::HandleId deferred_operation_handle)
+    {
+        if (deferred_operations_.find(deferred_operation_handle) != deferred_operations_.end())
+        {
+            return deferred_operations_[deferred_operation_handle];
+        }
+        else
+        {
+            return null_operation_;
+        }
+    }
+
+    void Remove(format::HandleId deferred_operation_handle)
+    {
+        std::unique_ptr<DeferredOperationInfo> deferred_operation = std::move(find(deferred_operation_handle));
+        deferred_operations_.erase(deferred_operation_handle);
+    }
+
+    DeferredOperationInfoManager() {}
+
+    ~DeferredOperationInfoManager() {}
+
+  protected:
+    std::unordered_map<format::HandleId, std::unique_ptr<DeferredOperationInfo>> deferred_operations_;
+    static std::unique_ptr<DeferredOperationInfoManager>                         instance_;
+    std::unique_ptr<DeferredOperationInfo> null_operation_ = std::unique_ptr<DeferredOperationInfo>(nullptr);
+};
+
+class DeferredOperationInfoCreateRayTracingPipelines : public DeferredOperationInfo
+{
+  public:
+    DeferredOperationInfoCreateRayTracingPipelines() :
+        DeferredOperationInfo(format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesKHR)
+    {}
+
+    ~DeferredOperationInfoCreateRayTracingPipelines() {}
+
+    format::HandleId& GetDeviceId() { return device_; }
+
+    format::HandleId& GetDeferredOperationId() { return deferredOperation_; }
+
+    format::HandleId& GetPipelineCacheId() { return pipelineCache_; }
+
+    uint32_t& GetCreateInfoCount() { return createInfoCount_; }
+
+    StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>& GetCreateInfos() { return CreateInfos_; }
+
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>& GetAllocator() { return Allocator_; }
+
+    HandlePointerDecoder<VkPipeline>& GetPipelines() { return Pipelines_; }
+
+    void SetPipelineHandleInfo(std::unique_ptr<std::vector<PipelineInfo>>& pipeline_infos)
+    {
+        pipeline_handle_info_ = std::move(pipeline_infos);
+    }
+
+    std::unique_ptr<std::vector<PipelineInfo>>& GetPipelineHandleInfo() { return pipeline_handle_info_; }
+
+    void SetModifiedCreateInfos(std::unique_ptr<std::vector<VkRayTracingPipelineCreateInfoKHR>>& modified_create_infos)
+    {
+        modified_create_infos_ = std::move(modified_create_infos);
+    }
+
+    std::unique_ptr<std::vector<VkRayTracingPipelineCreateInfoKHR>>& GetModifiedCreateInfos()
+    {
+        return modified_create_infos_;
+    }
+
+    void
+    SetModifiedGroups(std::unique_ptr<std::vector<std::vector<VkRayTracingShaderGroupCreateInfoKHR>>>& modified_pgroups)
+    {
+        modified_pgroups_ = std::move(modified_pgroups);
+    }
+
+    std::unique_ptr<std::vector<std::vector<VkRayTracingShaderGroupCreateInfoKHR>>>& GetModifiedGroups()
+    {
+        return modified_pgroups_;
+    };
+
+  private:
+    format::HandleId                                                                device_;
+    format::HandleId                                                                deferredOperation_;
+    format::HandleId                                                                pipelineCache_;
+    uint32_t                                                                        createInfoCount_;
+    HandlePointerDecoder<VkPipeline>                                                Pipelines_;
+    std::unique_ptr<std::vector<PipelineInfo>>                                      pipeline_handle_info_;
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>                             Allocator_;
+    StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>                 CreateInfos_;
+    std::unique_ptr<std::vector<VkRayTracingPipelineCreateInfoKHR>>                 modified_create_infos_;
+    std::unique_ptr<std::vector<std::vector<VkRayTracingShaderGroupCreateInfoKHR>>> modified_pgroups_;
+};
+
+GFXRECON_END_NAMESPACE(decode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_DECODE_DEFERRED_OPERATION_INFO_H

--- a/framework/decode/deferred_operation_info.h
+++ b/framework/decode/deferred_operation_info.h
@@ -1,16 +1,23 @@
 /*
-** Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
+** Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
 **
-**     http://www.apache.org/licenses/LICENSE-2.0
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
 **
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
 */
 
 #ifndef GFXRECON_DECODE_DEFERRED_OPERATION_INFO_H

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -44,6 +44,8 @@ target_sources(gfxrecon_encode
                     ${CMAKE_CURRENT_LIST_DIR}/parameter_buffer.h
                     ${CMAKE_CURRENT_LIST_DIR}/parameter_encoder.h
                     ${CMAKE_CURRENT_LIST_DIR}/struct_pointer_encoder.h
+                    ${CMAKE_CURRENT_LIST_DIR}/deferred_operation.h
+                    ${CMAKE_CURRENT_LIST_DIR}/deferred_operation.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/trace_manager.h
                     ${CMAKE_CURRENT_LIST_DIR}/trace_manager.cpp
                     ${CMAKE_CURRENT_LIST_DIR}/vulkan_handle_wrappers.h

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -1,6 +1,6 @@
 ###############################################################################
 # Copyright (c) 2018-2020 LunarG, Inc.
-# Copyright (c) 2019-2020 Advanced Micro Devices, Inc.
+# Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
 # All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/framework/encode/deferred_operation.cpp
+++ b/framework/encode/deferred_operation.cpp
@@ -1,16 +1,23 @@
 /*
-** Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
+** Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
 **
-**     http://www.apache.org/licenses/LICENSE-2.0
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
 **
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
 */
 
 #include "project_version.h"

--- a/framework/encode/deferred_operation.h
+++ b/framework/encode/deferred_operation.h
@@ -1,16 +1,23 @@
 /*
-** Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
+** Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
 **
-**     http://www.apache.org/licenses/LICENSE-2.0
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
 **
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
 */
 
 #ifndef GFXRECON_ENCODE_DEFERRED_OPERATION_H

--- a/framework/encode/deferred_operation.h
+++ b/framework/encode/deferred_operation.h
@@ -1,0 +1,179 @@
+/*
+** Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+
+#ifndef GFXRECON_ENCODE_DEFERRED_OPERATION_H
+#define GFXRECON_ENCODE_DEFERRED_OPERATION_H
+
+#include "encode/capture_settings.h"
+#include "encode/descriptor_update_template_info.h"
+#include "encode/parameter_buffer.h"
+#include "encode/parameter_encoder.h"
+#include "encode/vulkan_handle_wrapper_util.h"
+#include "encode/vulkan_handle_wrappers.h"
+#include "encode/vulkan_state_tracker.h"
+#include "format/api_call_id.h"
+#include "format/format.h"
+#include "format/platform_types.h"
+#include "generated/generated_vulkan_dispatch_table.h"
+#include "generated/generated_vulkan_command_buffer_util.h"
+#include "util/compressor.h"
+#include "util/defines.h"
+#include "util/file_output_stream.h"
+#include "util/keyboard.h"
+#include "util/shared_mutex.h"
+
+#include "vulkan/vulkan.h"
+
+#include <atomic>
+#include <cassert>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(encode)
+
+class DeferredOperation
+{
+  public:
+    DeferredOperation(format::ApiCallId call_id, VkDevice device, VkDeferredOperationKHR deferred_operation_handle) :
+        api_call_id_(call_id), deferred_operation_(deferred_operation_handle), device_(device)
+    {}
+    ~DeferredOperation() {}
+
+    virtual VkResult GetStatus();
+    virtual void     PostProcess() = 0;
+
+    format::ApiCallId GetApiCallId() { return api_call_id_; }
+  protected:
+    format::ApiCallId      api_call_id_;
+    VkDeferredOperationKHR deferred_operation_;
+    VkDevice               device_;
+};
+
+class DeferredOperationManager
+{
+  public:
+    static std::unique_ptr<DeferredOperationManager>& Get() { return instance_; }
+
+    void add(VkDeferredOperationKHR deferred_operation_handle, std::unique_ptr<DeferredOperation> operation)
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        if ((deferred_operation_handle != VK_NULL_HANDLE) && (operation))
+        {
+            deferred_operations_[deferred_operation_handle] = std::move(operation);
+        }
+    }
+
+    std::unique_ptr<DeferredOperation>& Find(VkDeferredOperationKHR deferred_operation_handle)
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        return FindDeferredOperation(deferred_operation_handle);
+    }
+
+    void PostProcess(VkDeferredOperationKHR deferred_operation_handle)
+    {
+        const std::lock_guard<std::mutex>   lock(mutex_);
+        std::unique_ptr<DeferredOperation>& deferred_operation = FindDeferredOperation(deferred_operation_handle);
+        if (deferred_operation)
+        {
+            deferred_operation->PostProcess();
+            deferred_operations_.erase(deferred_operation_handle);
+        }
+    }
+
+    // return the current status of the deferred operation.
+    // return VK_ERROR_UNKNOWN if deferred_operation_handle is not found.
+    VkResult GetStatus(VkDeferredOperationKHR deferred_operation_handle)
+    {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        VkResult                          result = VK_ERROR_UNKNOWN;
+
+        std::unique_ptr<DeferredOperation>& deferred_operation = FindDeferredOperation(deferred_operation_handle);
+        if (deferred_operation)
+        {
+            result = deferred_operation->GetStatus();
+        }
+        return result;
+    }
+
+    DeferredOperationManager() {}
+
+    ~DeferredOperationManager() {}
+
+  protected:
+    std::unique_ptr<DeferredOperation>& FindDeferredOperation(VkDeferredOperationKHR deferred_operation_handle)
+    {
+        if (deferred_operations_.find(deferred_operation_handle) != deferred_operations_.end())
+        {
+            return deferred_operations_[deferred_operation_handle];
+        }
+        else
+        {
+            return null_operation_;
+        }
+    }
+
+  private:
+    std::mutex                                                                     mutex_;
+    std::unordered_map<VkDeferredOperationKHR, std::unique_ptr<DeferredOperation>> deferred_operations_;
+    static std::unique_ptr<DeferredOperationManager>                               instance_;
+    std::unique_ptr<DeferredOperation> null_operation_ = std::unique_ptr<DeferredOperation>(nullptr);
+};
+
+class DeferredOperationCreateRayTracingPipelines : public DeferredOperation
+{
+  public:
+    DeferredOperationCreateRayTracingPipelines(VkDevice                                 device,
+                                               VkDeferredOperationKHR                   deferredOperation,
+                                               VkPipelineCache                          pipelineCache,
+                                               uint32_t                                 createInfoCount,
+                                               const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,
+                                               const VkAllocationCallbacks*             pAllocator,
+                                               VkPipeline*                              pPipelines) :
+        DeferredOperation(format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesKHR, device, deferredOperation),
+        pipeline_cache_(pipelineCache), create_info_count_(createInfoCount),
+        create_infos_(pCreateInfos), allocator_(pAllocator), pipelines_(pPipelines),
+        modified_create_infos_(std::make_unique<VkRayTracingPipelineCreateInfoKHR[]>(createInfoCount))
+    {}
+
+    ~DeferredOperationCreateRayTracingPipelines() {}
+
+    void PostProcess();
+
+    std::unique_ptr<VkRayTracingPipelineCreateInfoKHR[]>& GetModifiedCreateInfos() { return modified_create_infos_; }
+    HandleUnwrapMemory&                                   GetHandleUnwrapMemory() { return handle_unwrap_memory_; }
+    const VkRayTracingPipelineCreateInfoKHR*&             GetCreateInfosUnwrapped() { return create_infos_unwrapped_; }
+
+  private:
+    VkPipelineCache                          pipeline_cache_;
+    uint32_t                                 create_info_count_;
+    const VkRayTracingPipelineCreateInfoKHR* create_infos_;
+    const VkAllocationCallbacks*             allocator_;
+    VkPipeline*                              pipelines_;
+
+    HandleUnwrapMemory                                   handle_unwrap_memory_;
+    std::unique_ptr<VkRayTracingPipelineCreateInfoKHR[]> modified_create_infos_;
+    const VkRayTracingPipelineCreateInfoKHR*             create_infos_unwrapped_;
+};
+
+GFXRECON_END_NAMESPACE(encode)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_ENCODE_DEFERRED_OPERATION_H

--- a/framework/encode/trace_manager.cpp
+++ b/framework/encode/trace_manager.cpp
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
-** Copyright (c) 2019 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -925,6 +925,21 @@ class TraceManager
     void OverrideGetPhysicalDeviceSurfacePresentModesKHR(uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes);
 #endif
 
+    void WriteSetRayTracingShaderGroupHandlesCommand(format::HandleId device_id,
+                                                     format::HandleId pipeline_id,
+                                                     size_t           data_size,
+                                                     const void*      data);
+    typedef uint32_t CaptureMode;
+    enum CaptureModeFlags : uint32_t
+    {
+        kModeDisabled      = 0x0,
+        kModeWrite         = 0x01,
+        kModeTrack         = 0x02,
+        kModeWriteAndTrack = (kModeWrite | kModeTrack)
+    };
+
+    CaptureMode GetCaptureMode() { return capture_mode_; }
+    std::unique_ptr<VulkanStateTracker>& GetStateTracker() { return state_tracker_; }
   protected:
     TraceManager();
 
@@ -933,13 +948,6 @@ class TraceManager
     bool Initialize(std::string base_filename, const CaptureSettings::TraceSettings& trace_settings);
 
   private:
-    enum CaptureModeFlags : uint32_t
-    {
-        kModeDisabled      = 0x0,
-        kModeWrite         = 0x01,
-        kModeTrack         = 0x02,
-        kModeWriteAndTrack = (kModeWrite | kModeTrack)
-    };
 
     enum PageGuardMemoryMode : uint32_t
     {
@@ -949,7 +957,6 @@ class TraceManager
         kMemoryModeExternal          // Imported host memory without shadow allocations.
     };
 
-    typedef uint32_t CaptureMode;
 
     class ThreadData
     {
@@ -1025,11 +1032,6 @@ class TraceManager
     void WriteSetDeviceMemoryPropertiesCommand(format::HandleId                        physical_device_id,
                                                const VkPhysicalDeviceMemoryProperties& memory_properties);
     void WriteSetOpaqueAddressCommand(format::HandleId device_id, format::HandleId object_id, uint64_t address);
-
-    void WriteSetRayTracingShaderGroupHandlesCommand(format::HandleId device_id,
-                                                     format::HandleId pipeline_id,
-                                                     size_t           data_size,
-                                                     const void*      data);
 
     void SetDescriptorUpdateTemplateInfo(VkDescriptorUpdateTemplate                  update_template,
                                          const VkDescriptorUpdateTemplateCreateInfo* create_info);

--- a/framework/encode/trace_manager.h
+++ b/framework/encode/trace_manager.h
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
-** Copyright (c) 2019 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -39,6 +39,7 @@
 #include "generated/generated_vulkan_command_buffer_util.h"
 #include "generated/generated_vulkan_struct_handle_wrappers.h"
 #include "util/defines.h"
+#include "encode/deferred_operation.h"
 
 #include "vulkan/vulkan.h"
 
@@ -8481,6 +8482,12 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeferredOperationResultKHR(
 
     VkResult result = GetDeviceTable(device)->GetDeferredOperationResultKHR(device_unwrapped, operation_unwrapped);
 
+    if (result == VK_SUCCESS)
+    {
+        // The deferred operation done and return VK_SUCCESS
+        DeferredOperationManager::Get()->PostProcess(operation);
+    }
+
     auto encoder = TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkGetDeferredOperationResultKHR);
     if (encoder)
     {
@@ -8507,6 +8514,12 @@ VKAPI_ATTR VkResult VKAPI_CALL DeferredOperationJoinKHR(
     VkDeferredOperationKHR operation_unwrapped = GetWrappedHandle<VkDeferredOperationKHR>(operation);
 
     VkResult result = GetDeviceTable(device)->DeferredOperationJoinKHR(device_unwrapped, operation_unwrapped);
+
+    if (result == VK_SUCCESS)
+    {
+        // The deferred operation done and return VK_SUCCESS
+        DeferredOperationManager::Get()->PostProcess(operation);
+    }
 
     auto encoder = TraceManager::Get()->BeginApiCallTrace(format::ApiCallId::ApiCall_vkDeferredOperationJoinKHR);
     if (encoder)
@@ -14244,18 +14257,21 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(
         omit_output_data = true;
     }
 
-    auto encoder = TraceManager::Get()->BeginTrackedApiCallTrace(format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesKHR);
-    if (encoder)
+    if (deferredOperation == VK_NULL_HANDLE)
     {
-        encoder->EncodeHandleValue(device);
-        encoder->EncodeHandleValue(deferredOperation);
-        encoder->EncodeHandleValue(pipelineCache);
-        encoder->EncodeUInt32Value(createInfoCount);
-        EncodeStructArray(encoder, pCreateInfos, createInfoCount);
-        EncodeStructPtr(encoder, pAllocator);
-        encoder->EncodeHandleArray(pPipelines, createInfoCount, omit_output_data);
-        encoder->EncodeEnumValue(result);
-        TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, VkDeferredOperationKHR, PipelineWrapper, VkRayTracingPipelineCreateInfoKHR>(result, device, deferredOperation, createInfoCount, pPipelines, pCreateInfos);
+        auto encoder = TraceManager::Get()->BeginTrackedApiCallTrace(format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesKHR);
+        if (encoder)
+        {
+            encoder->EncodeHandleValue(device);
+            encoder->EncodeHandleValue(deferredOperation);
+            encoder->EncodeHandleValue(pipelineCache);
+            encoder->EncodeUInt32Value(createInfoCount);
+            EncodeStructArray(encoder, pCreateInfos, createInfoCount);
+            EncodeStructPtr(encoder, pAllocator);
+            encoder->EncodeHandleArray(pPipelines, createInfoCount, omit_output_data);
+            encoder->EncodeEnumValue(result);
+            TraceManager::Get()->EndGroupCreateApiCallTrace<VkDevice, VkDeferredOperationKHR, PipelineWrapper, VkRayTracingPipelineCreateInfoKHR>(result, device, deferredOperation, createInfoCount, pPipelines, pCreateInfos);
+        }
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesKHR>::Dispatch(TraceManager::Get(), result, device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
 ** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2019-2021 Advanced Micro Devices, Inc. All rights reserved.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_decoder.cpp
+++ b/framework/generated/generated_vulkan_decoder.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
 ** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_decoder.cpp
+++ b/framework/generated/generated_vulkan_decoder.cpp
@@ -33,6 +33,7 @@
 #include "decode/string_decoder.h"
 #include "decode/struct_pointer_decoder.h"
 #include "decode/value_decoder.h"
+#include "decode/deferred_operation_info.h"
 #include "generated/generated_vulkan_decoder.h"
 #include "generated/generated_vulkan_struct_decoders_forward.h"
 #include "util/defines.h"
@@ -40,9 +41,12 @@
 #include "vulkan/vulkan.h"
 
 #include <cstddef>
+#include <decode/vulkan_object_info.h>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
+
+std::unique_ptr<DeferredOperationInfoManager>          DeferredOperationInfoManager::instance_ = std::make_unique<DeferredOperationInfoManager>();
 
 size_t VulkanDecoder::Decode_vkCreateInstance(const uint8_t* parameter_buffer, size_t buffer_size)
 {
@@ -10066,17 +10070,24 @@ size_t VulkanDecoder::Decode_vkCreateRayTracingPipelinesKHR(const uint8_t* param
 {
     size_t bytes_read = 0;
 
-    format::HandleId device;
-    format::HandleId deferredOperation;
-    format::HandleId pipelineCache;
-    uint32_t createInfoCount;
-    StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR> pCreateInfos;
-    StructPointerDecoder<Decoded_VkAllocationCallbacks> pAllocator;
-    HandlePointerDecoder<VkPipeline> pPipelines;
+    std::unique_ptr<DeferredOperationInfoCreateRayTracingPipelines>&& deferred_operation_info_instance =
+        std::make_unique<DeferredOperationInfoCreateRayTracingPipelines>();
+    format::HandleId& device = deferred_operation_info_instance->GetDeviceId();
+    format::HandleId& deferredOperation = deferred_operation_info_instance->GetDeferredOperationId();
+    format::HandleId& pipelineCache = deferred_operation_info_instance->GetPipelineCacheId();
+    uint32_t& createInfoCount = deferred_operation_info_instance->GetCreateInfoCount();
+    StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>& pCreateInfos = deferred_operation_info_instance->GetCreateInfos();
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>& pAllocator = deferred_operation_info_instance->GetAllocator();
+    HandlePointerDecoder<VkPipeline>& pPipelines = deferred_operation_info_instance->GetPipelines();
     VkResult return_value;
 
     bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &device);
     bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &deferredOperation);
+    if (deferredOperation != gfxrecon::format::kNullHandleId)
+    {
+        DeferredOperationInfoManager::Get()->add(deferredOperation, std::move(deferred_operation_info_instance));
+    }
+
     bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &pipelineCache);
     bytes_read += ValueDecoder::DecodeUInt32Value((parameter_buffer + bytes_read), (buffer_size - bytes_read), &createInfoCount);
     bytes_read += pCreateInfos.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -30,6 +30,7 @@
 
 #include "decode/custom_vulkan_struct_handle_mappers.h"
 #include "decode/vulkan_handle_mapping_util.h"
+#include "decode/deferred_operation_info.h"
 #include "generated/generated_vulkan_dispatch_table.h"
 #include "generated/generated_vulkan_struct_handle_mappers.h"
 #include "util/defines.h"
@@ -3908,9 +3909,34 @@ void VulkanReplayConsumer::Process_vkDeferredOperationJoinKHR(
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
     VkDeferredOperationKHR in_operation = MapHandle<DeferredOperationKHRInfo>(operation, &VulkanObjectInfoTable::GetDeferredOperationKHRInfo);
-
-    VkResult replay_result = GetDeviceTable(in_device)->DeferredOperationJoinKHR(in_device, in_operation);
-    CheckResult("vkDeferredOperationJoinKHR", returnValue, replay_result);
+    VkResult replay_result = VK_NOT_READY;
+    if (returnValue == VK_SUCCESS)
+    {
+        while(replay_result != VK_SUCCESS)
+        {
+            replay_result = GetDeviceTable(in_device)->DeferredOperationJoinKHR(in_device, in_operation);
+        }
+        CheckResult("vkDeferredOperationJoinKHR", returnValue, replay_result);
+    }
+    else
+    {
+        replay_result = GetDeviceTable(in_device)->DeferredOperationJoinKHR(in_device, in_operation);
+    }
+    if (replay_result == VK_SUCCESS)
+    {
+        DeferredOperationInfoCreateRayTracingPipelines* deferred_operation_create_ray_tracing_pipelines = static_cast<DeferredOperationInfoCreateRayTracingPipelines*>(DeferredOperationInfoManager::Get()->find(operation).get());
+        if (deferred_operation_create_ray_tracing_pipelines != nullptr)
+        {
+            AddHandles<PipelineInfo>(deferred_operation_create_ray_tracing_pipelines->GetDeviceId(),
+                                 deferred_operation_create_ray_tracing_pipelines->GetPipelines().GetPointer(),
+                                 deferred_operation_create_ray_tracing_pipelines->GetPipelines().GetLength(),
+                                 deferred_operation_create_ray_tracing_pipelines->GetPipelines().GetHandlePointer(),
+                                 deferred_operation_create_ray_tracing_pipelines->GetCreateInfoCount(),
+                                 std::move(*deferred_operation_create_ray_tracing_pipelines->GetPipelineHandleInfo()),
+                                 &VulkanObjectInfoTable::AddPipelineInfo);
+            DeferredOperationInfoManager::Get()->Remove(operation);
+        }
+    }
 }
 
 void VulkanReplayConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
@@ -6497,13 +6523,20 @@ void VulkanReplayConsumer::Process_vkCreateRayTracingPipelinesKHR(
 
     MapStructArrayHandles(pCreateInfos->GetMetaStructPointer(), pCreateInfos->GetLength(), GetObjectInfoTable());
     if (!pPipelines->IsNull()) { pPipelines->SetHandleLength(createInfoCount); }
-    std::vector<PipelineInfo> handle_info(createInfoCount);
-    for (size_t i = 0; i < createInfoCount; ++i) { pPipelines->SetConsumerData(i, &handle_info[i]); }
+    std::unique_ptr<std::vector<PipelineInfo>> handle_info = std::make_unique<std::vector<PipelineInfo>>(createInfoCount);
+    for (size_t i = 0; i < createInfoCount; ++i) { pPipelines->SetConsumerData(i, &handle_info.get()[i]); }
 
     VkResult replay_result = OverrideCreateRayTracingPipelinesKHR(GetDeviceTable(in_device->handle)->CreateRayTracingPipelinesKHR, returnValue, in_device, in_deferredOperation, in_pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
-    CheckResult("vkCreateRayTracingPipelinesKHR", returnValue, replay_result);
-
-    AddHandles<PipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), pPipelines->GetHandlePointer(), createInfoCount, std::move(handle_info), &VulkanObjectInfoTable::AddPipelineInfo);
+    if (deferredOperation == gfxrecon::format::kNullHandleId)
+    {
+        CheckResult("vkCreateRayTracingPipelinesKHR", returnValue, replay_result);
+        AddHandles<PipelineInfo>(device, pPipelines->GetPointer(), pPipelines->GetLength(), pPipelines->GetHandlePointer(), createInfoCount, std::move(*handle_info), &VulkanObjectInfoTable::AddPipelineInfo);
+    }
+    else
+    {
+        DeferredOperationInfoCreateRayTracingPipelines* deferred_operation_create_ray_tracing_pipelines = static_cast<DeferredOperationInfoCreateRayTracingPipelines*>(DeferredOperationInfoManager::Get()->find(deferredOperation).get());
+        deferred_operation_create_ray_tracing_pipelines->SetPipelineHandleInfo(std::move(handle_info));
+    }
 }
 
 void VulkanReplayConsumer::Process_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2020 Valve Corporation
 ** Copyright (c) 2018-2020 LunarG, Inc.
+** Copyright (c) 2019-2021 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
 This pull request includes the following changes:  if vkCreateRayTracingPipelinesKHR
 is a deferred operation, the lifetime of the input parameters is extended to cover
 related vkDeferredOperationJoinKHR and vkGetDeferredOperationResultKHR
 until the return value show the deferred operation is finished. The post handling
 of vkCreateRayTracingPipelinesKHR will start after the deferred operation is
 finished.