### PR TITLE
Android VVL Documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -362,11 +362,11 @@ Next, add the following lines to the application's `build.gradle` file:
     gfxreconstruct/android/tools/replay/src/main/jniLibs/
         arm64-v8a/
             libVkLayer_khronos_validation.so
-          armeabi-v7a/
+        armeabi-v7a/
             libVkLayer_khronos_validation.so
-          x86/
+        x86/
             libVkLayer_khronos_validation.so
-          x86-64/
+        x86-64/
             libVkLayer_khronos_validation.so
     ```
 3. Rebuild and deploy `gfxrecon-replay`

--- a/BUILD.md
+++ b/BUILD.md
@@ -359,7 +359,7 @@ Next, add the following lines to the application's `build.gradle` file:
 1. Download the latest Android Vulkan Validation Layer binaries from the [GitHub release page](https://github.com/KhronosGroup/Vulkan-ValidationLayers/releases)
 2. Extract the prebuilt layer binaries and include them in the `gfxrecon-replay` APK by adding them to the following directories:
     ```
-    src/main/jniLibs/
+    gfxreconstruct/android/tools/replay/src/main/jniLibs/
         arm64-v8a/
             libVkLayer_khronos_validation.so
           armeabi-v7a/

--- a/BUILD.md
+++ b/BUILD.md
@@ -358,17 +358,17 @@ Next, add the following lines to the application's `build.gradle` file:
 
 1. Download the latest Android Vulkan Validation Layer binaries from the [GitHub release page](https://github.com/KhronosGroup/Vulkan-ValidationLayers/releases)
 2. Extract the prebuilt layer binaries and include them in the `gfxrecon-replay` APK by adding them to the following directories:
-    ```
-    gfxreconstruct/android/tools/replay/src/main/jniLibs/
-        arm64-v8a/
-            libVkLayer_khronos_validation.so
-        armeabi-v7a/
-            libVkLayer_khronos_validation.so
-        x86/
-            libVkLayer_khronos_validation.so
-        x86-64/
-            libVkLayer_khronos_validation.so
-    ```
+```text
+gfxreconstruct/android/tools/replay/src/main/jniLibs/
+    arm64-v8a/
+        libVkLayer_khronos_validation.so
+    armeabi-v7a/
+        libVkLayer_khronos_validation.so
+    x86/
+        libVkLayer_khronos_validation.so
+    x86-64/
+        libVkLayer_khronos_validation.so
+```
 3. Rebuild and deploy `gfxrecon-replay`
 
 The [Android Vulkan Validation Guide](https://developer.android.com/ndk/guides/graphics/validation-layer) has further instructions for advanced validation layer usage on Android

--- a/BUILD.md
+++ b/BUILD.md
@@ -353,3 +353,22 @@ Next, add the following lines to the application's `build.gradle` file:
         implementation project(':VkLayer_gfxreconstruct')
     }
 ```
+
+#### Adding the Vulkan Validation Layer to `gfxrecon-replay`
+
+1. Download the latest Android Vulkan Validation Layer binaries from the [GitHub release page](https://github.com/KhronosGroup/Vulkan-ValidationLayers/releases)
+2. Extract the prebuilt layer binaries and include them in the `gfxrecon-replay` APK by adding them to the following directories:
+    ```
+    src/main/jniLibs/
+        arm64-v8a/
+            libVkLayer_khronos_validation.so
+          armeabi-v7a/
+            libVkLayer_khronos_validation.so
+          x86/
+            libVkLayer_khronos_validation.so
+          x86-64/
+            libVkLayer_khronos_validation.so
+    ```
+3. Rebuild and deploy `gfxrecon-replay`
+
+The [Android Vulkan Validation Guide](https://developer.android.com/ndk/guides/graphics/validation-layer) has further instructions for advanced validation layer usage on Android

--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -370,6 +370,8 @@ adb shell am force-stop com.lunarg.gfxreconstruct.replay
 adb shell am start -n "com.lunarg.gfxreconstruct.replay/android.app.NativeActivity" -a android.intent.action.MAIN -c android.intent.category.LAUNCHER --es "args" "<arg-list>"
 ```
 
+If `gfxrecon-replay` was built with Vulkan Validation Layer support, `VK_LAYER_KHRONOS_validation` can be enabled and disabled in the same manner as `VK_LAYER_LUNARG_gfxreconstruct`
+
 #### Touch Controls
 
 The `gfxrecon-replay` tool for Android supports the following touch controls:


### PR DESCRIPTION
This PR adds instructions for building `gfxrecon-replay` with Vulkan Validation Layer support and instructions for enabling validation during replay.