### PR TITLE
Dev user vk registry

### DIFF
--- a/framework/generated/generate_vulkan.py
+++ b/framework/generated/generate_vulkan.py
@@ -20,21 +20,24 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+'''Generate GFXR Vulkan framework source code
+'''
 
+import argparse
 import os
 import sys
 import subprocess
 
-# Relative path from code generators to directory containing the Vulkan XML Registry.
-registry_path = '../../external/Vulkan-Headers/registry'
-
-# Relative path to vulkan code generators for trace encode/decode.
-generator_path = './vulkan_generators'
+SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
+KHRONOS_REGISTRY_DIR = os.path.normpath(
+    os.path.join(SCRIPT_DIR, '..', '..', 'external', 'Vulkan-Headers',
+                 'registry'))
+BASE_GENERATOR_DIR = os.path.join(SCRIPT_DIR, 'base_generators')
+GENERATOR_DIR = os.path.join(SCRIPT_DIR, 'vulkan_generators')
 
 # File names to provide to the Vulkan XML Registry generator script.
 generate_targets = [
-    'generated_encode_pnext_struct.cpp',
-    'generated_vulkan_struct_encoders.h',
+    'generated_encode_pnext_struct.cpp', 'generated_vulkan_struct_encoders.h',
     'generated_vulkan_struct_encoders.cpp',
     'generated_vulkan_struct_handle_wrappers.h',
     'generated_vulkan_struct_handle_wrappers.cpp',
@@ -42,16 +45,12 @@ generate_targets = [
     'generated_vulkan_api_call_encoders.cpp',
     'generated_vulkan_command_buffer_util.h',
     'generated_vulkan_command_buffer_util.cpp',
-    'generated_vulkan_dispatch_table.h',
-    'generated_layer_func_table.h',
+    'generated_vulkan_dispatch_table.h', 'generated_layer_func_table.h',
     'generated_vulkan_struct_decoders.h',
     'generated_vulkan_struct_decoders.cpp',
-    'generated_vulkan_struct_decoders_forward.h',
-    'generated_vulkan_decoder.h',
-    'generated_vulkan_decoder.cpp',
-    'generated_decode_pnext_struct.cpp',
-    'generated_vulkan_consumer.h',
-    'generated_vulkan_ascii_consumer.h',
+    'generated_vulkan_struct_decoders_forward.h', 'generated_vulkan_decoder.h',
+    'generated_vulkan_decoder.cpp', 'generated_decode_pnext_struct.cpp',
+    'generated_vulkan_consumer.h', 'generated_vulkan_ascii_consumer.h',
     'generated_vulkan_ascii_consumer.cpp',
     'generated_vulkan_replay_consumer.h',
     'generated_vulkan_replay_consumer.cpp',
@@ -59,8 +58,7 @@ generate_targets = [
     'generated_vulkan_referenced_resource_consumer.cpp',
     'generated_vulkan_struct_handle_mappers.h',
     'generated_vulkan_struct_handle_mappers.cpp',
-    'generated_vulkan_feature_util.cpp',
-    'generated_vulkan_enum_to_string.h',
+    'generated_vulkan_feature_util.cpp', 'generated_vulkan_enum_to_string.h',
     'generated_vulkan_enum_to_string.cpp',
     'generated_vulkan_pnext_to_string.cpp',
     'generated_vulkan_struct_to_string.h',
@@ -70,16 +68,64 @@ generate_targets = [
 ]
 
 if __name__ == '__main__':
-    current_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
-    generator_dir = os.path.normpath(os.path.join(current_dir, generator_path))
-    registry_dir = os.path.normpath(os.path.join(current_dir, registry_path))
-
-    sys.path.append(generator_dir)
-    sys.path.append(registry_dir)
-
-    env = os.environ
-    env['PYTHONPATH'] = os.pathsep.join(sys.path)
-
+    arg_parser = argparse.ArgumentParser(description=__doc__)
+    arg_parser.add_argument(
+        '--registry-dir',
+        dest='registry_dir',
+        default=None,
+        help='\n'.join([
+            'Path to a directory that holds the Vulkan registry file (vk.xml) used to generate Vulkan source.',
+            'If this option is not provide the registry from the external Khronos Vulkan headers sub module will be used.'
+        ]))
+    arg_parser.add_argument(
+        '--headers-dir',
+        dest='headers_dir',
+        default=None,
+        help='\n'.join([
+            'Path to a directory that holds additional Vulkan header files required to build.',
+            'These header files are included directly after the Vulkan header in all generated files.',
+            'All .h file under the given directory are assumed to be Vulkan headers.'
+        ]))
+    args = arg_parser.parse_args()
+    registry_dir = KHRONOS_REGISTRY_DIR
+    if args.registry_dir is not None:
+        registry_dir = os.path.abspath(args.registry_dir)
+    registry_path = os.path.join(registry_dir, 'vk.xml')
+    if not os.path.isfile(registry_path):
+        raise Exception(f'Error: {registry_path} does not exist')
+    BASE_GENERATOR_DIR = os.path.normpath(
+        os.path.join(SCRIPT_DIR, BASE_GENERATOR_DIR))
+    env = os.environ.copy()
+    if not 'PYTHONPATH' in env:
+        env['PYTHONPATH'] = ''
+    env['PYTHONPATH'] = os.pathsep.join([
+        KHRONOS_REGISTRY_DIR,
+        BASE_GENERATOR_DIR,
+        GENERATOR_DIR,
+    ])
     for target in generate_targets:
         print('Generating', target)
-        subprocess.call([sys.executable, os.path.join(generator_dir, 'gencode.py'), '-o', current_dir, '-configs', generator_dir, '-registry', os.path.join(registry_dir, 'vk.xml'), target], shell=False, env=env)
+        gencode_args = [
+            sys.executable,
+            os.path.join(GENERATOR_DIR, 'gencode.py'),
+            '-o',
+            SCRIPT_DIR,
+            '-configs',
+            GENERATOR_DIR,
+            '-registry',
+            registry_path,
+        ]
+        if args.headers_dir is not None:
+            if not os.path.isdir(args.headers_dir):
+                raise Exception('Error: extra headers dir', args.headers_dir,
+                                'is not a directory')
+            gencode_args.extend(
+                ['-headers-dir',
+                 os.path.abspath(args.headers_dir)])
+        gencode_args.append(target)
+        subprocess.call(
+            gencode_args,
+            shell=False,
+            env=env,
+            cwd=SCRIPT_DIR,
+        )

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -343,6 +343,14 @@ class BaseGenerator(OutputGenerator):
             write('#define ', headerSym, file=self.outFile)
             self.newline()
 
+    def includeVulkanHeaders(self, gen_opts):
+        """Write Vulkan header include statements
+        """
+        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        for extra_vulkan_header in gen_opts.extraVulkanHeaders:
+            header_include_path = re.sub(r'\\', '/', extra_vulkan_header)
+            write(f'#include "{header_include_path}"', file=self.outFile)
+
     # Method override
     def endFile(self):
         # Finish C++ wrapper and multiple inclusion protection

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -38,40 +38,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os,re,sys,json
-from generator import (GeneratorOptions, OutputGenerator, noneStr, regSortFeatures, write)
+import os, re, sys, json
+from generator import (GeneratorOptions, OutputGenerator, noneStr,
+                       regSortFeatures, write)
 from vkconventions import VulkanConventions
+
 
 # Turn a list of strings into a regexp string matching exactly those strings.
 # From Khronos genvk.py
-def _makeREstring(list, default = None):
+def _makeREstring(list, default=None):
     if (len(list) > 0) or (default is None):
         return '^(' + '|'.join(list) + ')$'
     else:
         return default
 
+
 # Descriptive names for various regexp patterns used to select versions and extensions.
 # From Khronos genvk.py
-_defaultExtensions  = 'vulkan'
-_extensions         = _features         = []
-_emitExtensions     = []
+_defaultExtensions = 'vulkan'
+_extensions = _features = []
+_emitExtensions = []
 
 # Exclude beta video extensions
-_removeExtensions   = ["VK_KHR_video_queue",
-                       "VK_KHR_video_decode_queue",
-                       "VK_KHR_video_encode_queue",
-                       "VK_EXT_video_encode_h264",
-                       "VK_EXT_video_decode_h264",
-                       "VK_EXT_video_decode_h265",
-                       "VK_NVX_binary_import",
-                       "VK_HUAWEI_subpass_shading"]
+_removeExtensions = [
+    "VK_KHR_video_queue", "VK_KHR_video_decode_queue",
+    "VK_KHR_video_encode_queue", "VK_EXT_video_encode_h264",
+    "VK_EXT_video_decode_h264", "VK_EXT_video_decode_h265",
+    "VK_NVX_binary_import", "VK_HUAWEI_subpass_shading"
+]
 
 # Turn lists of names/patterns into matching regular expressions.
 # From Khronos genvk.py
-_addExtensionsPat     = _makeREstring(_extensions)
-_removeExtensionsPat  = _makeREstring(_removeExtensions)
-_emitExtensionsPat    = _makeREstring(_emitExtensions, '.*')
-_featuresPat          = _makeREstring(_features, '.*')
+_addExtensionsPat = _makeREstring(_extensions)
+_removeExtensionsPat = _makeREstring(_removeExtensions)
+_emitExtensionsPat = _makeREstring(_emitExtensions, '.*')
+_featuresPat = _makeREstring(_features, '.*')
 
 
 # ValueInfo - Class to store parameter/struct member information.
@@ -94,13 +95,13 @@ class ValueInfo():
                  name,
                  baseType,
                  fullType,
-                 pointerCount = 0,
-                 arrayLength = None,
-                 arrayLengthValue = None,
-                 arrayCapacity = None,
-                 platformBaseType = None,
-                 platformFullType = None,
-                 bitfieldWidth = None):
+                 pointerCount=0,
+                 arrayLength=None,
+                 arrayLengthValue=None,
+                 arrayCapacity=None,
+                 platformBaseType=None,
+                 platformFullType=None,
+                 bitfieldWidth=None):
         self.name = name
         self.baseType = baseType
         self.fullType = fullType
@@ -146,30 +147,32 @@ class ValueInfo():
 #     separate line, align parameter names at the specified column
 class BaseGeneratorOptions(GeneratorOptions):
     """Options for Vulkan API parameter encoding and decoding C++ code generation"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 # Khronos CGeneratorOptions
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True,
-                 conventions = VulkanConventions(),
-                 apicall = 'VKAPI_ATTR ',
-                 apientry = 'VKAPI_CALL ',
-                 apientryp = 'VKAPI_PTR *',
-                 indentFuncProto = True,
-                 alignFuncParam = 48,
-                 sortProcedure = regSortFeatures,
-                 apiname = 'vulkan',
-                 profile = None,
-                 versions = _featuresPat,
-                 emitversions = _featuresPat,
-                 defaultExtensions = _defaultExtensions,
-                 addExtensions = _addExtensionsPat,
-                 removeExtensions = _removeExtensionsPat,
-                 emitExtensions = _emitExtensionsPat):
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            # Khronos CGeneratorOptions
+        filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            conventions=VulkanConventions(),
+            apicall='VKAPI_ATTR ',
+            apientry='VKAPI_CALL ',
+            apientryp='VKAPI_PTR *',
+            indentFuncProto=True,
+            alignFuncParam=48,
+            sortProcedure=regSortFeatures,
+            apiname='vulkan',
+            profile=None,
+            versions=_featuresPat,
+            emitversions=_featuresPat,
+            defaultExtensions=_defaultExtensions,
+            addExtensions=_addExtensionsPat,
+            removeExtensions=_removeExtensionsPat,
+            emitExtensions=_emitExtensionsPat,
+            extraVulkanHeaders=[]):
         GeneratorOptions.__init__(self,
                                   conventions=conventions,
                                   filename=filename,
@@ -186,15 +189,16 @@ class BaseGeneratorOptions(GeneratorOptions):
         self.blacklists = blacklists
         self.platformTypes = platformTypes
         # Khronos CGeneratorOptions
-        self.prefixText      = prefixText
-        self.protectFile     = protectFile
-        self.protectFeature  = protectFeature
-        self.apicall         = apicall
-        self.apientry        = apientry                  # NOTE: While not used in this file, apientry is expected to be defined here by the OutputGenerator base class.
-        self.apientryp       = apientryp                 # NOTE: While not used in this file, apientry is expected to be defined here by the OutputGenerator base class.
+        self.prefixText = prefixText
+        self.protectFile = protectFile
+        self.protectFeature = protectFeature
+        self.apicall = apicall
+        self.apientry = apientry  # NOTE: While not used in this file, apientry is expected to be defined here by the OutputGenerator base class.
+        self.apientryp = apientryp  # NOTE: While not used in this file, apientry is expected to be defined here by the OutputGenerator base class.
         self.indentFuncProto = indentFuncProto
-        self.alignFuncParam  = alignFuncParam
-        self.codeGenerator   = True
+        self.alignFuncParam = alignFuncParam
+        self.codeGenerator = True
+        self.extraVulkanHeaders = extraVulkanHeaders
 
 
 # BaseGenerator - subclass of OutputGenerator.
@@ -214,25 +218,52 @@ class BaseGenerator(OutputGenerator):
     # Platform specific structure types that have been defined extarnally to the Vulkan header.
     PLATFORM_STRUCTS = []
 
-    GENERIC_HANDLE_APICALLS = {'vkDebugReportMessageEXT' : {'object' : 'objectType' },
-                               'vkSetPrivateDataEXT' : {'objectHandle' : 'objectType' },
-                               'vkGetPrivateDataEXT' : {'objectHandle' : 'objectType' }}
+    GENERIC_HANDLE_APICALLS = {
+        'vkDebugReportMessageEXT': {
+            'object': 'objectType'
+        },
+        'vkSetPrivateDataEXT': {
+            'objectHandle': 'objectType'
+        },
+        'vkGetPrivateDataEXT': {
+            'objectHandle': 'objectType'
+        }
+    }
 
-    GENERIC_HANDLE_STRUCTS = {'VkDebugMarkerObjectNameInfoEXT' : {'object' : 'objectType' },
-                              'VkDebugMarkerObjectTagInfoEXT' : {'object' : 'objectType' },
-                              'VkDebugUtilsObjectNameInfoEXT' : {'objectHandle' : 'objectType' },
-                              'VkDebugUtilsObjectTagInfoEXT' : {'objectHandle' : 'objectType' }}
+    GENERIC_HANDLE_STRUCTS = {
+        'VkDebugMarkerObjectNameInfoEXT': {
+            'object': 'objectType'
+        },
+        'VkDebugMarkerObjectTagInfoEXT': {
+            'object': 'objectType'
+        },
+        'VkDebugUtilsObjectNameInfoEXT': {
+            'objectHandle': 'objectType'
+        },
+        'VkDebugUtilsObjectTagInfoEXT': {
+            'objectHandle': 'objectType'
+        }
+    }
 
-    VULKAN_REPLACE_TYPE = {"VkRemoteAddressNV" : {"baseType" : "void", "replaceWith" : "void*" }}
+    VULKAN_REPLACE_TYPE = {
+        "VkRemoteAddressNV": {
+            "baseType": "void",
+            "replaceWith": "void*"
+        }
+    }
 
     # These types represent pointers to non-Vulkan objects that were written as 64-bit address IDs.
     EXTERNAL_OBJECT_TYPES = ['void', 'Void']
 
     # Dispatchable handle types.
-    DISPATCHABLE_HANDLE_TYPES = ['VkInstance', 'VkPhysicalDevice', 'VkDevice', 'VkQueue', 'VkCommandBuffer']
+    DISPATCHABLE_HANDLE_TYPES = [
+        'VkInstance', 'VkPhysicalDevice', 'VkDevice', 'VkQueue',
+        'VkCommandBuffer'
+    ]
 
-    DUPLICATE_HANDLE_TYPES = ['VkDescriptorUpdateTemplateKHR', 'VkSamplerYcbcrConversionKHR']
-
+    DUPLICATE_HANDLE_TYPES = [
+        'VkDescriptorUpdateTemplateKHR', 'VkSamplerYcbcrConversionKHR'
+    ]
 
     # Default C++ code indentation size.
     INDENT_SIZE = 4
@@ -240,33 +271,39 @@ class BaseGenerator(OutputGenerator):
     def __init__(self,
                  processCmds,
                  processStructs,
-                 featureBreak = True,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 featureBreak=True,
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         OutputGenerator.__init__(self, errFile, warnFile, diagFile)
 
         # Typenames
-        self.structNames = set()                          # Set of Vulkan struct typenames
-        self.handleNames = set()                          # Set of Vulkan handle typenames
-        self.flagsTypes = dict()                          # Map of flags types to base flag type (VkFlags or VkFlags64)
-        self.enumNames = set()                            # Set of Vulkan enumeration typenames
-        self.enumAliases = dict()                         # Map of enum names to aliases
-        self.enumEnumerants = dict()                      # Map of enum names to enumerants
+        self.structNames = set()  # Set of Vulkan struct typenames
+        self.handleNames = set()  # Set of Vulkan handle typenames
+        self.flagsTypes = dict(
+        )  # Map of flags types to base flag type (VkFlags or VkFlags64)
+        self.enumNames = set()  # Set of Vulkan enumeration typenames
+        self.enumAliases = dict()  # Map of enum names to aliases
+        self.enumEnumerants = dict()  # Map of enum names to enumerants
 
         # Type processing options
-        self.processCmds = processCmds                    # Populate the featureCmdParams map
-        self.processStructs = processStructs              # Populate the featureStructMembers map
-        self.featureBreak = featureBreak                  # Insert a line break between features
+        self.processCmds = processCmds  # Populate the featureCmdParams map
+        self.processStructs = processStructs  # Populate the featureStructMembers map
+        self.featureBreak = featureBreak  # Insert a line break between features
 
         # Command parameter and struct member data for the current feature
         if self.processStructs:
-            self.featureStructMembers = dict()            # Map of struct names to lists of per-member ValueInfo
-            self.featureStructAliases = dict()            # Map of struct names to aliases
-            self.extensionStructsWithHandles = dict()     # Map of extension struct names to a Boolean value indicating that a struct member has a handle type
-            self.extensionStructsWithHandlePtrs = dict()  # Map of extension struct names to a Boolean value indicating that a struct member with a handle type is a pointer
+            self.featureStructMembers = dict(
+            )  # Map of struct names to lists of per-member ValueInfo
+            self.featureStructAliases = dict(
+            )  # Map of struct names to aliases
+            self.extensionStructsWithHandles = dict(
+            )  # Map of extension struct names to a Boolean value indicating that a struct member has a handle type
+            self.extensionStructsWithHandlePtrs = dict(
+            )  # Map of extension struct names to a Boolean value indicating that a struct member with a handle type is a pointer
         if self.processCmds:
-            self.featureCmdParams = dict()                # Map of cmd names to lists of per-parameter ValueInfo
+            self.featureCmdParams = dict(
+            )  # Map of cmd names to lists of per-parameter ValueInfo
 
     #
     # Indicates that the current feature has C++ code to generate.
@@ -300,7 +337,8 @@ class BaseGenerator(OutputGenerator):
 
         # Multiple inclusion protection & C++ wrappers.
         if (genOpts.protectFile and self.genOpts.filename):
-            headerSym = 'GFXRECON_' + re.sub('\.h', '_H', os.path.basename(self.genOpts.filename)).upper()
+            headerSym = 'GFXRECON_' + re.sub(
+                '\.h', '_H', os.path.basename(self.genOpts.filename)).upper()
             write('#ifndef ', headerSym, file=self.outFile)
             write('#define ', headerSym, file=self.outFile)
             self.newline()
@@ -344,7 +382,10 @@ class BaseGenerator(OutputGenerator):
             self.generateFeature()
 
             if (self.featureExtraProtect is not None):
-                write('#endif /*', self.featureExtraProtect, '*/', file=self.outFile)
+                write('#endif /*',
+                      self.featureExtraProtect,
+                      '*/',
+                      file=self.outFile)
 
         # Finish processing in superclass
         OutputGenerator.endFeature(self)
@@ -386,7 +427,8 @@ class BaseGenerator(OutputGenerator):
         # would produce multiple definition errors for functions with struct parameters.
         if self.processStructs:
             if not alias:
-                self.featureStructMembers[typename] = self.makeValueInfo(typeinfo.elem.findall('.//member'))
+                self.featureStructMembers[typename] = self.makeValueInfo(
+                    typeinfo.elem.findall('.//member'))
             else:
                 self.featureStructAliases[typename] = alias
 
@@ -435,7 +477,9 @@ class BaseGenerator(OutputGenerator):
             returnType = noneStr(proto.text) + noneStr(proto.find('type').text)
 
             # TODO: Define a class or namedtuple for the dictionary entry
-            self.featureCmdParams[name] = (returnType, protoDecl, self.makeValueInfo(cmdinfo.elem.findall('param')))
+            self.featureCmdParams[name] = (returnType, protoDecl,
+                                           self.makeValueInfo(
+                                               cmdinfo.elem.findall('param')))
 
     #
     # Generate a list of ValueInfo objects from a list of <param> or <member> tags
@@ -451,7 +495,8 @@ class BaseGenerator(OutputGenerator):
             # Get type info
             elem = param.find('type')
             baseType = noneStr(elem.text)
-            fullType = (noneStr(param.text) + baseType + noneStr(elem.tail)).strip()
+            fullType = (noneStr(param.text) + baseType +
+                        noneStr(elem.tail)).strip()
 
             # Check for platform specific type definitions that need to be converted to a recognized trace format type.
             platformBaseType = None
@@ -465,30 +510,31 @@ class BaseGenerator(OutputGenerator):
 
             # Get array length, always use altlen when available to avoid parsing latexmath
             if 'altlen' in param.attrib:
-                arrayLength =  param.attrib.get('altlen')
+                arrayLength = param.attrib.get('altlen')
             else:
                 arrayLength = self.getArrayLen(param)
 
             arrayCapacity = None
             if self.isStaticArray(param):
                 arrayCapacity = arrayLength
-                arrayLength = self.getStaticArrayLen(name, params, arrayCapacity)
+                arrayLength = self.getStaticArrayLen(name, params,
+                                                     arrayCapacity)
 
             # Get bitfield width
             bitfieldWidth = None
             if ':' in nameTail:
                 bitfieldWidth = nameTail
 
-            values.append(ValueInfo(
-                name = name,
-                baseType = baseType,
-                fullType = fullType,
-                pointerCount = self.getPointerCount(fullType),
-                arrayLength = arrayLength,
-                arrayCapacity = arrayCapacity,
-                platformBaseType = platformBaseType,
-                platformFullType = platformFullType,
-                bitfieldWidth = bitfieldWidth))
+            values.append(
+                ValueInfo(name=name,
+                          baseType=baseType,
+                          fullType=fullType,
+                          pointerCount=self.getPointerCount(fullType),
+                          arrayLength=arrayLength,
+                          arrayCapacity=arrayCapacity,
+                          platformBaseType=platformBaseType,
+                          platformFullType=platformFullType,
+                          bitfieldWidth=bitfieldWidth))
 
         # Link array values to their corresponding length values
         for arrayValue in [v for v in values if v.arrayLength]:
@@ -502,7 +548,8 @@ class BaseGenerator(OutputGenerator):
     #
     # Check for struct type
     def isStruct(self, baseType):
-        if (baseType in self.structNames) or (baseType in self.PLATFORM_STRUCTS):
+        if (baseType in self.structNames) or (baseType
+                                              in self.PLATFORM_STRUCTS):
             return True
         return False
 
@@ -570,7 +617,8 @@ class BaseGenerator(OutputGenerator):
     # Determine if a parameter is an output parameter
     def isOutputParameter(self, value):
         # Check for an output pointer/array or an in-out pointer.
-        if (value.isPointer or value.isArray) and not self.isInputPointer(value):
+        if (value.isPointer
+                or value.isArray) and not self.isInputPointer(value):
             return True
         return False
 
@@ -645,19 +693,26 @@ class BaseGenerator(OutputGenerator):
     #
     # Retrieves a filtered list of keys from self.featureStructMemebers with blacklisted items removed.
     def getFilteredStructNames(self):
-        return [key for key in self.featureStructMembers if not self.isStructBlackListed(key)]
+        return [
+            key for key in self.featureStructMembers
+            if not self.isStructBlackListed(key)
+        ]
 
     #
     # Retrieves a filtered list of keys from self.featureCmdParams with blacklisted items removed.
     def getFilteredCmdNames(self):
-        return [key for key in self.featureCmdParams if not self.isCmdBlackListed(key)]
+        return [
+            key for key in self.featureCmdParams
+            if not self.isCmdBlackListed(key)
+        ]
 
     #
     # Determines if the specified struct type can reference pNext extension structs that contain handles.
     def checkStructPNextHandles(self, typename):
         foundHandles = False
         foundHandlePtrs = False
-        validExtensionStructs = self.registry.validextensionstructs.get(typename)
+        validExtensionStructs = self.registry.validextensionstructs.get(
+            typename)
         if validExtensionStructs:
             # Need to search the XML tree for pNext structures that have not been processed yet.
             for structName in validExtensionStructs:
@@ -671,20 +726,30 @@ class BaseGenerator(OutputGenerator):
                     # If a pre-existing result was not found, check the XML registry for the struct
                     hasHandles = False
                     hasHandlePtrs = False
-                    typeInfo = self.registry.lookupElementInfo(structName, self.registry.typedict)
+                    typeInfo = self.registry.lookupElementInfo(
+                        structName, self.registry.typedict)
                     if typeInfo:
-                        memberInfos = [member for member in typeInfo.elem.findall('.//member/type')]
+                        memberInfos = [
+                            member for member in typeInfo.elem.findall(
+                                './/member/type')
+                        ]
                         if memberInfos:
                             for memberInfo in memberInfos:
-                                found = self.registry.tree.find("types/type/[name='" + memberInfo.text + "'][@category='handle']")
+                                found = self.registry.tree.find(
+                                    "types/type/[name='" + memberInfo.text +
+                                    "'][@category='handle']")
                                 if found:
                                     hasHandles = True
-                                    self.extensionStructsWithHandles[structName] = True
-                                    if memberInfo.tail and ('*' in memberInfo.tail):
-                                        self.extensionStructsWithHandlePtrs[structName] = True
+                                    self.extensionStructsWithHandles[
+                                        structName] = True
+                                    if memberInfo.tail and (
+                                            '*' in memberInfo.tail):
+                                        self.extensionStructsWithHandlePtrs[
+                                            structName] = True
                                         hasHandlePtrs = True
                                     else:
-                                        self.extensionStructsWithHandlePtrs[structName] = False
+                                        self.extensionStructsWithHandlePtrs[
+                                            structName] = False
 
                     if hasHandles:
                         foundHandles = True
@@ -700,26 +765,34 @@ class BaseGenerator(OutputGenerator):
     # Determines if the specified struct type contains members that have a handle type or are structs that contain handles.
     # Structs with member handles are added to a dictionary, where the key is the structure type and the value is a list of the handle members.
     # An optional list of structure types that contain handle members with pointer types may also be generated.
-    def checkStructMemberHandles(self, typename, structsWithHandles, structsWithHandlePtrs = None):
+    def checkStructMemberHandles(self,
+                                 typename,
+                                 structsWithHandles,
+                                 structsWithHandlePtrs=None):
         handles = []
         hasHandlePointer = False
         for value in self.featureStructMembers[typename]:
             if self.isHandle(value.baseType):
                 # The member is a handle.
                 handles.append(value)
-                if (not structsWithHandlePtrs is None) and (value.isPointer or value.isArray):
+                if (not structsWithHandlePtrs is None) and (value.isPointer
+                                                            or value.isArray):
                     hasHandlePointer = True
-            elif self.isStruct(value.baseType) and (value.baseType in structsWithHandles):
+            elif self.isStruct(value.baseType) and (value.baseType
+                                                    in structsWithHandles):
                 # The member is a struct that contains a handle.
                 handles.append(value)
-                if (not structsWithHandlePtrs is None)  and (value.name in structsWithHandlePtrs):
+                if (not structsWithHandlePtrs is None) and (
+                        value.name in structsWithHandlePtrs):
                     hasHandlePointer = True
             elif 'pNext' in value.name:
                 # The pNext chain may include a struct with handles.
-                hasPNextHandles, hasPNextHandlePtrs = self.checkStructPNextHandles(typename)
+                hasPNextHandles, hasPNextHandlePtrs = self.checkStructPNextHandles(
+                    typename)
                 if hasPNextHandles:
                     handles.append(value)
-                    if (not structsWithHandlePtrs is None) and hasPNextHandlePtrs:
+                    if (not structsWithHandlePtrs is None
+                        ) and hasPNextHandlePtrs:
                         hasHandlePointer = True
         if handles:
             structsWithHandles[typename] = handles
@@ -796,7 +869,8 @@ class BaseGenerator(OutputGenerator):
     #
     # makeAlignedParamDecl - return an indented parameter declaration string with the parameter
     #  name aligned to the specified column.
-    def makeAlignedParamDecl(self, paramType, paramName, indentColumn, alignColumn):
+    def makeAlignedParamDecl(self, paramType, paramName, indentColumn,
+                             alignColumn):
         paramDecl = ' ' * indentColumn
         paramDecl += paramType
 
@@ -834,7 +908,8 @@ class BaseGenerator(OutputGenerator):
         elif baseType.endswith('_t'):
             if baseType[0] == 'u':
                 # For unsigned types, capitalize the first two characters.
-                return baseType[0].upper() + baseType[1].upper() + baseType[2:-2]
+                return baseType[0].upper() + baseType[1].upper(
+                ) + baseType[2:-2]
             else:
                 return baseType[:-2].title()
         elif baseType[0].islower():
@@ -853,9 +928,11 @@ class BaseGenerator(OutputGenerator):
 
             if self.isStruct(typeName):
                 if count > 1:
-                    typeName = 'StructPointerDecoder<Decoded_{}*>'.format(typeName)
+                    typeName = 'StructPointerDecoder<Decoded_{}*>'.format(
+                        typeName)
                 else:
-                    typeName = 'StructPointerDecoder<Decoded_{}>'.format(typeName)
+                    typeName = 'StructPointerDecoder<Decoded_{}>'.format(
+                        typeName)
             elif typeName == 'wchar_t':
                 if count > 1:
                     typeName = 'WStringArrayDecoder'
@@ -886,7 +963,7 @@ class BaseGenerator(OutputGenerator):
                     typeName = 'PointerDecoder<{}>'.format(typeName)
         elif self.isFunctionPtr(typeName):
             # Function pointers are encoded as a 64-bit address value.
-            typeName ='uint64_t'
+            typeName = 'uint64_t'
         elif self.isStruct(typeName):
             typeName = 'Decoded_{}'.format(typeName)
         elif self.isHandle(typeName):
@@ -903,7 +980,9 @@ class BaseGenerator(OutputGenerator):
         paramDecls = []
 
         if returnType != 'void':
-            paramDecl = self.makeAlignedParamDecl(returnType, 'returnValue', self.INDENT_SIZE, self.genOpts.alignFuncParam)
+            paramDecl = self.makeAlignedParamDecl(returnType, 'returnValue',
+                                                  self.INDENT_SIZE,
+                                                  self.genOpts.alignFuncParam)
             paramDecls.append(paramDecl)
 
         for value in values:
@@ -912,7 +991,9 @@ class BaseGenerator(OutputGenerator):
             if 'Decoder' in paramType:
                 paramType = '{}*'.format(paramType)
 
-            paramDecl = self.makeAlignedParamDecl(paramType, value.name, self.INDENT_SIZE, self.genOpts.alignFuncParam)
+            paramDecl = self.makeAlignedParamDecl(paramType, value.name,
+                                                  self.INDENT_SIZE,
+                                                  self.genOpts.alignFuncParam)
             paramDecls.append(paramDecl)
 
         if paramDecls:
@@ -962,7 +1043,8 @@ class BaseGenerator(OutputGenerator):
                 # Static cast 64-bit length expression to eliminate warning in 32-bit builds
                 lengthExpr = 'static_cast<size_t>({})'.format(lengthExpr)
             # Add prefix to parameter in the length expression
-            lengthExpr = lengthExpr.replace(lengthValue.name, prefix + lengthValue.name)
+            lengthExpr = lengthExpr.replace(lengthValue.name,
+                                            prefix + lengthValue.name)
 
         return lengthExpr
 
@@ -974,7 +1056,8 @@ class BaseGenerator(OutputGenerator):
             for lengthExpr in lengthExprs:
                 # Prefix members
                 for v in values:
-                    lengthExpr = re.sub(r'\b({})\b'.format(v.name), r'{}\1'.format(prefix), lengthExpr)
+                    lengthExpr = re.sub(r'\b({})\b'.format(v.name),
+                                        r'{}\1'.format(prefix), lengthExpr)
                 lengths.append(lengthExpr)
             return lengths
         else:
@@ -985,14 +1068,23 @@ class BaseGenerator(OutputGenerator):
 
     #
     # Generate a parameter encoder method call invocation.
-    def makeEncoderMethodCall(self, name, value, values, prefix, omitOutputParam=None):
+    def makeEncoderMethodCall(self,
+                              name,
+                              value,
+                              values,
+                              prefix,
+                              omitOutputParam=None):
         argName = prefix + value.name
-        if self.isGenericStructHandleValue(name, value.name) or self.isGenericCmdHandleValue(name, value.name):
+        if self.isGenericStructHandleValue(
+                name, value.name) or self.isGenericCmdHandleValue(
+                    name, value.name):
             handleTypeName = prefix
             if self.isGenericStructHandleValue(name, value.name):
-                handleTypeName += self.getGenericStructHandleTypeValue(name, value.name)
+                handleTypeName += self.getGenericStructHandleTypeValue(
+                    name, value.name)
             else:
-                handleTypeName += self.getGenericCmdHandleTypeValue(name, value.name)
+                handleTypeName += self.getGenericCmdHandleTypeValue(
+                    name, value.name)
             argName = 'GetWrappedId({}, {})'.format(argName, handleTypeName)
 
         args = [argName]
@@ -1022,9 +1114,11 @@ class BaseGenerator(OutputGenerator):
         elif value.isArray:
             if value.pointerCount > 1:
                 methodCall += 'Array{}D'.format(value.pointerCount)
-                args.extend(self.makeArray2DLengthExpression(value, values, prefix))
+                args.extend(
+                    self.makeArray2DLengthExpression(value, values, prefix))
             elif ',' in value.arrayLength:
-                methodCall += '{}DMatrix'.format(value.arrayLength.count(',') + 1)
+                methodCall += '{}DMatrix'.format(
+                    value.arrayLength.count(',') + 1)
                 args.append(self.makeArrayLengthExpression(value, prefix))
             else:
                 methodCall += 'Array'
@@ -1050,20 +1144,20 @@ class BaseGenerator(OutputGenerator):
     def __getFeatureProtect(self, interface):
         # TODO: This should probably be in a JSON file.
         platform_dict = {
-            'android' : 'VK_USE_PLATFORM_ANDROID_KHR',
-            'fuchsia' : 'VK_USE_PLATFORM_FUCHSIA',
-            'ios' : 'VK_USE_PLATFORM_IOS_MVK',
-            'macos' : 'VK_USE_PLATFORM_MACOS_MVK',
-            'mir' : 'VK_USE_PLATFORM_MIR_KHR',
-            'vi' : 'VK_USE_PLATFORM_VI_NN',
-            'wayland' : 'VK_USE_PLATFORM_WAYLAND_KHR',
-            'win32' : 'VK_USE_PLATFORM_WIN32_KHR',
-            'xcb' : 'VK_USE_PLATFORM_XCB_KHR',
-            'xlib' : 'VK_USE_PLATFORM_XLIB_KHR',
-            'xlib_xrandr' : 'VK_USE_PLATFORM_XLIB_XRANDR_EXT',
-            'ggp' : 'VK_USE_PLATFORM_GGP',
-            'directfb' : 'VK_USE_PLATFORM_DIRECTFB_EXT',
-            'headless' : 'VK_USE_PLATFORM_HEADLESS'
+            'android': 'VK_USE_PLATFORM_ANDROID_KHR',
+            'fuchsia': 'VK_USE_PLATFORM_FUCHSIA',
+            'ios': 'VK_USE_PLATFORM_IOS_MVK',
+            'macos': 'VK_USE_PLATFORM_MACOS_MVK',
+            'mir': 'VK_USE_PLATFORM_MIR_KHR',
+            'vi': 'VK_USE_PLATFORM_VI_NN',
+            'wayland': 'VK_USE_PLATFORM_WAYLAND_KHR',
+            'win32': 'VK_USE_PLATFORM_WIN32_KHR',
+            'xcb': 'VK_USE_PLATFORM_XCB_KHR',
+            'xlib': 'VK_USE_PLATFORM_XLIB_KHR',
+            'xlib_xrandr': 'VK_USE_PLATFORM_XLIB_XRANDR_EXT',
+            'ggp': 'VK_USE_PLATFORM_GGP',
+            'directfb': 'VK_USE_PLATFORM_DIRECTFB_EXT',
+            'headless': 'VK_USE_PLATFORM_HEADLESS'
         }
 
         platform = interface.get('platform')

--- a/framework/generated/vulkan_generators/decode_pnext_struct_generator.py
+++ b/framework/generated/vulkan_generators/decode_pnext_struct_generator.py
@@ -21,34 +21,47 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 # Eliminates JSON blackLists and platformTypes files, which are not necessary for
 # pNext switch statement generation.
 class DecodePNextStructGeneratorOptions(BaseGeneratorOptions):
     """Options for Vulkan API pNext structure decoding C++ code generation"""
     def __init__(self,
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, None, None,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+                 filename=None,
+                 directory='.',
+                 prefixText='',
+                 protectFile=False,
+                 protectFeature=True,
+                 extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      None,
+                                      None,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # DecodePNextStructGenerator - subclass of BaseGenerator.
 # Generates C++ code for Vulkan API pNext structure decoding.
 class DecodePNextStructGenerator(BaseGenerator):
     """Generate pNext structure decoding C++ code"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=False, processStructs=False, featureBreak=False,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=False,
+                               processStructs=False,
+                               featureBreak=False,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
         # Map to store VkStructureType enum values.
         self.sTypeValues = dict()
@@ -57,11 +70,13 @@ class DecodePNextStructGenerator(BaseGenerator):
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
 
-        write('#include "decode/custom_vulkan_struct_decoders.h"', file=self.outFile)
+        write('#include "decode/custom_vulkan_struct_decoders.h"',
+              file=self.outFile)
         write('#include "decode/decode_allocator.h"', file=self.outFile)
         write('#include "decode/pnext_node.h"', file=self.outFile)
         write('#include "decode/pnext_typed_node.h"', file=self.outFile)
-        write('#include "generated/generated_vulkan_struct_decoders.h"', file=self.outFile)
+        write('#include "generated/generated_vulkan_struct_decoders.h"',
+              file=self.outFile)
         write('#include "util/logging.h"', file=self.outFile)
         self.newline()
         write('#include <cassert>', file=self.outFile)
@@ -69,40 +84,63 @@ class DecodePNextStructGenerator(BaseGenerator):
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)
         self.newline()
-        write('size_t DecodePNextStruct(const uint8_t* parameter_buffer, size_t buffer_size,  PNextNode** pNext)', file=self.outFile)
+        write(
+            'size_t DecodePNextStruct(const uint8_t* parameter_buffer, size_t buffer_size,  PNextNode** pNext)',
+            file=self.outFile)
         write('{', file=self.outFile)
         write('    assert(pNext != nullptr);', file=self.outFile)
         self.newline()
         write('    size_t bytes_read = 0;', file=self.outFile)
         write('    uint32_t attrib = 0;', file=self.outFile)
         self.newline()
-        write('    if ((parameter_buffer != nullptr) && (buffer_size >= sizeof(attrib)))', file=self.outFile)
+        write(
+            '    if ((parameter_buffer != nullptr) && (buffer_size >= sizeof(attrib)))',
+            file=self.outFile)
         write('    {', file=self.outFile)
         write('        size_t stype_offset = 0;', file=self.outFile)
         self.newline()
-        write('        // Peek at the pointer attribute mask to make sure we have a non-NULL value that can be decoded.', file=self.outFile)
-        write('        attrib = *(reinterpret_cast<const uint32_t*>(parameter_buffer));', file=self.outFile)
+        write(
+            '        // Peek at the pointer attribute mask to make sure we have a non-NULL value that can be decoded.',
+            file=self.outFile)
+        write(
+            '        attrib = *(reinterpret_cast<const uint32_t*>(parameter_buffer));',
+            file=self.outFile)
         self.newline()
-        write('        if ((attrib & format::PointerAttributes::kIsNull) != format::PointerAttributes::kIsNull)', file=self.outFile)
+        write(
+            '        if ((attrib & format::PointerAttributes::kIsNull) != format::PointerAttributes::kIsNull)',
+            file=self.outFile)
         write('        {', file=self.outFile)
-        write('            // Offset to VkStructureType, after the pointer encoding preamble.', file=self.outFile)
+        write(
+            '            // Offset to VkStructureType, after the pointer encoding preamble.',
+            file=self.outFile)
         write('            stype_offset = sizeof(attrib);', file=self.outFile)
         self.newline()
-        write('            if ((attrib & format::PointerAttributes::kHasAddress) == format::PointerAttributes::kHasAddress)', file=self.outFile)
+        write(
+            '            if ((attrib & format::PointerAttributes::kHasAddress) == format::PointerAttributes::kHasAddress)',
+            file=self.outFile)
         write('            {', file=self.outFile)
-        write('                stype_offset += sizeof(format::AddressEncodeType);', file=self.outFile)
+        write(
+            '                stype_offset += sizeof(format::AddressEncodeType);',
+            file=self.outFile)
         write('            }', file=self.outFile)
         write('        }', file=self.outFile)
         self.newline()
-        write('        if ((stype_offset != 0) && ((buffer_size - stype_offset) >= sizeof(VkStructureType)))', file=self.outFile)
+        write(
+            '        if ((stype_offset != 0) && ((buffer_size - stype_offset) >= sizeof(VkStructureType)))',
+            file=self.outFile)
         write('        {', file=self.outFile)
-        write('            const VkStructureType* sType = reinterpret_cast<const VkStructureType*>(parameter_buffer + stype_offset);', file=self.outFile)
+        write(
+            '            const VkStructureType* sType = reinterpret_cast<const VkStructureType*>(parameter_buffer + stype_offset);',
+            file=self.outFile)
         self.newline()
         write('            switch (*sType)', file=self.outFile)
         write('            {', file=self.outFile)
         write('            default:', file=self.outFile)
-        write('                // TODO: This may need to be a fatal error', file=self.outFile)
-        write('                GFXRECON_LOG_ERROR("Failed to decode pNext value with unrecognized VkStructurType = %d", (*sType));', file=self.outFile)
+        write('                // TODO: This may need to be a fatal error',
+              file=self.outFile)
+        write(
+            '                GFXRECON_LOG_ERROR("Failed to decode pNext value with unrecognized VkStructurType = %d", (*sType));',
+            file=self.outFile)
         write('                break;', file=self.outFile)
 
     # Method override
@@ -113,8 +151,12 @@ class DecodePNextStructGenerator(BaseGenerator):
         self.newline()
         write('    if ((bytes_read == 0) && (attrib != 0))', file=self.outFile)
         write('    {', file=self.outFile)
-        write('        // The encoded pointer attribute mask included kIsNull, or the sType was unrecognized.', file=self.outFile)
-        write('        // We will report that we read the attribute mask, but nothing else was decoded.', file=self.outFile)
+        write(
+            '        // The encoded pointer attribute mask included kIsNull, or the sType was unrecognized.',
+            file=self.outFile)
+        write(
+            '        // We will report that we read the attribute mask, but nothing else was decoded.',
+            file=self.outFile)
         write('        bytes_read = sizeof(attrib);', file=self.outFile)
         write('    }', file=self.outFile)
         self.newline()
@@ -148,8 +190,15 @@ class DecodePNextStructGenerator(BaseGenerator):
     # Performs C++ code generation for the feature.
     def generateFeature(self):
         for struct in self.sTypeValues:
-            write('            case {}:'.format(self.sTypeValues[struct]), file=self.outFile)
-            write('                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_{}>>();'.format(struct), file=self.outFile)
-            write('                bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);'.format(struct), file=self.outFile)
+            write('            case {}:'.format(self.sTypeValues[struct]),
+                  file=self.outFile)
+            write(
+                '                (*pNext) = DecodeAllocator::Allocate<PNextTypedNode<Decoded_{}>>();'
+                .format(struct),
+                file=self.outFile)
+            write(
+                '                bytes_read = (*pNext)->Decode(parameter_buffer, buffer_size);'
+                .format(struct),
+                file=self.outFile)
             write('                break;', file=self.outFile)
         self.sTypeValues = dict()

--- a/framework/generated/vulkan_generators/encode_pnext_struct_generator.py
+++ b/framework/generated/vulkan_generators/encode_pnext_struct_generator.py
@@ -78,7 +78,7 @@ class EncodePNextStructGenerator(BaseGenerator):
         write('#include "encode/trace_manager.h"', file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
-        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
         self.newline()
         write('#include <cassert>', file=self.outFile)
         write('#include <cstdio>', file=self.outFile)

--- a/framework/generated/vulkan_generators/encode_pnext_struct_generator.py
+++ b/framework/generated/vulkan_generators/encode_pnext_struct_generator.py
@@ -21,34 +21,47 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 # Eliminates JSON blackLists and platformTypes files, which are not necessary for
 # pNext switch statement generation.
 class EncodePNextStructGeneratorOptions(BaseGeneratorOptions):
     """Options for Vulkan API pNext structure encoding C++ code generation"""
     def __init__(self,
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, None, None,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+                 filename=None,
+                 directory='.',
+                 prefixText='',
+                 protectFile=False,
+                 protectFeature=True,
+                 extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      None,
+                                      None,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # EncodePNextStructGenerator - subclass of BaseGenerator.
 # Generates C++ code for Vulkan API pNext structure encoding.
 class EncodePNextStructGenerator(BaseGenerator):
     """Generate pNext structure encoding C++ code"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=False, processStructs=False, featureBreak=False,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=False,
+                               processStructs=False,
+                               featureBreak=False,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
         # Map to store VkStructureType enum values.
         self.sTypeValues = dict()
@@ -57,7 +70,8 @@ class EncodePNextStructGenerator(BaseGenerator):
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
 
-        write('#include "generated/generated_vulkan_struct_encoders.h"', file=self.outFile)
+        write('#include "generated/generated_vulkan_struct_encoders.h"',
+              file=self.outFile)
         self.newline()
         write('#include "encode/parameter_encoder.h"', file=self.outFile)
         write('#include "encode/struct_pointer_encoder.h"', file=self.outFile)
@@ -73,15 +87,25 @@ class EncodePNextStructGenerator(BaseGenerator):
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(encode)', file=self.outFile)
         self.newline()
-        write('void EncodePNextStruct(ParameterEncoder* encoder, const void* value)', file=self.outFile)
+        write(
+            'void EncodePNextStruct(ParameterEncoder* encoder, const void* value)',
+            file=self.outFile)
         write('{', file=self.outFile)
         write('    assert(encoder != nullptr);', file=self.outFile)
         self.newline()
-        write('    auto base = reinterpret_cast<const VkBaseInStructure*>(value);', file=self.outFile)
+        write(
+            '    auto base = reinterpret_cast<const VkBaseInStructure*>(value);',
+            file=self.outFile)
         self.newline()
-        write('    // Ignore the structures added to the pnext chain by the loader.', file=self.outFile)
-        write('    while ((base != nullptr) && ((base->sType == VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO) ||', file=self.outFile)
-        write('                                 (base->sType == VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO)))', file=self.outFile)
+        write(
+            '    // Ignore the structures added to the pnext chain by the loader.',
+            file=self.outFile)
+        write(
+            '    while ((base != nullptr) && ((base->sType == VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO) ||',
+            file=self.outFile)
+        write(
+            '                                 (base->sType == VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO)))',
+            file=self.outFile)
         write('    {', file=self.outFile)
         write('        base = base->pNext;', file=self.outFile)
         write('    }', file=self.outFile)
@@ -92,13 +116,25 @@ class EncodePNextStructGenerator(BaseGenerator):
         write('        {', file=self.outFile)
         write('        default:', file=self.outFile)
         write('            {', file=self.outFile)
-        write('                // pNext is unrecognized.  Write warning message to indicate it will be omitted from the capture and check to see if it points to a recognized value.', file=self.outFile)
-        write('                int32_t message_size = std::snprintf(nullptr, 0, "A pNext value with unrecognized VkStructureType = %d was omitted from the capture file, which may cause replay to fail.", base->sType);', file=self.outFile)
-        write('                std::unique_ptr<char[]> message = std::make_unique<char[]>(message_size + 1); // Add 1 for null-terminator.', file=self.outFile)
-        write('                std::snprintf(message.get(), (message_size + 1), "A pNext value with unrecognized VkStructureType = %d was omitted from the capture file, which may cause replay to fail.", base->sType);', file=self.outFile)
-        write('                TraceManager::Get()->WriteDisplayMessageCmd(message.get());', file=self.outFile)
-        write('                GFXRECON_LOG_WARNING("%s", message.get());', file=self.outFile)
-        write('                EncodePNextStruct(encoder, base->pNext);', file=self.outFile)
+        write(
+            '                // pNext is unrecognized.  Write warning message to indicate it will be omitted from the capture and check to see if it points to a recognized value.',
+            file=self.outFile)
+        write(
+            '                int32_t message_size = std::snprintf(nullptr, 0, "A pNext value with unrecognized VkStructureType = %d was omitted from the capture file, which may cause replay to fail.", base->sType);',
+            file=self.outFile)
+        write(
+            '                std::unique_ptr<char[]> message = std::make_unique<char[]>(message_size + 1); // Add 1 for null-terminator.',
+            file=self.outFile)
+        write(
+            '                std::snprintf(message.get(), (message_size + 1), "A pNext value with unrecognized VkStructureType = %d was omitted from the capture file, which may cause replay to fail.", base->sType);',
+            file=self.outFile)
+        write(
+            '                TraceManager::Get()->WriteDisplayMessageCmd(message.get());',
+            file=self.outFile)
+        write('                GFXRECON_LOG_WARNING("%s", message.get());',
+              file=self.outFile)
+        write('                EncodePNextStruct(encoder, base->pNext);',
+              file=self.outFile)
         write('            }', file=self.outFile)
         write('            break;', file=self.outFile)
 
@@ -108,8 +144,11 @@ class EncodePNextStructGenerator(BaseGenerator):
         write('    }', file=self.outFile)
         write('    else', file=self.outFile)
         write('    {', file=self.outFile)
-        write('        // pNext was either NULL or an ignored loader specific struct.  Write an encoding for a NULL pointer.', file=self.outFile)
-        write('        encoder->EncodeStructPtrPreamble(nullptr);', file=self.outFile)
+        write(
+            '        // pNext was either NULL or an ignored loader specific struct.  Write an encoding for a NULL pointer.',
+            file=self.outFile)
+        write('        encoder->EncodeStructPtrPreamble(nullptr);',
+              file=self.outFile)
         write('    }', file=self.outFile)
         write('}', file=self.outFile)
         self.newline()
@@ -140,7 +179,11 @@ class EncodePNextStructGenerator(BaseGenerator):
     # Performs C++ code generation for the feature.
     def generateFeature(self):
         for struct in self.sTypeValues:
-            write('        case {}:'.format(self.sTypeValues[struct]), file=self.outFile)
-            write('            EncodeStructPtr(encoder, reinterpret_cast<const {}*>(base));'.format(struct), file=self.outFile)
+            write('        case {}:'.format(self.sTypeValues[struct]),
+                  file=self.outFile)
+            write(
+                '            EncodeStructPtr(encoder, reinterpret_cast<const {}*>(base));'
+                .format(struct),
+                file=self.outFile)
             write('            break;', file=self.outFile)
         self.sTypeValues = dict()

--- a/framework/generated/vulkan_generators/gencode.py
+++ b/framework/generated/vulkan_generators/gencode.py
@@ -200,7 +200,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_decoder.h'] = [
@@ -212,7 +213,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=True,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     #
@@ -226,7 +228,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_struct_decoders_forward.h'] = [
@@ -238,7 +241,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=True,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_struct_decoders.h'] = [
@@ -250,7 +254,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=True,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_decode_pnext_struct.cpp'] = [
@@ -260,7 +265,8 @@ def makeGenOpts(args):
             directory=directory,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     #
@@ -277,7 +283,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=True,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_ascii_consumer.h'] = [
@@ -292,7 +299,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=True,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_referenced_resource_consumer.h'] = [
@@ -304,7 +312,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_replay_consumer.h'] = [
@@ -321,7 +330,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=True,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_ascii_consumer.cpp'] = [
@@ -333,7 +343,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_replay_consumer.cpp'] = [
@@ -346,7 +357,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_referenced_resource_consumer.cpp'] = [
@@ -358,7 +370,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_struct_handle_mappers.h'] = [
@@ -369,7 +382,8 @@ def makeGenOpts(args):
             blacklists=blacklists,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=True,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_struct_handle_mappers.cpp'] = [
@@ -380,7 +394,8 @@ def makeGenOpts(args):
             blacklists=blacklists,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_feature_util.cpp'] = [
@@ -391,7 +406,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     #
@@ -405,7 +421,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=True,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_api_call_encoders.cpp'] = [
@@ -418,7 +435,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_command_buffer_util.h'] = [
@@ -430,7 +448,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=True,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_command_buffer_util.cpp'] = [
@@ -442,7 +461,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_dispatch_table.h'] = [
@@ -452,7 +472,8 @@ def makeGenOpts(args):
             directory=directory,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=True,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_layer_func_table.h'] = [
@@ -462,7 +483,8 @@ def makeGenOpts(args):
                                        prefixText=prefixStrings +
                                        vkPrefixStrings,
                                        protectFile=True,
-                                       protectFeature=False)
+                                       protectFeature=False,
+                                       extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     #
@@ -476,7 +498,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_struct_encoders.h'] = [
@@ -488,7 +511,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=True,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_encode_pnext_struct.cpp'] = [
@@ -498,7 +522,8 @@ def makeGenOpts(args):
             directory=directory,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_struct_handle_wrappers.h'] = [
@@ -509,7 +534,8 @@ def makeGenOpts(args):
             blacklists=blacklists,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=True,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_struct_handle_wrappers.cpp'] = [
@@ -520,7 +546,8 @@ def makeGenOpts(args):
             blacklists=blacklists,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     #
@@ -534,7 +561,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=True,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_enum_to_string.cpp'] = [
@@ -546,7 +574,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_pnext_to_string.cpp'] = [
@@ -558,7 +587,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_struct_to_string.h'] = [
@@ -570,7 +600,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=True,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_struct_to_string.cpp'] = [
@@ -582,7 +613,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=False,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_object_info_table_base2.h'] = [
@@ -594,7 +626,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=True,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
     genOpts['generated_vulkan_state_table.h'] = [
@@ -606,7 +639,8 @@ def makeGenOpts(args):
             platformTypes=platformTypes,
             prefixText=prefixStrings + vkPrefixStrings,
             protectFile=True,
-            protectFeature=False)
+            protectFeature=False,
+            extraVulkanHeaders=extraVulkanHeaders)
     ]
 
 

--- a/framework/generated/vulkan_generators/gencode.py
+++ b/framework/generated/vulkan_generators/gencode.py
@@ -43,57 +43,59 @@ from reg import *
 from generator import write
 
 # API Call Decoders
-from vulkan_decoder_body_generator import VulkanDecoderBodyGenerator,VulkanDecoderBodyGeneratorOptions
-from vulkan_decoder_header_generator import VulkanDecoderHeaderGenerator,VulkanDecoderHeaderGeneratorOptions
+from vulkan_decoder_body_generator import VulkanDecoderBodyGenerator, VulkanDecoderBodyGeneratorOptions
+from vulkan_decoder_header_generator import VulkanDecoderHeaderGenerator, VulkanDecoderHeaderGeneratorOptions
 
 # Struct Decoders
-from vulkan_struct_decoders_body_generator import VulkanStructDecodersBodyGenerator,VulkanStructDecodersBodyGeneratorOptions
-from vulkan_struct_decoders_forward_generator import VulkanStructDecodersForwardGenerator,VulkanStructDecodersForwardGeneratorOptions
-from vulkan_struct_decoders_header_generator import VulkanStructDecodersHeaderGenerator,VulkanStructDecodersHeaderGeneratorOptions
-from decode_pnext_struct_generator import DecodePNextStructGenerator,DecodePNextStructGeneratorOptions
+from vulkan_struct_decoders_body_generator import VulkanStructDecodersBodyGenerator, VulkanStructDecodersBodyGeneratorOptions
+from vulkan_struct_decoders_forward_generator import VulkanStructDecodersForwardGenerator, VulkanStructDecodersForwardGeneratorOptions
+from vulkan_struct_decoders_header_generator import VulkanStructDecodersHeaderGenerator, VulkanStructDecodersHeaderGeneratorOptions
+from decode_pnext_struct_generator import DecodePNextStructGenerator, DecodePNextStructGeneratorOptions
 
 # Consumers
-from vulkan_consumer_header_generator import VulkanConsumerHeaderGenerator,VulkanConsumerHeaderGeneratorOptions
-from vulkan_ascii_consumer_body_generator import VulkanAsciiConsumerBodyGenerator,VulkanAsciiConsumerBodyGeneratorOptions
-from vulkan_replay_consumer_body_generator import VulkanReplayConsumerBodyGenerator,VulkanReplayConsumerBodyGeneratorOptions
-from vulkan_referenced_resource_consumer_header_generator import VulkanReferencedResourceHeaderGenerator,VulkanReferencedResourceHeaderGeneratorOptions
-from vulkan_referenced_resource_consumer_body_generator import VulkanReferencedResourceBodyGenerator,VulkanReferencedResourceBodyGeneratorOptions
-from vulkan_struct_handle_mappers_header_generator import VulkanStructHandleMappersHeaderGenerator,VulkanStructHandleMappersHeaderGeneratorOptions
-from vulkan_struct_handle_mappers_body_generator import VulkanStructHandleMappersBodyGenerator,VulkanStructHandleMappersBodyGeneratorOptions
-from vulkan_feature_util_body_generator import VulkanFeatureUtilBodyGenerator,VulkanFeatureUtilBodyGeneratorOptions
+from vulkan_consumer_header_generator import VulkanConsumerHeaderGenerator, VulkanConsumerHeaderGeneratorOptions
+from vulkan_ascii_consumer_body_generator import VulkanAsciiConsumerBodyGenerator, VulkanAsciiConsumerBodyGeneratorOptions
+from vulkan_replay_consumer_body_generator import VulkanReplayConsumerBodyGenerator, VulkanReplayConsumerBodyGeneratorOptions
+from vulkan_referenced_resource_consumer_header_generator import VulkanReferencedResourceHeaderGenerator, VulkanReferencedResourceHeaderGeneratorOptions
+from vulkan_referenced_resource_consumer_body_generator import VulkanReferencedResourceBodyGenerator, VulkanReferencedResourceBodyGeneratorOptions
+from vulkan_struct_handle_mappers_header_generator import VulkanStructHandleMappersHeaderGenerator, VulkanStructHandleMappersHeaderGeneratorOptions
+from vulkan_struct_handle_mappers_body_generator import VulkanStructHandleMappersBodyGenerator, VulkanStructHandleMappersBodyGeneratorOptions
+from vulkan_feature_util_body_generator import VulkanFeatureUtilBodyGenerator, VulkanFeatureUtilBodyGeneratorOptions
 
 # API Call Encoders
-from vulkan_api_call_encoders_body_generator import VulkanApiCallEncodersBodyGenerator,VulkanApiCallEncodersBodyGeneratorOptions
-from vulkan_api_call_encoders_header_generator import VulkanApiCallEncodersHeaderGenerator,VulkanApiCallEncodersHeaderGeneratorOptions
-from vulkan_command_buffer_util_body_generator import VulkanCommandBufferUtilBodyGenerator,VulkanCommandBufferUtilBodyGeneratorOptions
-from vulkan_command_buffer_util_header_generator import VulkanCommandBufferUtilHeaderGenerator,VulkanCommandBufferUtilHeaderGeneratorOptions
+from vulkan_api_call_encoders_body_generator import VulkanApiCallEncodersBodyGenerator, VulkanApiCallEncodersBodyGeneratorOptions
+from vulkan_api_call_encoders_header_generator import VulkanApiCallEncodersHeaderGenerator, VulkanApiCallEncodersHeaderGeneratorOptions
+from vulkan_command_buffer_util_body_generator import VulkanCommandBufferUtilBodyGenerator, VulkanCommandBufferUtilBodyGeneratorOptions
+from vulkan_command_buffer_util_header_generator import VulkanCommandBufferUtilHeaderGenerator, VulkanCommandBufferUtilHeaderGeneratorOptions
 from vulkan_dispatch_table_generator import VulkanDispatchTableGenerator, VulkanDispatchTableGeneratorOptions
-from layer_func_table_generator import LayerFuncTableGenerator,LayerFuncTableGeneratorOptions
+from layer_func_table_generator import LayerFuncTableGenerator, LayerFuncTableGeneratorOptions
 
 # Struct Encoders
-from vulkan_struct_encoders_body_generator import VulkanStructEncodersBodyGenerator,VulkanStructEncodersBodyGeneratorOptions
-from vulkan_struct_encoders_header_generator import VulkanStructEncodersHeaderGenerator,VulkanStructEncodersHeaderGeneratorOptions
-from encode_pnext_struct_generator import EncodePNextStructGenerator,EncodePNextStructGeneratorOptions
-from vulkan_struct_handle_wrappers_header_generator import VulkanStructHandleWrappersHeaderGenerator,VulkanStructHandleWrappersHeaderGeneratorOptions
-from vulkan_struct_handle_wrappers_body_generator import VulkanStructHandleWrappersBodyGenerator,VulkanStructHandleWrappersBodyGeneratorOptions
+from vulkan_struct_encoders_body_generator import VulkanStructEncodersBodyGenerator, VulkanStructEncodersBodyGeneratorOptions
+from vulkan_struct_encoders_header_generator import VulkanStructEncodersHeaderGenerator, VulkanStructEncodersHeaderGeneratorOptions
+from encode_pnext_struct_generator import EncodePNextStructGenerator, EncodePNextStructGeneratorOptions
+from vulkan_struct_handle_wrappers_header_generator import VulkanStructHandleWrappersHeaderGenerator, VulkanStructHandleWrappersHeaderGeneratorOptions
+from vulkan_struct_handle_wrappers_body_generator import VulkanStructHandleWrappersBodyGenerator, VulkanStructHandleWrappersBodyGeneratorOptions
 
 # To String
-from vulkan_enum_to_string_body_generator import VulkanEnumToStringBodyGenerator,VulkanEnumToStringBodyGeneratorOptions
-from vulkan_enum_to_string_header_generator import VulkanEnumToStringHeaderGenerator,VulkanEnumToStringHeaderGeneratorOptions
-from vulkan_struct_to_string_body_generator import VulkanStructToStringBodyGenerator,VulkanStructToStringBodyGeneratorOptions
-from vulkan_pnext_to_string_body_generator import VulkanPNextToStringBodyGenerator,VulkanPNextToStringBodyGeneratorOptions
-from vulkan_struct_to_string_header_generator import VulkanStructToStringHeaderGenerator,VulkanStructToStringHeaderGeneratorOptions
+from vulkan_enum_to_string_body_generator import VulkanEnumToStringBodyGenerator, VulkanEnumToStringBodyGeneratorOptions
+from vulkan_enum_to_string_header_generator import VulkanEnumToStringHeaderGenerator, VulkanEnumToStringHeaderGeneratorOptions
+from vulkan_struct_to_string_body_generator import VulkanStructToStringBodyGenerator, VulkanStructToStringBodyGeneratorOptions
+from vulkan_pnext_to_string_body_generator import VulkanPNextToStringBodyGenerator, VulkanPNextToStringBodyGeneratorOptions
+from vulkan_struct_to_string_header_generator import VulkanStructToStringHeaderGenerator, VulkanStructToStringHeaderGeneratorOptions
 
-from vulkan_object_info_table_base2_header_generator import VulkanObjectInfoTableBase2HeaderGenerator,VulkanObjectInfoTableBase2HeaderGeneratorOptions
-from vulkan_state_table_header_generator import VulkanStateTableHeaderGenerator,VulkanStateTableHeaderGeneratorOptions
+from vulkan_object_info_table_base2_header_generator import VulkanObjectInfoTableBase2HeaderGenerator, VulkanObjectInfoTableBase2HeaderGeneratorOptions
+from vulkan_state_table_header_generator import VulkanStateTableHeaderGenerator, VulkanStateTableHeaderGeneratorOptions
 
 # Simple timer functions
 startTime = None
+
 
 def startTimer(timeit):
     global startTime
     if timeit:
         startTime = time.process_time()
+
 
 def endTimer(timeit, msg):
     global startTime
@@ -102,11 +104,39 @@ def endTimer(timeit, msg):
         write(msg, endTime - startTime, file=sys.stderr)
         startTime = None
 
+
 # JSON files for customizing code generation
 defaultBlacklists = 'blacklists.json'
 defaultPlatformTypes = 'platform_types.json'
 defaultReplayOverrides = 'replay_overrides.json'
 defaultCaptureOverrides = 'capture_overrides.json'
+
+
+def _getExtraVulkanHeaders(extraHeadersDir):
+    '''
+    Recursively get a list of extra Vulkan headers used in the generated code,
+    that are included after vulkan/vulkan.h is included
+    '''
+    extraVulkanHeaders = []
+    for child in os.listdir(extraHeadersDir):
+        childPath = os.path.join(extraHeadersDir, child)
+        if os.path.isdir(childPath):
+            extraVulkanHeaders.extend(_getExtraVulkanHeaders(childPath))
+        else:
+            extraVulkanHeaders.append(childPath)
+    return extraVulkanHeaders
+
+
+def getExtraVulkanHeaders(extraHeadersDir):
+    '''
+    Get a list of extra Vulkan headers used in the generated code, that are
+    included after vulkan/vulkan.h is included
+    '''
+    return [
+        os.path.relpath(header, extraHeadersDir)
+        for header in _getExtraVulkanHeaders(extraHeadersDir)
+    ]
+
 
 # Returns a directory of [ generator function, generator options ] indexed
 # by specified short names. The generator options incorporate the following
@@ -128,10 +158,8 @@ def makeGenOpts(args):
 
     # Copyright text prefixing all headers (list of strings).
     prefixStrings = [
-        '/*',
-        '** Copyright (c) 2018-2021 Valve Corporation',
-        '** Copyright (c) 2018-2021 LunarG, Inc.',
-        '**',
+        '/*', '** Copyright (c) 2018-2021 Valve Corporation',
+        '** Copyright (c) 2018-2021 LunarG, Inc.', '**',
         '** Permission is hereby granted, free of charge, to any person obtaining a',
         '** copy of this software and associated documentation files (the "Software"),',
         '** to deal in the Software without restriction, including without limitation',
@@ -140,446 +168,447 @@ def makeGenOpts(args):
         '** Software is furnished to do so, subject to the following conditions:',
         '**',
         '** The above copyright notice and this permission notice shall be included in',
-        '** all copies or substantial portions of the Software.',
-        '**',
+        '** all copies or substantial portions of the Software.', '**',
         '** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR',
         '** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,',
         '** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE',
         '** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER',
         '** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING',
         '** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER',
-        '** DEALINGS IN THE SOFTWARE.',
-        '*/',
-        ''
+        '** DEALINGS IN THE SOFTWARE.', '*/', ''
     ]
 
     # Text specific to Vulkan headers
     vkPrefixStrings = [
         '/*',
         '** This file is generated from the Khronos Vulkan XML API Registry.',
-        '**',
-        '*/',
-        ''
+        '**', '*/', ''
     ]
+
+    extraVulkanHeaders = []
+    if args.headers_dir is not None:
+        extraVulkanHeaders = getExtraVulkanHeaders(args.headers_dir)
 
     #
     # API call decoder generators
     genOpts['generated_vulkan_decoder.cpp'] = [
-          VulkanDecoderBodyGenerator,
-          VulkanDecoderBodyGeneratorOptions(
-            filename          = 'generated_vulkan_decoder.cpp',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = False,
-            protectFeature    = False)
-        ]
+        VulkanDecoderBodyGenerator,
+        VulkanDecoderBodyGeneratorOptions(
+            filename='generated_vulkan_decoder.cpp',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_decoder.h'] = [
-          VulkanDecoderHeaderGenerator,
-          VulkanDecoderHeaderGeneratorOptions(
-            filename          = 'generated_vulkan_decoder.h',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = True,
-            protectFeature    = False)
-        ]
+        VulkanDecoderHeaderGenerator,
+        VulkanDecoderHeaderGeneratorOptions(
+            filename='generated_vulkan_decoder.h',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=True,
+            protectFeature=False)
+    ]
 
     #
     # Struct decoder generators
     genOpts['generated_vulkan_struct_decoders.cpp'] = [
-          VulkanStructDecodersBodyGenerator,
-          VulkanStructDecodersBodyGeneratorOptions(
-            filename          = 'generated_vulkan_struct_decoders.cpp',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = False,
-            protectFeature    = False)
-        ]
+        VulkanStructDecodersBodyGenerator,
+        VulkanStructDecodersBodyGeneratorOptions(
+            filename='generated_vulkan_struct_decoders.cpp',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_struct_decoders_forward.h'] = [
-          VulkanStructDecodersForwardGenerator,
-          VulkanStructDecodersForwardGeneratorOptions(
-            filename          = 'generated_vulkan_struct_decoders_forward.h',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = True,
-            protectFeature    = False)
-        ]
+        VulkanStructDecodersForwardGenerator,
+        VulkanStructDecodersForwardGeneratorOptions(
+            filename='generated_vulkan_struct_decoders_forward.h',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=True,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_struct_decoders.h'] = [
-          VulkanStructDecodersHeaderGenerator,
-          VulkanStructDecodersHeaderGeneratorOptions(
-            filename          = 'generated_vulkan_struct_decoders.h',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = True,
-            protectFeature    = False)
-        ]
+        VulkanStructDecodersHeaderGenerator,
+        VulkanStructDecodersHeaderGeneratorOptions(
+            filename='generated_vulkan_struct_decoders.h',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=True,
+            protectFeature=False)
+    ]
 
     genOpts['generated_decode_pnext_struct.cpp'] = [
-          DecodePNextStructGenerator,
-          DecodePNextStructGeneratorOptions(
-            filename          = 'generated_decode_pnext_struct.cpp',
-            directory         = directory,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = False,
-            protectFeature    = False)
-        ]
+        DecodePNextStructGenerator,
+        DecodePNextStructGeneratorOptions(
+            filename='generated_decode_pnext_struct.cpp',
+            directory=directory,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
+    ]
 
     #
     # Consumer generation
     genOpts['generated_vulkan_consumer.h'] = [
         VulkanConsumerHeaderGenerator,
         VulkanConsumerHeaderGeneratorOptions(
-        className         = 'VulkanConsumer',
-        baseClassHeader   = 'vulkan_consumer_base.h',
-        isOverride        = False,
-        filename          = 'generated_vulkan_consumer.h',
-        directory         = directory,
-        blacklists        = blacklists,
-        platformTypes     = platformTypes,
-        prefixText        = prefixStrings + vkPrefixStrings,
-        protectFile       = True,
-        protectFeature    = False)
+            className='VulkanConsumer',
+            baseClassHeader='vulkan_consumer_base.h',
+            isOverride=False,
+            filename='generated_vulkan_consumer.h',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=True,
+            protectFeature=False)
     ]
 
     genOpts['generated_vulkan_ascii_consumer.h'] = [
         VulkanConsumerHeaderGenerator,
         VulkanConsumerHeaderGeneratorOptions(
-        className         = 'VulkanAsciiConsumer',
-        baseClassHeader   = 'vulkan_ascii_consumer_base.h',
-        isOverride        = True,
-        filename          = 'generated_vulkan_ascii_consumer.h',
-        directory         = directory,
-        blacklists        = blacklists,
-        platformTypes     = platformTypes,
-        prefixText        = prefixStrings + vkPrefixStrings,
-        protectFile       = True,
-        protectFeature    = False)
+            className='VulkanAsciiConsumer',
+            baseClassHeader='vulkan_ascii_consumer_base.h',
+            isOverride=True,
+            filename='generated_vulkan_ascii_consumer.h',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=True,
+            protectFeature=False)
     ]
 
     genOpts['generated_vulkan_referenced_resource_consumer.h'] = [
         VulkanReferencedResourceHeaderGenerator,
         VulkanReferencedResourceHeaderGeneratorOptions(
-        filename          = 'generated_vulkan_referenced_resource_consumer.h',
-        directory         = directory,
-        blacklists        = blacklists,
-        platformTypes     = platformTypes,
-        prefixText        = prefixStrings + vkPrefixStrings,
-        protectFile       = False,
-        protectFeature    = False)
+            filename='generated_vulkan_referenced_resource_consumer.h',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
     ]
 
     genOpts['generated_vulkan_replay_consumer.h'] = [
         VulkanConsumerHeaderGenerator,
         VulkanConsumerHeaderGeneratorOptions(
-        className         = 'VulkanReplayConsumer',
-        baseClassHeader   = 'vulkan_replay_consumer_base.h',
-        isOverride        = True,
-        constructorArgs   = 'WindowFactory* window_factory, const ReplayOptions& options',
-        filename          = 'generated_vulkan_replay_consumer.h',
-        directory         = directory,
-        blacklists        = blacklists,
-        platformTypes     = platformTypes,
-        prefixText        = prefixStrings + vkPrefixStrings,
-        protectFile       = True,
-        protectFeature    = False)
+            className='VulkanReplayConsumer',
+            baseClassHeader='vulkan_replay_consumer_base.h',
+            isOverride=True,
+            constructorArgs=
+            'WindowFactory* window_factory, const ReplayOptions& options',
+            filename='generated_vulkan_replay_consumer.h',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=True,
+            protectFeature=False)
     ]
 
     genOpts['generated_vulkan_ascii_consumer.cpp'] = [
         VulkanAsciiConsumerBodyGenerator,
         VulkanAsciiConsumerBodyGeneratorOptions(
-        filename          = 'generated_vulkan_ascii_consumer.cpp',
-        directory         = directory,
-        blacklists        = blacklists,
-        platformTypes     = platformTypes,
-        prefixText        = prefixStrings + vkPrefixStrings,
-        protectFile       = False,
-        protectFeature    = False)
+            filename='generated_vulkan_ascii_consumer.cpp',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
     ]
 
     genOpts['generated_vulkan_replay_consumer.cpp'] = [
         VulkanReplayConsumerBodyGenerator,
         VulkanReplayConsumerBodyGeneratorOptions(
-        filename          = 'generated_vulkan_replay_consumer.cpp',
-        directory         = directory,
-        blacklists        = blacklists,
-        replayOverrides   = replayOverrides,
-        platformTypes     = platformTypes,
-        prefixText        = prefixStrings + vkPrefixStrings,
-        protectFile       = False,
-        protectFeature    = False)
+            filename='generated_vulkan_replay_consumer.cpp',
+            directory=directory,
+            blacklists=blacklists,
+            replayOverrides=replayOverrides,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
     ]
 
     genOpts['generated_vulkan_referenced_resource_consumer.cpp'] = [
         VulkanReferencedResourceBodyGenerator,
         VulkanReferencedResourceBodyGeneratorOptions(
-        filename          = 'generated_vulkan_referenced_resource_consumer.cpp',
-        directory         = directory,
-        blacklists        = blacklists,
-        platformTypes     = platformTypes,
-        prefixText        = prefixStrings + vkPrefixStrings,
-        protectFile       = False,
-        protectFeature    = False)
+            filename='generated_vulkan_referenced_resource_consumer.cpp',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
     ]
 
     genOpts['generated_vulkan_struct_handle_mappers.h'] = [
-          VulkanStructHandleMappersHeaderGenerator,
-          VulkanStructHandleMappersHeaderGeneratorOptions(
-            filename          = 'generated_vulkan_struct_handle_mappers.h',
-            directory         = directory,
-            blacklists        = blacklists,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = True,
-            protectFeature    = False)
-        ]
+        VulkanStructHandleMappersHeaderGenerator,
+        VulkanStructHandleMappersHeaderGeneratorOptions(
+            filename='generated_vulkan_struct_handle_mappers.h',
+            directory=directory,
+            blacklists=blacklists,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=True,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_struct_handle_mappers.cpp'] = [
-          VulkanStructHandleMappersBodyGenerator,
-          VulkanStructHandleMappersBodyGeneratorOptions(
-            filename          = 'generated_vulkan_struct_handle_mappers.cpp',
-            directory         = directory,
-            blacklists        = blacklists,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = False,
-            protectFeature    = False)
-        ]
+        VulkanStructHandleMappersBodyGenerator,
+        VulkanStructHandleMappersBodyGeneratorOptions(
+            filename='generated_vulkan_struct_handle_mappers.cpp',
+            directory=directory,
+            blacklists=blacklists,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_feature_util.cpp'] = [
         VulkanFeatureUtilBodyGenerator,
         VulkanFeatureUtilBodyGeneratorOptions(
-        filename          = 'generated_vulkan_feature_util.cpp',
-        directory         = directory,
-        platformTypes     = platformTypes,
-        prefixText        = prefixStrings + vkPrefixStrings,
-        protectFile       = False,
-        protectFeature    = False)
+            filename='generated_vulkan_feature_util.cpp',
+            directory=directory,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
     ]
 
     #
     # API call encoder generators
     genOpts['generated_vulkan_api_call_encoders.h'] = [
-          VulkanApiCallEncodersHeaderGenerator,
-          VulkanApiCallEncodersHeaderGeneratorOptions(
-            filename          = 'generated_vulkan_api_call_encoders.h',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = True,
-            protectFeature    = False)
-        ]
+        VulkanApiCallEncodersHeaderGenerator,
+        VulkanApiCallEncodersHeaderGeneratorOptions(
+            filename='generated_vulkan_api_call_encoders.h',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=True,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_api_call_encoders.cpp'] = [
-          VulkanApiCallEncodersBodyGenerator,
-          VulkanApiCallEncodersBodyGeneratorOptions(
-            filename          = 'generated_vulkan_api_call_encoders.cpp',
-            directory         = directory,
-            blacklists        = blacklists,
-            captureOverrides  = captureOverrides,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = False,
-            protectFeature    = False)
-        ]
+        VulkanApiCallEncodersBodyGenerator,
+        VulkanApiCallEncodersBodyGeneratorOptions(
+            filename='generated_vulkan_api_call_encoders.cpp',
+            directory=directory,
+            blacklists=blacklists,
+            captureOverrides=captureOverrides,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_command_buffer_util.h'] = [
-          VulkanCommandBufferUtilHeaderGenerator,
-          VulkanCommandBufferUtilHeaderGeneratorOptions(
-            filename          = 'generated_vulkan_command_buffer_util.h',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = True,
-            protectFeature    = False)
-        ]
+        VulkanCommandBufferUtilHeaderGenerator,
+        VulkanCommandBufferUtilHeaderGeneratorOptions(
+            filename='generated_vulkan_command_buffer_util.h',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=True,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_command_buffer_util.cpp'] = [
-          VulkanCommandBufferUtilBodyGenerator,
-          VulkanCommandBufferUtilBodyGeneratorOptions(
-            filename          = 'generated_vulkan_command_buffer_util.cpp',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = False,
-            protectFeature    = False)
-        ]
+        VulkanCommandBufferUtilBodyGenerator,
+        VulkanCommandBufferUtilBodyGeneratorOptions(
+            filename='generated_vulkan_command_buffer_util.cpp',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_dispatch_table.h'] = [
-            VulkanDispatchTableGenerator,
-            VulkanDispatchTableGeneratorOptions(
-            filename          = 'generated_vulkan_dispatch_table.h',
-            directory         = directory,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = True,
-            protectFeature    = False)
-        ]
+        VulkanDispatchTableGenerator,
+        VulkanDispatchTableGeneratorOptions(
+            filename='generated_vulkan_dispatch_table.h',
+            directory=directory,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=True,
+            protectFeature=False)
+    ]
 
     genOpts['generated_layer_func_table.h'] = [
-          LayerFuncTableGenerator,
-          LayerFuncTableGeneratorOptions(
-            filename          = 'generated_layer_func_table.h',
-            directory         = directory,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = True,
-            protectFeature    = False)
-        ]
+        LayerFuncTableGenerator,
+        LayerFuncTableGeneratorOptions(filename='generated_layer_func_table.h',
+                                       directory=directory,
+                                       prefixText=prefixStrings +
+                                       vkPrefixStrings,
+                                       protectFile=True,
+                                       protectFeature=False)
+    ]
 
     #
     # Struct encoder generators
     genOpts['generated_vulkan_struct_encoders.cpp'] = [
-          VulkanStructEncodersBodyGenerator,
-          VulkanStructEncodersBodyGeneratorOptions(
-            filename          = 'generated_vulkan_struct_encoders.cpp',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = False,
-            protectFeature    = False)
-        ]
+        VulkanStructEncodersBodyGenerator,
+        VulkanStructEncodersBodyGeneratorOptions(
+            filename='generated_vulkan_struct_encoders.cpp',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_struct_encoders.h'] = [
-          VulkanStructEncodersHeaderGenerator,
-          VulkanStructEncodersHeaderGeneratorOptions(
-            filename          = 'generated_vulkan_struct_encoders.h',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = True,
-            protectFeature    = False)
-        ]
+        VulkanStructEncodersHeaderGenerator,
+        VulkanStructEncodersHeaderGeneratorOptions(
+            filename='generated_vulkan_struct_encoders.h',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=True,
+            protectFeature=False)
+    ]
 
     genOpts['generated_encode_pnext_struct.cpp'] = [
-          EncodePNextStructGenerator,
-          EncodePNextStructGeneratorOptions(
-            filename          = 'generated_encode_pnext_struct.cpp',
-            directory         = directory,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = False,
-            protectFeature    = False)
-        ]
+        EncodePNextStructGenerator,
+        EncodePNextStructGeneratorOptions(
+            filename='generated_encode_pnext_struct.cpp',
+            directory=directory,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_struct_handle_wrappers.h'] = [
-          VulkanStructHandleWrappersHeaderGenerator,
-          VulkanStructHandleWrappersHeaderGeneratorOptions(
-            filename          = 'generated_vulkan_struct_handle_wrappers.h',
-            directory         = directory,
-            blacklists        = blacklists,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = True,
-            protectFeature    = False)
-        ]
+        VulkanStructHandleWrappersHeaderGenerator,
+        VulkanStructHandleWrappersHeaderGeneratorOptions(
+            filename='generated_vulkan_struct_handle_wrappers.h',
+            directory=directory,
+            blacklists=blacklists,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=True,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_struct_handle_wrappers.cpp'] = [
-          VulkanStructHandleWrappersBodyGenerator,
-          VulkanStructHandleWrappersBodyGeneratorOptions(
-            filename          = 'generated_vulkan_struct_handle_wrappers.cpp',
-            directory         = directory,
-            blacklists        = blacklists,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = False,
-            protectFeature    = False)
-        ]
+        VulkanStructHandleWrappersBodyGenerator,
+        VulkanStructHandleWrappersBodyGeneratorOptions(
+            filename='generated_vulkan_struct_handle_wrappers.cpp',
+            directory=directory,
+            blacklists=blacklists,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
+    ]
 
     #
     # To string generators
     genOpts['generated_vulkan_enum_to_string.h'] = [
-          VulkanEnumToStringHeaderGenerator,
-          VulkanEnumToStringHeaderGeneratorOptions(
-            filename          = 'generated_vulkan_enum_to_string.h',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = True,
-            protectFeature    = False)
-        ]
+        VulkanEnumToStringHeaderGenerator,
+        VulkanEnumToStringHeaderGeneratorOptions(
+            filename='generated_vulkan_enum_to_string.h',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=True,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_enum_to_string.cpp'] = [
-          VulkanEnumToStringBodyGenerator,
-          VulkanEnumToStringBodyGeneratorOptions(
-            filename          = 'generated_vulkan_enum_to_string.cpp',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = False,
-            protectFeature    = False)
-        ]
+        VulkanEnumToStringBodyGenerator,
+        VulkanEnumToStringBodyGeneratorOptions(
+            filename='generated_vulkan_enum_to_string.cpp',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_pnext_to_string.cpp'] = [
-          VulkanPNextToStringBodyGenerator,
-          VulkanPNextToStringBodyGeneratorOptions(
-            filename          = 'generated_vulkan_pnext_to_string.cpp',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = False,
-            protectFeature    = False)
-        ]
+        VulkanPNextToStringBodyGenerator,
+        VulkanPNextToStringBodyGeneratorOptions(
+            filename='generated_vulkan_pnext_to_string.cpp',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_struct_to_string.h'] = [
-          VulkanStructToStringHeaderGenerator,
-          VulkanStructToStringHeaderGeneratorOptions(
-            filename          = 'generated_vulkan_struct_to_string.h',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = True,
-            protectFeature    = False)
-        ]
+        VulkanStructToStringHeaderGenerator,
+        VulkanStructToStringHeaderGeneratorOptions(
+            filename='generated_vulkan_struct_to_string.h',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=True,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_struct_to_string.cpp'] = [
-          VulkanStructToStringBodyGenerator,
-          VulkanStructToStringBodyGeneratorOptions(
-            filename          = 'generated_vulkan_struct_to_string.cpp',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = False,
-            protectFeature    = False)
-        ]
+        VulkanStructToStringBodyGenerator,
+        VulkanStructToStringBodyGeneratorOptions(
+            filename='generated_vulkan_struct_to_string.cpp',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=False,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_object_info_table_base2.h'] = [
-          VulkanObjectInfoTableBase2HeaderGenerator,
-          VulkanObjectInfoTableBase2HeaderGeneratorOptions(
-            filename          = 'generated_vulkan_object_info_table_base2.h',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = True,
-            protectFeature    = False)
-        ]
+        VulkanObjectInfoTableBase2HeaderGenerator,
+        VulkanObjectInfoTableBase2HeaderGeneratorOptions(
+            filename='generated_vulkan_object_info_table_base2.h',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=True,
+            protectFeature=False)
+    ]
 
     genOpts['generated_vulkan_state_table.h'] = [
-          VulkanStateTableHeaderGenerator,
-          VulkanStateTableHeaderGeneratorOptions(
-            filename          = 'generated_vulkan_state_table.h',
-            directory         = directory,
-            blacklists        = blacklists,
-            platformTypes     = platformTypes,
-            prefixText        = prefixStrings + vkPrefixStrings,
-            protectFile       = True,
-            protectFeature    = False)
-        ]
+        VulkanStateTableHeaderGenerator,
+        VulkanStateTableHeaderGeneratorOptions(
+            filename='generated_vulkan_state_table.h',
+            directory=directory,
+            blacklists=blacklists,
+            platformTypes=platformTypes,
+            prefixText=prefixStrings + vkPrefixStrings,
+            protectFile=True,
+            protectFeature=False)
+    ]
+
 
 # Generate a target based on the options in the matching genOpts{} object.
 # This is encapsulated in a function so it can be profiled and/or timed.
@@ -600,22 +629,34 @@ def genTarget(args):
 
         if not args.quiet:
             write('* Building', options.filename, file=sys.stderr)
-            write('* options.versions          =', options.versions, file=sys.stderr)
-            write('* options.emitversions      =', options.emitversions, file=sys.stderr)
-            write('* options.defaultExtensions =', options.defaultExtensions, file=sys.stderr)
-            write('* options.addExtensions     =', options.addExtensions, file=sys.stderr)
-            write('* options.removeExtensions  =', options.removeExtensions, file=sys.stderr)
-            write('* options.emitExtensions    =', options.emitExtensions, file=sys.stderr)
+            write('* options.versions          =',
+                  options.versions,
+                  file=sys.stderr)
+            write('* options.emitversions      =',
+                  options.emitversions,
+                  file=sys.stderr)
+            write('* options.defaultExtensions =',
+                  options.defaultExtensions,
+                  file=sys.stderr)
+            write('* options.addExtensions     =',
+                  options.addExtensions,
+                  file=sys.stderr)
+            write('* options.removeExtensions  =',
+                  options.removeExtensions,
+                  file=sys.stderr)
+            write('* options.emitExtensions    =',
+                  options.emitExtensions,
+                  file=sys.stderr)
 
-        gen = createGenerator(errFile=errWarn,
-                              warnFile=errWarn,
-                              diagFile=diag)
+        gen = createGenerator(errFile=errWarn, warnFile=errWarn, diagFile=diag)
 
         return (gen, options)
     else:
         write('No generator options for unknown target:',
-              args.target, file=sys.stderr)
+              args.target,
+              file=sys.stderr)
         return None
+
 
 # -feature name
 # -extension name
@@ -624,39 +665,69 @@ def genTarget(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('-debug', action='store_true',
-                        help='Enable debugging')
-    parser.add_argument('-dump', action='store_true',
+    parser.add_argument('-debug', action='store_true', help='Enable debugging')
+    parser.add_argument('-dump',
+                        action='store_true',
                         help='Enable dump to stderr')
-    parser.add_argument('-diagfile', action='store',
+    parser.add_argument('-diagfile',
+                        action='store',
                         default=None,
                         help='Write diagnostics to specified file')
-    parser.add_argument('-errfile', action='store',
-                        default=None,
-                        help='Write errors and warnings to specified file instead of stderr')
-    parser.add_argument('-noprotect', dest='protect', action='store_false',
+    parser.add_argument(
+        '-errfile',
+        action='store',
+        default=None,
+        help='Write errors and warnings to specified file instead of stderr')
+    parser.add_argument('-noprotect',
+                        dest='protect',
+                        action='store_false',
                         help='Disable inclusion protection in output headers')
-    parser.add_argument('-profile', action='store_true',
+    parser.add_argument('-profile',
+                        action='store_true',
                         help='Enable profiling')
-    parser.add_argument('-registry', action='store',
+    parser.add_argument('-registry',
+                        action='store',
                         default='vk.xml',
                         help='Use specified registry file instead of vk.xml')
-    parser.add_argument('-time', action='store_true',
-                        help='Enable timing')
-    parser.add_argument('-validate', action='store_true',
+    parser.add_argument(
+        '-headers-dir',
+        dest='headers_dir',
+        action='store',
+        default=None,
+        help='\n'.join([
+            'Path to a directory that holds additional Vulkan header files required to build.',
+            'These header files are included directly after the Vulkan header in all generated files.'
+        ]))
+    parser.add_argument('-time', action='store_true', help='Enable timing')
+    parser.add_argument('-validate',
+                        action='store_true',
                         help='Enable group validation')
-    parser.add_argument('-o', action='store', dest='directory',
-                        default='.',
-                        help='Create target and related files in specified directory')
-    parser.add_argument('target', metavar='target', nargs='?',
+    parser.add_argument(
+        '-o',
+        action='store',
+        dest='directory',
+        default='.',
+        help='Create target and related files in specified directory')
+    parser.add_argument('target',
+                        metavar='target',
+                        nargs='?',
                         help='Specify target')
-    parser.add_argument('-quiet', action='store_true', default=True,
+    parser.add_argument('-quiet',
+                        action='store_true',
+                        default=True,
                         help='Suppress script output during normal execution.')
-    parser.add_argument('-verbose', action='store_false', dest='quiet', default=True,
+    parser.add_argument('-verbose',
+                        action='store_false',
+                        dest='quiet',
+                        default=True,
                         help='Enable script output during normal execution.')
-    parser.add_argument('-configs', action='store', dest='configs',
-                        default='.',
-                        help='Specify directory containing JSON configuration files for generators')
+    parser.add_argument(
+        '-configs',
+        action='store',
+        dest='configs',
+        default='.',
+        help=
+        'Specify directory containing JSON configuration files for generators')
 
     args = parser.parse_args()
 
@@ -688,7 +759,7 @@ if __name__ == '__main__':
 
     if (args.dump):
         write('* Dumping registry to regdump.txt', file=sys.stderr)
-        reg.dumpReg(filehandle = open('regdump.txt', 'w', encoding='utf-8'))
+        reg.dumpReg(filehandle=open('regdump.txt', 'w', encoding='utf-8'))
 
     if (args.debug):
         pdb.run('reg.apiGen()')

--- a/framework/generated/vulkan_generators/layer_func_table_generator.py
+++ b/framework/generated/vulkan_generators/layer_func_table_generator.py
@@ -87,7 +87,7 @@ class LayerFuncTableGenerator(BaseGenerator):
         write('#include "layer/trace_layer.h"', file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
-        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
         self.newline()
         write('#include <unordered_map>', file=self.outFile)
         self.newline()

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -102,7 +102,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
               file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
-        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
         self.newline()
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(encode)', file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_header_generator.py
@@ -21,34 +21,48 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanApiCallEncodersHeaderGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ function declarations for Vulkan API parameter encoding"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanApiCallEncodersHeaderGenerator - subclass of BaseGenerator.
 # Generates C++ functions responsible for encoding Vulkan API call parameter data.
 class VulkanApiCallEncodersHeaderGenerator(BaseGenerator):
     """Generate C++ function declarations for Vulkan API parameter encoding"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=True, processStructs=False, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=True,
+                               processStructs=False,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
     # Method override
     def beginFile(self, genOpts):
@@ -106,11 +120,12 @@ class VulkanApiCallEncodersHeaderGenerator(BaseGenerator):
             if value.isArray and not value.isDynamic:
                 valueName += '[{}]'.format(value.arrayCapacity)
 
-            paramDecl = self.makeAlignedParamDecl(valueType, valueName, self.INDENT_SIZE, self.genOpts.alignFuncParam)
+            paramDecl = self.makeAlignedParamDecl(valueType, valueName,
+                                                  self.INDENT_SIZE,
+                                                  self.genOpts.alignFuncParam)
             paramDecls.append(paramDecl)
 
         if paramDecls:
             return '{}(\n{});'.format(proto, ',\n'.join(paramDecls))
 
         return '{}();'.format(proto)
-

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_header_generator.py
@@ -71,7 +71,7 @@ class VulkanApiCallEncodersHeaderGenerator(BaseGenerator):
         write('#include "format/platform_types.h"', file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
-        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
         self.newline()
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(encode)', file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_ascii_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_ascii_consumer_body_generator.py
@@ -21,22 +21,32 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys,inspect
+import os, re, sys, inspect
 from base_generator import *
+
 
 class VulkanAsciiConsumerBodyGeneratorOptions(BaseGeneratorOptions):
     """Options for generating a C++ class for Vulkan capture file to ASCII file generation"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanAsciiConsumerBodyGenerator - subclass of BaseGenerator.
 # Generates C++ member definitions for the VulkanAsciiConsumer class responsible for
@@ -44,12 +54,16 @@ class VulkanAsciiConsumerBodyGeneratorOptions(BaseGeneratorOptions):
 class VulkanAsciiConsumerBodyGenerator(BaseGenerator):
     """Generate a C++ class for Vulkan capture file to ASCII file generation"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=True, processStructs=False, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=True,
+                               processStructs=False,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
         # The following functions require custom implementations for to ASCII
         self.customImplementationRequired = {
@@ -107,7 +121,9 @@ class VulkanAsciiConsumerBodyGenerator(BaseGenerator):
                 values = info[2]
 
                 cmddef = '' if first else '\n'
-                cmddef += self.makeConsumerFuncDecl(returnType, 'VulkanAsciiConsumer::Process_' + cmd, values) + '\n'
+                cmddef += self.makeConsumerFuncDecl(
+                    returnType, 'VulkanAsciiConsumer::Process_' + cmd,
+                    values) + '\n'
                 cmddef += inspect.cleandoc('''
                     {{
                         using namespace gfxrecon::util;
@@ -194,7 +210,9 @@ class VulkanAsciiConsumerBodyGenerator(BaseGenerator):
                         toString = 'ToString({0}, toStringFlags, tabCount, tabSize)'
 
             firstField = 'true' if not body else 'false'
-            valueName = ('[out]' if self.isOutputParameter(value) else '') + value.name
+            valueName = ('[out]'
+                         if self.isOutputParameter(value) else '') + value.name
             toString = toString.format(value.name, value.arrayLength)
-            body += '            FieldToString(strStrm, {0}, "{1}", toStringFlags, tabCount, tabSize, {2});\n'.format(firstField, valueName, toString)
+            body += '            FieldToString(strStrm, {0}, "{1}", toStringFlags, tabCount, tabSize, {2});\n'.format(
+                firstField, valueName, toString)
         return body

--- a/framework/generated/vulkan_generators/vulkan_ascii_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_ascii_consumer_body_generator.py
@@ -77,7 +77,7 @@ class VulkanAsciiConsumerBodyGenerator(BaseGenerator):
     # Method override
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
-        body = inspect.cleandoc('''
+        includes = inspect.cleandoc('''
             #include "generated/generated_vulkan_ascii_consumer.h"
             #include "decode/custom_vulkan_ascii_consumer.h"
             #include "decode/custom_vulkan_to_string.h"
@@ -85,12 +85,14 @@ class VulkanAsciiConsumerBodyGenerator(BaseGenerator):
             #include "generated/generated_vulkan_struct_to_string.h"
             #include "util/defines.h"
 
-            #include "vulkan/vulkan.h"
-
+            ''')
+        write(includes, file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
+        namespace = inspect.cleandoc('''
             GFXRECON_BEGIN_NAMESPACE(gfxrecon)
             GFXRECON_BEGIN_NAMESPACE(decode)
             ''')
-        write(body, file=self.outFile)
+        write(namespace, file=self.outFile)
 
     # Method override
     def endFile(self):

--- a/framework/generated/vulkan_generators/vulkan_command_buffer_util_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_command_buffer_util_body_generator.py
@@ -21,22 +21,32 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanCommandBufferUtilBodyGeneratorOptions(BaseGeneratorOptions):
     """Options for generating a C++ class for Vulkan capture file replay"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanCommandBufferUtilBodyGenerator - subclass of BaseGenerator.
 # Generates C++ member definitions for the VulkanReplayConsumer class responsible for
@@ -44,27 +54,34 @@ class VulkanCommandBufferUtilBodyGeneratorOptions(BaseGeneratorOptions):
 class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
     """Generate a C++ class for Vulkan capture file replay"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=True, processStructs=True, featureBreak=False,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=True,
+                               processStructs=True,
+                               featureBreak=False,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
         # Map of Vulkan structs containing handles to a list values for handle members or struct members
         # that contain handles (eg. VkGraphicsPipelineCreateInfo contains a VkPipelineShaderStageCreateInfo
         # member that contains handles).
         self.structsWithHandles = dict()
-        self.pNextStructs = dict()    # Map of Vulkan structure types to sType value for structs that can be part of a pNext chain.
-        self.commandInfo = dict()     # Map of Vulkan commands to parameter info
+        self.pNextStructs = dict(
+        )  # Map of Vulkan structure types to sType value for structs that can be part of a pNext chain.
+        self.commandInfo = dict()  # Map of Vulkan commands to parameter info
 
     # Method override
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
 
-        write('#include "generated/generated_vulkan_command_buffer_util.h"', file=self.outFile)
+        write('#include "generated/generated_vulkan_command_buffer_util.h"',
+              file=self.outFile)
         self.newline()
-        write('#include "encode/vulkan_handle_wrapper_util.h"', file=self.outFile)
+        write('#include "encode/vulkan_handle_wrapper_util.h"',
+              file=self.outFile)
         write('#include "encode/vulkan_state_info.h"', file=self.outFile)
         self.newline()
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
@@ -81,13 +98,16 @@ class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
                 if (handles):
                     # Generate a function to build a list of handle types and values.
                     cmddef = '\n'
-                    cmddef += 'void Track{}Handles(CommandBufferWrapper* wrapper, {})\n'.format(cmd[2:], self.getArgList(handles))
+                    cmddef += 'void Track{}Handles(CommandBufferWrapper* wrapper, {})\n'.format(
+                        cmd[2:], self.getArgList(handles))
                     cmddef += '{\n'
                     indent = self.INDENT_SIZE * ' '
                     cmddef += indent + 'assert(wrapper != nullptr);\n'
                     cmddef += '\n'
                     for index, handle in enumerate(handles):
-                        cmddef += self.insertCommandHandle(index, handle, indent=indent)
+                        cmddef += self.insertCommandHandle(index,
+                                                           handle,
+                                                           indent=indent)
                     cmddef += '}'
 
                     write(cmddef, file=self.outFile)
@@ -134,7 +154,9 @@ class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
         for value in values:
             if self.isHandle(value.baseType):
                 handles.append(value)
-            elif self.isStruct(value.baseType) and (value.baseType in self.structsWithHandles):
+            elif self.isStruct(
+                    value.baseType) and (value.baseType
+                                         in self.structsWithHandles):
                 handles.append(value)
         return handles
 
@@ -157,14 +179,16 @@ class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
         if (value.isPointer or value.isArray) and value.name != 'pnext_value':
             if index > 0:
                 body += '\n'
-            body += indent + 'if ({}{} != nullptr)\n'.format(valuePrefix, value.name)
+            body += indent + 'if ({}{} != nullptr)\n'.format(
+                valuePrefix, value.name)
             body += indent + '{\n'
             tail = indent + '}\n' + tail
             indent += ' ' * self.INDENT_SIZE
 
             if value.isArray:
                 indexName = '{}_index'.format(value.name)
-                body += indent + 'for (uint32_t {i} = 0; {i} < {}{}; ++{i})\n'.format(valuePrefix, value.arrayLength, i=indexName)
+                body += indent + 'for (uint32_t {i} = 0; {i} < {}{}; ++{i})\n'.format(
+                    valuePrefix, value.arrayLength, i=indexName)
                 body += indent + '{\n'
                 tail = indent + '}\n' + tail
                 indent += ' ' * self.INDENT_SIZE
@@ -177,9 +201,11 @@ class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
             elif value.isPointer:
                 valueName = '(*{})'.format(valueName)
 
-            body += indent + 'wrapper->command_handles[CommandHandleType::{}].insert(GetWrappedId({}));\n'.format(typeEnumValue, valueName)
+            body += indent + 'wrapper->command_handles[CommandHandleType::{}].insert(GetWrappedId({}));\n'.format(
+                typeEnumValue, valueName)
 
-        elif self.isStruct(value.baseType) and (value.baseType in self.structsWithHandles):
+        elif self.isStruct(value.baseType) and (value.baseType
+                                                in self.structsWithHandles):
             if value.isArray:
                 accessOperator = '[{}].'.format(indexName)
             elif value.isPointer:
@@ -187,11 +213,17 @@ class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
             else:
                 accessOperator = '.'
 
-            for index, entry in enumerate(self.structsWithHandles[value.baseType]):
+            for index, entry in enumerate(
+                    self.structsWithHandles[value.baseType]):
                 if entry.name == 'pNext':
-                    extStructsWithHandles = [extStruct for extStruct in self.registry.validextensionstructs[value.baseType] if extStruct in self.structsWithHandles]
+                    extStructsWithHandles = [
+                        extStruct for extStruct in
+                        self.registry.validextensionstructs[value.baseType]
+                        if extStruct in self.structsWithHandles
+                    ]
                     if extStructsWithHandles:
-                        body += indent + 'auto pnext_header = reinterpret_cast<const VkBaseInStructure*>({}{}->pNext);\n'.format(valuePrefix, value.name)
+                        body += indent + 'auto pnext_header = reinterpret_cast<const VkBaseInStructure*>({}{}->pNext);\n'.format(
+                            valuePrefix, value.name)
                         body += indent + 'while (pnext_header)\n'
                         body += indent + '{\n'
                         indent += ' ' * self.INDENT_SIZE
@@ -203,11 +235,18 @@ class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
                         body += indent + 'break;\n'
                         indent = indent[:-self.INDENT_SIZE]
                         for extStruct in extStructsWithHandles:
-                            body += indent + 'case {}:\n'.format(self.pNextStructs[extStruct])
+                            body += indent + 'case {}:\n'.format(
+                                self.pNextStructs[extStruct])
                             body += indent + '{\n'
                             indent += ' ' * self.INDENT_SIZE
-                            body += indent + 'auto pnext_value = reinterpret_cast<const {}*>(pnext_header);\n'.format(extStruct)
-                            body += self.insertCommandHandle(index, ValueInfo('pnext_value', extStruct, 'const {} *'.format(extStruct), 1), '', indent=indent)
+                            body += indent + 'auto pnext_value = reinterpret_cast<const {}*>(pnext_header);\n'.format(
+                                extStruct)
+                            body += self.insertCommandHandle(
+                                index,
+                                ValueInfo('pnext_value', extStruct,
+                                          'const {} *'.format(extStruct), 1),
+                                '',
+                                indent=indent)
                             body += indent + 'break;\n'
                             indent = indent[:-self.INDENT_SIZE]
                             body += indent + '}\n'
@@ -217,6 +256,8 @@ class VulkanCommandBufferUtilBodyGenerator(BaseGenerator):
                         indent = indent[:-self.INDENT_SIZE]
                         body += indent + '}\n'
                 else:
-                    body += self.insertCommandHandle(index, entry, valuePrefix + value.name + accessOperator, indent)
+                    body += self.insertCommandHandle(
+                        index, entry,
+                        valuePrefix + value.name + accessOperator, indent)
 
         return body + tail

--- a/framework/generated/vulkan_generators/vulkan_command_buffer_util_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_command_buffer_util_header_generator.py
@@ -77,7 +77,7 @@ class VulkanCommandBufferUtilHeaderGenerator(BaseGenerator):
         write('#include "encode/vulkan_handle_wrappers.h"', file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
-        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
         self.newline()
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(encode)', file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_command_buffer_util_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_command_buffer_util_header_generator.py
@@ -21,22 +21,32 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanCommandBufferUtilHeaderGeneratorOptions(BaseGeneratorOptions):
     """Options for generating a C++ class for Vulkan capture file replay"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanCommandBufferUtilBodyGenerator - subclass of BaseGenerator.
 # Generates C++ member definitions for the VulkanReplayConsumer class responsible for
@@ -44,12 +54,16 @@ class VulkanCommandBufferUtilHeaderGeneratorOptions(BaseGeneratorOptions):
 class VulkanCommandBufferUtilHeaderGenerator(BaseGenerator):
     """Generate a C++ class for Vulkan capture file replay"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=True, processStructs=True, featureBreak=False,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=True,
+                               processStructs=True,
+                               featureBreak=False,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
         # Map of Vulkan structs containing handles to a list values for handle members or struct members
         # that contain handles (eg. VkGraphicsPipelineCreateInfo contains a VkPipelineShaderStageCreateInfo
@@ -101,14 +115,16 @@ class VulkanCommandBufferUtilHeaderGenerator(BaseGenerator):
             returnType = info[0]
             values = info[2]
 
-            if values and (len(values) > 1) and (values[0].baseType == 'VkCommandBuffer'):
+            if values and (len(values) > 1) and (values[0].baseType
+                                                 == 'VkCommandBuffer'):
                 # Check for parameters with handle types, ignoring the first VkCommandBuffer parameter.
                 handles = self.getParamListHandles(values[1:])
 
                 if (handles):
                     # Generate a function to build a list of handle types and values.
                     cmddef = '\n'
-                    cmddef += 'void Track{}Handles(CommandBufferWrapper* wrapper, {});'.format(cmd[2:], self.getArgList(handles))
+                    cmddef += 'void Track{}Handles(CommandBufferWrapper* wrapper, {});'.format(
+                        cmd[2:], self.getArgList(handles))
                     write(cmddef, file=self.outFile)
                     first = False
 
@@ -119,7 +135,9 @@ class VulkanCommandBufferUtilHeaderGenerator(BaseGenerator):
         for value in values:
             if self.isHandle(value.baseType):
                 handles.append(value)
-            elif self.isStruct(value.baseType) and (value.baseType in self.structsWithHandles):
+            elif self.isStruct(
+                    value.baseType) and (value.baseType
+                                         in self.structsWithHandles):
                 handles.append(value)
         return handles
 

--- a/framework/generated/vulkan_generators/vulkan_consumer_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_consumer_header_generator.py
@@ -84,7 +84,7 @@ class VulkanConsumerHeaderGenerator(BaseGenerator):
               file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
-        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
         self.newline()
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_consumer_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_consumer_header_generator.py
@@ -21,33 +21,43 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 # Adds the following new option:
 #  isOverride - Specify whether the member function declarations are
 #               virtual function overrides or pure virtual functions.
 class VulkanConsumerHeaderGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ class declarations for Vulkan parameter processing"""
-    def __init__(self,
-                 className,
-                 baseClassHeader,
-                 isOverride,
-                 constructorArgs = '',
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            className,
+            baseClassHeader,
+            isOverride,
+            constructorArgs='',
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
         self.className = className
         self.baseClassHeader = baseClassHeader
         self.isOverride = isOverride
         self.constructorArgs = constructorArgs
+
 
 # VulkanConsumerHeaderGenerator - subclass of BaseGenerator.
 # Generates C++ member declarations for the VulkanConsumer class responsible for processing
@@ -55,18 +65,23 @@ class VulkanConsumerHeaderGeneratorOptions(BaseGeneratorOptions):
 class VulkanConsumerHeaderGenerator(BaseGenerator):
     """Generate C++ class declarations for Vulkan parameter processing"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=True, processStructs=False, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=True,
+                               processStructs=False,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
     # Method override
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
 
-        write('#include "decode/{}"'.format(genOpts.baseClassHeader), file=self.outFile)
+        write('#include "decode/{}"'.format(genOpts.baseClassHeader),
+              file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
         write('#include "vulkan/vulkan.h"', file=self.outFile)
@@ -74,15 +89,24 @@ class VulkanConsumerHeaderGenerator(BaseGenerator):
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)
         self.newline()
-        write('class {className} : public {className}Base'.format(className=genOpts.className), file=self.outFile)
+        write('class {className} : public {className}Base'.format(
+            className=genOpts.className),
+              file=self.outFile)
         write('{', file=self.outFile)
         write('  public:', file=self.outFile)
         if genOpts.constructorArgs:
-            argList = ', '.join([arg.split(' ')[-1] for arg in genOpts.constructorArgs.split(',')])
-            write('    {className}({}) : {className}Base({}) {{ }}\n'.format(genOpts.constructorArgs, argList, className=genOpts.className), file=self.outFile)
+            argList = ', '.join([
+                arg.split(' ')[-1]
+                for arg in genOpts.constructorArgs.split(',')
+            ])
+            write('    {className}({}) : {className}Base({}) {{ }}\n'.format(
+                genOpts.constructorArgs, argList, className=genOpts.className),
+                  file=self.outFile)
         else:
-            write('    {}() {{ }}\n'.format(genOpts.className), file=self.outFile)
-        write('    virtual ~{}() override {{ }}'.format(genOpts.className), file=self.outFile)
+            write('    {}() {{ }}\n'.format(genOpts.className),
+                  file=self.outFile)
+        write('    virtual ~{}() override {{ }}'.format(genOpts.className),
+              file=self.outFile)
 
     # Method override
     def endFile(self):
@@ -110,13 +134,16 @@ class VulkanConsumerHeaderGenerator(BaseGenerator):
             returnType = info[0]
             values = info[2]
 
-            decl = self.makeConsumerFuncDecl(returnType, 'Process_' + cmd, values)
+            decl = self.makeConsumerFuncDecl(returnType, 'Process_' + cmd,
+                                             values)
 
             cmddef = '' if first else '\n'
             if self.genOpts.isOverride:
-                cmddef += self.indent('virtual ' + decl + ' override;', self.INDENT_SIZE)
+                cmddef += self.indent('virtual ' + decl + ' override;',
+                                      self.INDENT_SIZE)
             else:
-                cmddef += self.indent('virtual ' + decl + ' {}', self.INDENT_SIZE)
+                cmddef += self.indent('virtual ' + decl + ' {}',
+                                      self.INDENT_SIZE)
 
             write(cmddef, file=self.outFile)
             first = False

--- a/framework/generated/vulkan_generators/vulkan_decoder_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_decoder_body_generator.py
@@ -21,22 +21,32 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanDecoderBodyGeneratorOptions(BaseGeneratorOptions):
     """Options for generating a C++ class for Vulkan API parameter decoding"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanDecoderBodyGenerator - subclass of BaseGenerator.
 # Generates C++ member functions for the VulkanDecoder class responsible for decoding
@@ -44,12 +54,16 @@ class VulkanDecoderBodyGeneratorOptions(BaseGeneratorOptions):
 class VulkanDecoderBodyGenerator(BaseGenerator):
     """Generate a C++ class for Vulkan API parameter decoding"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=True, processStructs=False, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=True,
+                               processStructs=False,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
         # Names of all Vulkan commands processed by the generator.
         self.cmdNames = []
@@ -65,8 +79,11 @@ class VulkanDecoderBodyGenerator(BaseGenerator):
         write('#include "decode/string_decoder.h"', file=self.outFile)
         write('#include "decode/struct_pointer_decoder.h"', file=self.outFile)
         write('#include "decode/value_decoder.h"', file=self.outFile)
-        write('#include "generated/generated_vulkan_decoder.h"', file=self.outFile)
-        write('#include "generated/generated_vulkan_struct_decoders_forward.h"', file=self.outFile)
+        write('#include "generated/generated_vulkan_decoder.h"',
+              file=self.outFile)
+        write(
+            '#include "generated/generated_vulkan_struct_decoders_forward.h"',
+            file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
         write('#include "vulkan/vulkan.h"', file=self.outFile)
@@ -107,7 +124,8 @@ class VulkanDecoderBodyGenerator(BaseGenerator):
             values = info[2]
 
             cmddef = '' if first else '\n'
-            cmddef += 'size_t VulkanDecoder::Decode_{}(const uint8_t* parameter_buffer, size_t buffer_size)\n'.format(cmd)
+            cmddef += 'size_t VulkanDecoder::Decode_{}(const uint8_t* parameter_buffer, size_t buffer_size)\n'.format(
+                cmd)
             cmddef += '{\n'
             cmddef += '    size_t bytes_read = 0;\n'
             cmddef += '\n'
@@ -145,7 +163,8 @@ class VulkanDecoderBodyGenerator(BaseGenerator):
         for value in values:
             body += self.makeDecodeInvocation(value)
         if returnType and returnType != 'void':
-            body += self.makeDecodeInvocation(ValueInfo('return_value', returnType, returnType))
+            body += self.makeDecodeInvocation(
+                ValueInfo('return_value', returnType, returnType))
 
         # Blank line after Decode() method invocations.
         if values or returnType:
@@ -190,44 +209,63 @@ class VulkanDecoderBodyGenerator(BaseGenerator):
             if typeName in self.EXTERNAL_OBJECT_TYPES and not value.isArray:
                 if value.pointerCount > 1:
                     # Pointer to a pointer to an unknown object type (void**), encoded as a pointer to a 64-bit integer ID.
-                    body += '    bytes_read += {}.DecodeVoidPtr({});\n'.format(value.name, bufferArgs)
+                    body += '    bytes_read += {}.DecodeVoidPtr({});\n'.format(
+                        value.name, bufferArgs)
                 else:
                     # Pointer to an unknown object type, encoded as a 64-bit integer ID.
-                    body += '    bytes_read += ValueDecoder::DecodeAddress({}, &{});\n'.format(bufferArgs, value.name)
+                    body += '    bytes_read += ValueDecoder::DecodeAddress({}, &{});\n'.format(
+                        bufferArgs, value.name)
             else:
                 if isStruct or isString or isHandle:
-                    body += '    bytes_read += {}.Decode({});\n'.format(value.name, bufferArgs)
+                    body += '    bytes_read += {}.Decode({});\n'.format(
+                        value.name, bufferArgs)
                 else:
-                    body += '    bytes_read += {}.Decode{}({});\n'.format(value.name, typeName, bufferArgs)
+                    body += '    bytes_read += {}.Decode{}({});\n'.format(
+                        value.name, typeName, bufferArgs)
         else:
             if isStruct:
-                body += '    bytes_read += DecodeStruct({}, &{});\n'.format(bufferArgs, value.name)
+                body += '    bytes_read += DecodeStruct({}, &{});\n'.format(
+                    bufferArgs, value.name)
             elif isFuncp:
-                body += '    bytes_read += ValueDecoder::DecodeAddress({}, &{});\n'.format(bufferArgs, value.name)
+                body += '    bytes_read += ValueDecoder::DecodeAddress({}, &{});\n'.format(
+                    bufferArgs, value.name)
             elif isHandle:
-                body += '    bytes_read += ValueDecoder::DecodeHandleIdValue({}, &{});\n'.format(bufferArgs, value.name)
+                body += '    bytes_read += ValueDecoder::DecodeHandleIdValue({}, &{});\n'.format(
+                    bufferArgs, value.name)
             else:
-                body += '    bytes_read += ValueDecoder::Decode{}Value({}, &{});\n'.format(typeName, bufferArgs, value.name)
+                body += '    bytes_read += ValueDecoder::Decode{}Value({}, &{});\n'.format(
+                    typeName, bufferArgs, value.name)
 
         return body
 
     #
     # Generate the VulkanDecoder::DecodeFunctionCall method.
     def generateDecodeCases(self):
-        write('void VulkanDecoder::DecodeFunctionCall(format::ApiCallId             call_id,', file=self.outFile)
-        write('                                       const ApiCallInfo&            call_info,', file=self.outFile)
-        write('                                       const uint8_t*                parameter_buffer,', file=self.outFile)
-        write('                                       size_t                        buffer_size)', file=self.outFile)
+        write(
+            'void VulkanDecoder::DecodeFunctionCall(format::ApiCallId             call_id,',
+            file=self.outFile)
+        write(
+            '                                       const ApiCallInfo&            call_info,',
+            file=self.outFile)
+        write(
+            '                                       const uint8_t*                parameter_buffer,',
+            file=self.outFile)
+        write(
+            '                                       size_t                        buffer_size)',
+            file=self.outFile)
         write('{', file=self.outFile)
         write('    switch(call_id)', file=self.outFile)
         write('    {', file=self.outFile)
         write('    default:', file=self.outFile)
-        write('        VulkanDecoderBase::DecodeFunctionCall(call_id, call_info, parameter_buffer, buffer_size);', file=self.outFile)
+        write(
+            '        VulkanDecoderBase::DecodeFunctionCall(call_id, call_info, parameter_buffer, buffer_size);',
+            file=self.outFile)
         write('        break;', file=self.outFile)
 
         for cmd in self.cmdNames:
             cmddef = '    case format::ApiCallId::ApiCall_{}:\n'.format(cmd)
-            cmddef += '        Decode_{}(parameter_buffer, buffer_size);\n'.format(cmd)
+            cmddef += '        Decode_{}(parameter_buffer, buffer_size);\n'.format(
+                cmd)
             cmddef += '        break;'
             write(cmddef, file=self.outFile)
 

--- a/framework/generated/vulkan_generators/vulkan_decoder_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_decoder_body_generator.py
@@ -86,7 +86,7 @@ class VulkanDecoderBodyGenerator(BaseGenerator):
             file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
-        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
         self.newline()
         write('#include <cstddef>', file=self.outFile)
         self.newline()

--- a/framework/generated/vulkan_generators/vulkan_decoder_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_decoder_header_generator.py
@@ -21,22 +21,32 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanDecoderHeaderGeneratorOptions(BaseGeneratorOptions):
     """Options for generating a C++ class declaration for Vulkan API parameter decoding"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanDecoderHeaderGenerator - subclass of BaseGenerator.
 # Generates C++ member declarations for the VulkanDecoder class responsible for decoding
@@ -44,12 +54,16 @@ class VulkanDecoderHeaderGeneratorOptions(BaseGeneratorOptions):
 class VulkanDecoderHeaderGenerator(BaseGenerator):
     """Generate a C++ class declaration for Vulkan API parameter decoding"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=True, processStructs=False, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=True,
+                               processStructs=False,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
     # Method override
     def beginFile(self, genOpts):
@@ -63,15 +77,24 @@ class VulkanDecoderHeaderGenerator(BaseGenerator):
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)
         self.newline()
-        write('class VulkanDecoder : public VulkanDecoderBase', file=self.outFile)
+        write('class VulkanDecoder : public VulkanDecoderBase',
+              file=self.outFile)
         write('{', file=self.outFile)
         write('  public:', file=self.outFile)
         write('    VulkanDecoder() { }\n', file=self.outFile)
         write('    virtual ~VulkanDecoder() override { }\n', file=self.outFile)
-        write('    virtual void DecodeFunctionCall(format::ApiCallId             call_id,', file=self.outFile)
-        write('                                    const ApiCallInfo&            call_info,', file=self.outFile)
-        write('                                    const uint8_t*                parameter_buffer,', file=self.outFile)
-        write('                                    size_t                        buffer_size) override;\n', file=self.outFile)
+        write(
+            '    virtual void DecodeFunctionCall(format::ApiCallId             call_id,',
+            file=self.outFile)
+        write(
+            '                                    const ApiCallInfo&            call_info,',
+            file=self.outFile)
+        write(
+            '                                    const uint8_t*                parameter_buffer,',
+            file=self.outFile)
+        write(
+            '                                    size_t                        buffer_size) override;\n',
+            file=self.outFile)
         write('  private:', end='', file=self.outFile)
 
     # Method override
@@ -97,6 +120,7 @@ class VulkanDecoderHeaderGenerator(BaseGenerator):
         first = True
         for cmd in self.getFilteredCmdNames():
             cmddef = '' if first else '\n'
-            cmddef += '    size_t Decode_{}(const uint8_t* parameter_buffer, size_t buffer_size);'.format(cmd)
+            cmddef += '    size_t Decode_{}(const uint8_t* parameter_buffer, size_t buffer_size);'.format(
+                cmd)
             write(cmddef, file=self.outFile)
             first = False

--- a/framework/generated/vulkan_generators/vulkan_decoder_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_decoder_header_generator.py
@@ -72,7 +72,7 @@ class VulkanDecoderHeaderGenerator(BaseGenerator):
         write('#include "decode/vulkan_decoder_base.h"', file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
-        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
         self.newline()
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_dispatch_table_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_dispatch_table_generator.py
@@ -88,7 +88,7 @@ class VulkanDispatchTableGenerator(BaseGenerator):
         write('#include "util/logging.h"', file=self.outFile)
         self.newline()
         write('#include "vulkan/vk_layer.h"', file=self.outFile)
-        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
         self.newline()
         write('#ifdef WIN32', file=self.outFile)
         write('#ifdef CreateEvent', file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_dispatch_table_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_dispatch_table_generator.py
@@ -21,45 +21,63 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanDispatchTableGeneratorOptions(BaseGeneratorOptions):
     """Options for generating a dispatch table for Vulkan API calls"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanDispatchTableGenerator - subclass of BaseGenerator.
 # Generates a dispatch table for Vulkan API calls.
 class VulkanDispatchTableGenerator(BaseGenerator):
     """Generate dispatch table for Vulkan API calls"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=True, processStructs=False, featureBreak=False,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=True,
+                               processStructs=False,
+                               featureBreak=False,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
         # Map of return types to default return values for no-op functions
-        self.RETURN_DEFAULTS = { 'VkResult' : 'VK_SUCCESS',
-                                 'VkBool32' : 'VK_TRUE',
-                                 'PFN_vkVoidFunction' : 'nullptr',
-                                 'VkDeviceAddress' : '0',
-                                 'VkDeviceSize' : '0',
-                                 'uint32_t' : '0',
-                                 'uint64_t' : '0' }
+        self.RETURN_DEFAULTS = {
+            'VkResult': 'VK_SUCCESS',
+            'VkBool32': 'VK_TRUE',
+            'PFN_vkVoidFunction': 'nullptr',
+            'VkDeviceAddress': '0',
+            'VkDeviceSize': '0',
+            'uint32_t': '0',
+            'uint64_t': '0'
+        }
 
-        self.instanceCmdNames = dict()      # Map of API call names to no-op function declarations
-        self.deviceCmdNames = dict()        # Map of API call names to no-op function declarations
+        self.instanceCmdNames = dict(
+        )  # Map of API call names to no-op function declarations
+        self.deviceCmdNames = dict(
+        )  # Map of API call names to no-op function declarations
 
     # Method override
     def beginFile(self, genOpts):
@@ -91,10 +109,14 @@ class VulkanDispatchTableGenerator(BaseGenerator):
         write('typedef const void* DispatchKey;', file=self.outFile)
         self.newline()
 
-        write('// Retrieve a dispatch key from a dispatchable handle', file=self.outFile)
-        write('static DispatchKey GetDispatchKey(const void* handle)', file=self.outFile)
+        write('// Retrieve a dispatch key from a dispatchable handle',
+              file=self.outFile)
+        write('static DispatchKey GetDispatchKey(const void* handle)',
+              file=self.outFile)
         write('{', file=self.outFile)
-        write('    const DispatchKey* dispatch_key = reinterpret_cast<const DispatchKey*>(handle);', file=self.outFile)
+        write(
+            '    const DispatchKey* dispatch_key = reinterpret_cast<const DispatchKey*>(handle);',
+            file=self.outFile)
         write('    return (*dispatch_key);', file=self.outFile)
         write('}', file=self.outFile)
 
@@ -104,8 +126,10 @@ class VulkanDispatchTableGenerator(BaseGenerator):
 
         write('struct LayerTable', file=self.outFile)
         write('{', file=self.outFile)
-        write('    PFN_vkCreateInstance CreateInstance{ nullptr };', file=self.outFile)
-        write('    PFN_vkCreateDevice CreateDevice{ nullptr };', file=self.outFile)
+        write('    PFN_vkCreateInstance CreateInstance{ nullptr };',
+              file=self.outFile)
+        write('    PFN_vkCreateDevice CreateDevice{ nullptr };',
+              file=self.outFile)
         write('};', file=self.outFile)
 
         self.newline()
@@ -114,10 +138,15 @@ class VulkanDispatchTableGenerator(BaseGenerator):
         self.generateDeviceCmdTable()
         self.newline()
 
-        write('template <typename GetProcAddr, typename Handle, typename FuncP>', file=self.outFile)
-        write('static void LoadFunction(GetProcAddr gpa, Handle handle, const char* name, FuncP* funcp)', file=self.outFile)
+        write(
+            'template <typename GetProcAddr, typename Handle, typename FuncP>',
+            file=self.outFile)
+        write(
+            'static void LoadFunction(GetProcAddr gpa, Handle handle, const char* name, FuncP* funcp)',
+            file=self.outFile)
         write('{', file=self.outFile)
-        write('    FuncP result = reinterpret_cast<FuncP>(gpa(handle, name));', file=self.outFile)
+        write('    FuncP result = reinterpret_cast<FuncP>(gpa(handle, name));',
+              file=self.outFile)
         write('    if (result != nullptr)', file=self.outFile)
         write('    {', file=self.outFile)
         write('        (*funcp) = result;', file=self.outFile)
@@ -158,10 +187,14 @@ class VulkanDispatchTableGenerator(BaseGenerator):
                         returnType = info[0]
                         proto = info[1]
 
-                        if not firstParam.baseType in ['VkInstance', 'VkPhysicalDevice']:
-                            self.deviceCmdNames[name] = self.makeCmdDecl(returnType, proto, values, name)
+                        if not firstParam.baseType in [
+                                'VkInstance', 'VkPhysicalDevice'
+                        ]:
+                            self.deviceCmdNames[name] = self.makeCmdDecl(
+                                returnType, proto, values, name)
                         else:
-                            self.instanceCmdNames[name] = self.makeCmdDecl(returnType, proto, values, name)
+                            self.instanceCmdNames[name] = self.makeCmdDecl(
+                                returnType, proto, values, name)
 
     #
     # Generate instance dispatch table structure
@@ -170,7 +203,8 @@ class VulkanDispatchTableGenerator(BaseGenerator):
         write('{', file=self.outFile)
 
         for name in self.instanceCmdNames:
-            decl = '    PFN_{} {}{{ noop::{} }};'.format(name, name[2:], name[2:])
+            decl = '    PFN_{} {}{{ noop::{} }};'.format(
+                name, name[2:], name[2:])
             write(decl, file=self.outFile)
 
         write('};', file=self.outFile)
@@ -182,7 +216,8 @@ class VulkanDispatchTableGenerator(BaseGenerator):
         write('{', file=self.outFile)
 
         for name in self.deviceCmdNames:
-            decl = '    PFN_{} {}{{ noop::{} }};'.format(name, name[2:], name[2:])
+            decl = '    PFN_{} {}{{ noop::{} }};'.format(
+                name, name[2:], name[2:])
             write(decl, file=self.outFile)
 
         write('};', file=self.outFile)
@@ -205,16 +240,20 @@ class VulkanDispatchTableGenerator(BaseGenerator):
     #
     # Generate function to set the instance table's functions with a getprocaddress routine
     def generateLoadInstanceTableFunc(self):
-        write('static void LoadInstanceTable(PFN_vkGetInstanceProcAddr gpa, VkInstance instance, InstanceTable* table)', file=self.outFile)
+        write(
+            'static void LoadInstanceTable(PFN_vkGetInstanceProcAddr gpa, VkInstance instance, InstanceTable* table)',
+            file=self.outFile)
         write('{', file=self.outFile)
         write('    assert(table != nullptr);', file=self.outFile)
         self.newline()
 
         for name in self.instanceCmdNames:
             if name == 'vkGetInstanceProcAddr':
-                write('    table->GetInstanceProcAddr = gpa;', file=self.outFile)
+                write('    table->GetInstanceProcAddr = gpa;',
+                      file=self.outFile)
             else:
-                expr = '    LoadFunction(gpa, instance, "{}", &table->{});'.format(name, name[2:])
+                expr = '    LoadFunction(gpa, instance, "{}", &table->{});'.format(
+                    name, name[2:])
                 write(expr, file=self.outFile)
 
         write('}', file=self.outFile)
@@ -222,7 +261,9 @@ class VulkanDispatchTableGenerator(BaseGenerator):
     #
     # Generate function to set the device table's functions with a getprocaddress routine
     def generateLoadDeviceTableFunc(self):
-        write('static void LoadDeviceTable(PFN_vkGetDeviceProcAddr gpa, VkDevice device, DeviceTable* table)', file=self.outFile)
+        write(
+            'static void LoadDeviceTable(PFN_vkGetDeviceProcAddr gpa, VkDevice device, DeviceTable* table)',
+            file=self.outFile)
         write('{', file=self.outFile)
         write('    assert(table != nullptr);', file=self.outFile)
         self.newline()
@@ -231,11 +272,11 @@ class VulkanDispatchTableGenerator(BaseGenerator):
             if name == 'vkGetDeviceProcAddr':
                 write('    table->GetDeviceProcAddr = gpa;', file=self.outFile)
             else:
-                expr = '    LoadFunction(gpa, device, "{}", &table->{});'.format(name, name[2:])
+                expr = '    LoadFunction(gpa, device, "{}", &table->{});'.format(
+                    name, name[2:])
                 write(expr, file=self.outFile)
 
         write('}', file=self.outFile)
-
 
     #
     # Generate the full typename for the NoOp function parameters; the array types need the [] moved from the parameter name to the parameter typename
@@ -250,12 +291,16 @@ class VulkanDispatchTableGenerator(BaseGenerator):
     def makeCmdDecl(self, returnType, proto, values, name):
         params = ', '.join([self.makeFullTypename(value) for value in values])
         if returnType == 'void':
-            return 'static {}({}) {{ GFXRECON_LOG_WARNING("Unsupported function {} was called, resulting in no-op behavior."); }}'.format(proto, params, name)
+            return 'static {}({}) {{ GFXRECON_LOG_WARNING("Unsupported function {} was called, resulting in no-op behavior."); }}'.format(
+                proto, params, name)
         else:
             returnValue = ''
             if returnType in self.RETURN_DEFAULTS:
                 returnValue = self.RETURN_DEFAULTS[returnType]
             else:
-                print('Unrecognized return type {} for no-op function generation; returning a zero initialized value'.format(returnType))
+                print(
+                    'Unrecognized return type {} for no-op function generation; returning a zero initialized value'
+                    .format(returnType))
                 returnValue = '{}{{}}'.format(returnType)
-            return 'static {}({}) {{ GFXRECON_LOG_WARNING("Unsupported function {} was called, resulting in no-op behavior."); return {}; }}'.format(proto, params, name, returnValue)
+            return 'static {}({}) {{ GFXRECON_LOG_WARNING("Unsupported function {} was called, resulting in no-op behavior."); return {}; }}'.format(
+                proto, params, name, returnValue)

--- a/framework/generated/vulkan_generators/vulkan_enum_to_string_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_enum_to_string_body_generator.py
@@ -20,34 +20,48 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys,inspect
+import os, re, sys, inspect
 from base_generator import *
+
 
 class VulkanEnumToStringBodyGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ functions for Vulkan ToString() functions"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanEnumToStringBodyGenerator - subclass of BaseGenerator.
 # Generates C++ functions for stringifying Vulkan API enums.
 class VulkanEnumToStringBodyGenerator(BaseGenerator):
     """Generate C++ functions for Vulkan ToString() functions"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=False, processStructs=True, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=False,
+                               processStructs=True,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
         # Set of enums that have been processed since we'll encounter enums that are
         #   referenced by extensions multiple times.  This list is prepopulated with
@@ -99,7 +113,8 @@ class VulkanEnumToStringBodyGenerator(BaseGenerator):
                 if len(self.enumEnumerants[enum]):
                     body += '    switch (value) {{\n'
                     for enumerant in self.enumEnumerants[enum]:
-                        body += '    case {0}: return "{0}";\n'.format(enumerant)
+                        body += '    case {0}: return "{0}";\n'.format(
+                            enumerant)
                     body += '    default: break;\n'
                     body += '    }}\n'
                 body += '    return "Unhandled {0}";\n'

--- a/framework/generated/vulkan_generators/vulkan_enum_to_string_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_enum_to_string_header_generator.py
@@ -20,34 +20,48 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys,inspect
+import os, re, sys, inspect
 from base_generator import *
+
 
 class VulkanEnumToStringHeaderGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ functions for Vulkan ToString() functions"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanEnumToStringHeaderGenerator - subclass of BaseGenerator.
 # Generates C++ functions for stringifying Vulkan API enums.
 class VulkanEnumToStringHeaderGenerator(BaseGenerator):
     """Generate C++ functions for Vulkan ToString() functions"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=False, processStructs=True, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=False,
+                               processStructs=True,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
         # Set of enums that have been processed since we'll encounter enums that are
         #   referenced by extensions multiple times.  This list is prepopulated with

--- a/framework/generated/vulkan_generators/vulkan_enum_to_string_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_enum_to_string_header_generator.py
@@ -74,16 +74,17 @@ class VulkanEnumToStringHeaderGenerator(BaseGenerator):
     # Method override
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
-        body = inspect.cleandoc('''
+        includes = inspect.cleandoc('''
             #include "format/platform_types.h"
             #include "util/to_string.h"
-            
-            #include "vulkan/vulkan.h"
-
+            ''')
+        write(includes, file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
+        namespace = inspect.cleandoc('''
             GFXRECON_BEGIN_NAMESPACE(gfxrecon)
             GFXRECON_BEGIN_NAMESPACE(util)
             ''')
-        write(body, file=self.outFile)
+        write(namespace, file=self.outFile)
 
     # Method override
     def endFile(self):

--- a/framework/generated/vulkan_generators/vulkan_feature_util_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_feature_util_body_generator.py
@@ -20,38 +20,46 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys,json
+import os, re, sys, json
 from base_generator import *
+
 
 class VulkanFeatureUtilBodyGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ code to alter Vulkan device createtion features"""
-    def __init__(self,
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
+    def __init__(
+            self,
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
         BaseGeneratorOptions.__init__(self,
                                       platformTypes=platformTypes,
                                       filename=filename,
                                       directory=directory,
                                       prefixText=prefixText,
                                       protectFile=protectFile,
-                                      protectFeature=protectFeature)
+                                      protectFeature=protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanFeatureUtilBodyGenerator - subclass of BaseGenerator.
 # Generates C++ functions to alter Vulkan device creation features.
 class VulkanFeatureUtilBodyGenerator(BaseGenerator):
     """Generate C++ code to alter Vulkan device creation features"""
-
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=False, processStructs=True, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=False,
+                               processStructs=True,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
         self.physicalDeviceFeatures2sTypes = dict()
         # List of 1.0 features
@@ -97,8 +105,9 @@ class VulkanFeatureUtilBodyGenerator(BaseGenerator):
                         if member.baseType == "VkBool32":
                             members.append(member.name)
                     self.physicalDeviceFeatures2sTypes[typename] = {
-                        'sType' : self.makeStructureTypeEnum(typeinfo, typename),
-                        'members' : members
+                        'sType':
+                        self.makeStructureTypeEnum(typeinfo, typename),
+                        'members': members
                     }
 
             #  Get all core 1.0 features
@@ -140,15 +149,20 @@ class VulkanFeatureUtilBodyGenerator(BaseGenerator):
 
             result += '            case {}:\n'.format(info['sType'])
             result += '            {\n'
-            result += '                const {}* currentNext = reinterpret_cast<const {}*>(next);\n'.format(typename, typename)
-            result += '                {} query = {{ {}, nullptr }};\n'.format(typename, info['sType'])
+            result += '                const {}* currentNext = reinterpret_cast<const {}*>(next);\n'.format(
+                typename, typename)
+            result += '                {} query = {{ {}, nullptr }};\n'.format(
+                typename, info['sType'])
             result += '                physicalDeviceFeatures2.pNext = &query;\n'
             result += '                GetPhysicalDeviceFeatures2(physicalDevice, &physicalDeviceFeatures2);\n'
             for member in info['members']:
-                result += '                if ((currentNext->{} == VK_TRUE) && (query.{} == VK_FALSE))\n'.format(member, member)
+                result += '                if ((currentNext->{} == VK_TRUE) && (query.{} == VK_FALSE))\n'.format(
+                    member, member)
                 result += '                {\n'
-                result += '                    GFXRECON_LOG_WARNING("Feature {}, which is not supported by the replay device, will not be enabled");\n'.format(member)
-                result += '                    const_cast<{}*>(currentNext)->{} = VK_FALSE;\n'.format(typename, member)
+                result += '                    GFXRECON_LOG_WARNING("Feature {}, which is not supported by the replay device, will not be enabled");\n'.format(
+                    member)
+                result += '                    const_cast<{}*>(currentNext)->{} = VK_FALSE;\n'.format(
+                    typename, member)
                 result += '                }\n'
             result += '                break;\n'
             result += '             }\n'
@@ -165,10 +179,13 @@ class VulkanFeatureUtilBodyGenerator(BaseGenerator):
         result += '        VkPhysicalDeviceFeatures query = {};\n'
         result += '        GetPhysicalDeviceFeatures(physicalDevice, &query);\n'
         for feature in self.physicalDeviceFeatures:
-            result += '        if ((physicalDeviceFeatures->{} == VK_TRUE) && (query.{} == VK_FALSE))\n'.format(feature, feature)
+            result += '        if ((physicalDeviceFeatures->{} == VK_TRUE) && (query.{} == VK_FALSE))\n'.format(
+                feature, feature)
             result += '        {\n'
-            result += '            GFXRECON_LOG_WARNING("Feature {}, which is not supported by the replay device, will not be enabled");\n'.format(feature)
-            result += '            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->{} = VK_FALSE;\n'.format(feature)
+            result += '            GFXRECON_LOG_WARNING("Feature {}, which is not supported by the replay device, will not be enabled");\n'.format(
+                feature)
+            result += '            const_cast<VkPhysicalDeviceFeatures*>(physicalDeviceFeatures)->{} = VK_FALSE;\n'.format(
+                feature)
             result += '        }\n'
         result += '    }\n'
         result += '}'

--- a/framework/generated/vulkan_generators/vulkan_object_info_table_base2_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_object_info_table_base2_header_generator.py
@@ -20,34 +20,46 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanObjectInfoTableBase2HeaderGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ function declarations for Vulkan API parameter encoding"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # Generates declarations for functions for Vulkan object info table
 class VulkanObjectInfoTableBase2HeaderGenerator(BaseGenerator):
-
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=True, processStructs=False, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
-
+                               processCmds=True,
+                               processStructs=False,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
     # Method override
     def beginFile(self, genOpts):
@@ -79,12 +91,18 @@ class VulkanObjectInfoTableBase2HeaderGenerator(BaseGenerator):
             handle_name = handle_name[2:]
             handle_info = handle_name + 'Info'
             handle_map = handle_name[0].lower() + handle_name[1:] + '_map_'
-            add_code += '    void Add{0}({0}&& info) {{ AddObjectInfo(std::move(info), &{1}); }}\n'.format(handle_info, handle_map)
-            remove_code += '    void Remove{0}(format::HandleId id) {{ {1}.erase(id); }}\n'.format(handle_info, handle_map)
-            const_get_code += '    const {0}* Get{0}(format::HandleId id) const {{ return GetObjectInfo<{0}>(id, &{1}); }}\n'.format(handle_info, handle_map)
-            get_code += '    {0}* Get{0}(format::HandleId id) {{ return GetObjectInfo<{0}>(id, &{1}); }}\n'.format(handle_info, handle_map)
-            visit_code += '    void Visit{0}(std::function<void(const {0}*)> visitor) const {{  for (const auto& entry : {1}) {{ visitor(&entry.second); }}  }}\n'.format(handle_info, handle_map)
-            map_code += '     std::unordered_map<format::HandleId, {0}> {1};\n'.format(handle_info, handle_map)
+            add_code += '    void Add{0}({0}&& info) {{ AddObjectInfo(std::move(info), &{1}); }}\n'.format(
+                handle_info, handle_map)
+            remove_code += '    void Remove{0}(format::HandleId id) {{ {1}.erase(id); }}\n'.format(
+                handle_info, handle_map)
+            const_get_code += '    const {0}* Get{0}(format::HandleId id) const {{ return GetObjectInfo<{0}>(id, &{1}); }}\n'.format(
+                handle_info, handle_map)
+            get_code += '    {0}* Get{0}(format::HandleId id) {{ return GetObjectInfo<{0}>(id, &{1}); }}\n'.format(
+                handle_info, handle_map)
+            visit_code += '    void Visit{0}(std::function<void(const {0}*)> visitor) const {{  for (const auto& entry : {1}) {{ visitor(&entry.second); }}  }}\n'.format(
+                handle_info, handle_map)
+            map_code += '     std::unordered_map<format::HandleId, {0}> {1};\n'.format(
+                handle_info, handle_map)
 
         self.newline()
         code = 'class VulkanObjectInfoTableBase2 : VulkanObjectInfoTableBase\n'
@@ -109,5 +127,6 @@ class VulkanObjectInfoTableBase2HeaderGenerator(BaseGenerator):
         write(code, file=self.outFile)
 
     def write_include(self):
-        write('#include "decode/vulkan_object_info_table_base.h"\n', file=self.outFile)
+        write('#include "decode/vulkan_object_info_table_base.h"\n',
+              file=self.outFile)
         self.newline()

--- a/framework/generated/vulkan_generators/vulkan_pnext_to_string_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_pnext_to_string_body_generator.py
@@ -20,34 +20,48 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys,inspect
+import os, re, sys, inspect
 from base_generator import *
+
 
 class VulkanPNextToStringBodyGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ functions for Vulkan ToString() functions"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanPNextToStringBodyGenerator - subclass of BaseGenerator.
 # Generates C++ functions for stringifying Vulkan API structures.
 class VulkanPNextToStringBodyGenerator(BaseGenerator):
     """Generate C++ functions for Vulkan ToString() functions"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=False, processStructs=True, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=False,
+                               processStructs=True,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
         # Map to store VkStructureType enum values
         self.sTypeValues = dict()
@@ -71,7 +85,8 @@ class VulkanPNextToStringBodyGenerator(BaseGenerator):
         body += '\n'
         for struct in self.sTypeValues:
             body += '        case {0}:\n'.format(self.sTypeValues[struct])
-            body += '            return ToString(*reinterpret_cast<const {0}*>(pNext), toStringFlags, tabCount, tabSize);\n'.format(struct)
+            body += '            return ToString(*reinterpret_cast<const {0}*>(pNext), toStringFlags, tabCount, tabSize);\n'.format(
+                struct)
         body += inspect.cleandoc('''
                 default: break;
                 }

--- a/framework/generated/vulkan_generators/vulkan_referenced_resource_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_referenced_resource_consumer_body_generator.py
@@ -20,22 +20,32 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanReferencedResourceBodyGeneratorOptions(BaseGeneratorOptions):
     """Options for generating a C++ class for detecting unreferenced resource handles in a capture file"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanReferencedResourceBodyGenerator - subclass of BaseGenerator.
 # Generates C++ member definitions for the VulkanReferencedResource class responsible for
@@ -43,7 +53,10 @@ class VulkanReferencedResourceBodyGeneratorOptions(BaseGeneratorOptions):
 class VulkanReferencedResourceBodyGenerator(BaseGenerator):
     """Generate a C++ class for detecting unreferenced resource handles in a capture file"""
     # All resource and resource associated handle types to be processed.
-    RESOURCE_HANDLE_TYPES = ['VkBuffer', 'VkImage', 'VkBufferView', 'VkImageView', 'VkFramebuffer', 'VkDescriptorSet', 'VkCommandBuffer']
+    RESOURCE_HANDLE_TYPES = [
+        'VkBuffer', 'VkImage', 'VkBufferView', 'VkImageView', 'VkFramebuffer',
+        'VkDescriptorSet', 'VkCommandBuffer'
+    ]
 
     # Handle types that contain resource and child resource handle types.
     CONTAINER_HANDLE_TYPES = ['VkDescriptorSet']
@@ -52,25 +65,32 @@ class VulkanReferencedResourceBodyGenerator(BaseGenerator):
     USER_HANDLE_TYPES = ['VkCommandBuffer']
 
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=True, processStructs=True, featureBreak=False,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=True,
+                               processStructs=True,
+                               featureBreak=False,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
         # Map of Vulkan structs containing handles to a list values for handle members or struct members
         # that contain handles (eg. VkGraphicsPipelineCreateInfo contains a VkPipelineShaderStageCreateInfo
         # member that contains handles).
         self.structsWithHandles = dict()
-        self.pNextStructs = dict()    # Map of Vulkan structure types to sType value for structs that can be part of a pNext chain.
-        self.commandInfo = dict()     # Map of Vulkan commands to parameter info
-        self.restrictHandles = True   # Determines if the 'isHandle' override limits the handle test to only the values conained by RESOURCE_HANDLE_TYPES.
+        self.pNextStructs = dict(
+        )  # Map of Vulkan structure types to sType value for structs that can be part of a pNext chain.
+        self.commandInfo = dict()  # Map of Vulkan commands to parameter info
+        self.restrictHandles = True  # Determines if the 'isHandle' override limits the handle test to only the values conained by RESOURCE_HANDLE_TYPES.
 
     # Method override
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
 
-        write('#include "generated/generated_vulkan_referenced_resource_consumer.h"', file=self.outFile)
+        write(
+            '#include "generated/generated_vulkan_referenced_resource_consumer.h"',
+            file=self.outFile)
         self.newline()
         write('#include <cassert>', file=self.outFile)
         self.newline()
@@ -92,7 +112,10 @@ class VulkanReferencedResourceBodyGenerator(BaseGenerator):
 
                     # Temporarily remove resource only matching restriction from isHandle() when generating the function signature.
                     self.restrictHandles = False
-                    cmddef += self.makeConsumerFuncDecl(returnType, 'VulkanReferencedResourceConsumer::Process_' + cmd, params) + '\n'
+                    cmddef += self.makeConsumerFuncDecl(
+                        returnType,
+                        'VulkanReferencedResourceConsumer::Process_' + cmd,
+                        params) + '\n'
                     self.restrictHandles = True
 
                     cmddef += '{\n'
@@ -102,13 +125,17 @@ class VulkanReferencedResourceBodyGenerator(BaseGenerator):
                     unrefCount = 0
                     for param in params[1:]:
                         if not param in handles:
-                            cmddef += indent + 'GFXRECON_UNREFERENCED_PARAMETER({});\n'.format(param.name)
+                            cmddef += indent + 'GFXRECON_UNREFERENCED_PARAMETER({});\n'.format(
+                                param.name)
                             unrefCount += 1
                     if unrefCount > 0:
                         cmddef += '\n'
 
                     for index, handle in enumerate(handles):
-                        cmddef += self.trackCommandHandle(index, params[0].name, handle, indent=indent)
+                        cmddef += self.trackCommandHandle(index,
+                                                          params[0].name,
+                                                          handle,
+                                                          indent=indent)
                     cmddef += '}'
 
                     write(cmddef, file=self.outFile)
@@ -165,13 +192,20 @@ class VulkanReferencedResourceBodyGenerator(BaseGenerator):
         for value in values:
             if self.isHandle(value.baseType):
                 handles.append(value)
-            elif self.isStruct(value.baseType) and (value.baseType in self.structsWithHandles):
+            elif self.isStruct(
+                    value.baseType) and (value.baseType
+                                         in self.structsWithHandles):
                 handles.append(value)
         return handles
 
     #
     #
-    def trackCommandHandle(self, index, commandParamName, value, valuePrefix='', indent=''):
+    def trackCommandHandle(self,
+                           index,
+                           commandParamName,
+                           value,
+                           valuePrefix='',
+                           indent=''):
         body = ''
         tail = ''
         indexName = None
@@ -197,7 +231,8 @@ class VulkanReferencedResourceBodyGenerator(BaseGenerator):
 
             # Add IsNull and HasData checks for the pointer decoder, before accessing its data.
             # Note that this does not handle the decoded struct member cases for static arrays, which would need to use '.' instead of '->'.
-            body += indent + 'if (!{prefix}{name}{op}IsNull() && ({prefix}{name}{op}HasData()))\n'.format(prefix=valuePrefix, name=value.name, op=accessOperator)
+            body += indent + 'if (!{prefix}{name}{op}IsNull() && ({prefix}{name}{op}HasData()))\n'.format(
+                prefix=valuePrefix, name=value.name, op=accessOperator)
             body += indent + '{\n'
             tail = indent + '}\n' + tail
             indent += ' ' * self.INDENT_SIZE
@@ -205,16 +240,20 @@ class VulkanReferencedResourceBodyGenerator(BaseGenerator):
             # Get the pointer from the pointer decoder object.
             valueName = '{}_ptr'.format(value.name)
             if isHandle:
-                body += indent + 'auto {} = {}{}{}GetPointer();\n'.format(valueName, valuePrefix, value.name, accessOperator)
+                body += indent + 'auto {} = {}{}{}GetPointer();\n'.format(
+                    valueName, valuePrefix, value.name, accessOperator)
             else:
-                body += indent + 'auto {} = {}{}{}GetMetaStructPointer();\n'.format(valueName, valuePrefix, value.name, accessOperator)
+                body += indent + 'auto {} = {}{}{}GetMetaStructPointer();\n'.format(
+                    valueName, valuePrefix, value.name, accessOperator)
 
             # Add a for loop for an array of values.
             if value.isArray:
                 indexName = '{}_index'.format(value.name)
                 countName = '{}_count'.format(value.name)
-                body += indent + 'size_t {} = {}{}{}GetLength();\n'.format(countName, valuePrefix, value.name, accessOperator)
-                body += indent + 'for (size_t {i} = 0; {i} < {}; ++{i})\n'.format(countName, i=indexName)
+                body += indent + 'size_t {} = {}{}{}GetLength();\n'.format(
+                    countName, valuePrefix, value.name, accessOperator)
+                body += indent + 'for (size_t {i} = 0; {i} < {}; ++{i})\n'.format(
+                    countName, i=indexName)
                 body += indent + '{\n'
                 tail = indent + '}\n' + tail
                 indent += ' ' * self.INDENT_SIZE
@@ -227,27 +266,38 @@ class VulkanReferencedResourceBodyGenerator(BaseGenerator):
                 valueName = '(*{})'.format(valueName)
 
             if value.baseType in self.CONTAINER_HANDLE_TYPES:
-                body += indent + 'GetTable().AddContainerToUser({}, {});\n'.format(commandParamName, valueName)
+                body += indent + 'GetTable().AddContainerToUser({}, {});\n'.format(
+                    commandParamName, valueName)
             elif value.baseType in self.USER_HANDLE_TYPES:
-                body += indent + 'GetTable().AddUserToUser({}, {});\n'.format(commandParamName, valueName)
+                body += indent + 'GetTable().AddUserToUser({}, {});\n'.format(
+                    commandParamName, valueName)
             else:
-                body += indent + 'GetTable().AddResourceToUser({}, {});\n'.format(commandParamName, valueName)
+                body += indent + 'GetTable().AddResourceToUser({}, {});\n'.format(
+                    commandParamName, valueName)
 
-        elif self.isStruct(value.baseType) and (value.baseType in self.structsWithHandles):
+        elif self.isStruct(value.baseType) and (value.baseType
+                                                in self.structsWithHandles):
             if value.isArray:
                 accessOperator = '[{}].'.format(indexName)
             else:
                 accessOperator = '->'
 
-            for index, entry in enumerate(self.structsWithHandles[value.baseType]):
+            for index, entry in enumerate(
+                    self.structsWithHandles[value.baseType]):
                 if entry.name == 'pNext':
-                    extStructsWithHandles = [extStruct for extStruct in self.registry.validextensionstructs[value.baseType] if extStruct in self.structsWithHandles]
+                    extStructsWithHandles = [
+                        extStruct for extStruct in
+                        self.registry.validextensionstructs[value.baseType]
+                        if extStruct in self.structsWithHandles
+                    ]
                     if extStructsWithHandles:
                         body += indent + 'const VkBaseInStructure* pnext_header = nullptr;\n'
-                        body += indent + 'if ({name}->pNext != nullptr)\n'.format(name=valueName)
+                        body += indent + 'if ({name}->pNext != nullptr)\n'.format(
+                            name=valueName)
                         body += indent + '{\n'
                         indent += ' ' * self.INDENT_SIZE
-                        body += indent + 'pnext_header = reinterpret_cast<const VkBaseInStructure*>({}->pNext->GetPointer());\n'.format(valueName)
+                        body += indent + 'pnext_header = reinterpret_cast<const VkBaseInStructure*>({}->pNext->GetPointer());\n'.format(
+                            valueName)
                         indent = indent[:-self.INDENT_SIZE]
                         body += indent + '}\n'
                         body += indent + 'while (pnext_header)\n'
@@ -261,11 +311,19 @@ class VulkanReferencedResourceBodyGenerator(BaseGenerator):
                         body += indent + 'break;\n'
                         indent = indent[:-self.INDENT_SIZE]
                         for extStruct in extStructsWithHandles:
-                            body += indent + 'case {}:\n'.format(self.pNextStructs[extStruct])
+                            body += indent + 'case {}:\n'.format(
+                                self.pNextStructs[extStruct])
                             body += indent + '{\n'
                             indent += ' ' * self.INDENT_SIZE
-                            body += indent + 'auto pnext_value = reinterpret_cast<const Decoded_{}*>({}->pNext->GetPointer());\n'.format(extStruct, valueName)
-                            body += self.trackCommandHandle(index, commandParamName, ValueInfo('pnext_value', extStruct, 'const {} *'.format(extStruct), 1), '', indent=indent)
+                            body += indent + 'auto pnext_value = reinterpret_cast<const Decoded_{}*>({}->pNext->GetPointer());\n'.format(
+                                extStruct, valueName)
+                            body += self.trackCommandHandle(
+                                index,
+                                commandParamName,
+                                ValueInfo('pnext_value', extStruct,
+                                          'const {} *'.format(extStruct), 1),
+                                '',
+                                indent=indent)
                             body += indent + 'break;\n'
                             indent = indent[:-self.INDENT_SIZE]
                             body += indent + '}\n'
@@ -275,6 +333,9 @@ class VulkanReferencedResourceBodyGenerator(BaseGenerator):
                         indent = indent[:-self.INDENT_SIZE]
                         body += indent + '}\n'
                 else:
-                    body += self.trackCommandHandle(index, commandParamName, entry, valueName + accessOperator, indent)
+                    body += self.trackCommandHandle(index, commandParamName,
+                                                    entry,
+                                                    valueName + accessOperator,
+                                                    indent)
 
         return body + tail

--- a/framework/generated/vulkan_generators/vulkan_referenced_resource_consumer_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_referenced_resource_consumer_header_generator.py
@@ -86,7 +86,7 @@ class VulkanReferencedResourceHeaderGenerator(BaseGenerator):
               file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
-        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
         self.newline()
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_referenced_resource_consumer_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_referenced_resource_consumer_header_generator.py
@@ -20,22 +20,32 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanReferencedResourceHeaderGeneratorOptions(BaseGeneratorOptions):
     """Options for generating the header to a C++ class for detecting unreferenced resource handles in a capture file"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanReferencedResourceHeaderGenerator - subclass of BaseGenerator.
 # Generates C++ member definitions for the VulkanReferencedResource class responsible for
@@ -43,21 +53,28 @@ class VulkanReferencedResourceHeaderGeneratorOptions(BaseGeneratorOptions):
 class VulkanReferencedResourceHeaderGenerator(BaseGenerator):
     """Generate the header to a C++ class for detecting unreferenced resource handles in a capture file"""
     # All resource and resource associated handle types to be processed.
-    RESOURCE_HANDLE_TYPES = ['VkBuffer', 'VkImage', 'VkBufferView', 'VkImageView', 'VkFramebuffer', 'VkDescriptorSet', 'VkCommandBuffer']
+    RESOURCE_HANDLE_TYPES = [
+        'VkBuffer', 'VkImage', 'VkBufferView', 'VkImageView', 'VkFramebuffer',
+        'VkDescriptorSet', 'VkCommandBuffer'
+    ]
 
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=True, processStructs=True, featureBreak=False,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=True,
+                               processStructs=True,
+                               featureBreak=False,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
         # Map of Vulkan structs containing handles to a list values for handle members or struct members
         # that contain handles (eg. VkGraphicsPipelineCreateInfo contains a VkPipelineShaderStageCreateInfo
         # member that contains handles).
         self.structsWithHandles = dict()
-        self.commandInfo = dict()     # Map of Vulkan commands to parameter info
-        self.restrictHandles = True   # Determines if the 'isHandle' override limits the handle test to only the values conained by RESOURCE_HANDLE_TYPES.
+        self.commandInfo = dict()  # Map of Vulkan commands to parameter info
+        self.restrictHandles = True  # Determines if the 'isHandle' override limits the handle test to only the values conained by RESOURCE_HANDLE_TYPES.
 
     # Method override
     def beginFile(self, genOpts):
@@ -65,7 +82,8 @@ class VulkanReferencedResourceHeaderGenerator(BaseGenerator):
 
         className = 'VulkanReferencedResourceConsumer'
 
-        write('#include "decode/vulkan_referenced_resource_consumer_base.h"', file=self.outFile)
+        write('#include "decode/vulkan_referenced_resource_consumer_base.h"',
+              file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
         write('#include "vulkan/vulkan.h"', file=self.outFile)
@@ -73,11 +91,13 @@ class VulkanReferencedResourceHeaderGenerator(BaseGenerator):
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)
         self.newline()
-        write('class {name} : public {name}Base'.format(name=className), file=self.outFile)
+        write('class {name} : public {name}Base'.format(name=className),
+              file=self.outFile)
         write('{', file=self.outFile)
         write('  public:', file=self.outFile)
         write('    {}() {{ }}\n'.format(className), file=self.outFile)
-        write('    virtual ~{}() override {{ }}'.format(className), file=self.outFile)
+        write('    virtual ~{}() override {{ }}'.format(className),
+              file=self.outFile)
 
     # Method override
     def endFile(self):
@@ -94,8 +114,10 @@ class VulkanReferencedResourceHeaderGenerator(BaseGenerator):
 
                     # Temporarily remove resource only matching restriction from isHandle() when generating the function signature.
                     self.restrictHandles = False
-                    decl = self.makeConsumerFuncDecl(returnType, 'Process_' + cmd, params)
-                    cmddef += self.indent('virtual ' + decl + ' override;', self.INDENT_SIZE)
+                    decl = self.makeConsumerFuncDecl(returnType,
+                                                     'Process_' + cmd, params)
+                    cmddef += self.indent('virtual ' + decl + ' override;',
+                                          self.INDENT_SIZE)
                     self.restrictHandles = True
 
                     write(cmddef, file=self.outFile)
@@ -146,6 +168,8 @@ class VulkanReferencedResourceHeaderGenerator(BaseGenerator):
         for value in values:
             if self.isHandle(value.baseType):
                 handles.append(value)
-            elif self.isStruct(value.baseType) and (value.baseType in self.structsWithHandles):
+            elif self.isStruct(
+                    value.baseType) and (value.baseType
+                                         in self.structsWithHandles):
                 handles.append(value)
         return handles

--- a/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_replay_consumer_body_generator.py
@@ -21,24 +21,34 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys,json
+import os, re, sys, json
 from base_generator import *
+
 
 class VulkanReplayConsumerBodyGeneratorOptions(BaseGeneratorOptions):
     """Options for generating a C++ class for Vulkan capture file replay"""
-    def __init__(self,
-                 replayOverrides = None,    # Path to JSON file listing Vulkan API calls to override on replay.
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            replayOverrides=None,  # Path to JSON file listing Vulkan API calls to override on replay.
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
         self.replayOverrides = replayOverrides
+
 
 # VulkanReplayConsumerBodyGenerator - subclass of BaseGenerator.
 # Generates C++ member definitions for the VulkanReplayConsumer class responsible for
@@ -51,16 +61,24 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
     REPLAY_OVERRIDES = {}
 
     # Map of pool object types associating the pool type with the allocated type and the allocated type with the pool type.
-    POOL_OBJECT_ASSOCIATIONS = { 'VkCommandBuffer' : 'VkCommandPool', 'VkDescriptorSet' : 'VkDescriptorPool',
-                                 'VkCommandPool' : 'VkCommandBuffer', 'VkDescriptorPool' : 'VkDescriptorSet' }
+    POOL_OBJECT_ASSOCIATIONS = {
+        'VkCommandBuffer': 'VkCommandPool',
+        'VkDescriptorSet': 'VkDescriptorPool',
+        'VkCommandPool': 'VkCommandBuffer',
+        'VkDescriptorPool': 'VkDescriptorSet'
+    }
 
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=True, processStructs=True, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=True,
+                               processStructs=True,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
         # Map of Vulkan structs containing handles to a list values for handle members or struct members
         # that contain handles (eg. VkGraphicsPipelineCreateInfo contains a VkPipelineShaderStageCreateInfo
@@ -70,7 +88,6 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
         # Map of struct types to associated VkStructureType.
         self.sTypeValues = dict()
 
-
     # Method override
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
@@ -78,12 +95,17 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
         if genOpts.replayOverrides:
             self.__loadReplayOverrides(genOpts.replayOverrides)
 
-        write('#include "generated/generated_vulkan_replay_consumer.h"', file=self.outFile)
+        write('#include "generated/generated_vulkan_replay_consumer.h"',
+              file=self.outFile)
         self.newline()
-        write('#include "decode/custom_vulkan_struct_handle_mappers.h"', file=self.outFile)
-        write('#include "decode/vulkan_handle_mapping_util.h"', file=self.outFile)
-        write('#include "generated/generated_vulkan_dispatch_table.h"', file=self.outFile)
-        write('#include "generated/generated_vulkan_struct_handle_mappers.h"', file=self.outFile)
+        write('#include "decode/custom_vulkan_struct_handle_mappers.h"',
+              file=self.outFile)
+        write('#include "decode/vulkan_handle_mapping_util.h"',
+              file=self.outFile)
+        write('#include "generated/generated_vulkan_dispatch_table.h"',
+              file=self.outFile)
+        write('#include "generated/generated_vulkan_struct_handle_mappers.h"',
+              file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
@@ -104,7 +126,8 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
         BaseGenerator.genStruct(self, typeinfo, typename, alias)
 
         if not alias:
-            self.checkStructMemberHandles(typename, self.structsWithHandles, self.structsWithHandlePtrs)
+            self.checkStructMemberHandles(typename, self.structsWithHandles,
+                                          self.structsWithHandlePtrs)
 
             sType = self.makeStructureTypeEnum(typeinfo, typename)
             if sType:
@@ -127,7 +150,9 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
             values = info[2]
 
             cmddef = '' if first else '\n'
-            cmddef += self.makeConsumerFuncDecl(returnType, 'VulkanReplayConsumer::Process_' + cmd, values) + '\n'
+            cmddef += self.makeConsumerFuncDecl(
+                returnType, 'VulkanReplayConsumer::Process_' + cmd,
+                values) + '\n'
             cmddef += '{\n'
             cmddef += self.makeConsumerFuncBody(returnType, cmd, values)
             cmddef += '}'
@@ -162,12 +187,14 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
         body = ''
         isOverride = name in self.REPLAY_OVERRIDES
 
-        args, preexpr, postexpr = self.makeBodyExpressions(returnType, name, values, isOverride)
+        args, preexpr, postexpr = self.makeBodyExpressions(
+            returnType, name, values, isOverride)
         arglist = ', '.join(args)
 
         dispatchfunc = ''
         if name not in ['vkCreateInstance', 'vkCreateDevice']:
-            dispatchfunc = 'GetInstanceTable' if self.useInstanceTable(values[0].baseType) else 'GetDeviceTable'
+            dispatchfunc = 'GetInstanceTable' if self.useInstanceTable(
+                values[0].baseType) else 'GetDeviceTable'
             if isOverride:
                 dispatchfunc += '({}->handle)->{}'.format(args[0], name[2:])
             else:
@@ -176,27 +203,33 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
         callExpr = ''
         if isOverride:
             if name in ['vkCreateInstance', 'vkCreateDevice']:
-                callExpr = '{}(returnValue, {})'.format(self.REPLAY_OVERRIDES[name], arglist)
+                callExpr = '{}(returnValue, {})'.format(
+                    self.REPLAY_OVERRIDES[name], arglist)
             elif returnType == 'VkResult':
                 # Override functions receive the decoded return value in addition to parameters.
-                callExpr = '{}({}, returnValue, {})'.format(self.REPLAY_OVERRIDES[name], dispatchfunc, arglist)
+                callExpr = '{}({}, returnValue, {})'.format(
+                    self.REPLAY_OVERRIDES[name], dispatchfunc, arglist)
             else:
-                callExpr = '{}({}, {})'.format(self.REPLAY_OVERRIDES[name], dispatchfunc, arglist)
+                callExpr = '{}({}, {})'.format(self.REPLAY_OVERRIDES[name],
+                                               dispatchfunc, arglist)
         else:
             callExpr = '{}({})'.format(dispatchfunc, arglist)
 
         if preexpr:
-            body += '\n'.join(['    ' + val if val else val for val in preexpr])
+            body += '\n'.join(
+                ['    ' + val if val else val for val in preexpr])
             body += '\n'
             body += '\n'
         if returnType == 'VkResult':
             body += '    VkResult replay_result = {};\n'.format(callExpr)
-            body += '    CheckResult("{}", returnValue, replay_result);\n'.format(name)
+            body += '    CheckResult("{}", returnValue, replay_result);\n'.format(
+                name)
         else:
             body += '    {};\n'.format(callExpr)
         if postexpr:
             body += '\n'
-            body += '\n'.join(['    ' + val if val else val for val in postexpr])
+            body += '\n'.join(
+                ['    ' + val if val else val for val in postexpr])
             body += '\n'
 
         cleanupExpr = self.makeRemoveHandleExpression(name, values)
@@ -214,13 +247,17 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
 
         indexId = 'k{}Array{}'.format(handleValue.baseType[2:], name[2:])
         handleType = '{}Info'.format(handleValue.baseType[2:])
-        infoFunc = '&VulkanObjectInfoTable::Get{}Info'.format(handleValue.baseType[2:])
+        infoFunc = '&VulkanObjectInfoTable::Get{}Info'.format(
+            handleValue.baseType[2:])
 
-        return 'if ({}->IsNull()) {{ SetOutputArrayCount<{}>({}, {}, {}, {}); }}'.format(value.name, handleType, handleValue.name, indexId, lengthName, infoFunc)
+        return 'if ({}->IsNull()) {{ SetOutputArrayCount<{}>({}, {}, {}, {}); }}'.format(
+            value.name, handleType, handleValue.name, indexId, lengthName,
+            infoFunc)
 
     #
     # Generate expressions to call a function that retrieves the count of an array containing a variable number of values.
-    def makeVariableLengthArrayGetCountCall(self, returnType, name, value, values):
+    def makeVariableLengthArrayGetCountCall(self, returnType, name, value,
+                                            values):
         returnValue = 'VK_SUCCESS'
         if (returnType == 'VkResult'):
             returnValue = 'returnValue'
@@ -235,13 +272,18 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
                 arrayName = v.name
 
         if not arrayName:
-            print("WARNING: Could not determine the name of the array parameter associate with function {} count parameter {}.".format(name, value.name))
+            print(
+                "WARNING: Could not determine the name of the array parameter associate with function {} count parameter {}."
+                .format(name, value.name))
 
         indexId = 'k{}Array{}'.format(handleValue.baseType[2:], name[2:])
         handleType = '{}Info'.format(handleValue.baseType[2:])
-        infoFunc = '&VulkanObjectInfoTable::Get{}Info'.format(handleValue.baseType[2:])
+        infoFunc = '&VulkanObjectInfoTable::Get{}Info'.format(
+            handleValue.baseType[2:])
 
-        return 'GetOutputArrayCount<{}, {}>("{}", {}, {}, {}, {}, {}, {})'.format(value.baseType, handleType, name, returnValue, handleValue.name, indexId, value.name, arrayName, infoFunc)
+        return 'GetOutputArrayCount<{}, {}>("{}", {}, {}, {}, {}, {}, {})'.format(
+            value.baseType, handleType, name, returnValue, handleValue.name,
+            indexId, value.name, arrayName, infoFunc)
 
     #
     # Generating expressions for mapping decoded parameters to arguments used in the API call
@@ -251,9 +293,11 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
         arrayLengths = dict()
         isVariableLength = False
 
-        args = []       # List of arguments to the API call.
-        preexpr = []    # Variable declarations for handle mappings, temporary output allocations, and input pointers.
-        postexpr = []   # Expressions to add new handles to the handle map and delete temporary allocations.
+        args = []  # List of arguments to the API call.
+        preexpr = [
+        ]  # Variable declarations for handle mappings, temporary output allocations, and input pointers.
+        postexpr = [
+        ]  # Expressions to add new handles to the handle map and delete temporary allocations.
 
         for value in values:
             if value.isPointer or value.isArray:
@@ -263,7 +307,8 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
                 needTempValue = True
                 expr = ''
 
-                if (value.baseType in self.EXTERNAL_OBJECT_TYPES) and not value.isArray:
+                if (value.baseType
+                        in self.EXTERNAL_OBJECT_TYPES) and not value.isArray:
                     # Currently, all arrays of external object types are 'void*' values that represent arrays of bytes, so we only have a
                     # pointer to an external object when the value is not an array.
                     isExtenalObject = True
@@ -298,7 +343,8 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
                         if needTempValue:
                             lengthName = 'in_' + lengthName
                         else:
-                            lengthName = lengthName.replace('->', '->GetPointer()->')
+                            lengthName = lengthName.replace(
+                                '->', '->GetPointer()->')
 
                 if not needTempValue:
                     args.append(value.name)
@@ -322,55 +368,106 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
                         # If possible, we will map the ID to an object previously created during replay.  Otherwise, we will
                         # need to report a warning that we may have a case that replay cannot handle.
                         if value.platformFullType:
-                            expr += 'static_cast<{}>(PreProcessExternalObject({}, format::ApiCallId::ApiCall_{name}, "{name}"));'.format(value.platformFullType, value.name, name=name)
+                            expr += 'static_cast<{}>(PreProcessExternalObject({}, format::ApiCallId::ApiCall_{name}, "{name}"));'.format(
+                                value.platformFullType, value.name, name=name)
                         else:
-                            expr += 'PreProcessExternalObject({}, format::ApiCallId::ApiCall_{name}, "{name}");'.format(value.name, name=name)
+                            expr += 'PreProcessExternalObject({}, format::ApiCallId::ApiCall_{name}, "{name}");'.format(
+                                value.name, name=name)
                     elif value.baseType == 'VkAllocationCallbacks':
                         if needTempValue:
                             # The replay consumer needs to override the allocation callbacks used by the captured application.
-                            expr += 'GetAllocationCallbacks({});'.format(value.name)
+                            expr += 'GetAllocationCallbacks({});'.format(
+                                value.name)
                     elif self.isHandle(value.baseType):
                         # We received an array of 64-bit integer IDs from the decoder.
-                        expr += 'MapHandles<{type}Info>({}, {}, &VulkanObjectInfoTable::Get{type}Info);'.format(value.name, lengthName, type=value.baseType[2:])
+                        expr += 'MapHandles<{type}Info>({}, {}, &VulkanObjectInfoTable::Get{type}Info);'.format(
+                            value.name, lengthName, type=value.baseType[2:])
                     else:
                         if needTempValue:
                             expr += '{}->GetPointer();'.format(value.name)
 
-                        if (value.baseType in self.structsWithHandles) or (value.baseType in self.GENERIC_HANDLE_STRUCTS):
+                        if (value.baseType in self.structsWithHandles) or (
+                                value.baseType in self.GENERIC_HANDLE_STRUCTS):
                             preexpr.append(expr)
                             if value.isArray:
-                                expr = 'MapStructArrayHandles({name}->GetMetaStructPointer(), {name}->GetLength(), GetObjectInfoTable());'.format(name=value.name)
+                                expr = 'MapStructArrayHandles({name}->GetMetaStructPointer(), {name}->GetLength(), GetObjectInfoTable());'.format(
+                                    name=value.name)
                             else:
-                                expr = 'MapStructHandles({}->GetMetaStructPointer(), GetObjectInfoTable());'.format(value.name)
+                                expr = 'MapStructHandles({}->GetMetaStructPointer(), GetObjectInfoTable());'.format(
+                                    value.name)
                 else:
                     # Initialize output pointer.
                     if value.isArray:
                         if isVariableLength:
                             # Store the result of an array size query.
-                            postexpr.append(self.makeVariableLengthArrayPostExpr(name, value, values, lengthName))
+                            postexpr.append(
+                                self.makeVariableLengthArrayPostExpr(
+                                    name, value, values, lengthName))
 
                         if value.baseType in self.EXTERNAL_OBJECT_TYPES:
                             # This is effectively an array with type void*, which was encoded as an array of bytes.
                             if needTempValue:
-                                expr += '{name}->IsNull() ? nullptr : {name}->AllocateOutputData({});'.format(lengthName, name=value.name)
+                                expr += '{name}->IsNull() ? nullptr : {name}->AllocateOutputData({});'.format(
+                                    lengthName, name=value.name)
                             else:
-                                expr = 'if (!{name}->IsNull()) {{ {name}->AllocateOutputData({}); }}'.format(lengthName, name=value.name)
+                                expr = 'if (!{name}->IsNull()) {{ {name}->AllocateOutputData({}); }}'.format(
+                                    lengthName, name=value.name)
                         elif self.isHandle(value.baseType):
                             # Add mappings for the newly created handles.
-                            preexpr.append('if (!{paramname}->IsNull()) {{ {paramname}->SetHandleLength({}); }}'.format(lengthName, paramname=value.name))
+                            preexpr.append(
+                                'if (!{paramname}->IsNull()) {{ {paramname}->SetHandleLength({}); }}'
+                                .format(lengthName, paramname=value.name))
                             if needTempValue:
-                                expr += '{}->GetHandlePointer();'.format(value.name)
+                                expr += '{}->GetHandlePointer();'.format(
+                                    value.name)
                                 if self.isPoolAllocation(name):
-                                    postexpr.append('AddPoolHandles<{pooltype}Info, {basetype}Info>({}, handle_mapping::GetPoolId({}->GetMetaStructPointer()), {paramname}->GetPointer(), {paramname}->GetLength(), {}, {}, &VulkanObjectInfoTable::Get{pooltype}Info, &VulkanObjectInfoTable::Add{basetype}Info);'.format(self.getParentId(value, values), values[1].name, argName, lengthName, paramname=value.name, basetype=value.baseType[2:], pooltype=self.POOL_OBJECT_ASSOCIATIONS[value.baseType][2:]))
+                                    postexpr.append(
+                                        'AddPoolHandles<{pooltype}Info, {basetype}Info>({}, handle_mapping::GetPoolId({}->GetMetaStructPointer()), {paramname}->GetPointer(), {paramname}->GetLength(), {}, {}, &VulkanObjectInfoTable::Get{pooltype}Info, &VulkanObjectInfoTable::Add{basetype}Info);'
+                                        .format(self.getParentId(
+                                            value, values),
+                                                values[1].name,
+                                                argName,
+                                                lengthName,
+                                                paramname=value.name,
+                                                basetype=value.baseType[2:],
+                                                pooltype=self.
+                                                POOL_OBJECT_ASSOCIATIONS[
+                                                    value.baseType][2:]))
                                 else:
-                                    postexpr.append('AddHandles<{basetype}Info>({}, {paramname}->GetPointer(), {paramname}->GetLength(), {}, {}, &VulkanObjectInfoTable::Add{basetype}Info);'.format(self.getParentId(value, values), argName, lengthName, paramname=value.name, basetype=value.baseType[2:]))
+                                    postexpr.append(
+                                        'AddHandles<{basetype}Info>({}, {paramname}->GetPointer(), {paramname}->GetLength(), {}, {}, &VulkanObjectInfoTable::Add{basetype}Info);'
+                                        .format(self.getParentId(
+                                            value, values),
+                                                argName,
+                                                lengthName,
+                                                paramname=value.name,
+                                                basetype=value.baseType[2:]))
                             else:
-                                preexpr.append('std::vector<{}Info> handle_info({});'.format(value.baseType[2:], lengthName))
-                                expr = 'for (size_t i = 0; i < {}; ++i) {{ {}->SetConsumerData(i, &handle_info[i]); }}'.format(lengthName, value.name);
+                                preexpr.append(
+                                    'std::vector<{}Info> handle_info({});'.
+                                    format(value.baseType[2:], lengthName))
+                                expr = 'for (size_t i = 0; i < {}; ++i) {{ {}->SetConsumerData(i, &handle_info[i]); }}'.format(
+                                    lengthName, value.name)
                                 if self.isPoolAllocation(name):
-                                    postexpr.append('AddPoolHandles<{pooltype}Info, {basetype}Info>({}, handle_mapping::GetPoolId({}->GetMetaStructPointer()), {paramname}->GetPointer(), {paramname}->GetLength(), {paramname}->GetHandlePointer(), {}, std::move(handle_info), &VulkanObjectInfoTable::Get{pooltype}Info, &VulkanObjectInfoTable::Add{basetype}Info);'.format(self.getParentId(value, values), values[1].name, lengthName, paramname=value.name, basetype=value.baseType[2:], pooltype=self.POOL_OBJECT_ASSOCIATIONS[value.baseType][2:]))
+                                    postexpr.append(
+                                        'AddPoolHandles<{pooltype}Info, {basetype}Info>({}, handle_mapping::GetPoolId({}->GetMetaStructPointer()), {paramname}->GetPointer(), {paramname}->GetLength(), {paramname}->GetHandlePointer(), {}, std::move(handle_info), &VulkanObjectInfoTable::Get{pooltype}Info, &VulkanObjectInfoTable::Add{basetype}Info);'
+                                        .format(self.getParentId(
+                                            value, values),
+                                                values[1].name,
+                                                lengthName,
+                                                paramname=value.name,
+                                                basetype=value.baseType[2:],
+                                                pooltype=self.
+                                                POOL_OBJECT_ASSOCIATIONS[
+                                                    value.baseType][2:]))
                                 else:
-                                    postexpr.append('AddHandles<{basetype}Info>({}, {paramname}->GetPointer(), {paramname}->GetLength(), {paramname}->GetHandlePointer(), {}, std::move(handle_info), &VulkanObjectInfoTable::Add{basetype}Info);'.format(self.getParentId(value, values), lengthName, paramname=value.name, basetype=value.baseType[2:]))
+                                    postexpr.append(
+                                        'AddHandles<{basetype}Info>({}, {paramname}->GetPointer(), {paramname}->GetLength(), {paramname}->GetHandlePointer(), {}, std::move(handle_info), &VulkanObjectInfoTable::Add{basetype}Info);'
+                                        .format(self.getParentId(
+                                            value, values),
+                                                lengthName,
+                                                paramname=value.name,
+                                                basetype=value.baseType[2:]))
 
                         elif self.isStruct(value.baseType):
                             # Generate the expression to allocate the output array.
@@ -378,78 +475,151 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
                             if value.baseType in self.sTypeValues:
                                 # If this is a struct with sType and pNext fields, we need to initialize them.
                                 # TODO: recreate pNext value read from the capture file.
-                                allocExpr += 'AllocateOutputData({}, {}{{ {}, nullptr }});'.format(lengthName, value.baseType, self.sTypeValues[value.baseType])
+                                allocExpr += 'AllocateOutputData({}, {}{{ {}, nullptr }});'.format(
+                                    lengthName, value.baseType,
+                                    self.sTypeValues[value.baseType])
                             else:
-                                allocExpr += 'AllocateOutputData({});'.format(lengthName)
+                                allocExpr += 'AllocateOutputData({});'.format(
+                                    lengthName)
 
                             if needTempValue:
-                                expr += '{paramname}->IsNull() ? nullptr : {paramname}->{}'.format(allocExpr, paramname=value.name)
+                                expr += '{paramname}->IsNull() ? nullptr : {paramname}->{}'.format(
+                                    allocExpr, paramname=value.name)
                                 # If this is a struct with handles, we need to add replay mappings for the embedded handles.
                                 if value.baseType in self.structsWithHandles:
                                     if value.baseType in self.structsWithHandlePtrs:
-                                        preexpr.append('SetStructArrayHandleLengths<Decoded_{}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength());'.format(value.baseType, paramname=value.name))
-                                    postexpr.append('AddStructArrayHandles<Decoded_{basetype}>({}, {paramname}->GetMetaStructPointer(), {paramname}->GetLength(), {}, {}, &GetObjectInfoTable());'.format(self.getParentId(value, values), argName, lengthName, paramname=value.name, basetype=value.baseType))
+                                        preexpr.append(
+                                            'SetStructArrayHandleLengths<Decoded_{}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength());'
+                                            .format(value.baseType,
+                                                    paramname=value.name))
+                                    postexpr.append(
+                                        'AddStructArrayHandles<Decoded_{basetype}>({}, {paramname}->GetMetaStructPointer(), {paramname}->GetLength(), {}, {}, &GetObjectInfoTable());'
+                                        .format(self.getParentId(
+                                            value, values),
+                                                argName,
+                                                lengthName,
+                                                paramname=value.name,
+                                                basetype=value.baseType))
                             else:
-                                expr += 'if (!{paramname}->IsNull()) {{ {paramname}->{} }}'.format(allocExpr, paramname=value.name)
+                                expr += 'if (!{paramname}->IsNull()) {{ {paramname}->{} }}'.format(
+                                    allocExpr, paramname=value.name)
                                 # If this is a struct with handles, we need to add replay mappings for the embedded handles.
                                 if value.baseType in self.structsWithHandles:
                                     if value.baseType in self.structsWithHandlePtrs:
-                                        preexpr.append('SetStructArrayHandleLengths<Decoded_{}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength());'.format(value.baseType, paramname=value.name))
-                                    postexpr.append('AddStructArrayHandles<Decoded_{basetype}>({}, {paramname}->GetMetaStructPointer(), {paramname}->GetLength(), {paramname}->GetOutputPointer(), {}, &GetObjectInfoTable());'.format(self.getParentId(value, values), lengthName, paramname=value.name, basetype=value.baseType))
+                                        preexpr.append(
+                                            'SetStructArrayHandleLengths<Decoded_{}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength());'
+                                            .format(value.baseType,
+                                                    paramname=value.name))
+                                    postexpr.append(
+                                        'AddStructArrayHandles<Decoded_{basetype}>({}, {paramname}->GetMetaStructPointer(), {paramname}->GetLength(), {paramname}->GetOutputPointer(), {}, &GetObjectInfoTable());'
+                                        .format(self.getParentId(
+                                            value, values),
+                                                lengthName,
+                                                paramname=value.name,
+                                                basetype=value.baseType))
                         else:
                             if needTempValue:
-                                expr += '{paramname}->IsNull() ? nullptr : {paramname}->AllocateOutputData({});'.format(lengthName, paramname=value.name)
+                                expr += '{paramname}->IsNull() ? nullptr : {paramname}->AllocateOutputData({});'.format(
+                                    lengthName, paramname=value.name)
                             else:
-                                expr = 'if ({paramname}->IsNull()) {{ {paramname}->AllocateOutputData({}); }}'.format(lengthName, paramname=value.name)
+                                expr = 'if ({paramname}->IsNull()) {{ {paramname}->AllocateOutputData({}); }}'.format(
+                                    lengthName, paramname=value.name)
                     else:
                         if isExtenalObject:
                             # Map the object ID to the new object
                             if value.platformFullType:
-                                expr += '{paramname}->IsNull() ? nullptr : reinterpret_cast<{}>({paramname}->AllocateOutputData(1));'.format(fullType, paramname=value.name)
-                                postexpr.append('PostProcessExternalObject(replay_result, (*{}->GetPointer()), static_cast<void*>(*{}), format::ApiCallId::ApiCall_{name}, "{name}");'.format(value.name, argName, name=name))
+                                expr += '{paramname}->IsNull() ? nullptr : reinterpret_cast<{}>({paramname}->AllocateOutputData(1));'.format(
+                                    fullType, paramname=value.name)
+                                postexpr.append(
+                                    'PostProcessExternalObject(replay_result, (*{}->GetPointer()), static_cast<void*>(*{}), format::ApiCallId::ApiCall_{name}, "{name}");'
+                                    .format(value.name, argName, name=name))
                             else:
-                                expr += '{paramname}->IsNull() ? nullptr : {paramname}->AllocateOutputData(1);'.format(paramname=value.name)
-                                postexpr.append('PostProcessExternalObject(replay_result, (*{paramname}->GetPointer()), *{paramname}->GetOutputPointer(), format::ApiCallId::ApiCall_{name}, "{name}");'.format(paramname=value.name, name=name))
+                                expr += '{paramname}->IsNull() ? nullptr : {paramname}->AllocateOutputData(1);'.format(
+                                    paramname=value.name)
+                                postexpr.append(
+                                    'PostProcessExternalObject(replay_result, (*{paramname}->GetPointer()), *{paramname}->GetOutputPointer(), format::ApiCallId::ApiCall_{name}, "{name}");'
+                                    .format(paramname=value.name, name=name))
                         elif self.isHandle(value.baseType):
                             # Add mapping for the newly created handle
-                            preexpr.append('if (!{paramname}->IsNull()) {{ {paramname}->SetHandleLength(1); }}'.format(paramname=value.name))
+                            preexpr.append(
+                                'if (!{paramname}->IsNull()) {{ {paramname}->SetHandleLength(1); }}'
+                                .format(paramname=value.name))
                             if needTempValue:
-                                expr += '{}->GetHandlePointer();'.format(value.name)
-                                postexpr.append('AddHandle<{basetype}Info>({}, {}->GetPointer(), {}, &VulkanObjectInfoTable::Add{basetype}Info);'.format(self.getParentId(value, values), value.name, argName, basetype=value.baseType[2:]))
+                                expr += '{}->GetHandlePointer();'.format(
+                                    value.name)
+                                postexpr.append(
+                                    'AddHandle<{basetype}Info>({}, {}->GetPointer(), {}, &VulkanObjectInfoTable::Add{basetype}Info);'
+                                    .format(self.getParentId(value, values),
+                                            value.name,
+                                            argName,
+                                            basetype=value.baseType[2:]))
                             else:
-                                preexpr.append('{}Info handle_info;'.format(value.baseType[2:]))
-                                expr = '{}->SetConsumerData(0, &handle_info);'.format(value.name);
-                                postexpr.append('AddHandle<{basetype}Info>({}, {paramname}->GetPointer(), {paramname}->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::Add{basetype}Info);'.format(self.getParentId(value, values), paramname=value.name, basetype=value.baseType[2:]))
+                                preexpr.append('{}Info handle_info;'.format(
+                                    value.baseType[2:]))
+                                expr = '{}->SetConsumerData(0, &handle_info);'.format(
+                                    value.name)
+                                postexpr.append(
+                                    'AddHandle<{basetype}Info>({}, {paramname}->GetPointer(), {paramname}->GetHandlePointer(), std::move(handle_info), &VulkanObjectInfoTable::Add{basetype}Info);'
+                                    .format(self.getParentId(value, values),
+                                            paramname=value.name,
+                                            basetype=value.baseType[2:]))
                         else:
                             if self.isArrayLen(value.name, values):
                                 # If this is an array length, it is an in/out parameter and we need to assign the input value.
-                                arrayLenExpr = self.makeVariableLengthArrayGetCountCall(returnType, name, value, values)
-                                expr += '{paramname}->IsNull() ? nullptr : {paramname}->AllocateOutputData(1, {});'.format(arrayLenExpr, paramname=value.name)
+                                arrayLenExpr = self.makeVariableLengthArrayGetCountCall(
+                                    returnType, name, value, values)
+                                expr += '{paramname}->IsNull() ? nullptr : {paramname}->AllocateOutputData(1, {});'.format(
+                                    arrayLenExpr, paramname=value.name)
                                 # Need to store the name of the intermediate value for use with allocating the array associated with this length.
                                 if needTempValue:
-                                    arrayLengths[value.name] = '*{}'.format(argName)
+                                    arrayLengths[value.name] = '*{}'.format(
+                                        argName)
                                 else:
-                                    arrayLengths[value.name] = '*{}->GetOutputPointer()'.format(value.name)
+                                    arrayLengths[
+                                        value.
+                                        name] = '*{}->GetOutputPointer()'.format(
+                                            value.name)
                             elif self.isStruct(value.baseType):
                                 # If this is a struct with sType and pNext fields, we need to initialize them.
                                 if value.baseType in self.sTypeValues:
                                     # TODO: recreate pNext value read from the capture file; pNext is currently null.
-                                    expr += '{paramname}->IsNull() ? nullptr : {paramname}->AllocateOutputData(1, {{ {}, nullptr }});'.format(self.sTypeValues[value.baseType], paramname=value.name)
+                                    expr += '{paramname}->IsNull() ? nullptr : {paramname}->AllocateOutputData(1, {{ {}, nullptr }});'.format(
+                                        self.sTypeValues[value.baseType],
+                                        paramname=value.name)
                                 else:
-                                    expr += '{paramname}->IsNull() ? nullptr : {paramname}->AllocateOutputData(1);'.format(paramname=value.name)
+                                    expr += '{paramname}->IsNull() ? nullptr : {paramname}->AllocateOutputData(1);'.format(
+                                        paramname=value.name)
 
                                 # If this is a struct with handles, we need to add replay mappings for the embedded handles.
                                 if value.baseType in self.structsWithHandles:
                                     if needTempValue:
                                         if value.baseType in self.structsWithHandlePtrs:
-                                            preexpr.append('SetStructHandleLengths<Decoded_{}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength());'.format(value.baseType, paramname=value.name))
-                                        postexpr.append('AddStructHandles<Decoded_{basetype}>({}, {name}->GetMetaStructPointer(), {}, &GetObjectInfoTable());'.format(self.getParentId(value, values), argName, name=value.name, basetype=value.baseType))
+                                            preexpr.append(
+                                                'SetStructHandleLengths<Decoded_{}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength());'
+                                                .format(value.baseType,
+                                                        paramname=value.name))
+                                        postexpr.append(
+                                            'AddStructHandles<Decoded_{basetype}>({}, {name}->GetMetaStructPointer(), {}, &GetObjectInfoTable());'
+                                            .format(self.getParentId(
+                                                value, values),
+                                                    argName,
+                                                    name=value.name,
+                                                    basetype=value.baseType))
                                     else:
                                         if value.baseType in self.structsWithHandlePtrs:
-                                            preexpr.append('SetStructHandleLengths<Decoded_{}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength());'.format(value.baseType, paramname=value.name))
-                                        postexpr.append('AddStructHandles<Decoded_{basetype}>({}, {name}->GetMetaStructPointer(), {name}->GetOutputPointer(), &GetObjectInfoTable());'.format(self.getParentId(value, values), name=value.name, basetype=value.baseType))
+                                            preexpr.append(
+                                                'SetStructHandleLengths<Decoded_{}>({paramname}->GetMetaStructPointer(), {paramname}->GetLength());'
+                                                .format(value.baseType,
+                                                        paramname=value.name))
+                                        postexpr.append(
+                                            'AddStructHandles<Decoded_{basetype}>({}, {name}->GetMetaStructPointer(), {name}->GetOutputPointer(), &GetObjectInfoTable());'
+                                            .format(self.getParentId(
+                                                value, values),
+                                                    name=value.name,
+                                                    basetype=value.baseType))
                             else:
-                                expr += '{paramname}->IsNull() ? nullptr : {paramname}->AllocateOutputData(1, static_cast<{}>(0));'.format(value.baseType, paramname=value.name)
+                                expr += '{paramname}->IsNull() ? nullptr : {paramname}->AllocateOutputData(1, static_cast<{}>(0));'.format(
+                                    value.baseType, paramname=value.name)
                 if expr:
                     preexpr.append(expr)
             elif self.isHandle(value.baseType):
@@ -458,32 +628,40 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
                 args.append(argName)
                 if isOverride:
                     # We use auto in case the compiler can determine if the value should be const or non-const based on the override function signature.
-                    expr = 'auto {} = GetObjectInfoTable().Get{}Info({});'.format(argName, value.baseType[2:], value.name)
+                    expr = 'auto {} = GetObjectInfoTable().Get{}Info({});'.format(
+                        argName, value.baseType[2:], value.name)
                     preexpr.append(expr)
                 else:
                     expr = '{} {} = '.format(value.fullType, argName)
-                    expr += 'MapHandle<{type}Info>({}, &VulkanObjectInfoTable::Get{type}Info);'.format(value.name, type=value.baseType[2:])
+                    expr += 'MapHandle<{type}Info>({}, &VulkanObjectInfoTable::Get{type}Info);'.format(
+                        value.name, type=value.baseType[2:])
                     preexpr.append(expr)
 
                     # If surface was not created, need to automatically ignore for non-overrides queries
                     # Swapchain also need to check if a dummy swapchain was created instead
                     if value.name == "surface":
-                        expr = 'if ({} == VK_NULL_HANDLE) {{ return; }}'.format(argName)
+                        expr = 'if ({} == VK_NULL_HANDLE) {{ return; }}'.format(
+                            argName)
                         preexpr.append(expr)
                     elif value.name == "swapchain":
-                        expr = 'if (GetObjectInfoTable().Get{}Info({})->surface == VK_NULL_HANDLE) {{ return; }}'.format(value.baseType[2:], value.name)
+                        expr = 'if (GetObjectInfoTable().Get{}Info({})->surface == VK_NULL_HANDLE) {{ return; }}'.format(
+                            value.baseType[2:], value.name)
                         preexpr.append(expr)
             elif self.isGenericCmdHandleValue(name, value.name):
                 # Handles need to be mapped.
                 argName = 'in_' + value.name
                 args.append(argName)
                 expr = '{} {} = '.format(value.fullType, argName)
-                expr += 'MapHandle({}, {});'.format(value.name, self.getGenericCmdHandleTypeValue(name, value.name))
+                expr += 'MapHandle({}, {});'.format(
+                    value.name,
+                    self.getGenericCmdHandleTypeValue(name, value.name))
                 preexpr.append(expr)
             elif self.isFunctionPtr(value.baseType):
                 # Function pointers are encoded as a 64-bit address value.
                 # TODO: Check for cases that need to be handled.
-                print("WARNING: Generating replay code for a function {} with a {} parameter that is undefined.".format(name, value.baseType))
+                print(
+                    "WARNING: Generating replay code for a function {} with a {} parameter that is undefined."
+                    .format(name, value.baseType))
             else:
                 # Only need to append the parameter name to the args list; no other expressions are necessary.
                 args.append(value.name)
@@ -494,16 +672,27 @@ class VulkanReplayConsumerBodyGenerator(BaseGenerator):
         if name.startswith('vkDestroy') or (name == 'vkFreeMemory'):
             # For functions starting with 'vkDestroy' and vkFreeMemory, the handle being destroyed/freed is the second parameter, except for.
             # vkDestroyInstance and vkDestroyDevice, where there is no parent object and the handle being destroyed is the first parameter.
-            value = values[0] if name in ['vkDestroyInstance', 'vkDestroyDevice'] else values[1]
+            value = values[0] if name in [
+                'vkDestroyInstance', 'vkDestroyDevice'
+            ] else values[1]
             if value.baseType not in self.POOL_OBJECT_ASSOCIATIONS:
-                expr = 'RemoveHandle({}, &VulkanObjectInfoTable::Remove{basetype}Info);'.format(value.name, basetype=value.baseType[2:])
+                expr = 'RemoveHandle({}, &VulkanObjectInfoTable::Remove{basetype}Info);'.format(
+                    value.name, basetype=value.baseType[2:])
             else:
                 # Pools require special case processing to cleanup objects allocated from them.
-                expr = 'RemovePoolHandle<{basetype}Info>({}, &VulkanObjectInfoTable::Get{basetype}Info, &VulkanObjectInfoTable::Remove{basetype}Info, &VulkanObjectInfoTable::Remove{}Info);'.format(value.name, self.POOL_OBJECT_ASSOCIATIONS[value.baseType][2:], basetype=value.baseType[2:])
+                expr = 'RemovePoolHandle<{basetype}Info>({}, &VulkanObjectInfoTable::Get{basetype}Info, &VulkanObjectInfoTable::Remove{basetype}Info, &VulkanObjectInfoTable::Remove{}Info);'.format(
+                    value.name,
+                    self.POOL_OBJECT_ASSOCIATIONS[value.baseType][2:],
+                    basetype=value.baseType[2:])
         elif name.startswith('vkFree'):
             # For pool based vkFreeCommandBuffers and vkFreeDescriptorSets, the pool handle is the second parameter, the array count is the third parameter and the array of handles to free is the fourth parameter.
-             value = values[3]
-             expr = 'RemovePoolHandles<{pooltype}Info, {basetype}Info>({}, {}, {}, &VulkanObjectInfoTable::Get{pooltype}Info, &VulkanObjectInfoTable::Remove{basetype}Info);'.format(values[1].name, value.name, values[2].name, basetype=value.baseType[2:], pooltype=self.POOL_OBJECT_ASSOCIATIONS[value.baseType][2:])
+            value = values[3]
+            expr = 'RemovePoolHandles<{pooltype}Info, {basetype}Info>({}, {}, {}, &VulkanObjectInfoTable::Get{pooltype}Info, &VulkanObjectInfoTable::Remove{basetype}Info);'.format(
+                values[1].name,
+                value.name,
+                values[2].name,
+                basetype=value.baseType[2:],
+                pooltype=self.POOL_OBJECT_ASSOCIATIONS[value.baseType][2:])
 
         return expr
 

--- a/framework/generated/vulkan_generators/vulkan_state_table_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_state_table_header_generator.py
@@ -20,34 +20,46 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanStateTableHeaderGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ function declarations for Vulkan API parameter encoding"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # Generates declarations for functions for Vulkan state table
 class VulkanStateTableHeaderGenerator(BaseGenerator):
-
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=True, processStructs=False, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
-
+                               processCmds=True,
+                               processStructs=False,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
     # Method override
     def beginFile(self, genOpts):
@@ -75,16 +87,22 @@ class VulkanStateTableHeaderGenerator(BaseGenerator):
 
         for handle_name in sorted(self.handleNames):
             if handle_name in self.DUPLICATE_HANDLE_TYPES:
-                continue            
+                continue
             handle_name = handle_name[2:]
             handle_wrapper = handle_name + 'Wrapper'
-            handle_map = handle_name[0].lower() + handle_name[1:] + '_map_'            
-            insert_code += '    bool InsertWrapper(format::HandleId id, {0}* wrapper) {{ return InsertEntry(id, wrapper, {1}); }}\n'.format(handle_wrapper, handle_map)
-            remove_code += '    bool RemoveWrapper(const {0}* wrapper) {{ return RemoveEntry(wrapper, {1}); }}\n'.format(handle_wrapper, handle_map)
-            visit_code += '    void VisitWrappers(std::function<void({0}*)> visitor) const {{ for (auto entry : {1}) {{ visitor(entry.second); }} }}\n'.format(handle_wrapper, handle_map)
-            get_code += '    {0}* Get{0}(format::HandleId id) {{ return GetWrapper<{0}>(id, {1}); }}\n'.format(handle_wrapper, handle_map)
-            const_get_code += '    const {0}* Get{0}(format::HandleId id) const {{ return GetWrapper<{0}>(id, {1}); }}\n'.format(handle_wrapper, handle_map)
-            map_code += '    std::map<format::HandleId, {0}*> {1};\n'.format(handle_wrapper, handle_map)
+            handle_map = handle_name[0].lower() + handle_name[1:] + '_map_'
+            insert_code += '    bool InsertWrapper(format::HandleId id, {0}* wrapper) {{ return InsertEntry(id, wrapper, {1}); }}\n'.format(
+                handle_wrapper, handle_map)
+            remove_code += '    bool RemoveWrapper(const {0}* wrapper) {{ return RemoveEntry(wrapper, {1}); }}\n'.format(
+                handle_wrapper, handle_map)
+            visit_code += '    void VisitWrappers(std::function<void({0}*)> visitor) const {{ for (auto entry : {1}) {{ visitor(entry.second); }} }}\n'.format(
+                handle_wrapper, handle_map)
+            get_code += '    {0}* Get{0}(format::HandleId id) {{ return GetWrapper<{0}>(id, {1}); }}\n'.format(
+                handle_wrapper, handle_map)
+            const_get_code += '    const {0}* Get{0}(format::HandleId id) const {{ return GetWrapper<{0}>(id, {1}); }}\n'.format(
+                handle_wrapper, handle_map)
+            map_code += '    std::map<format::HandleId, {0}*> {1};\n'.format(
+                handle_wrapper, handle_map)
 
         self.newline()
         code = 'class VulkanStateTable : VulkanStateTableBase\n'
@@ -109,5 +127,6 @@ class VulkanStateTableHeaderGenerator(BaseGenerator):
         write(code, file=self.outFile)
 
     def write_include(self):
-        write('#include "encode/vulkan_state_table_base.h"\n', file=self.outFile)
+        write('#include "encode/vulkan_state_table_base.h"\n',
+              file=self.outFile)
         self.newline()

--- a/framework/generated/vulkan_generators/vulkan_struct_decoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_decoders_body_generator.py
@@ -21,42 +21,58 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanStructDecodersBodyGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ functions for Vulkan struct decoding"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanStructDecodersBodyGenerator - subclass of BaseGenerator.
 # Generates C++ functions for decoding Vulkan API structures.
 class VulkanStructDecodersBodyGenerator(BaseGenerator):
     """Generate C++ functions for Vulkan struct decoding"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=False, processStructs=True, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=False,
+                               processStructs=True,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
     # Method override
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
 
-        write('#include "generated/generated_vulkan_struct_decoders.h"', file=self.outFile)
+        write('#include "generated/generated_vulkan_struct_decoders.h"',
+              file=self.outFile)
         self.newline()
-        write('#include "decode/custom_vulkan_struct_decoders.h"', file=self.outFile)
+        write('#include "decode/custom_vulkan_struct_decoders.h"',
+              file=self.outFile)
         write('#include "decode/decode_allocator.h"', file=self.outFile)
         self.newline()
         write('#include <cassert>', file=self.outFile)
@@ -64,7 +80,9 @@ class VulkanStructDecodersBodyGenerator(BaseGenerator):
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)
         self.newline()
-        write('size_t DecodePNextStruct(const uint8_t* buffer, size_t buffer_size, PNextNode** pNext);', file=self.outFile)
+        write(
+            'size_t DecodePNextStruct(const uint8_t* buffer, size_t buffer_size, PNextNode** pNext);',
+            file=self.outFile)
 
     # Method override
     def endFile(self):
@@ -88,14 +106,16 @@ class VulkanStructDecodersBodyGenerator(BaseGenerator):
         first = True
         for struct in self.getFilteredStructNames():
             body = '' if first else '\n'
-            body += 'size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_{}* wrapper)\n'.format(struct)
+            body += 'size_t DecodeStruct(const uint8_t* buffer, size_t buffer_size, Decoded_{}* wrapper)\n'.format(
+                struct)
             body += '{\n'
             body += '    assert((wrapper != nullptr) && (wrapper->decoded_value != nullptr));\n'
             body += '\n'
             body += '    size_t bytes_read = 0;\n'
             body += '    {}* value = wrapper->decoded_value;\n'.format(struct)
             body += '\n'
-            body += self.makeDecodeStructBody(struct, self.featureStructMembers[struct])
+            body += self.makeDecodeStructBody(
+                struct, self.featureStructMembers[struct])
             body += '\n'
             body += '    return bytes_read;\n'
             body += '}'
@@ -111,7 +131,8 @@ class VulkanStructDecodersBodyGenerator(BaseGenerator):
         for value in values:
             # pNext fields require special treatment and are not processed by type name
             if 'pNext' in value.name:
-                body += '    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->{}));\n'.format(value.name)
+                body += '    bytes_read += DecodePNextStruct((buffer + bytes_read), (buffer_size - bytes_read), &(wrapper->{}));\n'.format(
+                    value.name)
                 body += '    value->pNext = wrapper->pNext ? wrapper->pNext->GetPointer() : nullptr;\n'
             else:
                 body += self.makeDecodeInvocation(name, value)
@@ -145,24 +166,32 @@ class VulkanStructDecodersBodyGenerator(BaseGenerator):
         if value.isPointer or value.isArray:
             if typeName in self.EXTERNAL_OBJECT_TYPES and not value.isArray:
                 # Pointer to an unknown object type, encoded as a 64-bit integer ID.
-                body += '    bytes_read += ValueDecoder::DecodeAddress({}, &(wrapper->{}));\n'.format(bufferArgs, value.name)
+                body += '    bytes_read += ValueDecoder::DecodeAddress({}, &(wrapper->{}));\n'.format(
+                    bufferArgs, value.name)
                 body += '    value->{} = nullptr;\n'.format(value.name)
             else:
-                isStaticArray = True if (value.isArray and not value.isDynamic) else False
+                isStaticArray = True if (value.isArray
+                                         and not value.isDynamic) else False
                 accessOp = '.'
 
                 if isStruct:
-                    body += '    wrapper->{} = DecodeAllocator::Allocate<{}>();\n'.format(value.name, self.makeDecodedParamType(value))
+                    body += '    wrapper->{} = DecodeAllocator::Allocate<{}>();\n'.format(
+                        value.name, self.makeDecodedParamType(value))
                     accessOp = '->'
 
                 if isStaticArray:
                     # The pointer decoder will write directly to the struct member's memory.
-                    body += '    wrapper->{name}{}SetExternalMemory(value->{name}, {arraylen});\n'.format(accessOp, name=value.name, arraylen=value.arrayCapacity)
+                    body += '    wrapper->{name}{}SetExternalMemory(value->{name}, {arraylen});\n'.format(
+                        accessOp,
+                        name=value.name,
+                        arraylen=value.arrayCapacity)
 
                 if isStruct or isString or isHandle:
-                    body += '    bytes_read += wrapper->{}{}Decode({});\n'.format(value.name, accessOp, bufferArgs)
+                    body += '    bytes_read += wrapper->{}{}Decode({});\n'.format(
+                        value.name, accessOp, bufferArgs)
                 else:
-                    body += '    bytes_read += wrapper->{}.Decode{}({});\n'.format(value.name, typeName, bufferArgs)
+                    body += '    bytes_read += wrapper->{}.Decode{}({});\n'.format(
+                        value.name, typeName, bufferArgs)
 
                 if not isStaticArray:
                     if isHandle:
@@ -170,29 +199,38 @@ class VulkanStructDecodersBodyGenerator(BaseGenerator):
                         body += '    value->{} = nullptr;\n'.format(value.name)
                     else:
                         # Point the real struct's member pointer to the pointer decoder's memory.
-                        body += '    value->{name} = wrapper->{name}{}GetPointer();\n'.format(accessOp, name=value.name)
+                        body += '    value->{name} = wrapper->{name}{}GetPointer();\n'.format(
+                            accessOp, name=value.name)
         else:
             if isStruct:
-                body += '    wrapper->{} = DecodeAllocator::Allocate<{}>();\n'.format(value.name, self.makeDecodedParamType(value))
-                body += '    wrapper->{name}->decoded_value = &(value->{name});\n'.format(name=value.name)
-                body += '    bytes_read += DecodeStruct({}, wrapper->{});\n'.format(bufferArgs, value.name)
+                body += '    wrapper->{} = DecodeAllocator::Allocate<{}>();\n'.format(
+                    value.name, self.makeDecodedParamType(value))
+                body += '    wrapper->{name}->decoded_value = &(value->{name});\n'.format(
+                    name=value.name)
+                body += '    bytes_read += DecodeStruct({}, wrapper->{});\n'.format(
+                    bufferArgs, value.name)
             elif isFuncp:
-                body += '    bytes_read += ValueDecoder::DecodeAddress({}, &(wrapper->{}));\n'.format(bufferArgs, value.name)
+                body += '    bytes_read += ValueDecoder::DecodeAddress({}, &(wrapper->{}));\n'.format(
+                    bufferArgs, value.name)
                 body += '    value->{} = nullptr;\n'.format(value.name)
             elif isHandle:
-                body += '    bytes_read += ValueDecoder::DecodeHandleIdValue({}, &(wrapper->{}));\n'.format(bufferArgs, value.name)
+                body += '    bytes_read += ValueDecoder::DecodeHandleIdValue({}, &(wrapper->{}));\n'.format(
+                    bufferArgs, value.name)
                 body += '    value->{} = VK_NULL_HANDLE;\n'.format(value.name)
             elif self.isGenericStructHandleValue(name, value.name):
-                body += '    bytes_read += ValueDecoder::DecodeUInt64Value({}, &(wrapper->{}));\n'.format(bufferArgs, value.name)
+                body += '    bytes_read += ValueDecoder::DecodeUInt64Value({}, &(wrapper->{}));\n'.format(
+                    bufferArgs, value.name)
                 body += '    value->{} = 0;\n'.format(value.name)
             elif value.bitfieldWidth:
                 # Bit fields need to be read into a tempoaray and then assigned to the struct member.
                 tempParamName = 'temp_{}'.format(value.name)
                 body += '    {} {};\n'.format(value.baseType, tempParamName)
-                body += '    bytes_read += ValueDecoder::Decode{}Value({}, &{});\n'.format(typeName, bufferArgs, tempParamName)
-                body += '    value->{} = {};\n'.format(value.name, tempParamName)
+                body += '    bytes_read += ValueDecoder::Decode{}Value({}, &{});\n'.format(
+                    typeName, bufferArgs, tempParamName)
+                body += '    value->{} = {};\n'.format(value.name,
+                                                       tempParamName)
             else:
-                body += '    bytes_read += ValueDecoder::Decode{}Value({}, &(value->{}));\n'.format(typeName, bufferArgs, value.name)
+                body += '    bytes_read += ValueDecoder::Decode{}Value({}, &(value->{}));\n'.format(
+                    typeName, bufferArgs, value.name)
 
         return body
-

--- a/framework/generated/vulkan_generators/vulkan_struct_decoders_forward_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_decoders_forward_generator.py
@@ -21,34 +21,48 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanStructDecodersForwardGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ function and forward type declarations for Vulkan struct decoding"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanStructDecodersForwardGenerator - subclass of BaseGenerator.
 # Generates C++ type and function declarations for decoding Vulkan API structures.
 class VulkanStructDecodersForwardGenerator(BaseGenerator):
     """Generate C++ function and forward type declarations for Vulkan struct decoding"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=False, processStructs=True, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=False,
+                               processStructs=True,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
     # Method override
     def beginFile(self, genOpts):
@@ -88,4 +102,7 @@ class VulkanStructDecodersForwardGenerator(BaseGenerator):
         self.newline()
 
         for struct in self.getFilteredStructNames():
-            write('size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_{}* wrapper);'.format(struct), file=self.outFile)
+            write(
+                'size_t DecodeStruct(const uint8_t* parameter_buffer, size_t buffer_size, Decoded_{}* wrapper);'
+                .format(struct),
+                file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_struct_decoders_forward_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_decoders_forward_generator.py
@@ -70,7 +70,7 @@ class VulkanStructDecodersForwardGenerator(BaseGenerator):
 
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
-        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
         self.newline()
         write('#include <cstdint>', file=self.outFile)
         self.newline()

--- a/framework/generated/vulkan_generators/vulkan_struct_decoders_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_decoders_header_generator.py
@@ -83,7 +83,7 @@ class VulkanStructDecodersHeaderGenerator(BaseGenerator):
             file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
-        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
         self.newline()
         write('#include <memory>', file=self.outFile)
         self.newline()

--- a/framework/generated/vulkan_generators/vulkan_struct_decoders_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_decoders_header_generator.py
@@ -21,40 +21,55 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanStructDecodersHeaderGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ type declarations for Vulkan struct decoding"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanStructDecodersHeaderGenerator - subclass of BaseGenerator.
 # Generates C++ type declarations for the decoded Vulkan API structure wrappers.
 class VulkanStructDecodersHeaderGenerator(BaseGenerator):
     """Generate C++ type declarations for Vulkan struct decoding"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=False, processStructs=True, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=False,
+                               processStructs=True,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
     # Method override
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
 
-        write('#include "decode/custom_vulkan_struct_decoders_forward.h"', file=self.outFile)
+        write('#include "decode/custom_vulkan_struct_decoders_forward.h"',
+              file=self.outFile)
         write('#include "decode/handle_pointer_decoder.h"', file=self.outFile)
         write('#include "decode/pnext_node.h"', file=self.outFile)
         write('#include "decode/pointer_decoder.h"', file=self.outFile)
@@ -63,7 +78,9 @@ class VulkanStructDecodersHeaderGenerator(BaseGenerator):
         write('#include "decode/struct_pointer_decoder.h"', file=self.outFile)
         write('#include "format/format.h"', file=self.outFile)
         write('#include "format/platform_types.h"', file=self.outFile)
-        write('#include "generated/generated_vulkan_struct_decoders_forward.h"', file=self.outFile)
+        write(
+            '#include "generated/generated_vulkan_struct_decoders_forward.h"',
+            file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
         write('#include "vulkan/vulkan.h"', file=self.outFile)
@@ -101,7 +118,8 @@ class VulkanStructDecodersHeaderGenerator(BaseGenerator):
             body += '\n'
             body += '    {}* decoded_value{{ nullptr }};\n'.format(struct)
 
-            decls = self.makeMemberDeclarations(struct, self.featureStructMembers[struct])
+            decls = self.makeMemberDeclarations(
+                struct, self.featureStructMembers[struct])
             if decls:
                 body += '\n'
                 body += decls
@@ -114,7 +132,8 @@ class VulkanStructDecodersHeaderGenerator(BaseGenerator):
         # Write typedefs for any aliases
         for struct in self.featureStructAliases:
             body = '' if first else '\n'
-            body += 'typedef Decoded_{} Decoded_{};'.format(self.featureStructAliases[struct], struct)
+            body += 'typedef Decoded_{} Decoded_{};'.format(
+                self.featureStructAliases[struct], struct)
             write(body, file=self.outFile)
             first = False
 
@@ -160,10 +179,12 @@ class VulkanStructDecodersHeaderGenerator(BaseGenerator):
 
                 defaultValue = self.getDefaultInitValue(typeName)
                 if defaultValue:
-                    body += '    {} {}{{ {} }};\n'.format(typeName, value.name, defaultValue)
+                    body += '    {} {}{{ {} }};\n'.format(
+                        typeName, value.name, defaultValue)
                 else:
                     if self.isStruct(value.baseType):
-                        body += '    {} {}{{ nullptr }};\n'.format(typeName, value.name)
+                        body += '    {} {}{{ nullptr }};\n'.format(
+                            typeName, value.name)
                     else:
                         body += '    {} {};\n'.format(typeName, value.name)
 

--- a/framework/generated/vulkan_generators/vulkan_struct_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_encoders_body_generator.py
@@ -21,42 +21,58 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanStructEncodersBodyGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ functions for Vulkan struct encoding"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanStructEncodersBodyGenerator - subclass of BaseGenerator.
 # Generates C++ functions for encoding Vulkan API structures.
 class VulkanStructEncodersBodyGenerator(BaseGenerator):
     """Generate C++ functions for Vulkan struct encoding"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=False, processStructs=True, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=False,
+                               processStructs=True,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
     # Method override
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
 
-        write('#include "generated/generated_vulkan_struct_encoders.h"', file=self.outFile)
+        write('#include "generated/generated_vulkan_struct_encoders.h"',
+              file=self.outFile)
         self.newline()
-        write('#include "encode/custom_vulkan_struct_encoders.h"', file=self.outFile)
+        write('#include "encode/custom_vulkan_struct_encoders.h"',
+              file=self.outFile)
         write('#include "encode/parameter_encoder.h"', file=self.outFile)
         write('#include "encode/struct_pointer_encoder.h"', file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
@@ -88,9 +104,12 @@ class VulkanStructEncodersBodyGenerator(BaseGenerator):
         first = True
         for struct in self.getFilteredStructNames():
             body = '' if first else '\n'
-            body += 'void EncodeStruct(ParameterEncoder* encoder, const {}& value)\n'.format(struct)
+            body += 'void EncodeStruct(ParameterEncoder* encoder, const {}& value)\n'.format(
+                struct)
             body += '{\n'
-            body += self.makeStructBody(struct, self.featureStructMembers[struct], 'value.')
+            body += self.makeStructBody(struct,
+                                        self.featureStructMembers[struct],
+                                        'value.')
             body += '}'
             write(body, file=self.outFile)
 
@@ -105,9 +124,11 @@ class VulkanStructEncodersBodyGenerator(BaseGenerator):
         for value in values:
             # pNext fields require special treatment and are not processed by typename
             if 'pNext' in value.name:
-                body += '    EncodePNextStruct(encoder, {});\n'.format(prefix + value.name)
+                body += '    EncodePNextStruct(encoder, {});\n'.format(
+                    prefix + value.name)
             else:
-                methodCall = self.makeEncoderMethodCall(name, value, values, prefix)
+                methodCall = self.makeEncoderMethodCall(
+                    name, value, values, prefix)
                 body += '    {};\n'.format(methodCall)
 
         return body

--- a/framework/generated/vulkan_generators/vulkan_struct_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_encoders_body_generator.py
@@ -77,7 +77,7 @@ class VulkanStructEncodersBodyGenerator(BaseGenerator):
         write('#include "encode/struct_pointer_encoder.h"', file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
-        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
         self.newline()
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(encode)', file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_struct_encoders_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_encoders_header_generator.py
@@ -72,7 +72,7 @@ class VulkanStructEncodersHeaderGenerator(BaseGenerator):
         write('#include "format/platform_types.h"', file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
-        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
         self.newline()
         write('#include <cstdint>', file=self.outFile)
         self.newline()

--- a/framework/generated/vulkan_generators/vulkan_struct_encoders_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_encoders_header_generator.py
@@ -21,34 +21,48 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanStructEncodersHeaderGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ function declarations for Vulkan struct encoding"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanStructEncodersHeaderGenerator - subclass of BaseGenerator.
 # Generates C++ type and function declarations for encoding Vulkan API structures.
 class VulkanStructEncodersHeaderGenerator(BaseGenerator):
     """Generate C++ function declarations for Vulkan struct encoding"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=False, processStructs=True, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=False,
+                               processStructs=True,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
     # Method override
     def beginFile(self, genOpts):
@@ -65,7 +79,9 @@ class VulkanStructEncodersHeaderGenerator(BaseGenerator):
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(encode)', file=self.outFile)
         self.newline()
-        write('void EncodePNextStruct(ParameterEncoder* encoder, const void* value);', file=self.outFile)
+        write(
+            'void EncodePNextStruct(ParameterEncoder* encoder, const void* value);',
+            file=self.outFile)
 
     # Method override
     def endFile(self):
@@ -87,4 +103,7 @@ class VulkanStructEncodersHeaderGenerator(BaseGenerator):
     # Performs C++ code generation for the feature.
     def generateFeature(self):
         for struct in self.getFilteredStructNames():
-            write('void EncodeStruct(ParameterEncoder* encoder, const {}& value);'.format(struct), file=self.outFile)
+            write(
+                'void EncodeStruct(ParameterEncoder* encoder, const {}& value);'
+                .format(struct),
+                file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_body_generator.py
@@ -21,22 +21,32 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanStructHandleMappersBodyGeneratorOptions(BaseGeneratorOptions):
     """Options for generating functions to map Vulkan struct member handles at file replay"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanStructHandleMappersBodyGenerator - subclass of BaseGenerator.
 # Generates C++ functions responsible for mapping struct member handles
@@ -44,19 +54,24 @@ class VulkanStructHandleMappersBodyGeneratorOptions(BaseGeneratorOptions):
 class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
     """Generate C++ functions for Vulkan struct member handle mapping at file replay"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=True, processStructs=True, featureBreak=False,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=True,
+                               processStructs=True,
+                               featureBreak=False,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
         # Map of Vulkan structs containing handles to a list values for handle members or struct members
         # that contain handles (eg. VkGraphicsPipelineCreateInfo contains a VkPipelineShaderStageCreateInfo
         # member that contains handles).
         self.structsWithHandles = dict()
         self.structsWithHandlePtrs = []
-        self.pNextStructs = dict()          # Map of Vulkan structure types to sType value for structs that can be part of a pNext chain.
+        self.pNextStructs = dict(
+        )  # Map of Vulkan structure types to sType value for structs that can be part of a pNext chain.
         # List of structs containing handles that are also used as output parameters for a command
         self.outputStructsWithHandles = []
 
@@ -64,12 +79,16 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
 
-        write('#include "generated/generated_vulkan_struct_handle_mappers.h"', file=self.outFile)
+        write('#include "generated/generated_vulkan_struct_handle_mappers.h"',
+              file=self.outFile)
         self.newline()
-        write('#include "decode/custom_vulkan_struct_decoders.h"', file=self.outFile)
+        write('#include "decode/custom_vulkan_struct_decoders.h"',
+              file=self.outFile)
         write('#include "decode/handle_pointer_decoder.h"', file=self.outFile)
-        write('#include "decode/vulkan_handle_mapping_util.h"', file=self.outFile)
-        write('#include "generated/generated_vulkan_struct_decoders.h"', file=self.outFile)
+        write('#include "decode/vulkan_handle_mapping_util.h"',
+              file=self.outFile)
+        write('#include "generated/generated_vulkan_struct_decoders.h"',
+              file=self.outFile)
         self.newline()
         write('#include <algorithm>', file=self.outFile)
         write('#include <cassert>', file=self.outFile)
@@ -81,20 +100,31 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
     def endFile(self):
         # Generate the pNext handle mapping code.
         self.newline()
-        write('void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectInfoTable& object_info_table)', file=self.outFile)
+        write(
+            'void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectInfoTable& object_info_table)',
+            file=self.outFile)
         write('{', file=self.outFile)
-        write('    if ((value != nullptr) && (wrapper != nullptr))', file=self.outFile)
+        write('    if ((value != nullptr) && (wrapper != nullptr))',
+              file=self.outFile)
         write('    {', file=self.outFile)
-        write('        const VkBaseInStructure* base = reinterpret_cast<const VkBaseInStructure*>(value);', file=self.outFile)
+        write(
+            '        const VkBaseInStructure* base = reinterpret_cast<const VkBaseInStructure*>(value);',
+            file=self.outFile)
         write('', file=self.outFile)
         write('        switch (base->sType)', file=self.outFile)
         write('        {', file=self.outFile)
         write('        default:', file=self.outFile)
-        write('            // TODO: Report or raise fatal error for unrecongized sType?', file=self.outFile)
+        write(
+            '            // TODO: Report or raise fatal error for unrecongized sType?',
+            file=self.outFile)
         write('            break;', file=self.outFile)
         for baseType in self.pNextStructs:
-            write('        case {}:'.format(self.pNextStructs[baseType]), file=self.outFile)
-            write('            MapStructHandles(reinterpret_cast<Decoded_{}*>(wrapper), object_info_table);'.format(baseType), file=self.outFile)
+            write('        case {}:'.format(self.pNextStructs[baseType]),
+                  file=self.outFile)
+            write(
+                '            MapStructHandles(reinterpret_cast<Decoded_{}*>(wrapper), object_info_table);'
+                .format(baseType),
+                file=self.outFile)
             write('            break;', file=self.outFile)
         write('        }', file=self.outFile)
         write('    }', file=self.outFile)
@@ -103,13 +133,17 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
         # Generate handle adding functions for output structs with handles
         for struct in self.outputStructsWithHandles:
             self.newline()
-            write(self.makeStructHandleAdditions(struct, self.structsWithHandles[struct]), file=self.outFile)
+            write(self.makeStructHandleAdditions(
+                struct, self.structsWithHandles[struct]),
+                  file=self.outFile)
 
         # Generate handle memory allocation functions for output structs with handles
         for struct in self.outputStructsWithHandles:
             if struct in self.structsWithHandlePtrs:
                 self.newline()
-                write(self.makeStructHandleAllocations(struct, self.structsWithHandles[struct]), file=self.outFile)
+                write(self.makeStructHandleAllocations(
+                    struct, self.structsWithHandles[struct]),
+                      file=self.outFile)
 
         self.newline()
         write('GFXRECON_END_NAMESPACE(decode)', file=self.outFile)
@@ -124,7 +158,8 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
         BaseGenerator.genStruct(self, typeinfo, typename, alias)
 
         if not alias:
-            if self.checkStructMemberHandles(typename, self.structsWithHandles, self.structsWithHandlePtrs):
+            if self.checkStructMemberHandles(typename, self.structsWithHandles,
+                                             self.structsWithHandlePtrs):
                 # Track this struct if it can be present in a pNext chain, for generating the MapPNextStructHandles code.
                 parentStructs = typeinfo.elem.get('structextends')
                 if parentStructs:
@@ -157,7 +192,8 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
     # Performs C++ code generation for the feature.
     def generateFeature(self):
         for struct in self.getFilteredStructNames():
-            if (struct in self.structsWithHandles) or (struct in self.GENERIC_HANDLE_STRUCTS):
+            if (struct in self.structsWithHandles) or (
+                    struct in self.GENERIC_HANDLE_STRUCTS):
                 handleMembers = dict()
                 genericHandleMembers = dict()
 
@@ -173,12 +209,14 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
                     needsValuePtr = True
                 else:
                     for member in handleMembers:
-                        if self.isHandle(member.baseType) and not (member.isArray and not member.isDynamic):
+                        if self.isHandle(member.baseType) and not (
+                                member.isArray and not member.isDynamic):
                             needsValuePtr = True
                             break
 
                 body = '\n'
-                body += 'void MapStructHandles(Decoded_{}* wrapper, const VulkanObjectInfoTable& object_info_table)\n'.format(struct)
+                body += 'void MapStructHandles(Decoded_{}* wrapper, const VulkanObjectInfoTable& object_info_table)\n'.format(
+                    struct)
                 body += '{\n'
 
                 if not needsValuePtr:
@@ -187,9 +225,11 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
                 else:
                     body += '    if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))\n'
                     body += '    {\n'
-                    body += '        {}* value = wrapper->decoded_value;\n'.format(struct)
+                    body += '        {}* value = wrapper->decoded_value;\n'.format(
+                        struct)
 
-                body += self.makeStructHandleMappings(struct, handleMembers, genericHandleMembers)
+                body += self.makeStructHandleMappings(struct, handleMembers,
+                                                      genericHandleMembers)
                 body += '    }\n'
                 body += '}'
 
@@ -197,7 +237,8 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
 
     #
     # Generating expressions for mapping struct handles read from the capture file to handles created at replay.
-    def makeStructHandleMappings(self, name, handleMembers, genericHandleMembers):
+    def makeStructHandleMappings(self, name, handleMembers,
+                                 genericHandleMembers):
         body = ''
 
         for member in handleMembers:
@@ -211,34 +252,42 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
             elif self.isStruct(member.baseType):
                 # This is a struct that includes handles.
                 if member.isArray:
-                    body += '        MapStructArrayHandles<Decoded_{}>(wrapper->{name}->GetMetaStructPointer(), wrapper->{name}->GetLength(), object_info_table);\n'.format(member.baseType, name=member.name)
+                    body += '        MapStructArrayHandles<Decoded_{}>(wrapper->{name}->GetMetaStructPointer(), wrapper->{name}->GetLength(), object_info_table);\n'.format(
+                        member.baseType, name=member.name)
                 elif member.isPointer:
-                    body += '        MapStructArrayHandles<Decoded_{}>(wrapper->{}->GetMetaStructPointer(), 1, object_info_table);\n'.format(member.baseType, member.name)
+                    body += '        MapStructArrayHandles<Decoded_{}>(wrapper->{}->GetMetaStructPointer(), 1, object_info_table);\n'.format(
+                        member.baseType, member.name)
                 else:
-                    body += '        MapStructHandles(wrapper->{}, object_info_table);\n'.format(member.name)
+                    body += '        MapStructHandles(wrapper->{}, object_info_table);\n'.format(
+                        member.name)
             else:
                 # If it is an array or pointer, map with the utility function.
                 if (member.isArray or member.isPointer):
                     if member.isDynamic or member.isPointer:
-                        body += '        value->{name} = handle_mapping::MapHandleArray<{type}Info>(&wrapper->{name}, object_info_table, &VulkanObjectInfoTable::Get{type}Info);\n'.format(type=member.baseType[2:], name=member.name)
+                        body += '        value->{name} = handle_mapping::MapHandleArray<{type}Info>(&wrapper->{name}, object_info_table, &VulkanObjectInfoTable::Get{type}Info);\n'.format(
+                            type=member.baseType[2:], name=member.name)
                     else:
-                        body += '        handle_mapping::MapHandleArray<{type}Info>(&wrapper->{name}, object_info_table, &VulkanObjectInfoTable::Get{type}Info);\n'.format(type=member.baseType[2:], name=member.name)
+                        body += '        handle_mapping::MapHandleArray<{type}Info>(&wrapper->{name}, object_info_table, &VulkanObjectInfoTable::Get{type}Info);\n'.format(
+                            type=member.baseType[2:], name=member.name)
                 else:
-                    body += '        value->{name} = handle_mapping::MapHandle<{type}Info>(wrapper->{name}, object_info_table, &VulkanObjectInfoTable::Get{type}Info);\n'.format(type=member.baseType[2:], name=member.name)
+                    body += '        value->{name} = handle_mapping::MapHandle<{type}Info>(wrapper->{name}, object_info_table, &VulkanObjectInfoTable::Get{type}Info);\n'.format(
+                        type=member.baseType[2:], name=member.name)
 
         for member in genericHandleMembers:
             body += '\n'
-            body += '        value->{name} = handle_mapping::MapHandle(wrapper->{name}, value->{}, object_info_table);\n'.format(genericHandleMembers[member], name=member);
+            body += '        value->{name} = handle_mapping::MapHandle(wrapper->{name}, value->{}, object_info_table);\n'.format(
+                genericHandleMembers[member], name=member)
 
         return body
 
     #
     # Generating expressions for adding mappings for handles created at replay that are embedded in structs
     def makeStructHandleAdditions(self, name, members):
-        body = 'void AddStructHandles(format::HandleId parent_id, const Decoded_{name}* id_wrapper, const {name}* handle_struct, VulkanObjectInfoTable* object_info_table)\n'.format(name=name)
-        body +='{\n'
-        body +='    if (id_wrapper != nullptr)\n'
-        body +='    {\n'
+        body = 'void AddStructHandles(format::HandleId parent_id, const Decoded_{name}* id_wrapper, const {name}* handle_struct, VulkanObjectInfoTable* object_info_table)\n'.format(
+            name=name)
+        body += '{\n'
+        body += '    if (id_wrapper != nullptr)\n'
+        body += '    {\n'
 
         for member in members:
 
@@ -250,20 +299,30 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
             elif self.isStruct(member.baseType):
                 # This is a struct that includes handles.
                 if member.isArray:
-                    body += '        AddStructArrayHandles<Decoded_{}>(parent_id, id_wrapper->{name}->GetMetaStructPointer(), id_wrapper->{name}->GetLength(), handle_struct->{name}, static_cast<size_t>(handle_struct->{length}), object_info_table);\n'.format(member.baseType, name=member.name, length=member.arrayLength)
+                    body += '        AddStructArrayHandles<Decoded_{}>(parent_id, id_wrapper->{name}->GetMetaStructPointer(), id_wrapper->{name}->GetLength(), handle_struct->{name}, static_cast<size_t>(handle_struct->{length}), object_info_table);\n'.format(
+                        member.baseType,
+                        name=member.name,
+                        length=member.arrayLength)
                 elif member.isPointer:
-                    body += '        AddStructArrayHandles<Decoded_{}>(parent_id, id_wrapper->{name}->GetMetaStructPointer(), 1, handle_struct->{name}, 1, object_info_table);\n'.format(member.baseType, name=member.name)
+                    body += '        AddStructArrayHandles<Decoded_{}>(parent_id, id_wrapper->{name}->GetMetaStructPointer(), 1, handle_struct->{name}, 1, object_info_table);\n'.format(
+                        member.baseType, name=member.name)
                 else:
-                    body += '        AddStructHandles(parent_id, id_wrapper->{name}, &handle_struct->{name}, object_info_table);\n'.format(name=member.name)
+                    body += '        AddStructHandles(parent_id, id_wrapper->{name}, &handle_struct->{name}, object_info_table);\n'.format(
+                        name=member.name)
             else:
                 # If it is an array or pointer, add with the utility function.
                 if (member.isArray or member.isPointer):
                     if member.isArray:
-                        body += '        handle_mapping::AddHandleArray<{type}Info>(parent_id, id_wrapper->{name}.GetPointer(), id_wrapper->{name}.GetLength(), handle_struct->{name}, handle_struct->{length}, object_info_table, &VulkanObjectInfoTable::Add{type}Info);\n'.format(type=member.baseType[2:], name=member.name, length=member.arrayLength)
+                        body += '        handle_mapping::AddHandleArray<{type}Info>(parent_id, id_wrapper->{name}.GetPointer(), id_wrapper->{name}.GetLength(), handle_struct->{name}, handle_struct->{length}, object_info_table, &VulkanObjectInfoTable::Add{type}Info);\n'.format(
+                            type=member.baseType[2:],
+                            name=member.name,
+                            length=member.arrayLength)
                     else:
-                        body += '        handle_mapping::AddHandleArray<{type}Info>(parent_id, id_wrapper->{name}.GetPointer(), 1, handle_struct->{name}, 1, object_info_table, &VulkanObjectInfoTable::Add{type}Info);\n'.format(type=member.baseType[2:], name=member.name)
+                        body += '        handle_mapping::AddHandleArray<{type}Info>(parent_id, id_wrapper->{name}.GetPointer(), 1, handle_struct->{name}, 1, object_info_table, &VulkanObjectInfoTable::Add{type}Info);\n'.format(
+                            type=member.baseType[2:], name=member.name)
                 else:
-                    body += '        handle_mapping::AddHandle<{type}Info>(parent_id, id_wrapper->{name}, handle_struct->{name}, object_info_table, &VulkanObjectInfoTable::Add{type}Info);\n'.format(type=member.baseType[2:], name=member.name)
+                    body += '        handle_mapping::AddHandle<{type}Info>(parent_id, id_wrapper->{name}, handle_struct->{name}, object_info_table, &VulkanObjectInfoTable::Add{type}Info);\n'.format(
+                        type=member.baseType[2:], name=member.name)
 
         body += '    }\n'
         body += '}'
@@ -276,12 +335,14 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
         # and does not need a temporary variable referencing the struct value.
         needsValuePtr = False
         for member in members:
-            if self.isHandle(member.baseType) and not (member.isArray and not member.isDynamic):
+            if self.isHandle(member.baseType) and not (member.isArray and
+                                                       not member.isDynamic):
                 needsValuePtr = False
                 break
 
-        body = 'void SetStructHandleLengths(Decoded_{name}* wrapper)\n'.format(name=name)
-        body +='{\n'
+        body = 'void SetStructHandleLengths(Decoded_{name}* wrapper)\n'.format(
+            name=name)
+        body += '{\n'
 
         if not needsValuePtr:
             body += '    if (wrapper != nullptr)\n'
@@ -289,7 +350,8 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
         else:
             body += '    if ((wrapper != nullptr) && (wrapper->decoded_value != nullptr))\n'
             body += '    {\n'
-            body += '        {}* value = wrapper->decoded_value;\n'.format(name)
+            body += '        {}* value = wrapper->decoded_value;\n'.format(
+                name)
             body += '\n'
 
         for member in members:
@@ -301,21 +363,27 @@ class VulkanStructHandleMappersBodyGenerator(BaseGenerator):
             elif self.isStruct(member.baseType):
                 # This is a struct that includes handles.
                 if member.isArray:
-                    body += '        SetStructArrayHandleLengths<Decoded_{}>(wrapper->{name}->GetMetaStructPointer(), wrapper->{name}->GetLength());\n'.format(member.baseType, name=member.name)
+                    body += '        SetStructArrayHandleLengths<Decoded_{}>(wrapper->{name}->GetMetaStructPointer(), wrapper->{name}->GetLength());\n'.format(
+                        member.baseType, name=member.name)
                 elif member.isPointer:
-                    body += '        SetStructArrayHandleLengths<Decoded_{}>(wrapper->{name}->GetMetaStructPointer(), 1);\n'.format(member.baseType, name=member.name)
+                    body += '        SetStructArrayHandleLengths<Decoded_{}>(wrapper->{name}->GetMetaStructPointer(), 1);\n'.format(
+                        member.baseType, name=member.name)
                 else:
-                    body += '        SetStructHandleLengths(wrapper->{name});\n'.format(name=member.name)
+                    body += '        SetStructHandleLengths(wrapper->{name});\n'.format(
+                        name=member.name)
             else:
                 # If it is an array or pointer, add with the utility function.
                 if (member.isArray or member.isPointer):
                     if member.isArray:
-                        body += '        wrapper->{name}.SetHandleLength(wrapper->{name}.GetLength());\n'.format(name=member.name)
+                        body += '        wrapper->{name}.SetHandleLength(wrapper->{name}.GetLength());\n'.format(
+                            name=member.name)
                     else:
-                        body += '        wrapper->{}.SetHandleLength(1);\n'.format(member.name)
+                        body += '        wrapper->{}.SetHandleLength(1);\n'.format(
+                            member.name)
 
                     if member.isDynamic or member.isPointer:
-                        body += '        value->{name} = wrapper->{name}.GetHandlePointer();\n'.format(name=member.name)
+                        body += '        value->{name} = wrapper->{name}.GetHandlePointer();\n'.format(
+                            name=member.name)
 
         body += '    }\n'
         body += '}'

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
@@ -21,22 +21,32 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanStructHandleMappersHeaderGeneratorOptions(BaseGeneratorOptions):
     """Options for generating function prototypes to map Vulkan struct member handles at file replay"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanStructHandleMappersHeaderGenerator - subclass of BaseGenerator.
 # Generates C++ function prototypes for mapping struct member handles
@@ -44,12 +54,16 @@ class VulkanStructHandleMappersHeaderGeneratorOptions(BaseGeneratorOptions):
 class VulkanStructHandleMappersHeaderGenerator(BaseGenerator):
     """Generate C++ functions for Vulkan struct member handle mapping at file replay"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=True, processStructs=True, featureBreak=False,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=True,
+                               processStructs=True,
+                               featureBreak=False,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
         # Map of Vulkan structs containing handles to a list values for handle members or struct members
         # that contain handles (eg. VkGraphicsPipelineCreateInfo contains a VkPipelineShaderStageCreateInfo
@@ -64,9 +78,12 @@ class VulkanStructHandleMappersHeaderGenerator(BaseGenerator):
         BaseGenerator.beginFile(self, genOpts)
 
         write('#include "decode/pnext_node.h"', file=self.outFile)
-        write('#include "decode/vulkan_object_info_table.h"', file=self.outFile)
+        write('#include "decode/vulkan_object_info_table.h"',
+              file=self.outFile)
         write('#include "format/platform_types.h"', file=self.outFile)
-        write('#include "generated/generated_vulkan_struct_decoders_forward.h"', file=self.outFile)
+        write(
+            '#include "generated/generated_vulkan_struct_decoders_forward.h"',
+            file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
         write('#include "vulkan/vulkan.h"', file=self.outFile)
@@ -77,35 +94,50 @@ class VulkanStructHandleMappersHeaderGenerator(BaseGenerator):
     # Method override
     def endFile(self):
         self.newline()
-        write('void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectInfoTable& object_info_table);', file=self.outFile)
+        write(
+            'void MapPNextStructHandles(const void* value, void* wrapper, const VulkanObjectInfoTable& object_info_table);',
+            file=self.outFile)
         self.newline()
         write('template <typename T>', file=self.outFile)
-        write('void MapStructArrayHandles(T* structs, size_t len, const VulkanObjectInfoTable& object_info_table)', file=self.outFile)
+        write(
+            'void MapStructArrayHandles(T* structs, size_t len, const VulkanObjectInfoTable& object_info_table)',
+            file=self.outFile)
         write('{', file=self.outFile)
         write('    if (structs != nullptr)', file=self.outFile)
         write('    {', file=self.outFile)
         write('        for (size_t i = 0; i < len; ++i)', file=self.outFile)
         write('        {', file=self.outFile)
-        write('            MapStructHandles(&structs[i], object_info_table);', file=self.outFile)
+        write('            MapStructHandles(&structs[i], object_info_table);',
+              file=self.outFile)
         write('        }', file=self.outFile)
         write('    }', file=self.outFile)
         write('}', file=self.outFile)
         self.newline()
 
         for struct in self.outputStructsWithHandles:
-            write('void AddStructHandles(format::HandleId parent_id, const Decoded_{type}* id_wrapper, const {type}* handle_struct, VulkanObjectInfoTable* object_info_table);'.format(type=struct), file=self.outFile)
+            write(
+                'void AddStructHandles(format::HandleId parent_id, const Decoded_{type}* id_wrapper, const {type}* handle_struct, VulkanObjectInfoTable* object_info_table);'
+                .format(type=struct),
+                file=self.outFile)
             self.newline()
 
         write('template <typename T>', file=self.outFile)
-        write('void AddStructArrayHandles(format::HandleId parent_id, const T* id_wrappers, size_t id_len, const typename T::struct_type* handle_structs, size_t handle_len, VulkanObjectInfoTable* object_info_table)', file=self.outFile)
+        write(
+            'void AddStructArrayHandles(format::HandleId parent_id, const T* id_wrappers, size_t id_len, const typename T::struct_type* handle_structs, size_t handle_len, VulkanObjectInfoTable* object_info_table)',
+            file=self.outFile)
         write('{', file=self.outFile)
-        write('    if (id_wrappers != nullptr && handle_structs != nullptr)', file=self.outFile)
+        write('    if (id_wrappers != nullptr && handle_structs != nullptr)',
+              file=self.outFile)
         write('    {', file=self.outFile)
-        write('        // TODO: Improved handling of array size mismatch.', file=self.outFile)
-        write('        size_t len = std::min(id_len, handle_len);', file=self.outFile)
+        write('        // TODO: Improved handling of array size mismatch.',
+              file=self.outFile)
+        write('        size_t len = std::min(id_len, handle_len);',
+              file=self.outFile)
         write('        for (size_t i = 0; i < len; ++i)', file=self.outFile)
         write('        {', file=self.outFile)
-        write('            AddStructHandles(parent_id, &id_wrappers[i], &handle_structs[i], object_info_table);', file=self.outFile)
+        write(
+            '            AddStructHandles(parent_id, &id_wrappers[i], &handle_structs[i], object_info_table);',
+            file=self.outFile)
         write('        }', file=self.outFile)
         write('    }', file=self.outFile)
         write('}', file=self.outFile)
@@ -113,17 +145,21 @@ class VulkanStructHandleMappersHeaderGenerator(BaseGenerator):
 
         for struct in self.outputStructsWithHandles:
             if struct in self.structsWithHandlePtrs:
-                write('void SetStructHandleLengths(Decoded_{type}* wrapper);'.format(type=struct), file=self.outFile)
+                write('void SetStructHandleLengths(Decoded_{type}* wrapper);'.
+                      format(type=struct),
+                      file=self.outFile)
                 self.newline()
 
         write('template <typename T>', file=self.outFile)
-        write('void SetStructArrayHandleLengths(T* wrappers, size_t len)', file=self.outFile)
+        write('void SetStructArrayHandleLengths(T* wrappers, size_t len)',
+              file=self.outFile)
         write('{', file=self.outFile)
         write('    if (wrappers != nullptr)', file=self.outFile)
         write('    {', file=self.outFile)
         write('        for (size_t i = 0; i < len; ++i)', file=self.outFile)
         write('        {', file=self.outFile)
-        write('            SetStructHandleLengths(&wrappers[i]);', file=self.outFile)
+        write('            SetStructHandleLengths(&wrappers[i]);',
+              file=self.outFile)
         write('        }', file=self.outFile)
         write('    }', file=self.outFile)
         write('}', file=self.outFile)
@@ -141,7 +177,8 @@ class VulkanStructHandleMappersHeaderGenerator(BaseGenerator):
         BaseGenerator.genStruct(self, typeinfo, typename, alias)
 
         if not alias:
-            self.checkStructMemberHandles(typename, self.structsWithHandles, self.structsWithHandlePtrs)
+            self.checkStructMemberHandles(typename, self.structsWithHandles,
+                                          self.structsWithHandlePtrs)
 
     #
     # Method override
@@ -168,7 +205,9 @@ class VulkanStructHandleMappersHeaderGenerator(BaseGenerator):
     # Performs C++ code generation for the feature.
     def generateFeature(self):
         for struct in self.getFilteredStructNames():
-            if (struct in self.structsWithHandles) or (struct in self.GENERIC_HANDLE_STRUCTS):
+            if (struct in self.structsWithHandles) or (
+                    struct in self.GENERIC_HANDLE_STRUCTS):
                 body = '\n'
-                body += 'void MapStructHandles(Decoded_{}* wrapper, const VulkanObjectInfoTable& object_info_table);'.format(struct)
+                body += 'void MapStructHandles(Decoded_{}* wrapper, const VulkanObjectInfoTable& object_info_table);'.format(
+                    struct)
                 write(body, file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_mappers_header_generator.py
@@ -86,7 +86,7 @@ class VulkanStructHandleMappersHeaderGenerator(BaseGenerator):
             file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
-        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
         self.newline()
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(decode)', file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_wrappers_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_wrappers_body_generator.py
@@ -21,22 +21,32 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanStructHandleWrappersBodyGeneratorOptions(BaseGeneratorOptions):
     """Options for generating functions to wrap Vulkan struct member handles at API capture"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanStructHandleWrappersBodyGenerator - subclass of BaseGenerator.
 # Generates C++ functions responsible for wrapping struct member handles
@@ -44,25 +54,32 @@ class VulkanStructHandleWrappersBodyGeneratorOptions(BaseGeneratorOptions):
 class VulkanStructHandleWrappersBodyGenerator(BaseGenerator):
     """Generate C++ functions for Vulkan struct member handle wrapping at API capture"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=False, processStructs=True, featureBreak=False,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=False,
+                               processStructs=True,
+                               featureBreak=False,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
         # Map of Vulkan structs containing handles to a list values for handle members or struct members
         # that contain handles (eg. VkGraphicsPipelineCreateInfo contains a VkPipelineShaderStageCreateInfo
         # member that contains handles).
         self.structsWithHandles = dict()
-        self.pNextStructsWithHandles = dict()          # Map of Vulkan structure types to sType value for structs that can be part of a pNext chain and contain handles.
-        self.pNextStructsWithoutHandles = dict()       # Map of Vulkan structure types to sType value for structs that can be part of a pNext chain and do not contain handles.
+        self.pNextStructsWithHandles = dict(
+        )  # Map of Vulkan structure types to sType value for structs that can be part of a pNext chain and contain handles.
+        self.pNextStructsWithoutHandles = dict(
+        )  # Map of Vulkan structure types to sType value for structs that can be part of a pNext chain and do not contain handles.
 
     # Method override
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
 
-        write('#include "generated/generated_vulkan_struct_handle_wrappers.h"', file=self.outFile)
+        write('#include "generated/generated_vulkan_struct_handle_wrappers.h"',
+              file=self.outFile)
         self.newline()
         write('#include "vulkan/vk_layer.h"', file=self.outFile)
         self.newline()
@@ -73,7 +90,9 @@ class VulkanStructHandleWrappersBodyGenerator(BaseGenerator):
     def endFile(self):
         # Generate the pNext shallow copy code, for pNext structs that don't have handles, but need to be preserved in the overall copy for handle wrapping.
         self.newline()
-        write('static VkBaseInStructure* CopyPNextStruct(const VkBaseInStructure* base, HandleUnwrapMemory* unwrap_memory)', file=self.outFile)
+        write(
+            'static VkBaseInStructure* CopyPNextStruct(const VkBaseInStructure* base, HandleUnwrapMemory* unwrap_memory)',
+            file=self.outFile)
         write('{', file=self.outFile)
         write('    assert(base != nullptr);', file=self.outFile)
         self.newline()
@@ -81,17 +100,30 @@ class VulkanStructHandleWrappersBodyGenerator(BaseGenerator):
         write('    switch (base->sType)', file=self.outFile)
         write('    {', file=self.outFile)
         write('    default:', file=self.outFile)
-        write('        GFXRECON_LOG_WARNING("Failed to copy entire pNext chain when unwrapping handles due to unrecognized sType %d", base->sType);', file=self.outFile)
+        write(
+            '        GFXRECON_LOG_WARNING("Failed to copy entire pNext chain when unwrapping handles due to unrecognized sType %d", base->sType);',
+            file=self.outFile)
         write('        break;', file=self.outFile)
-        write('    case VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO:', file=self.outFile)
-        write('        copy = reinterpret_cast<VkBaseInStructure*>(MakeUnwrapStructs(reinterpret_cast<const VkLayerInstanceCreateInfo*>(base), 1, unwrap_memory));', file=self.outFile)
+        write('    case VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO:',
+              file=self.outFile)
+        write(
+            '        copy = reinterpret_cast<VkBaseInStructure*>(MakeUnwrapStructs(reinterpret_cast<const VkLayerInstanceCreateInfo*>(base), 1, unwrap_memory));',
+            file=self.outFile)
         write('        break;', file=self.outFile)
-        write('    case VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO:', file=self.outFile)
-        write('        copy = reinterpret_cast<VkBaseInStructure*>(MakeUnwrapStructs(reinterpret_cast<const VkLayerDeviceCreateInfo*>(base), 1, unwrap_memory));', file=self.outFile)
+        write('    case VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO:',
+              file=self.outFile)
+        write(
+            '        copy = reinterpret_cast<VkBaseInStructure*>(MakeUnwrapStructs(reinterpret_cast<const VkLayerDeviceCreateInfo*>(base), 1, unwrap_memory));',
+            file=self.outFile)
         write('        break;', file=self.outFile)
         for baseType in self.pNextStructsWithoutHandles:
-            write('    case {}:'.format(self.pNextStructsWithoutHandles[baseType]), file=self.outFile)
-            write('        copy = reinterpret_cast<VkBaseInStructure*>(MakeUnwrapStructs(reinterpret_cast<const {}*>(base), 1, unwrap_memory));'.format(baseType), file=self.outFile)
+            write('    case {}:'.format(
+                self.pNextStructsWithoutHandles[baseType]),
+                  file=self.outFile)
+            write(
+                '        copy = reinterpret_cast<VkBaseInStructure*>(MakeUnwrapStructs(reinterpret_cast<const {}*>(base), 1, unwrap_memory));'
+                .format(baseType),
+                file=self.outFile)
             write('        break;', file=self.outFile)
         write('    }', file=self.outFile)
         self.newline()
@@ -100,27 +132,42 @@ class VulkanStructHandleWrappersBodyGenerator(BaseGenerator):
 
         # Generate the pNext handle wrapping code.
         self.newline()
-        write('const void* UnwrapPNextStructHandles(const void* value, HandleUnwrapMemory* unwrap_memory)', file=self.outFile)
+        write(
+            'const void* UnwrapPNextStructHandles(const void* value, HandleUnwrapMemory* unwrap_memory)',
+            file=self.outFile)
         write('{', file=self.outFile)
         write('    if (value != nullptr)', file=self.outFile)
         write('    {', file=self.outFile)
-        write('        const VkBaseInStructure* base = reinterpret_cast<const VkBaseInStructure*>(value);', file=self.outFile)
+        write(
+            '        const VkBaseInStructure* base = reinterpret_cast<const VkBaseInStructure*>(value);',
+            file=self.outFile)
         self.newline()
         write('        switch (base->sType)', file=self.outFile)
         write('        {', file=self.outFile)
         write('        default:', file=self.outFile)
         write('        {', file=self.outFile)
-        write('            // This structure does not contain handles, but may point to a structure that does.', file=self.outFile)
-        write('            VkBaseInStructure* copy = CopyPNextStruct(base, unwrap_memory);', file=self.outFile)
+        write(
+            '            // This structure does not contain handles, but may point to a structure that does.',
+            file=self.outFile)
+        write(
+            '            VkBaseInStructure* copy = CopyPNextStruct(base, unwrap_memory);',
+            file=self.outFile)
         write('            if (copy != nullptr)', file=self.outFile)
         write('            {', file=self.outFile)
-        write('                copy->pNext = reinterpret_cast<const VkBaseInStructure*>(UnwrapPNextStructHandles(base->pNext, unwrap_memory));', file=self.outFile)
+        write(
+            '                copy->pNext = reinterpret_cast<const VkBaseInStructure*>(UnwrapPNextStructHandles(base->pNext, unwrap_memory));',
+            file=self.outFile)
         write('            }', file=self.outFile)
         write('            return copy;', file=self.outFile)
         write('        }', file=self.outFile)
         for baseType in self.pNextStructsWithHandles:
-            write('        case {}:'.format(self.pNextStructsWithHandles[baseType]), file=self.outFile)
-            write('            return UnwrapStructPtrHandles(reinterpret_cast<const {}*>(base), unwrap_memory);'.format(baseType), file=self.outFile)
+            write('        case {}:'.format(
+                self.pNextStructsWithHandles[baseType]),
+                  file=self.outFile)
+            write(
+                '            return UnwrapStructPtrHandles(reinterpret_cast<const {}*>(base), unwrap_memory);'
+                .format(baseType),
+                file=self.outFile)
         write('        }', file=self.outFile)
         write('    }', file=self.outFile)
         self.newline()
@@ -140,7 +187,8 @@ class VulkanStructHandleWrappersBodyGenerator(BaseGenerator):
         BaseGenerator.genStruct(self, typeinfo, typename, alias)
 
         if not alias:
-            hasHandles = self.checkStructMemberHandles(typename, self.structsWithHandles)
+            hasHandles = self.checkStructMemberHandles(typename,
+                                                       self.structsWithHandles)
 
             # Track this struct if it can be present in a pNext chain.
             parentStructs = typeinfo.elem.get('structextends')
@@ -163,7 +211,8 @@ class VulkanStructHandleWrappersBodyGenerator(BaseGenerator):
     # Performs C++ code generation for the feature.
     def generateFeature(self):
         for struct in self.getFilteredStructNames():
-            if (struct in self.structsWithHandles) or (struct in self.GENERIC_HANDLE_STRUCTS):
+            if (struct in self.structsWithHandles) or (
+                    struct in self.GENERIC_HANDLE_STRUCTS):
                 handleMembers = dict()
                 genericHandleMembers = dict()
 
@@ -173,11 +222,13 @@ class VulkanStructHandleWrappersBodyGenerator(BaseGenerator):
                     genericHandleMembers = self.GENERIC_HANDLE_STRUCTS[struct]
 
                 body = '\n'
-                body += 'void UnwrapStructHandles({}* value, HandleUnwrapMemory* unwrap_memory)\n'.format(struct)
+                body += 'void UnwrapStructHandles({}* value, HandleUnwrapMemory* unwrap_memory)\n'.format(
+                    struct)
                 body += '{\n'
                 body += '    if (value != nullptr)\n'
                 body += '    {'
-                body += self.makeStructHandleUnwrappings(struct, handleMembers, genericHandleMembers)
+                body += self.makeStructHandleUnwrappings(
+                    struct, handleMembers, genericHandleMembers)
                 body += '    }\n'
                 body += '}'
 
@@ -185,7 +236,8 @@ class VulkanStructHandleWrappersBodyGenerator(BaseGenerator):
 
     #
     # Generating expressions for unwrapping struct handles before an API call.
-    def makeStructHandleUnwrappings(self, name, handleMembers, genericHandleMembers):
+    def makeStructHandleUnwrappings(self, name, handleMembers,
+                                    genericHandleMembers):
         body = ''
 
         for member in handleMembers:
@@ -199,25 +251,37 @@ class VulkanStructHandleWrappersBodyGenerator(BaseGenerator):
             elif self.isStruct(member.baseType):
                 # This is a struct that includes handles.
                 if member.isArray:
-                    body += '        value->{name} = UnwrapStructArrayHandles(value->{name}, value->{}, unwrap_memory);\n'.format(member.arrayLength, name=member.name)
+                    body += '        value->{name} = UnwrapStructArrayHandles(value->{name}, value->{}, unwrap_memory);\n'.format(
+                        member.arrayLength, name=member.name)
                 elif member.isPointer:
-                    body += '        value->{name} = UnwrapStructPtrHandles(value->{name}, unwrap_memory);\n'.format(name=member.name)
+                    body += '        value->{name} = UnwrapStructPtrHandles(value->{name}, unwrap_memory);\n'.format(
+                        name=member.name)
                 else:
-                    body += '        UnwrapStructHandles(&value->{}, unwrap_memory);\n'.format(member.name)
+                    body += '        UnwrapStructHandles(&value->{}, unwrap_memory);\n'.format(
+                        member.name)
             else:
                 # If it is an array or pointer, map with the utility function.
                 if member.isArray:
                     if member.isDynamic:
-                        body += '        value->{name} = UnwrapHandles<{}>(value->{name}, value->{}, unwrap_memory);\n'.format(member.baseType, member.arrayLength, name=member.name);
+                        body += '        value->{name} = UnwrapHandles<{}>(value->{name}, value->{}, unwrap_memory);\n'.format(
+                            member.baseType,
+                            member.arrayLength,
+                            name=member.name)
                     else:
-                        body += '        std::transform(value->{name}, value->{name} + value->{}, value->{name}, GetWrappedHandle<{}>);\n'.format(member.arrayLength, member.baseType, name=member.name);
+                        body += '        std::transform(value->{name}, value->{name} + value->{}, value->{name}, GetWrappedHandle<{}>);\n'.format(
+                            member.arrayLength,
+                            member.baseType,
+                            name=member.name)
                 elif member.isPointer:
-                    body += '        value->{name} = UnwrapHandles<{}>(value->{name}, 1, unwrap_memory);\n'.format(member.baseType, name=member.name);
+                    body += '        value->{name} = UnwrapHandles<{}>(value->{name}, 1, unwrap_memory);\n'.format(
+                        member.baseType, name=member.name)
                 else:
-                    body += '        value->{name} = GetWrappedHandle<{}>(value->{name});\n'.format(member.baseType, name=member.name);
+                    body += '        value->{name} = GetWrappedHandle<{}>(value->{name});\n'.format(
+                        member.baseType, name=member.name)
 
         for member in genericHandleMembers:
             body += '\n'
-            body += '        value->{name} = GetWrappedHandle(value->{name}, value->{});\n'.format(genericHandleMembers[member], name=member);
+            body += '        value->{name} = GetWrappedHandle(value->{name}, value->{});\n'.format(
+                genericHandleMembers[member], name=member)
 
         return body

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_wrappers_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_wrappers_header_generator.py
@@ -83,7 +83,7 @@ class VulkanStructHandleWrappersHeaderGenerator(BaseGenerator):
         write('#include "format/platform_types.h"', file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
-        write('#include "vulkan/vulkan.h"', file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
         self.newline()
         write('GFXRECON_BEGIN_NAMESPACE(gfxrecon)', file=self.outFile)
         write('GFXRECON_BEGIN_NAMESPACE(encode)', file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_struct_handle_wrappers_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_handle_wrappers_header_generator.py
@@ -21,22 +21,32 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys
+import os, re, sys
 from base_generator import *
+
 
 class VulkanStructHandleWrappersHeaderGeneratorOptions(BaseGeneratorOptions):
     """Options for generating function prototypes to wrap Vulkan struct member handles at API capture"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanStructHandleWrappersHeaderGenerator - subclass of BaseGenerator.
 # Generates C++ function prototypes for wrapping struct member handles
@@ -44,25 +54,32 @@ class VulkanStructHandleWrappersHeaderGeneratorOptions(BaseGeneratorOptions):
 class VulkanStructHandleWrappersHeaderGenerator(BaseGenerator):
     """Generate C++ functions for Vulkan struct member handle wrapping at API capture"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=True, processStructs=True, featureBreak=False,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=True,
+                               processStructs=True,
+                               featureBreak=False,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
         # Map of Vulkan structs containing handles to a list values for handle members or struct members
         # that contain handles (eg. VkGraphicsPipelineCreateInfo contains a VkPipelineShaderStageCreateInfo
         # member that contains handles).
         self.structsWithHandles = dict()
-        self.outputStructs = []           # Output structures that retrieve handles, which need to be wrapped.
+        self.outputStructs = [
+        ]  # Output structures that retrieve handles, which need to be wrapped.
 
     # Method override
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
 
-        write('#include "encode/custom_vulkan_struct_handle_wrappers.h"', file=self.outFile)
-        write('#include "encode/vulkan_handle_wrapper_util.h"', file=self.outFile)
+        write('#include "encode/custom_vulkan_struct_handle_wrappers.h"',
+              file=self.outFile)
+        write('#include "encode/vulkan_handle_wrapper_util.h"',
+              file=self.outFile)
         write('#include "format/platform_types.h"', file=self.outFile)
         write('#include "util/defines.h"', file=self.outFile)
         self.newline()
@@ -74,62 +91,92 @@ class VulkanStructHandleWrappersHeaderGenerator(BaseGenerator):
     # Method override
     def endFile(self):
         self.newline()
-        write('const void* UnwrapPNextStructHandles(const void* value, HandleUnwrapMemory* unwrap_memory);', file=self.outFile)
+        write(
+            'const void* UnwrapPNextStructHandles(const void* value, HandleUnwrapMemory* unwrap_memory);',
+            file=self.outFile)
         self.newline()
         self.generateCreateWrapperFuncs()
-        write('template <typename ParentWrapper, typename CoParentWrapper, typename T>', file=self.outFile)
-        write('void CreateWrappedStructArrayHandles(typename ParentWrapper::HandleType parent, typename CoParentWrapper::HandleType co_parent, T* value, size_t len, PFN_GetHandleId get_id)', file=self.outFile)
+        write(
+            'template <typename ParentWrapper, typename CoParentWrapper, typename T>',
+            file=self.outFile)
+        write(
+            'void CreateWrappedStructArrayHandles(typename ParentWrapper::HandleType parent, typename CoParentWrapper::HandleType co_parent, T* value, size_t len, PFN_GetHandleId get_id)',
+            file=self.outFile)
         write('{', file=self.outFile)
         write('    if (value != nullptr)', file=self.outFile)
         write('    {', file=self.outFile)
         write('        for (size_t i = 0; i < len; ++i)', file=self.outFile)
         write('        {', file=self.outFile)
-        write('            CreateWrappedStructHandles<ParentWrapper, CoParentWrapper>(parent, co_parent, &value[i], get_id);', file=self.outFile)
+        write(
+            '            CreateWrappedStructHandles<ParentWrapper, CoParentWrapper>(parent, co_parent, &value[i], get_id);',
+            file=self.outFile)
         write('        }', file=self.outFile)
         write('    }', file=self.outFile)
         write('}', file=self.outFile)
         self.newline()
         write('template <typename T>', file=self.outFile)
-        write('T* MakeUnwrapStructs(const T* values, size_t len, HandleUnwrapMemory* unwrap_memory)', file=self.outFile)
+        write(
+            'T* MakeUnwrapStructs(const T* values, size_t len, HandleUnwrapMemory* unwrap_memory)',
+            file=self.outFile)
         write('{', file=self.outFile)
-        write('    assert((values != nullptr) && (len > 0) && (unwrap_memory != nullptr));', file=self.outFile)
+        write(
+            '    assert((values != nullptr) && (len > 0) && (unwrap_memory != nullptr));',
+            file=self.outFile)
         self.newline()
-        write('    const uint8_t* bytes     = reinterpret_cast<const uint8_t*>(values);', file=self.outFile)
-        write('    size_t         num_bytes = len * sizeof(T);', file=self.outFile)
+        write(
+            '    const uint8_t* bytes     = reinterpret_cast<const uint8_t*>(values);',
+            file=self.outFile)
+        write('    size_t         num_bytes = len * sizeof(T);',
+              file=self.outFile)
         self.newline()
-        write('    return reinterpret_cast<T*>(unwrap_memory->GetFilledBuffer(bytes, num_bytes));', file=self.outFile)
+        write(
+            '    return reinterpret_cast<T*>(unwrap_memory->GetFilledBuffer(bytes, num_bytes));',
+            file=self.outFile)
         write('}', file=self.outFile)
         self.newline()
         write('template <typename T>', file=self.outFile)
-        write('const T* UnwrapStructPtrHandles(const T* value, HandleUnwrapMemory* unwrap_memory)', file=self.outFile)
+        write(
+            'const T* UnwrapStructPtrHandles(const T* value, HandleUnwrapMemory* unwrap_memory)',
+            file=self.outFile)
         write('{', file=self.outFile)
         write('    T* unwrapped_struct = nullptr;', file=self.outFile)
         self.newline()
         write('    if (value != nullptr)', file=self.outFile)
         write('    {', file=self.outFile)
-        write('        unwrapped_struct = MakeUnwrapStructs(value, 1, unwrap_memory);', file=self.outFile)
-        write('        UnwrapStructHandles(unwrapped_struct, unwrap_memory);', file=self.outFile)
+        write(
+            '        unwrapped_struct = MakeUnwrapStructs(value, 1, unwrap_memory);',
+            file=self.outFile)
+        write('        UnwrapStructHandles(unwrapped_struct, unwrap_memory);',
+              file=self.outFile)
         write('    }', file=self.outFile)
         self.newline()
         write('    return unwrapped_struct;', file=self.outFile)
         write('}', file=self.outFile)
         self.newline()
         write('template <typename T>', file=self.outFile)
-        write('const T* UnwrapStructArrayHandles(const T* values, size_t len, HandleUnwrapMemory* unwrap_memory)', file=self.outFile)
+        write(
+            'const T* UnwrapStructArrayHandles(const T* values, size_t len, HandleUnwrapMemory* unwrap_memory)',
+            file=self.outFile)
         write('{', file=self.outFile)
         write('    if ((values != nullptr) && (len > 0))', file=self.outFile)
         write('    {', file=self.outFile)
-        write('        auto unwrapped_structs = MakeUnwrapStructs(values, len, unwrap_memory);', file=self.outFile)
+        write(
+            '        auto unwrapped_structs = MakeUnwrapStructs(values, len, unwrap_memory);',
+            file=self.outFile)
         self.newline()
         write('        for (size_t i = 0; i < len; ++i)', file=self.outFile)
         write('        {', file=self.outFile)
-        write('            UnwrapStructHandles(&unwrapped_structs[i], unwrap_memory);', file=self.outFile)
+        write(
+            '            UnwrapStructHandles(&unwrapped_structs[i], unwrap_memory);',
+            file=self.outFile)
         write('        }', file=self.outFile)
         self.newline()
         write('        return unwrapped_structs;', file=self.outFile)
         write('    }', file=self.outFile)
         self.newline()
-        write('    // Leave the original memory in place when the pointer is not null, but size is zero.', file=self.outFile)
+        write(
+            '    // Leave the original memory in place when the pointer is not null, but size is zero.',
+            file=self.outFile)
         write('    return values;', file=self.outFile)
         write('}', file=self.outFile)
         self.newline()
@@ -163,14 +210,20 @@ class VulkanStructHandleWrappersHeaderGenerator(BaseGenerator):
             values = info[2]
 
             for value in values:
-                if self.isOutputParameter(value) and self.isStruct(value.baseType) and (value.baseType in self.structsWithHandles) and (value.baseType not in self.outputStructs):
+                if self.isOutputParameter(value) and self.isStruct(
+                        value.baseType) and (value.baseType
+                                             in self.structsWithHandles) and (
+                                                 value.baseType
+                                                 not in self.outputStructs):
                     self.outputStructs.append(value.baseType)
 
         # Generate unwrap and rewrap code for input structures.
         for struct in self.getFilteredStructNames():
-            if (struct in self.structsWithHandles) or (struct in self.GENERIC_HANDLE_STRUCTS):
+            if (struct in self.structsWithHandles) or (
+                    struct in self.GENERIC_HANDLE_STRUCTS):
                 body = '\n'
-                body += 'void UnwrapStructHandles({}* value, HandleUnwrapMemory* unwrap_memory);'.format(struct)
+                body += 'void UnwrapStructHandles({}* value, HandleUnwrapMemory* unwrap_memory);'.format(
+                    struct)
                 write(body, file=self.outFile)
 
     #
@@ -178,7 +231,8 @@ class VulkanStructHandleWrappersHeaderGenerator(BaseGenerator):
     def generateCreateWrapperFuncs(self):
         for struct in self.outputStructs:
             body = 'template <typename ParentWrapper, typename CoParentWrapper>\n'
-            body += 'void CreateWrappedStructHandles(typename ParentWrapper::HandleType parent, typename CoParentWrapper::HandleType co_parent, {}* value, PFN_GetHandleId get_id)\n'.format(struct)
+            body += 'void CreateWrappedStructHandles(typename ParentWrapper::HandleType parent, typename CoParentWrapper::HandleType co_parent, {}* value, PFN_GetHandleId get_id)\n'.format(
+                struct)
             body += '{\n'
             body += '    if (value != nullptr)\n'
             body += '    {\n'
@@ -187,18 +241,25 @@ class VulkanStructHandleWrappersHeaderGenerator(BaseGenerator):
             for member in members:
                 if self.isStruct(member.baseType):
                     if member.isArray:
-                        body += '        CreateWrappedStructArrayHandles<ParentWrapper, CoParentWrapper, {}>(parent, co_parent, value->{}, value->{}, get_id);\n'.format(member.baseType, member.name, member.arrayLength)
+                        body += '        CreateWrappedStructArrayHandles<ParentWrapper, CoParentWrapper, {}>(parent, co_parent, value->{}, value->{}, get_id);\n'.format(
+                            member.baseType, member.name, member.arrayLength)
                     elif member.isPointer:
-                        body += '        CreateWrappedStructHandles<ParentWrapper, CoParentWrapper>(parent, co_parent, value->{}, get_id);\n'.format(member.name)
+                        body += '        CreateWrappedStructHandles<ParentWrapper, CoParentWrapper>(parent, co_parent, value->{}, get_id);\n'.format(
+                            member.name)
                     else:
-                        body += '        CreateWrappedStructHandles<ParentWrapper, CoParentWrapper>(parent, co_parent, &value->{}, get_id);\n'.format(member.name)
+                        body += '        CreateWrappedStructHandles<ParentWrapper, CoParentWrapper>(parent, co_parent, &value->{}, get_id);\n'.format(
+                            member.name)
                 else:
                     if member.isArray:
-                        body += '        CreateWrappedHandles<ParentWrapper, CoParentWrapper, {}Wrapper>(parent, co_parent, value->{}, value->{}, get_id);\n'.format(member.baseType[2:], member.name, member.arrayLength)
+                        body += '        CreateWrappedHandles<ParentWrapper, CoParentWrapper, {}Wrapper>(parent, co_parent, value->{}, value->{}, get_id);\n'.format(
+                            member.baseType[2:], member.name,
+                            member.arrayLength)
                     elif member.isPointer:
-                        body += '        CreateWrappedHandle<ParentWrapper, CoParentWrapper, {}Wrapper>(parent, co_parent, value->{}, get_id);\n'.format(member.baseType[2:], member.name)
+                        body += '        CreateWrappedHandle<ParentWrapper, CoParentWrapper, {}Wrapper>(parent, co_parent, value->{}, get_id);\n'.format(
+                            member.baseType[2:], member.name)
                     else:
-                        body += '        CreateWrappedHandle<ParentWrapper, CoParentWrapper, {}Wrapper>(parent, co_parent, &value->{}, get_id);\n'.format(member.baseType[2:], member.name)
+                        body += '        CreateWrappedHandle<ParentWrapper, CoParentWrapper, {}Wrapper>(parent, co_parent, &value->{}, get_id);\n'.format(
+                            member.baseType[2:], member.name)
 
             body += '    }\n'
             body += '}\n'

--- a/framework/generated/vulkan_generators/vulkan_struct_to_string_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_to_string_body_generator.py
@@ -20,34 +20,48 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys,inspect
+import os, re, sys, inspect
 from base_generator import *
+
 
 class VulkanStructToStringBodyGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ functions for Vulkan ToString() functions"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanStructToStringBodyGenerator - subclass of BaseGenerator.
 # Generates C++ functions for stringifying Vulkan API structures.
 class VulkanStructToStringBodyGenerator(BaseGenerator):
     """Generate C++ functions for Vulkan ToString() functions"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=False, processStructs=True, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=False,
+                               processStructs=True,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
         # The following structures require custom implementations for ToString()
         self.customImplementationRequired = {
@@ -105,7 +119,8 @@ class VulkanStructToStringBodyGenerator(BaseGenerator):
                             {{
                     '''.format(struct))
                 body += '\n'
-                body += self.makeStructBody(struct, self.featureStructMembers[struct])
+                body += self.makeStructBody(struct,
+                                            self.featureStructMembers[struct])
                 body += inspect.cleandoc('''
                             }
                         );
@@ -187,5 +202,6 @@ class VulkanStructToStringBodyGenerator(BaseGenerator):
 
             firstField = 'true' if not body else 'false'
             toString = toString.format(value.name, value.arrayLength)
-            body += '            FieldToString(strStrm, {0}, "{1}", toStringFlags, tabCount, tabSize, {2});\n'.format(firstField, value.name, toString)
+            body += '            FieldToString(strStrm, {0}, "{1}", toStringFlags, tabCount, tabSize, {2});\n'.format(
+                firstField, value.name, toString)
         return body

--- a/framework/generated/vulkan_generators/vulkan_struct_to_string_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_to_string_header_generator.py
@@ -20,34 +20,48 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
-import os,re,sys,inspect
+import os, re, sys, inspect
 from base_generator import *
+
 
 class VulkanStructToStringHeaderGeneratorOptions(BaseGeneratorOptions):
     """Options for generating C++ functions for Vulkan ToString() functions"""
-    def __init__(self,
-                 blacklists = None,         # Path to JSON file listing apicalls and structs to ignore.
-                 platformTypes = None,      # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
-                 filename = None,
-                 directory = '.',
-                 prefixText = '',
-                 protectFile = False,
-                 protectFeature = True):
-        BaseGeneratorOptions.__init__(self, blacklists, platformTypes,
-                                      filename, directory, prefixText,
-                                      protectFile, protectFeature)
+    def __init__(
+            self,
+            blacklists=None,  # Path to JSON file listing apicalls and structs to ignore.
+            platformTypes=None,  # Path to JSON file listing platform (WIN32, X11, etc.) defined types.
+            filename=None,
+            directory='.',
+            prefixText='',
+            protectFile=False,
+            protectFeature=True,
+            extraVulkanHeaders=[]):
+        BaseGeneratorOptions.__init__(self,
+                                      blacklists,
+                                      platformTypes,
+                                      filename,
+                                      directory,
+                                      prefixText,
+                                      protectFile,
+                                      protectFeature,
+                                      extraVulkanHeaders=extraVulkanHeaders)
+
 
 # VulkanStructToStringHeaderGenerator - subclass of BaseGenerator.
 # Generates C++ functions for stringifying Vulkan API structures.
 class VulkanStructToStringHeaderGenerator(BaseGenerator):
     """Generate C++ functions for Vulkan ToString() functions"""
     def __init__(self,
-                 errFile = sys.stderr,
-                 warnFile = sys.stderr,
-                 diagFile = sys.stdout):
+                 errFile=sys.stderr,
+                 warnFile=sys.stderr,
+                 diagFile=sys.stdout):
         BaseGenerator.__init__(self,
-                               processCmds=False, processStructs=True, featureBreak=True,
-                               errFile=errFile, warnFile=warnFile, diagFile=diagFile)
+                               processCmds=False,
+                               processStructs=True,
+                               featureBreak=True,
+                               errFile=errFile,
+                               warnFile=warnFile,
+                               diagFile=diagFile)
 
     # Method override
     def beginFile(self, genOpts):
@@ -86,5 +100,6 @@ class VulkanStructToStringHeaderGenerator(BaseGenerator):
     # Performs C++ code generation for the feature.
     def generateFeature(self):
         for struct in self.getFilteredStructNames():
-            body = 'template <> std::string ToString<{0}>(const {0}& obj, ToStringFlags toStriingFlags, uint32_t tabCount, uint32_t tabSize);'.format(struct)
+            body = 'template <> std::string ToString<{0}>(const {0}& obj, ToStringFlags toStriingFlags, uint32_t tabCount, uint32_t tabSize);'.format(
+                struct)
             write(body, file=self.outFile)

--- a/framework/generated/vulkan_generators/vulkan_struct_to_string_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_to_string_header_generator.py
@@ -66,16 +66,17 @@ class VulkanStructToStringHeaderGenerator(BaseGenerator):
     # Method override
     def beginFile(self, genOpts):
         BaseGenerator.beginFile(self, genOpts)
-        body = inspect.cleandoc('''
+        includes = inspect.cleandoc('''
             #include "format/platform_types.h"
             #include "util/to_string.h"
-            
-            #include "vulkan/vulkan.h"
-
+            ''')
+        write(includes, file=self.outFile)
+        self.includeVulkanHeaders(genOpts)
+        namespace = inspect.cleandoc('''
             GFXRECON_BEGIN_NAMESPACE(gfxrecon)
             GFXRECON_BEGIN_NAMESPACE(util)
             ''')
-        write(body, file=self.outFile)
+        write(namespace, file=self.outFile)
 
     # Method override
     def endFile(self):


### PR DESCRIPTION
Adds an option to use a user provided Vulkan registry and Vulkan header files to generate source code.

This is useful to generate GFXR code for experimental features and proposals that are not part of the official Vulkan registry.

Note that the script code contains some formatting change that resulted from running YAPF.