### PR TITLE
wsi-context

### DIFF
--- a/android/framework/application/CMakeLists.txt
+++ b/android/framework/application/CMakeLists.txt
@@ -2,12 +2,14 @@ add_library(gfxrecon_application STATIC "")
 
 target_sources(gfxrecon_application
                PRIVATE
-                   ${GFXRECON_SOURCE_DIR}/framework/application/android_application.h
-                   ${GFXRECON_SOURCE_DIR}/framework/application/android_application.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/application/android_context.h
+                   ${GFXRECON_SOURCE_DIR}/framework/application/android_context.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/application/android_window.h
                    ${GFXRECON_SOURCE_DIR}/framework/application/android_window.cpp
                    ${GFXRECON_SOURCE_DIR}/framework/application/application.h
                    ${GFXRECON_SOURCE_DIR}/framework/application/application.cpp
+                   ${GFXRECON_SOURCE_DIR}/framework/application/wsi_context.h
+                   ${GFXRECON_SOURCE_DIR}/framework/application/wsi_context.cpp
               )
 
 target_include_directories(gfxrecon_application

--- a/framework/application/CMakeLists.txt
+++ b/framework/application/CMakeLists.txt
@@ -32,25 +32,27 @@ target_sources(gfxrecon_application
                PRIVATE
                     ${CMAKE_CURRENT_LIST_DIR}/application.h
                     ${CMAKE_CURRENT_LIST_DIR}/application.cpp
-                    $<$<BOOL:${HEADLESS}>:${CMAKE_CURRENT_LIST_DIR}/headless_application.h>
+                    ${CMAKE_CURRENT_LIST_DIR}/wsi_context.h
+                    ${CMAKE_CURRENT_LIST_DIR}/wsi_context.cpp
+                    $<$<BOOL:${HEADLESS}>:${CMAKE_CURRENT_LIST_DIR}/headless_context.h>
                     $<$<BOOL:${HEADLESS}>:${CMAKE_CURRENT_LIST_DIR}/headless_window.h>
-                    $<$<BOOL:${HEADLESS}>:${CMAKE_CURRENT_LIST_DIR}/headless_application.cpp>
+                    $<$<BOOL:${HEADLESS}>:${CMAKE_CURRENT_LIST_DIR}/headless_context.cpp>
                     $<$<BOOL:${HEADLESS}>:${CMAKE_CURRENT_LIST_DIR}/headless_window.cpp>
-                    $<$<BOOL:${XCB_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/xcb_application.h>
+                    $<$<BOOL:${XCB_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/xcb_context.h>
                     $<$<BOOL:${XCB_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/xcb_window.h>
-                    $<$<BOOL:${XCB_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/xcb_application.cpp>
+                    $<$<BOOL:${XCB_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/xcb_context.cpp>
                     $<$<BOOL:${XCB_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/xcb_window.cpp>
-                    $<$<BOOL:${X11_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/xlib_application.h>
+                    $<$<BOOL:${X11_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/xlib_context.h>
                     $<$<BOOL:${X11_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/xlib_window.h>
-                    $<$<BOOL:${X11_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/xlib_application.cpp>
+                    $<$<BOOL:${X11_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/xlib_context.cpp>
                     $<$<BOOL:${X11_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/xlib_window.cpp>
-                    $<$<BOOL:${WAYLAND_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/wayland_application.h>
+                    $<$<BOOL:${WAYLAND_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/wayland_context.h>
                     $<$<BOOL:${WAYLAND_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/wayland_window.h>
-                    $<$<BOOL:${WAYLAND_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/wayland_application.cpp>
+                    $<$<BOOL:${WAYLAND_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/wayland_context.cpp>
                     $<$<BOOL:${WAYLAND_FOUND}>:${CMAKE_CURRENT_LIST_DIR}/wayland_window.cpp>
-                    $<$<BOOL:${WIN32}>:${CMAKE_CURRENT_LIST_DIR}/win32_application.h>
+                    $<$<BOOL:${WIN32}>:${CMAKE_CURRENT_LIST_DIR}/win32_context.h>
                     $<$<BOOL:${WIN32}>:${CMAKE_CURRENT_LIST_DIR}/win32_window.h>
-                    $<$<BOOL:${WIN32}>:${CMAKE_CURRENT_LIST_DIR}/win32_application.cpp>
+                    $<$<BOOL:${WIN32}>:${CMAKE_CURRENT_LIST_DIR}/win32_context.cpp>
                     $<$<BOOL:${WIN32}>:${CMAKE_CURRENT_LIST_DIR}/win32_window.cpp>
               )
 
@@ -77,4 +79,3 @@ if (${RUN_TESTS})
     common_build_directives(gfxrecon_application_test)
     common_test_directives(gfxrecon_application_test)
 endif()
-

--- a/framework/application/android_context.cpp
+++ b/framework/application/android_context.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2021 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -21,8 +21,8 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#include "application/android_application.h"
-
+#include "application/android_context.h"
+#include "application/application.h"
 #include "application/android_window.h"
 
 #include <jni.h>
@@ -30,22 +30,21 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
-AndroidApplication::AndroidApplication(const std::string& name, struct android_app* app) :
-    Application(name), window_(nullptr), android_app_(app)
+AndroidContext::AndroidContext(ApplicationEx* application, struct android_app* app) :
+    WsiContext(application), android_app_(app)
 {
-    assert(app != nullptr);
+    assert(android_app_);
+    window_factory_ = std::make_unique<AndroidWindowFactory>(this);
 }
 
-bool AndroidApplication::Initialize(decode::FileProcessor* file_processor)
+AndroidContext::~AndroidContext()
 {
-
-    SetFileProcessor(file_processor);
-
-    return true;
 }
 
-void AndroidApplication::ProcessEvents(bool wait_for_input)
+void AndroidContext::ProcessEvents(bool wait_for_input)
 {
+    assert(application_);
+    assert(android_app_);
     // Process all pending events.
     for (;;)
     {
@@ -72,7 +71,7 @@ void AndroidApplication::ProcessEvents(bool wait_for_input)
 
             if (android_app_->destroyRequested != 0)
             {
-                StopRunning();
+                application_->StopRunning();
                 break;
             }
         }
@@ -83,12 +82,12 @@ void AndroidApplication::ProcessEvents(bool wait_for_input)
     }
 }
 
-void AndroidApplication::InitWindow()
+void AndroidContext::InitWindow()
 {
     window_ = std::make_unique<AndroidWindow>(this, android_app_->window);
 }
 
-void AndroidApplication::SetOrientation(ScreenOrientation orientation)
+void AndroidContext::SetOrientation(ScreenOrientation orientation)
 {
     JavaVM* jni_vm       = nullptr;
     jobject jni_activity = nullptr;

--- a/framework/application/android_context.h
+++ b/framework/application/android_context.h
@@ -1,0 +1,70 @@
+/*
+** Copyright (c) 2018 Valve Corporation
+** Copyright (c) 2018-2021 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef GFXRECON_APPLICATION_ANDROID_CONTEXT_H
+#define GFXRECON_APPLICATION_ANDROID_CONTEXT_H
+
+#include "application/wsi_context.h"
+#include "util/defines.h"
+#include "util/platform.h"
+
+#include <android_native_app_glue.h>
+
+#include <memory>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(application)
+
+class ApplicationEx;
+class AndroidWindow;
+
+class AndroidContext : public WsiContext
+{
+  public:
+    enum ScreenOrientation : int32_t
+    {
+        kLandscape = 0,
+        kPortrait  = 1
+    };
+
+    AndroidContext(ApplicationEx* application, struct android_app* app);
+
+    ~AndroidContext() override;
+
+    virtual void ProcessEvents(bool wait_for_input) override;
+
+    AndroidWindow* GetWindow() const { return window_.get(); }
+
+    void InitWindow();
+
+    void SetOrientation(ScreenOrientation orientation);
+
+  private:
+    std::unique_ptr<AndroidWindow> window_ { };
+    struct android_app*            android_app_ { };
+};
+
+GFXRECON_END_NAMESPACE(application)
+GFXRECON_END_NAMESPACE(gfxrecon)
+
+#endif // GFXRECON_APPLICATION_ANDROID_CONTEXT_H

--- a/framework/application/android_window.cpp
+++ b/framework/application/android_window.cpp
@@ -22,7 +22,7 @@
 */
 
 #include "application/android_window.h"
-
+#include "application/application.h"
 #include "util/logging.h"
 
 #include <android/native_window.h>
@@ -35,10 +35,10 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
-AndroidWindow::AndroidWindow(AndroidApplication* application, ANativeWindow* window) :
-    android_application_(application), window_(window), width_(0), height_(0), pre_transform_(0)
+AndroidWindow::AndroidWindow(AndroidContext* android_context, ANativeWindow* window) :
+    android_context_(android_context), window_(window), width_(0), height_(0), pre_transform_(0)
 {
-    assert((application != nullptr) && (window != nullptr));
+    assert((android_context_ != nullptr) && (window != nullptr));
 
     width_  = ANativeWindow_getWidth(window_);
     height_ = ANativeWindow_getHeight(window_);
@@ -67,8 +67,8 @@ void AndroidWindow::SetSizePreTransform(const uint32_t width, const uint32_t hei
         if (((width != height) && ((width < height) != (pixel_width < pixel_height))) ||
             (pre_transform != format::ResizeWindowPreTransform::kPreTransform0))
         {
-            const std::array<AndroidApplication::ScreenOrientation, 2> kOrientations{
-                AndroidApplication::ScreenOrientation::kLandscape, AndroidApplication::ScreenOrientation::kPortrait
+            const std::array<AndroidContext::ScreenOrientation, 2> kOrientations{
+                AndroidContext::ScreenOrientation::kLandscape, AndroidContext::ScreenOrientation::kPortrait
             };
 
             uint32_t orientation_index = 0;
@@ -85,7 +85,7 @@ void AndroidWindow::SetSizePreTransform(const uint32_t width, const uint32_t hei
                 orientation_index ^= 1;
             }
 
-            android_application_->SetOrientation(kOrientations[orientation_index]);
+            android_context_->SetOrientation(kOrientations[orientation_index]);
         }
 
         int32_t result = ANativeWindow_setBuffersGeometry(window_, width, height, ANativeWindow_getFormat(window_));
@@ -136,9 +136,9 @@ void AndroidWindow::DestroySurface(const encode::InstanceTable* table, VkInstanc
     }
 }
 
-AndroidWindowFactory::AndroidWindowFactory(AndroidApplication* application) : android_application_(application)
+AndroidWindowFactory::AndroidWindowFactory(AndroidContext* android_context) : android_context_(android_context)
 {
-    assert(application != nullptr);
+    assert(android_context_ != nullptr);
 }
 
 AndroidWindowFactory::~AndroidWindowFactory() {}
@@ -151,12 +151,12 @@ AndroidWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t wi
     GFXRECON_UNREFERENCED_PARAMETER(width);
     GFXRECON_UNREFERENCED_PARAMETER(height);
 
-    return android_application_->GetWindow();
+    return android_context_->GetWindow();
 }
 
 void AndroidWindowFactory::Destroy(decode::Window* window)
 {
-    // Android currently has a single window whose lifetime is managed by AndroidApplication.
+    // Android currently has a single window whose lifetime is managed by AndroidContext.
     GFXRECON_UNREFERENCED_PARAMETER(window);
 }
 

--- a/framework/application/android_window.h
+++ b/framework/application/android_window.h
@@ -24,7 +24,7 @@
 #ifndef GFXRECON_APPLICATION_ANDROID_WINDOW_H
 #define GFXRECON_APPLICATION_ANDROID_WINDOW_H
 
-#include "application/android_application.h"
+#include "application/android_context.h"
 #include "decode/window.h"
 #include "util/defines.h"
 #include "util/platform.h"
@@ -37,7 +37,7 @@ GFXRECON_BEGIN_NAMESPACE(application)
 class AndroidWindow : public decode::Window
 {
   public:
-    AndroidWindow(AndroidApplication* application, ANativeWindow* window);
+    AndroidWindow(AndroidContext* android_context, ANativeWindow* window);
 
     virtual ~AndroidWindow() override {}
 
@@ -71,17 +71,17 @@ class AndroidWindow : public decode::Window
     virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
-    AndroidApplication* android_application_;
-    ANativeWindow*      window_;
-    uint32_t            width_;
-    uint32_t            height_;
-    uint32_t            pre_transform_;
+    AndroidContext* android_context_;
+    ANativeWindow*  window_;
+    uint32_t        width_;
+    uint32_t        height_;
+    uint32_t        pre_transform_;
 };
 
 class AndroidWindowFactory : public decode::WindowFactory
 {
   public:
-    AndroidWindowFactory(AndroidApplication* application);
+    AndroidWindowFactory(AndroidContext* android_context);
 
     virtual ~AndroidWindowFactory();
 
@@ -97,7 +97,7 @@ class AndroidWindowFactory : public decode::WindowFactory
                                                           uint32_t                     queue_family_index) override;
 
   private:
-    AndroidApplication* android_application_;
+    AndroidContext* android_context_;
 };
 
 GFXRECON_END_NAMESPACE(application)

--- a/framework/application/application.cpp
+++ b/framework/application/application.cpp
@@ -22,8 +22,26 @@
 */
 
 #include "application/application.h"
-
 #include "util/logging.h"
+
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+#include "application/win32_context.h"
+#endif
+#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+#include "application/wayland_context.h"
+#endif
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+#include "application/xcb_context.h"
+#endif
+#if defined(VK_USE_PLATFORM_XLIB_KHR)
+#include "application/xlib_context.h"
+#endif
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+#include "application/android_context.h"
+#endif
+#if defined(VK_USE_PLATFORM_HEADLESS)
+#include "application/headless_context.h"
+#endif
 
 #include <algorithm>
 #include <cassert>
@@ -31,30 +49,16 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
-Application::Application(const std::string& name) :
-    file_processor_(nullptr), running_(false), paused_(false), name_(name)
-{}
-
-Application::~Application()
+ApplicationEx::ApplicationEx(const std::string& name, decode::FileProcessor* file_processor) :
+    name_(name), file_processor_(file_processor), running_(false), paused_(false), pause_frame_(0)
 {
-    if (!windows_.empty())
-    {
-        GFXRECON_LOG_INFO(
-            "Application manager is destroying windows that were not previously destroyed by their owner");
-
-        for (auto window : windows_)
-        {
-            delete window;
-        }
-    }
 }
 
-void Application::SetFileProcessor(decode::FileProcessor* file_processor)
+ApplicationEx ::~ApplicationEx()
 {
-    file_processor_ = file_processor;
 }
 
-void Application::Run()
+void ApplicationEx::Run()
 {
     running_ = true;
 
@@ -70,9 +74,8 @@ void Application::Run()
     }
 }
 
-void Application::SetPaused(bool paused)
+void ApplicationEx::SetPaused(bool paused)
 {
-
     paused_ = paused;
 
     if (paused_ && (file_processor_ != nullptr))
@@ -85,7 +88,7 @@ void Application::SetPaused(bool paused)
     }
 }
 
-bool Application::PlaySingleFrame()
+bool ApplicationEx::PlaySingleFrame()
 {
     bool success = false;
 
@@ -117,37 +120,64 @@ bool Application::PlaySingleFrame()
     return success;
 }
 
-bool Application::RegisterWindow(decode::Window* window)
+void ApplicationEx::ProcessEvents(bool wait_for_input)
 {
-    assert(window != nullptr);
-
-    if (std::find(windows_.begin(), windows_.end(), window) != windows_.end())
+    if (wsi_context_)
     {
-        GFXRECON_LOG_INFO("A window was registered with the application more than once");
-        return false;
+        wsi_context_->ProcessEvents(wait_for_input);
     }
-
-    windows_.push_back(window);
-
-    return true;
 }
 
-bool Application::UnregisterWindow(decode::Window* window)
+void ApplicationEx::InitializeWsiContext(const char* surfaceExtensionName, void* pPlatformSpecificData)
 {
-    assert(window != nullptr);
-
-    auto pos = std::find(windows_.begin(), windows_.end(), window);
-
-    if (pos == windows_.end())
+    if (!wsi_context_)
     {
-        GFXRECON_LOG_INFO(
-            "A remove window request was made for an window that was never registered with the application");
-        return false;
+        #if defined(VK_USE_PLATFORM_WIN32_KHR)
+        if (!strcmp(surfaceExtensionName, VK_KHR_WIN32_SURFACE_EXTENSION_NAME))
+        {
+            wsi_context_ = std::make_unique<Win32Context>(this);
+        }
+        else
+        #endif
+        #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+        if (!strcmp(surfaceExtensionName, VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME))
+        {
+            wsi_context_ = std::make_unique<WaylandContext>(this);
+        }
+        else
+        #endif
+        #if defined(VK_USE_PLATFORM_XCB_KHR)
+        if (!strcmp(surfaceExtensionName, VK_KHR_XCB_SURFACE_EXTENSION_NAME))
+        {
+            wsi_context_ = std::make_unique<XcbContext>(this);
+        }
+        else
+        #endif
+        #if defined(VK_USE_PLATFORM_XLIB_KHR)
+        if (!strcmp(surfaceExtensionName, VK_KHR_XLIB_SURFACE_EXTENSION_NAME))
+        {
+            wsi_context_ = std::make_unique<XlibContext>(this);
+        }
+        else
+        #endif
+        #if defined(VK_USE_PLATFORM_ANDROID_KHR)
+        if (!strcmp(surfaceExtensionName, VK_KHR_ANDROID_SURFACE_EXTENSION_NAME))
+        {
+            wsi_context_ = std::make_unique<AndroidContext>(this, reinterpret_cast<struct android_app*>(pPlatformSpecificData));
+        }
+        else
+        #endif
+        #if defined(VK_USE_PLATFORM_HEADLESS)
+        if (!strcmp(surfaceExtensionName, VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME))
+        {
+            wsi_context_ = std::make_unique<HeadlessContext>(this);
+        }
+        else
+        #endif
+        {
+            // NOOP :
+        }
     }
-
-    windows_.erase(pos);
-
-    return true;
 }
 
 GFXRECON_END_NAMESPACE(application)

--- a/framework/application/headless_context.cpp
+++ b/framework/application/headless_context.cpp
@@ -1,5 +1,4 @@
 /*
-** Copyright (c) 2021, Arm Limited.
 ** Copyright (c) 2021 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
@@ -21,19 +20,17 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#include "application/headless_application.h"
-
+#include "application/headless_context.h"
+#include "application/application.h"
 #include "application/headless_window.h"
 #include "decode/vulkan_feature_util.h"
 #include "graphics/vulkan_util.h"
-#include "util/platform.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
-HeadlessApplication::HeadlessApplication(const std::string& name) : Application(name) {}
-
-bool HeadlessApplication::Initialize(decode::FileProcessor* file_processor)
+HeadlessContext::HeadlessContext(ApplicationEx* application, bool dpi_aware) :
+    WsiContext(application)
 {
     bool supported = false;
 
@@ -61,19 +58,11 @@ bool HeadlessApplication::Initialize(decode::FileProcessor* file_processor)
 
         graphics::ReleaseLoader(loader_handle);
     }
-
-    if (supported)
-    {
-        SetFileProcessor(file_processor);
-    }
-
-    return supported;
 }
 
-void HeadlessApplication::ProcessEvents(bool wait_for_input)
+void HeadlessContext::ProcessEvents(bool wait_for_input)
 {
     // No winsys events to process for headless.
-    return;
 }
 
 GFXRECON_END_NAMESPACE(application)

--- a/framework/application/headless_context.h
+++ b/framework/application/headless_context.h
@@ -1,6 +1,5 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2021 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -21,52 +20,24 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#ifndef GFXRECON_APPLICATION_ANDROID_APPLICATION_H
-#define GFXRECON_APPLICATION_ANDROID_APPLICATION_H
+#ifndef GFXRECON_APPLICATION_HEADLESS_CONTEXT_H
+#define GFXRECON_APPLICATION_HEADLESS_CONTEXT_H
 
-#include "application/application.h"
+#include "application/wsi_context.h"
 #include "util/defines.h"
-#include "util/platform.h"
-
-#include <android_native_app_glue.h>
-
-#include <memory>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
-class AndroidWindow;
-
-class AndroidApplication : public Application
+class HeadlessContext : public WsiContext
 {
   public:
-    enum ScreenOrientation : int32_t
-    {
-        kLandscape = 0,
-        kPortrait  = 1
-    };
-
-  public:
-    AndroidApplication(const std::string& name, struct android_app* app);
-
-    virtual ~AndroidApplication() override {}
-
-    virtual bool Initialize(decode::FileProcessor* file_processor) override;
+    HeadlessContext(ApplicationEx* application, bool dpi_aware = true);
 
     virtual void ProcessEvents(bool wait_for_input) override;
-
-    AndroidWindow* GetWindow() const { return window_.get(); }
-
-    void InitWindow();
-
-    void SetOrientation(ScreenOrientation orientation);
-
-  private:
-    std::unique_ptr<AndroidWindow> window_;
-    struct android_app*            android_app_;
 };
 
 GFXRECON_END_NAMESPACE(application)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
-#endif // GFXRECON_APPLICATION_ANDROID_APPLICATION_H
+#endif // GFXRECON_APPLICATION_HEADLESS_CONTEXT_H

--- a/framework/application/headless_window.cpp
+++ b/framework/application/headless_window.cpp
@@ -22,15 +22,16 @@
 */
 
 #include "application/headless_window.h"
+#include "application/application.h"
 
 #include <cassert>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
-HeadlessWindow::HeadlessWindow(HeadlessApplication* application) : headless_application_(application)
+HeadlessWindow::HeadlessWindow(HeadlessContext* headless_context) : headless_context_(headless_context)
 {
-    assert(application != nullptr);
+    assert(headless_context_ != nullptr);
 }
 
 HeadlessWindow::~HeadlessWindow() {}
@@ -115,16 +116,19 @@ void HeadlessWindow::DestroySurface(const encode::InstanceTable* table, VkInstan
     }
 }
 
-HeadlessWindowFactory::HeadlessWindowFactory(HeadlessApplication* application) : headless_application_(application)
+HeadlessWindowFactory::HeadlessWindowFactory(HeadlessContext* headless_context) : headless_context_(headless_context)
 {
-    assert(application != nullptr);
+    assert(headless_context_ != nullptr);
 }
 
 decode::Window*
 HeadlessWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height)
 {
-    auto window = new HeadlessWindow(headless_application_);
-    window->Create(headless_application_->GetName(), x, y, width, height);
+    assert(headless_context_);
+    decode::Window* window = new HeadlessWindow(headless_context_);
+    auto application = headless_context_->GetApplication();
+    assert(application);
+    window->Create(application->GetName(), x, y, width, height);
     return window;
 }
 

--- a/framework/application/headless_window.h
+++ b/framework/application/headless_window.h
@@ -24,7 +24,7 @@
 #ifndef GFXRECON_APPLICATION_HEADLESS_WINDOW_H
 #define GFXRECON_APPLICATION_HEADLESS_WINDOW_H
 
-#include "application/headless_application.h"
+#include "application/headless_context.h"
 #include "decode/window.h"
 #include "util/defines.h"
 
@@ -34,7 +34,7 @@ GFXRECON_BEGIN_NAMESPACE(application)
 class HeadlessWindow : public decode::Window
 {
   public:
-    HeadlessWindow(HeadlessApplication* application);
+    HeadlessWindow(HeadlessContext* headless_context);
 
     virtual ~HeadlessWindow() override;
 
@@ -69,13 +69,13 @@ class HeadlessWindow : public decode::Window
     virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
-    HeadlessApplication* headless_application_;
+    HeadlessContext* headless_context_;
 };
 
 class HeadlessWindowFactory : public decode::WindowFactory
 {
   public:
-    HeadlessWindowFactory(HeadlessApplication* application);
+    HeadlessWindowFactory(HeadlessContext* headless_context);
 
     virtual const char* GetSurfaceExtensionName() const override { return VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME; }
 
@@ -89,7 +89,7 @@ class HeadlessWindowFactory : public decode::WindowFactory
                                                           uint32_t                     queue_family_index) override;
 
   private:
-    HeadlessApplication* headless_application_;
+    HeadlessContext* headless_context_;
 };
 
 GFXRECON_END_NAMESPACE(application)

--- a/framework/application/wayland_context.h
+++ b/framework/application/wayland_context.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2021 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -21,8 +21,8 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#ifndef GFXRECON_APPLICATION_WAYLAND_APPLICATION_H
-#define GFXRECON_APPLICATION_WAYLAND_APPLICATION_H
+#ifndef GFXRECON_APPLICATION_WAYLAND_CONTEXT_H
+#define GFXRECON_APPLICATION_WAYLAND_CONTEXT_H
 
 #include "application/application.h"
 #include "util/defines.h"
@@ -33,9 +33,10 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
+class ApplicationEx;
 class WaylandWindow;
 
-class WaylandApplication : public Application
+class WaylandContext : public WsiContext
 {
   public:
     struct OutputInfo
@@ -45,10 +46,9 @@ class WaylandApplication : public Application
         int32_t height;
     };
 
-  public:
-    WaylandApplication(const std::string& name);
+    WaylandContext(ApplicationEx* application);
 
-    virtual ~WaylandApplication() override;
+    virtual ~WaylandContext() override;
 
     const util::WaylandLoader::FunctionTable& GetWaylandFunctionTable() const { return wayland_loader_.GetFunctionTable(); }
 
@@ -59,8 +59,6 @@ class WaylandApplication : public Application
     struct wl_compositor* GetCompositor() const { return compositor_; }
 
     const OutputInfo& GetOutputInfo(const struct wl_output* wl_output) { return output_info_map_[wl_output]; }
-
-    virtual bool Initialize(decode::FileProcessor* file_processor) override;
 
     bool RegisterWaylandWindow(WaylandWindow* window);
 
@@ -128,31 +126,29 @@ class WaylandApplication : public Application
     static void HandleOutputDone(void* data, struct wl_output* wl_output);
     static void HandleOutputScale(void* data, struct wl_output* wl_output, int32_t factor);
 
-  private:
     typedef std::unordered_map<struct wl_surface*, WaylandWindow*> WaylandWindowMap;
     typedef std::unordered_map<const struct wl_output*, OutputInfo> OutputInfoMap;
 
-  private:
     static struct wl_pointer_listener  pointer_listener_;
     static struct wl_keyboard_listener keyboard_listener_;
     static struct wl_seat_listener     seat_listener_;
     static struct wl_registry_listener registry_listener_;
     static struct wl_output_listener   output_listener_;
-    struct wl_display*                 display_;
-    struct wl_shell*                   shell_;
-    struct wl_compositor*              compositor_;
-    struct wl_registry*                registry_;
-    struct wl_seat*                    seat_;
-    struct wl_pointer*                 pointer_;
-    struct wl_keyboard*                keyboard_;
-    struct wl_surface*                 current_keyboard_surface_;
-    struct wl_surface*                 current_pointer_surface_;
-    WaylandWindowMap                   wayland_windows_;
-    OutputInfoMap                      output_info_map_;
-    util::WaylandLoader                wayland_loader_;
+    struct wl_display*                 display_ { };
+    struct wl_shell*                   shell_ { };
+    struct wl_compositor*              compositor_ { };
+    struct wl_registry*                registry_ { };
+    struct wl_seat*                    seat_ { };
+    struct wl_pointer*                 pointer_ { };
+    struct wl_keyboard*                keyboard_ { };
+    struct wl_surface*                 current_keyboard_surface_ { };
+    struct wl_surface*                 current_pointer_surface_ { };
+    WaylandWindowMap                   wayland_windows_ { };
+    OutputInfoMap                      output_info_map_ { };
+    util::WaylandLoader                wayland_loader_ { };
 };
 
 GFXRECON_END_NAMESPACE(application)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
-#endif // GFXRECON_APPLICATION_WAYLAND_APPLICATION_H
+#endif // GFXRECON_APPLICATION_WAYLAND_CONTEXT_H

--- a/framework/application/wayland_window.cpp
+++ b/framework/application/wayland_window.cpp
@@ -34,11 +34,11 @@ GFXRECON_BEGIN_NAMESPACE(application)
 struct wl_surface_listener       WaylandWindow::surface_listener_;
 struct wl_shell_surface_listener WaylandWindow::shell_surface_listener_;
 
-WaylandWindow::WaylandWindow(WaylandApplication* application) :
-    wayland_application_(application), surface_(nullptr), shell_surface_(nullptr), width_(0), height_(0), scale_(1),
+WaylandWindow::WaylandWindow(WaylandContext* wayland_context) :
+    wayland_context_(wayland_context), surface_(nullptr), shell_surface_(nullptr), width_(0), height_(0), scale_(1),
     output_(nullptr)
 {
-    assert(application != nullptr);
+    assert(wayland_context_ != nullptr);
 
     // Populate callback structs
     surface_listener_.enter = HandleSurfaceEnter;
@@ -51,7 +51,7 @@ WaylandWindow::WaylandWindow(WaylandApplication* application) :
 
 WaylandWindow::~WaylandWindow()
 {
-    auto& wl = wayland_application_->GetWaylandFunctionTable();
+    auto& wl = wayland_context_->GetWaylandFunctionTable();
     if (surface_)
     {
         if (shell_surface_)
@@ -69,8 +69,8 @@ bool WaylandWindow::Create(
     GFXRECON_UNREFERENCED_PARAMETER(x);
     GFXRECON_UNREFERENCED_PARAMETER(y);
 
-    auto& wl = wayland_application_->GetWaylandFunctionTable();
-    surface_ = wl.compositor_create_surface(wayland_application_->GetCompositor());
+    auto& wl = wayland_context_->GetWaylandFunctionTable();
+    surface_ = wl.compositor_create_surface(wayland_context_->GetCompositor());
 
     if (surface_ == nullptr)
     {
@@ -78,14 +78,14 @@ bool WaylandWindow::Create(
         return false;
     }
 
-    shell_surface_ = wl.shell_get_shell_surface(wayland_application_->GetShell(), surface_);
+    shell_surface_ = wl.shell_get_shell_surface(wayland_context_->GetShell(), surface_);
     if (!shell_surface_)
     {
         GFXRECON_LOG_ERROR("Failed to create Wayland shell surface");
         return false;
     }
 
-    wayland_application_->RegisterWaylandWindow(this);
+    wayland_context_->RegisterWaylandWindow(this);
 
     wl.surface_add_listener(surface_, &WaylandWindow::surface_listener_, this);
     wl.shell_surface_add_listener(shell_surface_, &WaylandWindow::shell_surface_listener_, this);
@@ -102,7 +102,7 @@ bool WaylandWindow::Destroy()
 {
     if (surface_)
     {
-        auto& wl = wayland_application_->GetWaylandFunctionTable();
+        auto& wl = wayland_context_->GetWaylandFunctionTable();
         if (shell_surface_)
         {
             wl.shell_surface_destroy(shell_surface_);
@@ -110,7 +110,7 @@ bool WaylandWindow::Destroy()
         }
 
         wl.surface_destroy(surface_);
-        wayland_application_->UnregisterWaylandWindow(this);
+        wayland_context_->UnregisterWaylandWindow(this);
         surface_ = nullptr;
         return true;
     }
@@ -120,7 +120,7 @@ bool WaylandWindow::Destroy()
 
 void WaylandWindow::SetTitle(const std::string& title)
 {
-    auto& wl = wayland_application_->GetWaylandFunctionTable();
+    auto& wl = wayland_context_->GetWaylandFunctionTable();
     wl.shell_surface_set_title(shell_surface_, title.c_str());
 }
 
@@ -160,7 +160,7 @@ bool WaylandWindow::GetNativeHandle(HandleType type, void** handle)
     switch (type)
     {
         case Window::kWaylandDisplay:
-            *handle = reinterpret_cast<void*>(wayland_application_->GetDisplay());
+            *handle = reinterpret_cast<void*>(wayland_context_->GetDisplay());
             return true;
         case Window::kWaylandSurface:
             *handle = reinterpret_cast<void*>(surface_);
@@ -180,7 +180,7 @@ VkResult WaylandWindow::CreateSurface(const encode::InstanceTable* table,
         VkWaylandSurfaceCreateInfoKHR create_info{ VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR,
                                                    nullptr,
                                                    flags,
-                                                   wayland_application_->GetDisplay(),
+                                                   wayland_context_->GetDisplay(),
                                                    surface_ };
 
         return table->CreateWaylandSurfaceKHR(instance, &create_info, nullptr, pSurface);
@@ -199,10 +199,10 @@ void WaylandWindow::DestroySurface(const encode::InstanceTable* table, VkInstanc
 
 void WaylandWindow::UpdateWindowSize()
 {
-    auto& wl = wayland_application_->GetWaylandFunctionTable();
+    auto& wl = wayland_context_->GetWaylandFunctionTable();
     if (output_)
     {
-        auto& output_info = wayland_application_->GetOutputInfo(output_);
+        auto& output_info = wayland_context_->GetOutputInfo(output_);
 
         if (output_info.scale > 0 && output_info.scale != scale_)
         {
@@ -237,7 +237,7 @@ void WaylandWindow::HandleSurfaceLeave(void* data, struct wl_surface* surface, s
 
 void WaylandWindow::HandlePing(void* data, wl_shell_surface* shell_surface, uint32_t serial)
 {
-    auto& wl = reinterpret_cast<WaylandWindow*>(data)->wayland_application_->GetWaylandFunctionTable();
+    auto& wl = reinterpret_cast<WaylandWindow*>(data)->wayland_context_->GetWaylandFunctionTable();
     wl.shell_surface_pong(shell_surface, serial);
 }
 
@@ -247,16 +247,19 @@ void WaylandWindow::HandleConfigure(
 
 void WaylandWindow::HandlePopupDone(void* data, wl_shell_surface* shell_surface) {}
 
-WaylandWindowFactory::WaylandWindowFactory(WaylandApplication* application) : wayland_application_(application)
+WaylandWindowFactory::WaylandWindowFactory(WaylandContext* wayland_context) : wayland_context_(wayland_context)
 {
-    assert(application != nullptr);
+    assert(wayland_context_ != nullptr);
 }
 
 decode::Window*
 WaylandWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height)
 {
-    auto window = new WaylandWindow(wayland_application_);
-    window->Create(wayland_application_->GetName(), x, y, width, height);
+    assert(wayland_context_);
+    decode::Window* window = new WaylandWindow(wayland_context_);
+    auto application = wayland_context_->GetApplication();
+    assert(application);
+    window->Create(application->GetName(), x, y, width, height);
     return window;
 }
 
@@ -273,9 +276,9 @@ VkBool32 WaylandWindowFactory::GetPhysicalDevicePresentationSupport(const encode
                                                                     VkPhysicalDevice             physical_device,
                                                                     uint32_t                     queue_family_index)
 {
-    assert(wayland_application_->GetDisplay() != nullptr);
+    assert(wayland_context_->GetDisplay() != nullptr);
     return table->GetPhysicalDeviceWaylandPresentationSupportKHR(
-        physical_device, queue_family_index, wayland_application_->GetDisplay());
+        physical_device, queue_family_index, wayland_context_->GetDisplay());
 }
 
 GFXRECON_END_NAMESPACE(application)

--- a/framework/application/wayland_window.h
+++ b/framework/application/wayland_window.h
@@ -24,7 +24,7 @@
 #ifndef GFXRECON_APPLICATION_WAYLAND_WINDOW_H
 #define GFXRECON_APPLICATION_WAYLAND_WINDOW_H
 
-#include "application/wayland_application.h"
+#include "application/wayland_context.h"
 #include "decode/window.h"
 #include "util/defines.h"
 
@@ -36,7 +36,7 @@ GFXRECON_BEGIN_NAMESPACE(application)
 class WaylandWindow : public decode::Window
 {
   public:
-    WaylandWindow(WaylandApplication* application);
+    WaylandWindow(WaylandContext* wayland_context);
 
     virtual ~WaylandWindow() override;
 
@@ -90,7 +90,7 @@ class WaylandWindow : public decode::Window
   private:
     static struct wl_surface_listener       surface_listener_;
     static struct wl_shell_surface_listener shell_surface_listener_;
-    WaylandApplication*                     wayland_application_;
+    WaylandContext*                         wayland_context_;
     struct wl_surface*                      surface_;
     struct wl_shell_surface*                shell_surface_;
     uint32_t                                width_;
@@ -102,7 +102,7 @@ class WaylandWindow : public decode::Window
 class WaylandWindowFactory : public decode::WindowFactory
 {
   public:
-    WaylandWindowFactory(WaylandApplication* application);
+    WaylandWindowFactory(WaylandContext* wayland_context);
 
     virtual const char* GetSurfaceExtensionName() const override { return VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME; }
 
@@ -116,7 +116,7 @@ class WaylandWindowFactory : public decode::WindowFactory
                                                           uint32_t                     queue_family_index) override;
 
   private:
-    WaylandApplication* wayland_application_;
+    WaylandContext* wayland_context_;
 };
 
 GFXRECON_END_NAMESPACE(util)

--- a/framework/application/win32_context.h
+++ b/framework/application/win32_context.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2021 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -20,46 +20,27 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#ifndef GFXRECON_APPLICATION_XLIB_APPLICATION_H
-#define GFXRECON_APPLICATION_XLIB_APPLICATION_H
+#ifndef GFXRECON_APPLICATION_WIN32_CONTEXT_H
+#define GFXRECON_APPLICATION_WIN32_CONTEXT_H
 
-#include "application/application.h"
+#include "application/wsi_context.h"
 #include "util/defines.h"
-#include "util/xlib_loader.h"
+#include "util/platform.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
-class XlibWindow;
-
-class XlibApplication : public Application
+class Win32Context : public WsiContext
 {
   public:
-    XlibApplication(const std::string& name);
-
-    virtual ~XlibApplication() override;
-
-    const util::XlibLoader::FunctionTable& GetXlibFunctionTable() const { return xlib_loader_.GetFunctionTable(); }
-
-    Display* OpenDisplay();
-
-    void CloseDisplay(Display* display);
-
-    virtual bool Initialize(decode::FileProcessor* file_processor) override;
-
-    bool RegisterXlibWindow(XlibWindow* window);
-
-    bool UnregisterXlibWindow(XlibWindow* window);
+    Win32Context(ApplicationEx* application, bool dpi_aware = true);
 
     virtual void ProcessEvents(bool wait_for_input) override;
 
-  private:
-    Display*         display_;
-    size_t           display_open_count_;
-    util::XlibLoader xlib_loader_;
+    static LRESULT WINAPI WindowProc(HWND window, unsigned int msg, WPARAM wp, LPARAM lp);
 };
 
 GFXRECON_END_NAMESPACE(application)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
-#endif // GFXRECON_APPLICATION_XLIB_APPLICATION_H
+#endif // GFXRECON_APPLICATION_WIN32_CONTEXT_H

--- a/framework/application/win32_window.cpp
+++ b/framework/application/win32_window.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "application/win32_window.h"
+#include "application/application.h"
 #include "util/logging.h"
 
 #include <cassert>
@@ -35,12 +36,12 @@ GFXRECON_BEGIN_NAMESPACE(application)
 const uint32_t kWindowedStyle   = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU;
 const uint32_t kFullscreenStyle = WS_POPUP;
 
-Win32Window::Win32Window(Win32Application* application) :
-    hwnd_(nullptr), win32_application_(application), width_(0), height_(0),
+Win32Window::Win32Window(Win32Context* win32_context) :
+    hwnd_(nullptr), win32_context_(win32_context), width_(0), height_(0),
     screen_width_(std::numeric_limits<uint32_t>::max()), screen_height_(std::numeric_limits<uint32_t>::max()),
     fullscreen_(false), hinstance_(nullptr)
 {
-    assert(application != nullptr);
+    assert(win32_context_ != nullptr);
 }
 
 Win32Window::~Win32Window()
@@ -67,7 +68,7 @@ bool Win32Window::Create(
     WNDCLASSEX wcex    = {};
     wcex.cbSize        = sizeof(WNDCLASSEX);
     wcex.style         = CS_HREDRAW | CS_VREDRAW;
-    wcex.lpfnWndProc   = Win32Application::WindowProc;
+    wcex.lpfnWndProc   = Win32Context::WindowProc;
     wcex.cbClsExtra    = 0;
     wcex.cbWndExtra    = 0;
     wcex.hInstance     = hinstance_;
@@ -129,11 +130,11 @@ bool Win32Window::Create(
                          nullptr,
                          nullptr,
                          wcex.hInstance,
-                         win32_application_);
+                         win32_context_);
 
     if (hwnd_)
     {
-        win32_application_->RegisterWindow(this);
+        win32_context_->RegisterWindow(this);
 
         width_  = width;
         height_ = height;
@@ -155,7 +156,7 @@ bool Win32Window::Destroy()
     if (hwnd_ != nullptr)
     {
         DestroyWindow(hwnd_);
-        win32_application_->UnregisterWindow(this);
+        win32_context_->UnregisterWindow(this);
         hwnd_ = nullptr;
         return true;
     }
@@ -284,16 +285,19 @@ void Win32Window::DestroySurface(const encode::InstanceTable* table, VkInstance 
     }
 }
 
-Win32WindowFactory::Win32WindowFactory(Win32Application* application) : win32_application_(application)
+Win32WindowFactory::Win32WindowFactory(Win32Context* win32_context) : win32_context_(win32_context)
 {
-    assert(application != nullptr);
+    assert(win32_context_);
 }
 
 decode::Window*
 Win32WindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height)
 {
-    decode::Window* window = new Win32Window(win32_application_);
-    window->Create(win32_application_->GetName(), x, y, width, height);
+    assert(win32_context_);
+    decode::Window* window = new Win32Window(win32_context_);
+    auto application = win32_context_->GetApplication();
+    assert(application);
+    window->Create(application->GetName(), x, y, width, height);
     return window;
 }
 

--- a/framework/application/win32_window.h
+++ b/framework/application/win32_window.h
@@ -24,7 +24,7 @@
 #ifndef GFXRECON_APPLICATION_WIN32_WINDOW_H
 #define GFXRECON_APPLICATION_WIN32_WINDOW_H
 
-#include "application/win32_application.h"
+#include "application/win32_context.h"
 #include "decode/window.h"
 #include "util/defines.h"
 #include "util/platform.h"
@@ -37,7 +37,7 @@ GFXRECON_BEGIN_NAMESPACE(application)
 class Win32Window : public decode::Window
 {
   public:
-    Win32Window(Win32Application* application);
+    Win32Window(Win32Context* win32_context);
 
     virtual ~Win32Window() override;
 
@@ -72,25 +72,24 @@ class Win32Window : public decode::Window
     virtual void DestroySurface(const encode::InstanceTable* table, VkInstance instance, VkSurfaceKHR surface) override;
 
   private:
-    HWND              hwnd_;
-    Win32Application* win32_application_;
-    uint32_t          width_;
-    uint32_t          height_;
-    uint32_t          screen_width_;
-    uint32_t          screen_height_;
-    bool              fullscreen_;
-    HINSTANCE         hinstance_;
+    HWND            hwnd_;
+    Win32Context*   win32_context_;
+    uint32_t        width_;
+    uint32_t        height_;
+    uint32_t        screen_width_;
+    uint32_t        screen_height_;
+    bool            fullscreen_;
+    HINSTANCE       hinstance_;
 };
 
 class Win32WindowFactory : public decode::WindowFactory
 {
   public:
-    Win32WindowFactory(Win32Application* application);
+    Win32WindowFactory(Win32Context* win32_context);
 
     virtual const char* GetSurfaceExtensionName() const override { return VK_KHR_WIN32_SURFACE_EXTENSION_NAME; }
 
-    virtual decode::Window*
-    Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) override;
+    virtual decode::Window* Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height) override;
 
     void Destroy(decode::Window* window) override;
 
@@ -99,7 +98,7 @@ class Win32WindowFactory : public decode::WindowFactory
                                                           uint32_t                     queue_family_index) override;
 
   private:
-    Win32Application* win32_application_;
+    Win32Context* win32_context_;
 };
 
 GFXRECON_END_NAMESPACE(application)

--- a/framework/application/wsi_context.cpp
+++ b/framework/application/wsi_context.cpp
@@ -1,0 +1,89 @@
+/*
+** Copyright (c) 2021 LunarG, Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and associated documentation files (the "Software"),
+** to deal in the Software without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Software, and to permit persons to whom the
+** Software is furnished to do so, subject to the following conditions:
+**
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+** DEALINGS IN THE SOFTWARE.
+*/
+
+#include "application/wsi_context.h"
+
+#include <algorithm>
+
+GFXRECON_BEGIN_NAMESPACE(gfxrecon)
+GFXRECON_BEGIN_NAMESPACE(application)
+
+WsiContext::WsiContext(ApplicationEx* application) : application_(application)
+{
+    assert(application_);
+}
+
+WsiContext ::~WsiContext()
+{
+    if (!windows_.empty())
+    {
+        GFXRECON_LOG_INFO(
+            "WsiContext is destroying windows that were not previously destroyed by their owner");
+
+        for (auto window : windows_)
+        {
+            delete window;
+        }
+    }
+}
+
+bool WsiContext::RegisterWindow(decode::Window* window)
+{
+    assert(window != nullptr);
+
+    if (std::find(windows_.begin(), windows_.end(), window) != windows_.end())
+    {
+        GFXRECON_LOG_INFO("A window was registered with the WsiContext more than once");
+        return false;
+    }
+
+    windows_.push_back(window);
+
+    return true;
+}
+
+bool WsiContext::UnregisterWindow(decode::Window* window)
+{
+    assert(window != nullptr);
+
+    auto pos = std::find(windows_.begin(), windows_.end(), window);
+
+    if (pos == windows_.end())
+    {
+        GFXRECON_LOG_INFO(
+            "A remove window request was made for an window that was never registered with the WsiContext");
+        return false;
+    }
+
+    windows_.erase(pos);
+
+    return true;
+}
+
+void WsiContext::ProcessEvents(bool wait_for_input)
+{
+    (void)wait_for_input;
+    // NOOP :
+}
+
+GFXRECON_END_NAMESPACE(application)
+GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/application/wsi_context.h
+++ b/framework/application/wsi_context.h
@@ -1,6 +1,5 @@
 /*
-** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2021 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -21,31 +20,50 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#ifndef GFXRECON_APPLICATION_WIN32_APPLICATION_H
-#define GFXRECON_APPLICATION_WIN32_APPLICATION_H
+#ifndef GFXRECON_APPLICATION_WSI_CONTEXT_H
+#define GFXRECON_APPLICATION_WSI_CONTEXT_H
 
-#include "application/application.h"
+#include "decode/window.h"
 #include "util/defines.h"
-#include "util/platform.h"
+
+#include <memory>
+#include <vector>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
-class Win32Application : public Application
+class ApplicationEx;
+
+class WsiContext
 {
   public:
-    Win32Application(const std::string& name, bool dpi_aware = true);
+    WsiContext(ApplicationEx* application);
 
-    virtual ~Win32Application() override {}
+    virtual ~WsiContext() = 0;
 
-    virtual bool Initialize(decode::FileProcessor* file_processor) override;
+    const ApplicationEx* GetApplication() const { return application_; }
 
-    virtual void ProcessEvents(bool wait_for_input) override;
+    ApplicationEx* GetApplication() { return application_; }
 
-    static LRESULT WINAPI WindowProc(HWND window, unsigned int msg, WPARAM wp, LPARAM lp);
+    const decode::WindowFactory* GetWindowFactory() const { return window_factory_.get(); }
+
+    decode::WindowFactory* GetWindowFactory() { return window_factory_.get(); }
+
+    bool RegisterWindow(decode::Window* window);
+
+    bool UnregisterWindow(decode::Window* window);
+
+    virtual void ProcessEvents(bool wait_for_input);
+
+  protected:
+    ApplicationEx*                         application_;
+    std::unique_ptr<decode::WindowFactory> window_factory_;
+
+  private:
+    std::vector<decode::Window*> windows_;
 };
 
 GFXRECON_END_NAMESPACE(application)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
-#endif // GFXRECON_APPLICATION_WIN32_APPLICATION_H
+#endif // GFXRECON_APPLICATION_WSI_CONTEXT_H

--- a/framework/application/xcb_context.cpp
+++ b/framework/application/xcb_context.cpp
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2021 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -21,9 +21,9 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
+#include "application/xcb_context.h"
+#include "application/application.h"
 #include "application/xcb_window.h"
-
-#include "application/xcb_application.h"
 #include "util/logging.h"
 
 #include <cstdlib>
@@ -31,9 +31,39 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
-XcbApplication::XcbApplication(const std::string& name) : Application(name), connection_(nullptr), screen_(nullptr) {}
+XcbContext::XcbContext(ApplicationEx* application) : WsiContext(application)
+{
+    xcb_loader_.Initialize();
+    // TODO : window_factory_ update...
+    // if (!xcb_loader_.Initialize())
+    // {
+    //     return false;
+    // }
 
-XcbApplication::~XcbApplication()
+    auto& xcb          = xcb_loader_.GetFunctionTable();
+    int   screen_count = 0;
+    connection_        = xcb.connect(nullptr, &screen_count);
+
+    if (xcb.connection_has_error(connection_))
+    {
+        GFXRECON_LOG_DEBUG("Failed to connect to an X server");
+        // TODO : window_factory_ update...
+        // return false;
+    }
+
+    const xcb_setup_t*    setup = xcb.get_setup(connection_);
+    xcb_screen_iterator_t iter  = xcb.setup_roots_iterator(setup);
+
+    for (int i = 0; i < screen_count; ++i)
+    {
+        xcb.screen_next(&iter);
+    }
+
+    screen_ = iter.data;
+    window_factory_ = std::make_unique<XcbWindowFactory>(this);
+}
+
+XcbContext::~XcbContext()
 {
     if (connection_ != nullptr)
     {
@@ -42,7 +72,8 @@ XcbApplication::~XcbApplication()
     }
 }
 
-bool XcbApplication::Initialize(decode::FileProcessor* file_processor)
+#if 0
+bool XcbContext::Initialize(decode::FileProcessor* file_processor)
 {
     if (!xcb_loader_.Initialize())
     {
@@ -73,10 +104,11 @@ bool XcbApplication::Initialize(decode::FileProcessor* file_processor)
 
     return true;
 }
+#endif
 
-bool XcbApplication::RegisterXcbWindow(XcbWindow* window)
+bool XcbContext::RegisterXcbWindow(XcbWindow* window)
 {
-    bool success = Application::RegisterWindow(window);
+    bool success = WsiContext::RegisterWindow(window);
 
     if (success)
     {
@@ -91,9 +123,9 @@ bool XcbApplication::RegisterXcbWindow(XcbWindow* window)
     return success;
 }
 
-bool XcbApplication::UnregisterXcbWindow(XcbWindow* window)
+bool XcbContext::UnregisterXcbWindow(XcbWindow* window)
 {
-    bool success = Application::UnregisterWindow(window);
+    bool success = WsiContext::UnregisterWindow(window);
 
     if (success)
     {
@@ -103,9 +135,10 @@ bool XcbApplication::UnregisterXcbWindow(XcbWindow* window)
     return success;
 }
 
-void XcbApplication::ProcessEvents(bool wait_for_input)
+void XcbContext::ProcessEvents(bool wait_for_input)
 {
-    while (IsRunning())
+    assert(application_);
+    while (application_->IsRunning())
     {
         xcb_generic_event_t* event = nullptr;
         const auto&          xcb   = xcb_loader_.GetFunctionTable();
@@ -155,7 +188,7 @@ void XcbApplication::ProcessEvents(bool wait_for_input)
 
                         if (message_event->data.data32[0] == atom)
                         {
-                            StopRunning();
+                            application_->StopRunning();
                         }
                     }
 
@@ -169,11 +202,11 @@ void XcbApplication::ProcessEvents(bool wait_for_input)
                     switch (key->detail)
                     {
                         case 0x9: // Escape
-                            StopRunning();
+                            application_->StopRunning();
                             break;
                         case 0x21: // p
                         case 0x41: // Space
-                            SetPaused(!GetPaused());
+                            application_->SetPaused(!application_->GetPaused());
                             break;
                         default:
                             break;
@@ -191,9 +224,9 @@ void XcbApplication::ProcessEvents(bool wait_for_input)
                         // Using XCB_KEY_PRESS for repeat when key is held down.
                         case 0x72: // Right arrow
                         case 0x39: // n
-                            if (GetPaused())
+                            if (application_->GetPaused())
                             {
-                                PlaySingleFrame();
+                                application_->PlaySingleFrame();
                             }
                             break;
                         default:

--- a/framework/application/xcb_context.h
+++ b/framework/application/xcb_context.h
@@ -1,6 +1,6 @@
 /*
 ** Copyright (c) 2018 Valve Corporation
-** Copyright (c) 2018 LunarG, Inc.
+** Copyright (c) 2018-2021 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -21,10 +21,10 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#ifndef GFXRECON_APPLICATION_XCB_APPLICATION_H
-#define GFXRECON_APPLICATION_XCB_APPLICATION_H
+#ifndef GFXRECON_APPLICATION_XCB_CONTEXT_H
+#define GFXRECON_APPLICATION_XCB_CONTEXT_H
 
-#include "application/application.h"
+#include "application/wsi_context.h"
 #include "util/defines.h"
 #include "util/xcb_loader.h"
 
@@ -33,14 +33,15 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
+class ApplicationEx;
 class XcbWindow;
 
-class XcbApplication : public Application
+class XcbContext : public WsiContext
 {
   public:
-    XcbApplication(const std::string& name);
+    XcbContext(ApplicationEx* application);
 
-    virtual ~XcbApplication() override;
+    virtual ~XcbContext() override;
 
     const util::XcbLoader::FunctionTable& GetXcbFunctionTable() const { return xcb_loader_.GetFunctionTable(); }
 
@@ -51,8 +52,6 @@ class XcbApplication : public Application
     uint32_t GetLastErrorSequence() const { return last_error_sequence_; }
 
     uint8_t GetLastErrorCode() const { return last_error_code_; }
-
-    virtual bool Initialize(decode::FileProcessor* file_processor) override;
 
     bool RegisterXcbWindow(XcbWindow* window);
 
@@ -69,16 +68,15 @@ class XcbApplication : public Application
   private:
     typedef std::unordered_map<xcb_window_t, XcbWindow*> XcbWindowMap;
 
-  private:
-    xcb_connection_t* connection_;
-    xcb_screen_t*     screen_;
-    uint32_t          last_error_sequence_;
-    uint8_t           last_error_code_;
-    XcbWindowMap      xcb_windows_;
-    util::XcbLoader   xcb_loader_;
+    xcb_connection_t* connection_ { };
+    xcb_screen_t*     screen_ { };
+    uint32_t          last_error_sequence_ { };
+    uint8_t           last_error_code_ { };
+    XcbWindowMap      xcb_windows_ { };
+    util::XcbLoader   xcb_loader_ { };
 };
 
 GFXRECON_END_NAMESPACE(application)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
-#endif // GFXRECON_APPLICATION_XCB_APPLICATION_H
+#endif // GFXRECON_APPLICATION_XCB_CONTEXT_H

--- a/framework/application/xcb_window.cpp
+++ b/framework/application/xcb_window.cpp
@@ -22,7 +22,7 @@
 */
 
 #include "application/xcb_window.h"
-
+#include "application/application.h"
 #include "util/logging.h"
 
 #include <cassert>
@@ -45,20 +45,20 @@ const uint16_t kConfigurePositionMask     = XCB_CONFIG_WINDOW_X | XCB_CONFIG_WIN
 const uint16_t kConfigureSizeMask         = XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT;
 const uint16_t kConfigurePositionSizeMask = kConfigurePositionMask | kConfigureSizeMask;
 
-XcbWindow::XcbWindow(XcbApplication* application) :
-    xcb_application_(application), width_(0), height_(0), screen_width_(std::numeric_limits<uint32_t>::max()),
+XcbWindow::XcbWindow(XcbContext* xcb_context) :
+    xcb_context_(xcb_context), width_(0), height_(0), screen_width_(std::numeric_limits<uint32_t>::max()),
     screen_height_(std::numeric_limits<uint32_t>::max()), visible_(false), fullscreen_(false), window_(0),
     protocol_atom_(0), delete_window_atom_(0), state_atom_(0), state_fullscreen_atom_(0), bypass_compositor_atom_(0)
 {
-    assert(application != nullptr);
+    assert(xcb_context_ != nullptr);
 }
 
 XcbWindow::~XcbWindow()
 {
     if (window_ != 0)
     {
-        auto&             xcb        = xcb_application_->GetXcbFunctionTable();
-        xcb_connection_t* connection = xcb_application_->GetConnection();
+        auto&             xcb        = xcb_context_->GetXcbFunctionTable();
+        xcb_connection_t* connection = xcb_context_->GetConnection();
         xcb.destroy_window(connection, window_);
         xcb.flush(connection);
     }
@@ -67,9 +67,9 @@ XcbWindow::~XcbWindow()
 bool XcbWindow::Create(
     const std::string& title, const int32_t xpos, const int32_t ypos, const uint32_t width, const uint32_t height)
 {
-    auto&             xcb        = xcb_application_->GetXcbFunctionTable();
-    xcb_connection_t* connection = xcb_application_->GetConnection();
-    xcb_screen_t*     screen     = xcb_application_->GetScreen();
+    auto&             xcb        = xcb_context_->GetXcbFunctionTable();
+    xcb_connection_t* connection = xcb_context_->GetConnection();
+    xcb_screen_t*     screen     = xcb_context_->GetScreen();
 
     window_ = xcb.generate_id(connection);
     if (window_ == 0)
@@ -78,7 +78,7 @@ bool XcbWindow::Create(
         return false;
     }
 
-    xcb_application_->RegisterXcbWindow(this);
+    xcb_context_->RegisterXcbWindow(this);
 
     // Get screen dimensions.
     xcb_generic_error_t*      error       = nullptr;
@@ -181,8 +181,8 @@ bool XcbWindow::Destroy()
 {
     if (window_ != 0)
     {
-        auto&             xcb        = xcb_application_->GetXcbFunctionTable();
-        xcb_connection_t* connection = xcb_application_->GetConnection();
+        auto&             xcb        = xcb_context_->GetXcbFunctionTable();
+        xcb_connection_t* connection = xcb_context_->GetConnection();
 
         SetFullscreen(false);
         SetVisibility(false);
@@ -192,10 +192,10 @@ bool XcbWindow::Destroy()
 
         if (!WaitForEvent(cookie.sequence, XCB_DESTROY_NOTIFY))
         {
-            GFXRECON_LOG_ERROR("Failed to destroy window with error %u", xcb_application_->GetLastErrorCode());
+            GFXRECON_LOG_ERROR("Failed to destroy window with error %u", xcb_context_->GetLastErrorCode());
         }
 
-        xcb_application_->UnregisterXcbWindow(this);
+        xcb_context_->UnregisterXcbWindow(this);
         window_ = 0;
         return true;
     }
@@ -205,8 +205,8 @@ bool XcbWindow::Destroy()
 
 void XcbWindow::SetTitle(const std::string& title)
 {
-    auto&             xcb        = xcb_application_->GetXcbFunctionTable();
-    xcb_connection_t* connection = xcb_application_->GetConnection();
+    auto&             xcb        = xcb_context_->GetXcbFunctionTable();
+    xcb_connection_t* connection = xcb_context_->GetConnection();
 
     xcb.change_property(connection,
                         XCB_PROP_MODE_REPLACE,
@@ -221,8 +221,8 @@ void XcbWindow::SetTitle(const std::string& title)
 
 void XcbWindow::SetPosition(const int32_t x, const int32_t y)
 {
-    auto&             xcb        = xcb_application_->GetXcbFunctionTable();
-    xcb_connection_t* connection = xcb_application_->GetConnection();
+    auto&             xcb        = xcb_context_->GetXcbFunctionTable();
+    xcb_connection_t* connection = xcb_context_->GetConnection();
     uint32_t          values[]   = { static_cast<uint32_t>(x), static_cast<uint32_t>(y) };
 
     xcb.configure_window(connection, window_, kConfigurePositionMask, values);
@@ -233,8 +233,8 @@ void XcbWindow::SetSize(const uint32_t width, const uint32_t height)
 {
     if ((width != width_) || (height != height_))
     {
-        auto&             xcb        = xcb_application_->GetXcbFunctionTable();
-        xcb_connection_t* connection = xcb_application_->GetConnection();
+        auto&             xcb        = xcb_context_->GetXcbFunctionTable();
+        xcb_connection_t* connection = xcb_context_->GetConnection();
         xcb_void_cookie_t cookie     = { 0 };
 
         if ((screen_width_ == width) || (screen_height_ == height))
@@ -264,7 +264,7 @@ void XcbWindow::SetSize(const uint32_t width, const uint32_t height)
             // Wait for configure notification.
             if (!WaitForEvent(cookie.sequence, XCB_CONFIGURE_NOTIFY))
             {
-                GFXRECON_LOG_ERROR("Failed to resize window with error %u", xcb_application_->GetLastErrorCode());
+                GFXRECON_LOG_ERROR("Failed to resize window with error %u", xcb_context_->GetLastErrorCode());
             }
             else
             {
@@ -285,9 +285,9 @@ void XcbWindow::SetFullscreen(bool fullscreen)
 {
     if (fullscreen != fullscreen_)
     {
-        auto&             xcb        = xcb_application_->GetXcbFunctionTable();
-        xcb_connection_t* connection = xcb_application_->GetConnection();
-        xcb_screen_t*     screen     = xcb_application_->GetScreen();
+        auto&             xcb        = xcb_context_->GetXcbFunctionTable();
+        xcb_connection_t* connection = xcb_context_->GetConnection();
+        xcb_screen_t*     screen     = xcb_context_->GetScreen();
 
         xcb_client_message_event_t event;
         event.response_type  = XCB_CLIENT_MESSAGE;
@@ -340,7 +340,7 @@ void XcbWindow::SetFullscreen(bool fullscreen)
         {
             GFXRECON_LOG_ERROR("Failed to %s fullscreen mode with error %u",
                                fullscreen ? "enter" : "exit",
-                               xcb_application_->GetLastErrorCode());
+                               xcb_context_->GetLastErrorCode());
         }
     }
 }
@@ -349,8 +349,8 @@ void XcbWindow::SetVisibility(bool show)
 {
     if (show != visible_)
     {
-        auto&             xcb        = xcb_application_->GetXcbFunctionTable();
-        xcb_connection_t* connection = xcb_application_->GetConnection();
+        auto&             xcb        = xcb_context_->GetXcbFunctionTable();
+        xcb_connection_t* connection = xcb_context_->GetConnection();
         xcb_void_cookie_t cookie;
 
         if (show)
@@ -368,15 +368,15 @@ void XcbWindow::SetVisibility(bool show)
         if (!WaitForEvent(cookie.sequence, XCB_MAP_NOTIFY))
         {
             GFXRECON_LOG_ERROR("Failed to change window visibility with error %u",
-                               xcb_application_->GetLastErrorCode());
+                               xcb_context_->GetLastErrorCode());
         }
     }
 }
 
 void XcbWindow::SetForeground()
 {
-    auto&             xcb        = xcb_application_->GetXcbFunctionTable();
-    xcb_connection_t* connection = xcb_application_->GetConnection();
+    auto&             xcb        = xcb_context_->GetXcbFunctionTable();
+    xcb_connection_t* connection = xcb_context_->GetConnection();
     uint32_t          values[]   = { XCB_STACK_MODE_ABOVE };
 
     xcb.configure_window(connection, window_, XCB_CONFIG_WINDOW_STACK_MODE, values);
@@ -389,7 +389,7 @@ bool XcbWindow::GetNativeHandle(HandleType type, void** handle)
     switch (type)
     {
         case Window::kXcbConnection:
-            *handle = reinterpret_cast<void*>(xcb_application_->GetConnection());
+            *handle = reinterpret_cast<void*>(xcb_context_->GetConnection());
             return true;
         case Window::kXcbWindow:
             *handle = reinterpret_cast<void*>(window_);
@@ -405,7 +405,7 @@ XcbWindow::CreateSurface(const encode::InstanceTable* table, VkInstance instance
     if (table != nullptr)
     {
         VkXcbSurfaceCreateInfoKHR create_info{
-            VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR, nullptr, flags, xcb_application_->GetConnection(), window_
+            VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR, nullptr, flags, xcb_context_->GetConnection(), window_
         };
 
         return table->CreateXcbSurfaceKHR(instance, &create_info, nullptr, pSurface);
@@ -425,14 +425,14 @@ void XcbWindow::DestroySurface(const encode::InstanceTable* table, VkInstance in
 xcb_intern_atom_cookie_t
 XcbWindow::SendAtomRequest(xcb_connection_t* connection, const char* name, uint8_t only_if_exists) const
 {
-    auto& xcb = xcb_application_->GetXcbFunctionTable();
+    auto& xcb = xcb_context_->GetXcbFunctionTable();
     return xcb.intern_atom(connection, only_if_exists, strlen(name), name);
 }
 
 xcb_atom_t
 XcbWindow::GetAtomReply(xcb_connection_t* connection, const char* name, xcb_intern_atom_cookie_t cookie) const
 {
-    auto&                    xcb   = xcb_application_->GetXcbFunctionTable();
+    auto&                    xcb   = xcb_context_->GetXcbFunctionTable();
     xcb_atom_t               atom  = 0;
     xcb_generic_error_t*     error = nullptr;
     xcb_intern_atom_reply_t* reply = xcb.intern_atom_reply(connection, cookie, &error);
@@ -452,7 +452,7 @@ XcbWindow::GetAtomReply(xcb_connection_t* connection, const char* name, xcb_inte
 
 void XcbWindow::InitializeAtoms()
 {
-    xcb_connection_t* connection = xcb_application_->GetConnection();
+    xcb_connection_t* connection = xcb_context_->GetConnection();
 
     // Send requests.
     xcb_intern_atom_cookie_t protocol_atom_cookie          = SendAtomRequest(connection, kProtocolName, 1);
@@ -483,14 +483,16 @@ bool XcbWindow::WaitForEvent(uint32_t sequence, uint32_t type)
     pending_event_.type     = type;
     pending_event_.complete = false;
 
-    xcb_application_->ClearLastError();
+    xcb_context_->ClearLastError();
 
-    while (!pending_event_.complete && xcb_application_->IsRunning())
+    auto application = xcb_context_->GetApplication();
+    assert(application);
+    while (!pending_event_.complete && application->IsRunning())
     {
-        xcb_application_->ProcessEvents(true);
+        xcb_context_->ProcessEvents(true);
 
         // TODO: We may need to check for any error, not an error for a specific sequence number.
-        if (xcb_application_->GetLastErrorSequence() == pending_event_.sequence)
+        if (xcb_context_->GetLastErrorSequence() == pending_event_.sequence)
         {
             return false;
         }
@@ -499,15 +501,18 @@ bool XcbWindow::WaitForEvent(uint32_t sequence, uint32_t type)
     return true;
 }
 
-XcbWindowFactory::XcbWindowFactory(XcbApplication* application) : xcb_application_(application)
+XcbWindowFactory::XcbWindowFactory(XcbContext* xcb_context) : xcb_context_(xcb_context)
 {
-    assert(application != nullptr);
+    assert(xcb_context_ != nullptr);
 }
 
 decode::Window* XcbWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height)
 {
-    auto window = new XcbWindow(xcb_application_);
-    window->Create(xcb_application_->GetName(), x, y, width, height);
+    assert(xcb_context_);
+    decode::Window* window = new XcbWindow(xcb_context_);
+    auto application = xcb_context_->GetApplication();
+    assert(application);
+    window->Create(application->GetName(), x, y, width, height);
     return window;
 }
 
@@ -524,8 +529,8 @@ VkBool32 XcbWindowFactory::GetPhysicalDevicePresentationSupport(const encode::In
                                                                 VkPhysicalDevice             physical_device,
                                                                 uint32_t                     queue_family_index)
 {
-    xcb_connection_t* connection = xcb_application_->GetConnection();
-    xcb_screen_t*     screen     = xcb_application_->GetScreen();
+    xcb_connection_t* connection = xcb_context_->GetConnection();
+    xcb_screen_t*     screen     = xcb_context_->GetScreen();
 
     assert((connection != nullptr) && (screen != nullptr));
 

--- a/framework/application/xcb_window.h
+++ b/framework/application/xcb_window.h
@@ -24,7 +24,7 @@
 #ifndef GFXRECON_APPLICATION_XCB_WINDOW_H
 #define GFXRECON_APPLICATION_XCB_WINDOW_H
 
-#include "application/xcb_application.h"
+#include "application/xcb_context.h"
 #include "decode/window.h"
 #include "util/defines.h"
 
@@ -36,7 +36,7 @@ GFXRECON_BEGIN_NAMESPACE(application)
 class XcbWindow : public decode::Window
 {
   public:
-    XcbWindow(XcbApplication* application);
+    XcbWindow(XcbContext* xcb_context);
 
     virtual ~XcbWindow() override;
 
@@ -112,26 +112,26 @@ class XcbWindow : public decode::Window
     };
 
   private:
-    XcbApplication* xcb_application_;
-    uint32_t        width_;
-    uint32_t        height_;
-    uint32_t        screen_width_;
-    uint32_t        screen_height_;
-    EventInfo       pending_event_;
-    bool            visible_;
-    bool            fullscreen_;
-    xcb_window_t    window_;
-    xcb_atom_t      protocol_atom_;
-    xcb_atom_t      delete_window_atom_;
-    xcb_atom_t      state_atom_;
-    xcb_atom_t      state_fullscreen_atom_;
-    xcb_atom_t      bypass_compositor_atom_;
+    XcbContext*  xcb_context_;
+    uint32_t     width_;
+    uint32_t     height_;
+    uint32_t     screen_width_;
+    uint32_t     screen_height_;
+    EventInfo    pending_event_;
+    bool         visible_;
+    bool         fullscreen_;
+    xcb_window_t window_;
+    xcb_atom_t   protocol_atom_;
+    xcb_atom_t   delete_window_atom_;
+    xcb_atom_t   state_atom_;
+    xcb_atom_t   state_fullscreen_atom_;
+    xcb_atom_t   bypass_compositor_atom_;
 };
 
 class XcbWindowFactory : public decode::WindowFactory
 {
   public:
-    XcbWindowFactory(XcbApplication* application);
+    XcbWindowFactory(XcbContext* xcb_context);
 
     virtual const char* GetSurfaceExtensionName() const override { return VK_KHR_XCB_SURFACE_EXTENSION_NAME; }
 
@@ -145,7 +145,7 @@ class XcbWindowFactory : public decode::WindowFactory
                                                           uint32_t                     queue_family_index) override;
 
   private:
-    XcbApplication* xcb_application_;
+    XcbContext* xcb_context_;
 };
 
 GFXRECON_END_NAMESPACE(application)

--- a/framework/application/xlib_context.h
+++ b/framework/application/xlib_context.h
@@ -1,6 +1,6 @@
 /*
-** Copyright (c) 2021, Arm Limited.
-** Copyright (c) 2021 LunarG, Inc.
+** Copyright (c) 2018 Valve Corporation
+** Copyright (c) 2018-2021 LunarG, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -21,30 +21,45 @@
 ** DEALINGS IN THE SOFTWARE.
 */
 
-#ifndef GFXRECON_APPLICATION_HEADLESS_APPLICATION_H
-#define GFXRECON_APPLICATION_HEADLESS_APPLICATION_H
+#ifndef GFXRECON_APPLICATION_XLIB_CONTEXT_H
+#define GFXRECON_APPLICATION_XLIB_CONTEXT_H
 
-#include "application/application.h"
+#include "application/wsi_context.h"
 #include "util/defines.h"
+#include "util/xlib_loader.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
-class HeadlessWindow;
+class ApplicationEx;
+class XlibWindow;
 
-class HeadlessApplication : public Application
+class XlibContext : public WsiContext
 {
   public:
-    HeadlessApplication(const std::string& name);
+    XlibContext(ApplicationEx* application);
 
-    virtual ~HeadlessApplication() override{};
+    virtual ~XlibContext() override;
 
-    virtual bool Initialize(decode::FileProcessor* file_processor) override;
+    const util::XlibLoader::FunctionTable& GetXlibFunctionTable() const { return xlib_loader_.GetFunctionTable(); }
+
+    Display* OpenDisplay();
+
+    void CloseDisplay(Display* display);
+
+    bool RegisterXlibWindow(XlibWindow* window);
+
+    bool UnregisterXlibWindow(XlibWindow* window);
 
     virtual void ProcessEvents(bool wait_for_input) override;
+
+  private:
+    Display*         display_ { };
+    size_t           display_open_count_ { };
+    util::XlibLoader xlib_loader_ { };
 };
 
 GFXRECON_END_NAMESPACE(application)
 GFXRECON_END_NAMESPACE(gfxrecon)
 
-#endif // GFXRECON_APPLICATION_HEADLESS_APPLICATION_H
+#endif // GFXRECON_APPLICATION_XLIB_CONTEXT_H

--- a/framework/application/xlib_window.cpp
+++ b/framework/application/xlib_window.cpp
@@ -21,7 +21,7 @@
 */
 
 #include "application/xlib_window.h"
-
+#include "application/application.h"
 #include "util/logging.h"
 
 #include "X11/Xatom.h"
@@ -34,12 +34,12 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
-XlibWindow::XlibWindow(XlibApplication* application) :
-    xlib_application_(application), display_(nullptr), window_(0), width_(0), height_(0),
+XlibWindow::XlibWindow(XlibContext* xlib_context) :
+    xlib_context_(xlib_context), display_(nullptr), window_(0), width_(0), height_(0),
     screen_width_(std::numeric_limits<uint32_t>::max()), screen_height_(std::numeric_limits<uint32_t>::max()),
     visible_(false), fullscreen_(false)
 {
-    assert(application != nullptr);
+    assert(xlib_context_ != nullptr);
 }
 
 XlibWindow::~XlibWindow() {}
@@ -47,13 +47,13 @@ XlibWindow::~XlibWindow() {}
 bool XlibWindow::Create(
     const std::string& title, const int32_t xpos, const int32_t ypos, const uint32_t width, const uint32_t height)
 {
-    display_ = xlib_application_->OpenDisplay();
+    display_ = xlib_context_->OpenDisplay();
 
-    const auto xlib   = xlib_application_->GetXlibFunctionTable();
+    const auto xlib   = xlib_context_->GetXlibFunctionTable();
     const auto screen = DefaultScreen(display_);
     const auto root   = RootWindow(display_, screen);
 
-    xlib_application_->RegisterXlibWindow(this);
+    xlib_context_->RegisterXlibWindow(this);
 
     // Get screen size
     XWindowAttributes root_attributes;
@@ -126,7 +126,7 @@ bool XlibWindow::Destroy()
 {
     if (window_ != 0)
     {
-        const auto xlib = xlib_application_->GetXlibFunctionTable();
+        const auto xlib = xlib_context_->GetXlibFunctionTable();
 
         SetFullscreen(false);
         SetVisibility(false);
@@ -134,10 +134,10 @@ bool XlibWindow::Destroy()
         xlib.DestroyWindow(display_, window_);
         xlib.Sync(display_, true);
 
-        xlib_application_->CloseDisplay(display_);
+        xlib_context_->CloseDisplay(display_);
         display_ = nullptr;
 
-        xlib_application_->UnregisterXlibWindow(this);
+        xlib_context_->UnregisterXlibWindow(this);
         window_ = 0;
 
         return true;
@@ -148,13 +148,13 @@ bool XlibWindow::Destroy()
 
 void XlibWindow::SetTitle(const std::string& title)
 {
-    const auto xlib = xlib_application_->GetXlibFunctionTable();
+    const auto xlib = xlib_context_->GetXlibFunctionTable();
     xlib.StoreName(display_, window_, title.c_str());
 }
 
 void XlibWindow::SetPosition(const int32_t x, const int32_t y)
 {
-    const auto xlib = xlib_application_->GetXlibFunctionTable();
+    const auto xlib = xlib_context_->GetXlibFunctionTable();
     xlib.MoveWindow(display_, window_, x, y);
 }
 
@@ -180,7 +180,7 @@ void XlibWindow::SetSize(const uint32_t width, const uint32_t height)
             }
 
             SetFullscreen(false);
-            const auto xlib = xlib_application_->GetXlibFunctionTable();
+            const auto xlib = xlib_context_->GetXlibFunctionTable();
             xlib.ResizeWindow(display_, window_, width, height);
             xlib.Sync(display_, true);
         }
@@ -199,7 +199,7 @@ void XlibWindow::SetFullscreen(bool fullscreen)
 {
     if (fullscreen != fullscreen_)
     {
-        const auto xlib   = xlib_application_->GetXlibFunctionTable();
+        const auto xlib   = xlib_context_->GetXlibFunctionTable();
         const auto screen = DefaultScreen(display_);
         const auto root   = RootWindow(display_, screen);
 
@@ -239,7 +239,7 @@ void XlibWindow::SetVisibility(bool show)
 {
     if (show != visible_)
     {
-        const auto xlib = xlib_application_->GetXlibFunctionTable();
+        const auto xlib = xlib_context_->GetXlibFunctionTable();
         if (show)
         {
             xlib.MapWindow(display_, window_);
@@ -255,7 +255,7 @@ void XlibWindow::SetVisibility(bool show)
 
 void XlibWindow::SetForeground()
 {
-    const auto xlib   = xlib_application_->GetXlibFunctionTable();
+    const auto xlib   = xlib_context_->GetXlibFunctionTable();
     const auto screen = DefaultScreen(display_);
     const auto root   = RootWindow(display_, screen);
 
@@ -313,15 +313,18 @@ void XlibWindow::DestroySurface(const encode::InstanceTable* table, VkInstance i
     }
 }
 
-XlibWindowFactory::XlibWindowFactory(XlibApplication* application) : xlib_application_(application)
+XlibWindowFactory::XlibWindowFactory(XlibContext* context) : xlib_context_(context)
 {
-    assert(application != nullptr);
+    assert(xlib_context_ != nullptr);
 }
 
 decode::Window* XlibWindowFactory::Create(const int32_t x, const int32_t y, const uint32_t width, const uint32_t height)
 {
-    const auto window = new XlibWindow(xlib_application_);
-    window->Create(xlib_application_->GetName(), x, y, width, height);
+    assert(xlib_context_);
+    decode::Window* window = new XlibWindow(xlib_context_);
+    auto application = xlib_context_->GetApplication();
+    assert(application);
+    window->Create(application->GetName(), x, y, width, height);
     return window;
 }
 
@@ -338,8 +341,8 @@ VkBool32 XlibWindowFactory::GetPhysicalDevicePresentationSupport(const encode::I
                                                                  VkPhysicalDevice             physical_device,
                                                                  uint32_t                     queue_family_index)
 {
-    const auto display = xlib_application_->OpenDisplay();
-    const auto xlib    = xlib_application_->GetXlibFunctionTable();
+    const auto display = xlib_context_->OpenDisplay();
+    const auto xlib    = xlib_context_->GetXlibFunctionTable();
 
     // Get visual ID which will be inherited from parent at window creation
     XWindowAttributes root_attributes;
@@ -349,7 +352,7 @@ VkBool32 XlibWindowFactory::GetPhysicalDevicePresentationSupport(const encode::I
     const auto result =
         table->GetPhysicalDeviceXlibPresentationSupportKHR(physical_device, queue_family_index, display, visual_id);
 
-    xlib_application_->CloseDisplay(display);
+    xlib_context_->CloseDisplay(display);
     return result;
 }
 

--- a/framework/application/xlib_window.h
+++ b/framework/application/xlib_window.h
@@ -23,7 +23,7 @@
 #ifndef GFXRECON_APPLICATION_XLIB_WINDOW_H
 #define GFXRECON_APPLICATION_XLIB_WINDOW_H
 
-#include "application/xlib_application.h"
+#include "application/xlib_context.h"
 #include "decode/window.h"
 #include "util/defines.h"
 
@@ -33,7 +33,7 @@ GFXRECON_BEGIN_NAMESPACE(application)
 class XlibWindow : public decode::Window
 {
   public:
-    XlibWindow(XlibApplication* application);
+    XlibWindow(XlibContext* xlib_context);
 
     virtual ~XlibWindow() override;
 
@@ -72,21 +72,21 @@ class XlibWindow : public decode::Window
 
   private:
   private:
-    XlibApplication* xlib_application_;
-    Display*         display_;
-    ::Window         window_;
-    uint32_t         width_;
-    uint32_t         height_;
-    uint32_t         screen_width_;
-    uint32_t         screen_height_;
-    bool             visible_;
-    bool             fullscreen_;
+    XlibContext* xlib_context_;
+    Display*     display_;
+    ::Window     window_;
+    uint32_t     width_;
+    uint32_t     height_;
+    uint32_t     screen_width_;
+    uint32_t     screen_height_;
+    bool         visible_;
+    bool         fullscreen_;
 };
 
 class XlibWindowFactory : public decode::WindowFactory
 {
   public:
-    XlibWindowFactory(XlibApplication* application);
+    XlibWindowFactory(XlibContext* xlib_context);
 
     virtual const char* GetSurfaceExtensionName() const override { return VK_KHR_XLIB_SURFACE_EXTENSION_NAME; }
 
@@ -100,7 +100,7 @@ class XlibWindowFactory : public decode::WindowFactory
                                                           uint32_t                     queue_family_index) override;
 
   private:
-    XlibApplication* xlib_application_;
+    XlibContext* xlib_context_;
 };
 
 GFXRECON_END_NAMESPACE(application)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -22,7 +22,6 @@
 */
 
 #include "decode/vulkan_replay_consumer_base.h"
-
 #include "decode/custom_vulkan_struct_handle_mappers.h"
 #include "decode/descriptor_update_template_decoder.h"
 #include "decode/resource_util.h"
@@ -138,12 +137,13 @@ static uint32_t GetHardwareBufferFormatBpp(uint32_t format)
 }
 #endif
 
-VulkanReplayConsumerBase::VulkanReplayConsumerBase(WindowFactory* window_factory, const ReplayOptions& options) :
-    loader_handle_(nullptr), get_instance_proc_addr_(nullptr), create_instance_proc_(nullptr),
-    window_factory_(window_factory), options_(options), loading_trim_state_(false), have_imported_semaphores_(false),
-    create_surface_count_(0), fps_info_(nullptr)
+VulkanReplayConsumerBase::VulkanReplayConsumerBase(application::ApplicationEx* application,
+                                                   const ReplayOptions&        options) :
+    loader_handle_(nullptr),
+    get_instance_proc_addr_(nullptr), create_instance_proc_(nullptr), application_(application), options_(options),
+    loading_trim_state_(false), have_imported_semaphores_(false), create_surface_count_(0), fps_info_(nullptr)
 {
-    assert(window_factory != nullptr);
+    assert(application_ != nullptr);
     assert(options.create_resource_allocator != nullptr);
 
     if (!options.screenshot_ranges.empty())
@@ -186,9 +186,14 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
         [this](const void* handle) { return GetDeviceTable(handle); });
 
     // Destroy any windows that were created for Vulkan surfaces.
-    for (auto window : active_windows_)
+    auto wsi_context = application_ ? application_->GetWsiContext() : nullptr;
+    auto window_factory = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
+    if (window_factory)
     {
-        window_factory_->Destroy(window);
+        for (auto window : active_windows_)
+        {
+            window_factory->Destroy(window);
+        }
     }
 
     if (loader_handle_ != nullptr)
@@ -2084,8 +2089,14 @@ VkResult VulkanReplayConsumerBase::CreateSurface(InstanceInfo*                  
     if ((options_.surface_index == -1) || (options_.surface_index == create_surface_count_))
     {
         // Create a window for our surface.
-        Window* window = window_factory_->Create(
-            kDefaultWindowPositionX, kDefaultWindowPositionY, kDefaultWindowWidth, kDefaultWindowHeight);
+        // Window* window = window_factory_->Create(
+        //     kDefaultWindowPositionX, kDefaultWindowPositionY, kDefaultWindowWidth, kDefaultWindowHeight);
+        assert(application_);
+        auto wsi_context = application_ ? application_->GetWsiContext() : nullptr;
+        assert(wsi_context);
+        auto window_factory = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
+        assert(window_factory);
+        auto window = window_factory ? window_factory->Create(kDefaultWindowPositionX, kDefaultWindowPositionY, kDefaultWindowWidth, kDefaultWindowHeight) : nullptr;
 
         if (window == nullptr)
         {
@@ -2107,7 +2118,7 @@ VkResult VulkanReplayConsumerBase::CreateSurface(InstanceInfo*                  
         }
         else
         {
-            window_factory_->Destroy(window);
+            window_factory->Destroy(window);
         }
     }
     else
@@ -2377,18 +2388,25 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
 
         if (replay_create_info->ppEnabledExtensionNames)
         {
+            // TODO : window_factory_ update...
             // Swap the surface extension supported by platform the replay is running on if different from trace
             for (uint32_t i = 0; i < replay_create_info->enabledExtensionCount; ++i)
             {
                 const char* current_extension = replay_create_info->ppEnabledExtensionNames[i];
-                if (kSurfaceExtensions.find(current_extension) != kSurfaceExtensions.end())
-                {
-                    filtered_extensions.push_back(window_factory_->GetSurfaceExtensionName());
-                }
-                else
-                {
-                    filtered_extensions.push_back(current_extension);
-                }
+                // if (kSurfaceExtensions.find(current_extension) != kSurfaceExtensions.end())
+                // {
+                //     filtered_extensions.push_back(window_factory_->GetSurfaceExtensionName());
+                // }
+                // else
+                // {
+                //     filtered_extensions.push_back(current_extension);
+                // }
+                filtered_extensions.push_back(current_extension);
+            }
+            for (const auto& extension : filtered_extensions)
+            {
+                assert(application_);
+                application_->InitializeWsiContext(extension);
             }
 
             PFN_vkEnumerateInstanceExtensionProperties instance_extension_proc =
@@ -5345,8 +5363,10 @@ VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWin32PresentationSup
 
     VkPhysicalDevice physical_device = physical_device_info->handle;
 
-    return window_factory_->GetPhysicalDevicePresentationSupport(
-        GetInstanceTable(physical_device), physical_device, queueFamilyIndex);
+    auto wsi_context = application_ ? application_->GetWsiContext() : nullptr;
+    auto window_factory = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
+    return window_factory ? window_factory->GetPhysicalDevicePresentationSupport(
+        GetInstanceTable(physical_device), physical_device, queueFamilyIndex) : false;
 }
 
 VkResult VulkanReplayConsumerBase::OverrideCreateXcbSurfaceKHR(
@@ -5385,8 +5405,10 @@ VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXcbPresentationSuppo
 
     VkPhysicalDevice physical_device = physical_device_info->handle;
 
-    return window_factory_->GetPhysicalDevicePresentationSupport(
-        GetInstanceTable(physical_device), physical_device, queueFamilyIndex);
+    auto wsi_context = application_ ? application_->GetWsiContext() : nullptr;
+    auto window_factory = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
+    return window_factory ? window_factory->GetPhysicalDevicePresentationSupport(
+        GetInstanceTable(physical_device), physical_device, queueFamilyIndex) : false;
 }
 
 VkResult VulkanReplayConsumerBase::OverrideCreateXlibSurfaceKHR(
@@ -5425,8 +5447,10 @@ VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXlibPresentationSupp
 
     VkPhysicalDevice physical_device = physical_device_info->handle;
 
-    return window_factory_->GetPhysicalDevicePresentationSupport(
-        GetInstanceTable(physical_device), physical_device, queueFamilyIndex);
+    auto wsi_context = application_ ? application_->GetWsiContext() : nullptr;
+    auto window_factory = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
+    return window_factory ? window_factory->GetPhysicalDevicePresentationSupport(
+        GetInstanceTable(physical_device), physical_device, queueFamilyIndex) : false;
 }
 
 VkResult VulkanReplayConsumerBase::OverrideCreateWaylandSurfaceKHR(
@@ -5463,8 +5487,10 @@ VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWaylandPresentationS
 
     VkPhysicalDevice physical_device = physical_device_info->handle;
 
-    return window_factory_->GetPhysicalDevicePresentationSupport(
-        GetInstanceTable(physical_device), physical_device, queueFamilyIndex);
+    auto wsi_context = application_ ? application_->GetWsiContext() : nullptr;
+    auto window_factory = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
+    return window_factory ? window_factory->GetPhysicalDevicePresentationSupport(
+        GetInstanceTable(physical_device), physical_device, queueFamilyIndex) : false;
 }
 
 void VulkanReplayConsumerBase::OverrideDestroySurfaceKHR(
@@ -5489,7 +5515,12 @@ void VulkanReplayConsumerBase::OverrideDestroySurfaceKHR(
     {
         window->DestroySurface(GetInstanceTable(instance), instance, surface);
         active_windows_.erase(window);
-        window_factory_->Destroy(window);
+        auto wsi_context = application_ ? application_->GetWsiContext() : nullptr;
+        auto window_factory = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
+        if (window_factory)
+        {
+            window_factory->Destroy(window);
+        }
     }
     else
     {

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -44,6 +44,8 @@
 #include "util/defines.h"
 #include "util/logging.h"
 
+#include "application/application.h"
+
 #include "vulkan/vulkan.h"
 
 #include <algorithm>
@@ -66,7 +68,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 class VulkanReplayConsumerBase : public VulkanConsumer
 {
   public:
-    VulkanReplayConsumerBase(WindowFactory* window_factory, const ReplayOptions& options);
+    VulkanReplayConsumerBase(application::ApplicationEx* application, const ReplayOptions& options);
 
     virtual ~VulkanReplayConsumerBase() override;
 
@@ -977,7 +979,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::unordered_map<encode::DispatchKey, encode::InstanceTable>   instance_tables_;
     std::unordered_map<encode::DispatchKey, encode::DeviceTable>     device_tables_;
     std::function<void(const char*)>                                 fatal_error_handler_;
-    WindowFactory*                                                   window_factory_;
+    // WindowFactory*                                                   window_factory_;
+    application::ApplicationEx*                                      application_;
     VulkanObjectInfoTable                                            object_info_table_;
     ActiveWindows                                                    active_windows_;
     ReplayOptions                                                    options_;

--- a/framework/generated/generated_vulkan_replay_consumer.h
+++ b/framework/generated/generated_vulkan_replay_consumer.h
@@ -32,6 +32,8 @@
 #include "decode/vulkan_replay_consumer_base.h"
 #include "util/defines.h"
 
+#include "application/application.h"
+
 #include "vulkan/vulkan.h"
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
@@ -40,7 +42,8 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 class VulkanReplayConsumer : public VulkanReplayConsumerBase
 {
   public:
-    VulkanReplayConsumer(WindowFactory* window_factory, const ReplayOptions& options) : VulkanReplayConsumerBase(window_factory, options) { }
+    // VulkanReplayConsumer(WindowFactory* window_factory, const ReplayOptions& options) : VulkanReplayConsumerBase(window_factory, options) { }
+    VulkanReplayConsumer(application::ApplicationEx* application, const ReplayOptions& options) : VulkanReplayConsumerBase(application, options) { }
 
     virtual ~VulkanReplayConsumer() override { }
 

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -23,7 +23,7 @@
 
 #include "replay_settings.h"
 
-#include "application/android_application.h"
+#include "application/android_context.h"
 #include "application/android_window.h"
 #include "decode/file_processor.h"
 #include "decode/vulkan_replay_options.h"
@@ -94,8 +94,8 @@ void android_main(struct android_app* app)
         try
         {
             gfxrecon::decode::FileProcessor                            file_processor;
-            std::unique_ptr<gfxrecon::application::AndroidApplication> application;
-            std::unique_ptr<gfxrecon::decode::WindowFactory>           window_factory;
+            // std::unique_ptr<gfxrecon::application::AndroidApplication> application;
+            // std::unique_ptr<gfxrecon::decode::WindowFactory>           window_factory;
 
             if (!file_processor.Initialize(filename))
             {
@@ -104,10 +104,13 @@ void android_main(struct android_app* app)
             else
             {
                 // Setup platform specific application and window factory.
-                application    = std::make_unique<gfxrecon::application::AndroidApplication>(kApplicationName, app);
-                window_factory = std::make_unique<gfxrecon::application::AndroidWindowFactory>(application.get());
+                // application    = std::make_unique<gfxrecon::application::AndroidApplication>(kApplicationName, app);
+                // window_factory = std::make_unique<gfxrecon::application::AndroidWindowFactory>(application.get());
 
-                if (!application->Initialize(&file_processor))
+                auto application = std::make_unique<gfxrecon::application::ApplicationEx>(kApplicationName, &file_processor);
+                application->InitializeWsiContext(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME, app);
+
+                if (/* !application->Initialize(&file_processor)*/ !application)
                 {
                     GFXRECON_WRITE_CONSOLE(
                         "Failed to initialize platform specific window system management.\nEnsure that the appropriate "
@@ -117,7 +120,7 @@ void android_main(struct android_app* app)
                 {
                     gfxrecon::decode::VulkanTrackedObjectInfoTable tracked_object_info_table;
                     gfxrecon::decode::VulkanReplayConsumer         replay_consumer(
-                        window_factory.get(), GetReplayOptions(arg_parser, filename, &tracked_object_info_table));
+                        application.get(), GetReplayOptions(arg_parser, filename, &tracked_object_info_table));
                     gfxrecon::decode::VulkanDecoder decoder;
 
                     replay_consumer.SetFatalErrorHandler(
@@ -213,24 +216,27 @@ void ProcessAppCmd(struct android_app* app, int32_t cmd)
 {
     if (app->userData != nullptr)
     {
-        gfxrecon::application::AndroidApplication* android_application =
-            reinterpret_cast<gfxrecon::application::AndroidApplication*>(app->userData);
+        using namespace gfxrecon::application;
+        auto application = reinterpret_cast<ApplicationEx*>(app->userData);
+        assert(application);
 
         switch (cmd)
         {
             case APP_CMD_INIT_WINDOW:
             {
-                android_application->InitWindow();
+                auto android_context = reinterpret_cast<AndroidContext*>(application->GetWsiContext());
+                assert(android_context);
+                android_context->InitWindow();
                 break;
             }
             case APP_CMD_GAINED_FOCUS:
             {
-                android_application->SetPaused(false);
+                application->SetPaused(false);
                 break;
             }
             case APP_CMD_LOST_FOCUS:
             {
-                android_application->SetPaused(true);
+                application->SetPaused(true);
                 break;
             }
         }
@@ -253,7 +259,8 @@ int32_t ProcessInputEvent(struct android_app* app, AInputEvent* event)
 
             if (action == AMOTION_EVENT_ACTION_UP)
             {
-                auto android_application = reinterpret_cast<gfxrecon::application::AndroidApplication*>(app->userData);
+                auto application = reinterpret_cast<gfxrecon::application::ApplicationEx*>(app->userData);
+                assert(application);
                 int32_t horizontal_distance = 0;
                 int32_t vertical_distance   = 0;
 
@@ -266,10 +273,10 @@ int32_t ProcessInputEvent(struct android_app* app, AInputEvent* event)
                 if (abs(horizontal_distance) > kSwipeDistance)
                 {
                     if ((horizontal_distance < 0) && (abs(horizontal_distance) > abs(vertical_distance)) &&
-                        android_application->GetPaused())
+                        application->GetPaused())
                     {
                         // Treat as swipe right-to-left to advance frame while paused.
-                        android_application->PlaySingleFrame();
+                        application->PlaySingleFrame();
                     }
                 }
                 else if (abs(vertical_distance) > kSwipeDistance)
@@ -279,7 +286,7 @@ int32_t ProcessInputEvent(struct android_app* app, AInputEvent* event)
                 else
                 {
                     // Treat as a tap to toggle pause state.
-                    android_application->SetPaused(!android_application->GetPaused());
+                    application->SetPaused(!application->GetPaused());
                 }
 
                 return 1;
@@ -304,12 +311,13 @@ int32_t ProcessInputEvent(struct android_app* app, AInputEvent* event)
             //  N     = 42
             if (action == AKEY_EVENT_ACTION_UP)
             {
-                auto android_application = reinterpret_cast<gfxrecon::application::AndroidApplication*>(app->userData);
+                auto application = reinterpret_cast<gfxrecon::application::ApplicationEx*>(app->userData);
+                assert(application);
                 switch (key)
                 {
                     case AKEYCODE_SPACE:
                     case AKEYCODE_P:
-                        android_application->SetPaused(!android_application->GetPaused());
+                        application->SetPaused(!application->GetPaused());
                         break;
                     default:
                         break;
@@ -317,14 +325,15 @@ int32_t ProcessInputEvent(struct android_app* app, AInputEvent* event)
             }
             else if (action == AKEY_EVENT_ACTION_DOWN)
             {
-                auto android_application = reinterpret_cast<gfxrecon::application::AndroidApplication*>(app->userData);
+                auto application = reinterpret_cast<gfxrecon::application::ApplicationEx*>(app->userData);
+                assert(application);
                 switch (key)
                 {
                     case AKEYCODE_DPAD_RIGHT:
                     case AKEYCODE_N:
-                        if (android_application->GetPaused())
+                        if (application->GetPaused())
                         {
-                            android_application->PlaySingleFrame();
+                            application->PlaySingleFrame();
                         }
                         break;
                     default:


### PR DESCRIPTION
This PR breaks the `Application` class into two parts.  The first part remains `Application` and is responsible for reading the captured stream file, advancing the stream, preparing API calls for decoding, etc.  The second part is `WsiContext`, this is responsible for handling message procedures, window callbacks, etc.  In addition, each 0f the WSI specific extended `Application` classes now extend `WsiContext`.

This change is necessary due to the need for `Application` to be created before we're reading the captured stream...this meant that the WSI specific `Application` object had to be created before we were aware of what WSI system was actually used at capture time.  Now we're able to create a `WsiContext` after creating `Application`.
