### PR TITLE
Add thread support for multi-threaded drivers

### DIFF
--- a/tools/replay/CMakeLists.txt
+++ b/tools/replay/CMakeLists.txt
@@ -38,6 +38,13 @@ target_include_directories(gfxrecon-replay PUBLIC ${CMAKE_BINARY_DIR})
 
 target_link_libraries(gfxrecon-replay gfxrecon_application gfxrecon_decode gfxrecon_graphics gfxrecon_format gfxrecon_util platform_specific)
 
+# A multithreaded Vulkan driver loaded through dlopen() mechanism
+# won't work if libstdc++ has started in a single-threaded mode.
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+target_link_libraries(gfxrecon-replay Threads::Threads)
+
 common_build_directives(gfxrecon-replay)
 
 install(TARGETS gfxrecon-replay RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
The libstdc++ must be initialised in multi-threaded mode otherwise shared
lib added with dlopen() won't have access to std::thread.