### PR TITLE
fix VS2015 warning for BOOL assignment to bool

### DIFF
--- a/framework/util/file_path.cpp
+++ b/framework/util/file_path.cpp
@@ -171,7 +171,7 @@ bool GetWindowsSystemLibrariesPath(std::string& base_path)
     GetModuleFileNameA(nullptr, module_name, MAX_PATH);
 
     DWORD bin_type = 0;
-    bool  success  = GetBinaryTypeA(module_name, &bin_type);
+    bool  success  = GetBinaryTypeA(module_name, &bin_type) == TRUE;
 
     if (success == true)
     {


### PR DESCRIPTION
Potentially fix this warning from VS2015 treated as error:
```
C:\j\msdk\build\gfxreconstruct\repo\framework\util\file_path.cpp(174): error C2220: warning treated as error - no 'object' file generated [C:\j\msdk\build\gfxreconstruct\repo\build32\framework\util\gfxrecon_util.vcxproj]
C:\j\msdk\build\gfxreconstruct\repo\framework\util\file_path.cpp(174): warning C4800: 'BOOL': forcing value to bool 'true' or 'false' (performance warning) [C:\j\msdk\build\gfxreconstruct\repo\build32\framework\util\gfxrecon_util.vcxproj]
```