### PR TITLE
Wrong error log for VK_EXT_buffer_device_address 

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -205,6 +205,12 @@ sudo apt-get install git cmake build-essential libx11-xcb-dev libxcb-keysyms1-de
         libwayland-dev libxrandr-dev zlib1g-dev liblz4-dev libzstd-dev
 ```
 
+For 32-bit builds (DXVK might require 32-bit):
+```bash
+sudo apt-get install g++-multilib libx11-xcb-dev:i386 libxcb-keysyms1-dev:i386 \
+        libwayland-dev:i386 libxrandr-dev:i386 zlib1g-dev:i386 liblz4-dev:i386 libzstd-dev:i386
+```
+
 For arm64 builds (cross compilation):
 
 ```bash

--- a/framework/graphics/vulkan_device_util.cpp
+++ b/framework/graphics/vulkan_device_util.cpp
@@ -142,12 +142,6 @@ VulkanDeviceUtil::EnableRequiredPhysicalDeviceFeatures(uint32_t                 
                     instance_api_version, instance_table, physical_device, buffer_address_features);
             }
             break;
-            case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT:
-            {
-                GFXRECON_LOG_ERROR("Extension %s is not supported by GFXReconstruct.",
-                                   VK_EXT_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
-            }
-            break;
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR:
             {
                 // Enable accelerationStructureCaptureReplay


### PR DESCRIPTION
close: https://github.com/LunarG/gfxreconstruct/issues/548

1. Right now, Portal 2 doesn't use either `VK_EXT_buffer_device_address` and `VK_KHR_buffer_device_address` extensions. We also don't keep the old captured file to test, so the error can't be regenerated. 

2. https://github.com/locke-lunarg/Vulkan-Tools/tree/locke-test
I added `VK_EXT_buffer_device_address` into vkcube. It ran capture and replay successfully after I removed the `GFXRECON_LOG_ERROR`. (Some devices might not support `VK_EXT_buffer_device_address`) In this case, I think we should remove the `GFXRECON_LOG_ERROR`.