### PR TITLE
[patrick-lunarg][wsi-selection]

### DIFF
--- a/framework/application/android_context.cpp
+++ b/framework/application/android_context.cpp
@@ -82,7 +82,6 @@ void AndroidContext::ProcessEvents(bool wait_for_input)
 
 void AndroidContext::InitWindow()
 {
-    GFXRECON_LOG_DEBUG("AndroidContext::InitWindow()");
     window_ = std::make_unique<AndroidWindow>(this, android_app_->window);
 }
 

--- a/framework/application/android_context.cpp
+++ b/framework/application/android_context.cpp
@@ -82,6 +82,7 @@ void AndroidContext::ProcessEvents(bool wait_for_input)
 
 void AndroidContext::InitWindow()
 {
+    GFXRECON_LOG_DEBUG("AndroidContext::InitWindow()");
     window_ = std::make_unique<AndroidWindow>(this, android_app_->window);
 }
 

--- a/framework/application/android_window.cpp
+++ b/framework/application/android_window.cpp
@@ -111,6 +111,11 @@ bool AndroidWindow::GetNativeHandle(HandleType type, void** handle)
     }
 }
 
+std::string AndroidWindow::GetWsiExtension() const
+{
+    return VK_KHR_ANDROID_SURFACE_EXTENSION_NAME;
+}
+
 VkResult AndroidWindow::CreateSurface(const encode::InstanceTable* table,
                                       VkInstance                   instance,
                                       VkFlags                      flags,

--- a/framework/application/android_window.h
+++ b/framework/application/android_window.h
@@ -63,6 +63,8 @@ class AndroidWindow : public decode::Window
 
     virtual bool GetNativeHandle(HandleType type, void** handle) override;
 
+    virtual std::string GetWsiExtension() const override;
+
     virtual VkResult CreateSurface(const encode::InstanceTable* table,
                                    VkInstance                   instance,
                                    VkFlags                      flags,

--- a/framework/application/application.cpp
+++ b/framework/application/application.cpp
@@ -54,10 +54,61 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
 
 Application::Application(const std::string& name, decode::FileProcessor* file_processor) :
-    name_(name), file_processor_(file_processor), running_(false), paused_(false), pause_frame_(0)
+    Application(name, std::string(), file_processor)
 {}
 
+Application::Application(const std::string&     name,
+                         const std::string&     cli_wsi_extension,
+                         decode::FileProcessor* file_processor) :
+    name_(name),
+    file_processor_(file_processor), cli_wsi_extension_(cli_wsi_extension), running_(false), paused_(false),
+    pause_frame_(0)
+{
+    if (!cli_wsi_extension_.empty())
+    {
+        InitializeWsiContext(cli_wsi_extension_.c_str());
+    }
+}
+
 Application ::~Application() {}
+
+const WsiContext* Application::GetWsiContext(const std::string& wsi_extension, bool auto_select) const
+{
+    auto itr = wsi_contexts_.end();
+
+    // If auto_select is enabled and a WSI extension was selected on the CLI,
+    //  attempt to get that WSI context
+    if (auto_select && !cli_wsi_extension_.empty())
+    {
+        itr = wsi_contexts_.find(cli_wsi_extension_);
+    }
+
+    // If we don't have a valid WSI context after potential auto_select, fallback
+    //  to the current API call request
+    if (itr == wsi_contexts_.end())
+    {
+        itr = wsi_contexts_.find(wsi_extension);
+    }
+
+    // If auto_select is enabled and we still don't have a valid WSI context, use
+    //  first one we have
+    if (auto_select && itr == wsi_contexts_.end())
+    {
+        itr = wsi_contexts_.begin();
+    }
+
+    // If we've gotten here without a valid WSI context then we'll simply return
+    //  nullptr letting the caller know that we do not have a WSI context loaded
+    //  for the given WSI extension
+    return itr != wsi_contexts_.end() ? itr->second.get() : nullptr;
+}
+
+WsiContext* Application::GetWsiContext(const std::string& wsi_extension, bool auto_select)
+{
+    auto const_this  = const_cast<const Application*>(this);
+    auto wsi_context = const_this->GetWsiContext(wsi_extension, auto_select);
+    return const_cast<WsiContext*>(wsi_context);
+}
 
 void Application::Run()
 {
@@ -123,63 +174,73 @@ bool Application::PlaySingleFrame()
 
 void Application::ProcessEvents(bool wait_for_input)
 {
-    if (wsi_context_)
+    for (const auto& itr : wsi_contexts_)
     {
-        wsi_context_->ProcessEvents(wait_for_input);
+        const auto& wsi_context      = itr.second;
+        bool        activeWsiContext = wsi_context && !wsi_context->GetWindows().empty();
+        auto        pWindowFactory   = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
+        bool        androidWsiContext =
+            pWindowFactory && pWindowFactory->GetSurfaceExtensionName() == "VK_KHR_android_surface";
+        if (activeWsiContext || androidWsiContext)
+        {
+            wsi_context->ProcessEvents(wait_for_input);
+        }
     }
 }
 
-void Application::InitializeWsiContext(const char* surfaceExtensionName, void* pPlatformSpecificData)
+void Application::InitializeWsiContext(const char* pSurfaceExtensionName, void* pPlatformSpecificData)
 {
-    if (!wsi_context_)
+    assert(pSurfaceExtensionName);
+    auto itr = wsi_contexts_.find(pSurfaceExtensionName);
+    if (itr == wsi_contexts_.end())
     {
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
-        if (!util::platform::StringCompare(surfaceExtensionName, VK_KHR_WIN32_SURFACE_EXTENSION_NAME))
+        if (!util::platform::StringCompare(pSurfaceExtensionName, VK_KHR_WIN32_SURFACE_EXTENSION_NAME))
         {
-            wsi_context_ = std::make_unique<Win32Context>(this);
+            wsi_contexts_[VK_KHR_WIN32_SURFACE_EXTENSION_NAME] = std::make_unique<Win32Context>(this);
         }
         else
 #endif
 #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
-            if (!util::platform::StringCompare(surfaceExtensionName, VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME))
+            if (!util::platform::StringCompare(pSurfaceExtensionName, VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME))
         {
-            wsi_context_ = std::make_unique<WaylandContext>(this);
+            wsi_contexts_[VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME] = std::make_unique<WaylandContext>(this);
         }
         else
 #endif
 #if defined(VK_USE_PLATFORM_XCB_KHR)
-            if (!util::platform::StringCompare(surfaceExtensionName, VK_KHR_XCB_SURFACE_EXTENSION_NAME))
+            if (!util::platform::StringCompare(pSurfaceExtensionName, VK_KHR_XCB_SURFACE_EXTENSION_NAME))
         {
-            wsi_context_ = std::make_unique<XcbContext>(this);
+            wsi_contexts_[VK_KHR_XCB_SURFACE_EXTENSION_NAME] = std::make_unique<XcbContext>(this);
         }
         else
 #endif
 #if defined(VK_USE_PLATFORM_XLIB_KHR)
-            if (!util::platform::StringCompare(surfaceExtensionName, VK_KHR_XLIB_SURFACE_EXTENSION_NAME))
+            if (!util::platform::StringCompare(pSurfaceExtensionName, VK_KHR_XLIB_SURFACE_EXTENSION_NAME))
         {
-            wsi_context_ = std::make_unique<XlibContext>(this);
+            wsi_contexts_[VK_KHR_XLIB_SURFACE_EXTENSION_NAME] = std::make_unique<XlibContext>(this);
         }
         else
 #endif
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-            if (!util::platform::StringCompare(surfaceExtensionName, VK_KHR_ANDROID_SURFACE_EXTENSION_NAME))
+            if (!util::platform::StringCompare(pSurfaceExtensionName, VK_KHR_ANDROID_SURFACE_EXTENSION_NAME))
         {
-            wsi_context_ =
+            wsi_contexts_[VK_KHR_ANDROID_SURFACE_EXTENSION_NAME] =
                 std::make_unique<AndroidContext>(this, reinterpret_cast<struct android_app*>(pPlatformSpecificData));
         }
         else
 #endif
 #if defined(VK_USE_PLATFORM_DISPLAY_KHR)
-            if (!util::platform::StringCompare(surfaceExtensionName, VK_KHR_DISPLAY_EXTENSION_NAME))
+            if (!util::platform::StringCompare(pSurfaceExtensionName, VK_KHR_DISPLAY_EXTENSION_NAME))
         {
-            wsi_context_ = std::make_unique<DisplayContext>(this);
+            wsi_contexts_[VK_KHR_DISPLAY_EXTENSION_NAME] = std::make_unique<DisplayContext>(this);
         }
         else
 #endif
 #if defined(VK_USE_PLATFORM_HEADLESS)
-            if (!util::platform::StringCompare(surfaceExtensionName, VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME))
+            if (!util::platform::StringCompare(pSurfaceExtensionName, VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME))
         {
-            wsi_context_ = std::make_unique<HeadlessContext>(this);
+            wsi_contexts_[VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME] = std::make_unique<HeadlessContext>(this);
         }
         else
 #endif

--- a/framework/application/application.h
+++ b/framework/application/application.h
@@ -31,6 +31,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -42,13 +43,17 @@ class Application final
   public:
     Application(const std::string& name, decode::FileProcessor* file_processor);
 
+    Application(const std::string& name, const std::string& cli_wsi_extension, decode::FileProcessor* file_processor);
+
     ~Application();
 
     const std::string& GetName() const { return name_; }
 
-    const WsiContext* GetWsiContext() const { return wsi_context_.get(); }
+    const std::unordered_map<std::string, std::unique_ptr<WsiContext>>& GetWsiContexts() const { return wsi_contexts_; }
 
-    WsiContext* GetWsiContext() { return wsi_context_.get(); }
+    const WsiContext* GetWsiContext(const std::string& wsi_extension, bool auto_select = false) const;
+
+    WsiContext* GetWsiContext(const std::string& wsi_extension, bool auto_select = false);
 
     bool IsRunning() const { return running_; }
 
@@ -70,12 +75,13 @@ class Application final
 
   private:
     // clang-format off
-    std::string                 name_;           ///< Application name to display in window title bar.
-    decode::FileProcessor*      file_processor_; ///< The FileProcessor object responsible for decoding and processing capture file data.
-    bool                        running_;        ///< Indicates that the application is actively processing system events for playback.
-    bool                        paused_;         ///< Indicates that the playback has been paused.  When paused the application will stop rendering, but will continue processing system events.
-    uint32_t                    pause_frame_;    ///< The number for a frame that replay should pause after.
-    std::unique_ptr<WsiContext> wsi_context_;    ///< The window system context used for playback
+    std::string                                                  name_;              ///< Application name to display in window title bar.
+    decode::FileProcessor*                                       file_processor_;    ///< The FileProcessor object responsible for decoding and processing capture file data.
+    bool                                                         running_;           ///< Indicates that the application is actively processing system events for playback.
+    bool                                                         paused_;            ///< Indicates that the playback has been paused.  When paused the application will stop rendering, but will continue processing system events.
+    uint32_t                                                     pause_frame_;       ///< The number for a frame that replay should pause after.
+    std::unordered_map<std::string, std::unique_ptr<WsiContext>> wsi_contexts_;      ///< Loaded WSI contexts from CLI and VkInstanceCreateInfo
+    std::string                                                  cli_wsi_extension_; ///< WSI extension selected on CLI, empty string if no CLI selection
     // clang-format on
 };
 

--- a/framework/application/display_window.cpp
+++ b/framework/application/display_window.cpp
@@ -194,6 +194,11 @@ VkResult DisplayWindow::SelectPlane(const encode::InstanceTable* table,
     return VK_ERROR_INITIALIZATION_FAILED;
 }
 
+std::string DisplayWindow::GetWsiExtension() const
+{
+    return VK_KHR_DISPLAY_EXTENSION_NAME;
+}
+
 VkResult DisplayWindow::CreateSurface(const encode::InstanceTable* table,
                                       VkInstance                   instance,
                                       VkFlags                      flags,

--- a/framework/application/display_window.h
+++ b/framework/application/display_window.h
@@ -59,6 +59,8 @@ class DisplayWindow : public decode::Window
 
     virtual bool GetNativeHandle(HandleType, void**) override { return false; }
 
+    virtual std::string GetWsiExtension() const override;
+
     virtual VkResult CreateSurface(const encode::InstanceTable* table,
                                    VkInstance                   instance,
                                    VkFlags                      flags,

--- a/framework/application/headless_window.cpp
+++ b/framework/application/headless_window.cpp
@@ -91,6 +91,11 @@ bool HeadlessWindow::GetNativeHandle(HandleType type, void** handle)
     return false;
 }
 
+std::string HeadlessWindow::GetWsiExtension() const
+{
+    return VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME;
+}
+
 VkResult HeadlessWindow::CreateSurface(const encode::InstanceTable* table,
                                        VkInstance                   instance,
                                        VkFlags                      flags,

--- a/framework/application/headless_window.h
+++ b/framework/application/headless_window.h
@@ -61,6 +61,8 @@ class HeadlessWindow : public decode::Window
 
     virtual bool GetNativeHandle(HandleType type, void** handle) override;
 
+    virtual std::string GetWsiExtension() const override;
+
     virtual VkResult CreateSurface(const encode::InstanceTable* table,
                                    VkInstance                   instance,
                                    VkFlags                      flags,

--- a/framework/application/wayland_window.cpp
+++ b/framework/application/wayland_window.cpp
@@ -170,6 +170,11 @@ bool WaylandWindow::GetNativeHandle(HandleType type, void** handle)
     }
 }
 
+std::string WaylandWindow::GetWsiExtension() const
+{
+    return VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME;
+}
+
 VkResult WaylandWindow::CreateSurface(const encode::InstanceTable* table,
                                       VkInstance                   instance,
                                       VkFlags                      flags,

--- a/framework/application/wayland_window.h
+++ b/framework/application/wayland_window.h
@@ -67,6 +67,8 @@ class WaylandWindow : public decode::Window
 
     virtual bool GetNativeHandle(HandleType type, void** handle) override;
 
+    virtual std::string GetWsiExtension() const override;
+
     virtual VkResult CreateSurface(const encode::InstanceTable* table,
                                    VkInstance                   instance,
                                    VkFlags                      flags,

--- a/framework/application/win32_window.cpp
+++ b/framework/application/win32_window.cpp
@@ -260,6 +260,11 @@ bool Win32Window::GetNativeHandle(HandleType type, void** handle)
     }
 }
 
+std::string Win32Window::GetWsiExtension() const
+{
+    return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
+}
+
 VkResult Win32Window::CreateSurface(const encode::InstanceTable* table,
                                     VkInstance                   instance,
                                     VkFlags                      flags,

--- a/framework/application/win32_window.h
+++ b/framework/application/win32_window.h
@@ -64,6 +64,8 @@ class Win32Window : public decode::Window
 
     virtual bool GetNativeHandle(HandleType type, void** handle) override;
 
+    virtual std::string GetWsiExtension() const override;
+
     virtual VkResult CreateSurface(const encode::InstanceTable* table,
                                    VkInstance                   instance,
                                    VkFlags                      flags,

--- a/framework/application/wsi_context.h
+++ b/framework/application/wsi_context.h
@@ -49,6 +49,8 @@ class WsiContext
 
     decode::WindowFactory* GetWindowFactory() { return window_factory_.get(); }
 
+    const std::vector<decode::Window*>& GetWindows() const { return windows_; }
+
     bool RegisterWindow(decode::Window* window);
 
     bool UnregisterWindow(decode::Window* window);

--- a/framework/application/xcb_window.cpp
+++ b/framework/application/xcb_window.cpp
@@ -398,6 +398,11 @@ bool XcbWindow::GetNativeHandle(HandleType type, void** handle)
     }
 }
 
+std::string XcbWindow::GetWsiExtension() const
+{
+    return VK_KHR_XCB_SURFACE_EXTENSION_NAME;
+}
+
 VkResult
 XcbWindow::CreateSurface(const encode::InstanceTable* table, VkInstance instance, VkFlags flags, VkSurfaceKHR* pSurface)
 {

--- a/framework/application/xcb_window.h
+++ b/framework/application/xcb_window.h
@@ -82,6 +82,8 @@ class XcbWindow : public decode::Window
 
     virtual bool GetNativeHandle(HandleType type, void** handle) override;
 
+    virtual std::string GetWsiExtension() const override;
+
     virtual VkResult CreateSurface(const encode::InstanceTable* table,
                                    VkInstance                   instance,
                                    VkFlags                      flags,

--- a/framework/application/xlib_window.cpp
+++ b/framework/application/xlib_window.cpp
@@ -289,6 +289,11 @@ bool XlibWindow::GetNativeHandle(HandleType type, void** handle)
     }
 }
 
+std::string XlibWindow::GetWsiExtension() const
+{
+    return VK_KHR_XLIB_SURFACE_EXTENSION_NAME;
+}
+
 VkResult XlibWindow::CreateSurface(const encode::InstanceTable* table,
                                    VkInstance                   instance,
                                    VkFlags                      flags,

--- a/framework/application/xlib_window.h
+++ b/framework/application/xlib_window.h
@@ -60,6 +60,8 @@ class XlibWindow : public decode::Window
 
     virtual bool GetNativeHandle(HandleType type, void** handle) override;
 
+    virtual std::string GetWsiExtension() const override;
+
     virtual VkResult CreateSurface(const encode::InstanceTable* table,
                                    VkInstance                   instance,
                                    VkFlags                      flags,

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -186,14 +186,12 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
         [this](const void* handle) { return GetDeviceTable(handle); });
 
     // Destroy any windows that were created for Vulkan surfaces.
-    auto wsi_context    = application_ ? application_->GetWsiContext() : nullptr;
-    auto window_factory = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
-    if (window_factory)
+    for (auto window : active_windows_)
     {
-        for (auto window : active_windows_)
-        {
-            window_factory->Destroy(window);
-        }
+        auto wsi_context    = application_ ? application_->GetWsiContext(window->GetWsiExtension()) : nullptr;
+        auto window_factory = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
+        assert(window_factory);
+        window_factory->Destroy(window);
     }
 
     if (loader_handle_ != nullptr)
@@ -2070,6 +2068,7 @@ void VulkanReplayConsumerBase::InitializeResourceAllocator(const PhysicalDeviceI
 }
 
 VkResult VulkanReplayConsumerBase::CreateSurface(InstanceInfo*                       instance_info,
+                                                 const std::string&                  wsi_extension,
                                                  VkFlags                             flags,
                                                  HandlePointerDecoder<VkSurfaceKHR>* surface)
 {
@@ -2090,7 +2089,7 @@ VkResult VulkanReplayConsumerBase::CreateSurface(InstanceInfo*                  
     {
         // Create a window for our surface.
         assert(application_);
-        auto wsi_context = application_ ? application_->GetWsiContext() : nullptr;
+        auto wsi_context = application_ ? application_->GetWsiContext(wsi_extension, true) : nullptr;
         assert(wsi_context);
         auto window_factory = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
         assert(window_factory);
@@ -2390,22 +2389,19 @@ VulkanReplayConsumerBase::OverrideCreateInstance(VkResult original_result,
 
         if (replay_create_info->ppEnabledExtensionNames)
         {
-            // If a WSI was selected on the command line we need to add that WSI surface extension name to the
-            // VkInstance
+            // If a specific WSI extension was selected on the command line we need to make sure that extension is
+            // loaded
             assert(application_);
-            auto wsi_context       = application_->GetWsiContext();
-            auto window_factory    = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
-            auto cli_wsi_extension = window_factory ? window_factory->GetSurfaceExtensionName() : nullptr;
-            if (cli_wsi_extension)
+            for (const auto& itr : application_->GetWsiContexts())
             {
-                filtered_extensions.push_back(cli_wsi_extension);
+                filtered_extensions.push_back(itr.first.c_str());
             }
 
             for (uint32_t i = 0; i < replay_create_info->enabledExtensionCount; ++i)
             {
                 auto current_extension = replay_create_info->ppEnabledExtensionNames[i];
                 filtered_extensions.push_back(current_extension);
-                if (!cli_wsi_extension && kSurfaceExtensions.find(current_extension) != kSurfaceExtensions.end())
+                if (kSurfaceExtensions.find(current_extension) != kSurfaceExtensions.end())
                 {
                     application_->InitializeWsiContext(current_extension);
                 }
@@ -5330,7 +5326,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateAndroidSurfaceKHR(
 
     assert((replay_create_info != nullptr) && (pSurface != nullptr) && (pSurface->GetHandlePointer() != nullptr));
 
-    return CreateSurface(instance_info, replay_create_info->flags, pSurface);
+    return CreateSurface(instance_info, "VK_KHR_android_surface", replay_create_info->flags, pSurface);
 }
 
 VkResult VulkanReplayConsumerBase::OverrideCreateWin32SurfaceKHR(
@@ -5351,7 +5347,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateWin32SurfaceKHR(
 
     assert((replay_create_info != nullptr) && (pSurface != nullptr) && (pSurface->GetHandlePointer() != nullptr));
 
-    return CreateSurface(instance_info, replay_create_info->flags, pSurface);
+    return CreateSurface(instance_info, "VK_KHR_win32_surface", replay_create_info->flags, pSurface);
 }
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWin32PresentationSupportKHR(
@@ -5365,7 +5361,7 @@ VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWin32PresentationSup
 
     VkPhysicalDevice physical_device = physical_device_info->handle;
 
-    auto wsi_context    = application_ ? application_->GetWsiContext() : nullptr;
+    auto wsi_context    = application_ ? application_->GetWsiContext("VK_KHR_win32_surface") : nullptr;
     auto window_factory = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
     return window_factory ? window_factory->GetPhysicalDevicePresentationSupport(
                                 GetInstanceTable(physical_device), physical_device, queueFamilyIndex)
@@ -5390,7 +5386,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateXcbSurfaceKHR(
 
     assert((replay_create_info != nullptr) && (pSurface != nullptr) && (pSurface->GetHandlePointer() != nullptr));
 
-    return CreateSurface(instance_info, replay_create_info->flags, pSurface);
+    return CreateSurface(instance_info, "VK_KHR_xcb_surface", replay_create_info->flags, pSurface);
 }
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXcbPresentationSupportKHR(
@@ -5408,7 +5404,7 @@ VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXcbPresentationSuppo
 
     VkPhysicalDevice physical_device = physical_device_info->handle;
 
-    auto wsi_context    = application_ ? application_->GetWsiContext() : nullptr;
+    auto wsi_context    = application_ ? application_->GetWsiContext("VK_KHR_xcb_surface") : nullptr;
     auto window_factory = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
     return window_factory ? window_factory->GetPhysicalDevicePresentationSupport(
                                 GetInstanceTable(physical_device), physical_device, queueFamilyIndex)
@@ -5433,7 +5429,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateXlibSurfaceKHR(
 
     assert((replay_create_info != nullptr) && (pSurface != nullptr) && (pSurface->GetHandlePointer() != nullptr));
 
-    return CreateSurface(instance_info, replay_create_info->flags, pSurface);
+    return CreateSurface(instance_info, "VK_KHR_xlib_surface", replay_create_info->flags, pSurface);
 }
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXlibPresentationSupportKHR(
@@ -5451,7 +5447,7 @@ VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceXlibPresentationSupp
 
     VkPhysicalDevice physical_device = physical_device_info->handle;
 
-    auto wsi_context    = application_ ? application_->GetWsiContext() : nullptr;
+    auto wsi_context    = application_ ? application_->GetWsiContext("VK_KHR_xlib_surface") : nullptr;
     auto window_factory = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
     return window_factory ? window_factory->GetPhysicalDevicePresentationSupport(
                                 GetInstanceTable(physical_device), physical_device, queueFamilyIndex)
@@ -5476,7 +5472,7 @@ VkResult VulkanReplayConsumerBase::OverrideCreateWaylandSurfaceKHR(
 
     assert((replay_create_info != nullptr) && (pSurface != nullptr) && (pSurface->GetHandlePointer() != nullptr));
 
-    return CreateSurface(instance_info, replay_create_info->flags, pSurface);
+    return CreateSurface(instance_info, "VK_KHR_wayland_surface", replay_create_info->flags, pSurface);
 }
 
 VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWaylandPresentationSupportKHR(
@@ -5492,7 +5488,7 @@ VkBool32 VulkanReplayConsumerBase::OverrideGetPhysicalDeviceWaylandPresentationS
 
     VkPhysicalDevice physical_device = physical_device_info->handle;
 
-    auto wsi_context    = application_ ? application_->GetWsiContext() : nullptr;
+    auto wsi_context    = application_ ? application_->GetWsiContext("VK_KHR_wayland_surface") : nullptr;
     auto window_factory = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
     return window_factory ? window_factory->GetPhysicalDevicePresentationSupport(
                                 GetInstanceTable(physical_device), physical_device, queueFamilyIndex)
@@ -5521,7 +5517,7 @@ void VulkanReplayConsumerBase::OverrideDestroySurfaceKHR(
     {
         window->DestroySurface(GetInstanceTable(instance), instance, surface);
         active_windows_.erase(window);
-        auto wsi_context    = application_ ? application_->GetWsiContext() : nullptr;
+        auto wsi_context    = application_ ? application_->GetWsiContext(window->GetWsiExtension()) : nullptr;
         auto window_factory = wsi_context ? wsi_context->GetWindowFactory() : nullptr;
         if (window_factory)
         {

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -894,7 +894,10 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                      const std::vector<std::string>& enabled_device_extensions,
                                      VulkanResourceAllocator*        allocator);
 
-    VkResult CreateSurface(InstanceInfo* instance_info, VkFlags flags, HandlePointerDecoder<VkSurfaceKHR>* surface);
+    VkResult CreateSurface(InstanceInfo*                       instance_info,
+                           const std::string&                  wsi_extension,
+                           VkFlags                             flags,
+                           HandlePointerDecoder<VkSurfaceKHR>* surface);
 
     void MapDescriptorUpdateTemplateHandles(const DescriptorUpdateTemplateInfo* update_template_info,
                                             DescriptorUpdateTemplateDecoder*    decoder);

--- a/framework/decode/window.h
+++ b/framework/decode/window.h
@@ -77,6 +77,8 @@ class Window
 
     virtual bool GetNativeHandle(HandleType type, void** handle) = 0;
 
+    virtual std::string GetWsiExtension() const = 0;
+
     virtual VkResult
     CreateSurface(const encode::InstanceTable* table, VkInstance instance, VkFlags flags, VkSurfaceKHR* pSurface) = 0;
 

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -209,7 +209,7 @@ void ProcessAppCmd(struct android_app* app, int32_t cmd)
         {
             case APP_CMD_INIT_WINDOW:
             {
-                auto android_context = reinterpret_cast<AndroidContext*>(application->GetWsiContext());
+                auto android_context = reinterpret_cast<AndroidContext*>(application->GetWsiContext(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME));
                 assert(android_context);
                 android_context->InitWindow();
                 break;

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -107,79 +107,10 @@ int main(int argc, const char** argv)
         }
         else
         {
-            auto application = std::make_shared<gfxrecon::application::Application>(kApplicationName, &file_processor);
-
-            // Setup WSI context based on CLI
-            auto wsi_platform = GetWsiPlatform(arg_parser);
-#if defined(WIN32)
-#if defined(VK_USE_PLATFORM_WIN32_KHR)
-            if (wsi_platform == WsiPlatform::kWin32)
-            {
-                application->InitializeWsiContext(VK_KHR_WIN32_SURFACE_EXTENSION_NAME);
-                if (!application->GetWsiContext())
-                {
-                    GFXRECON_WRITE_CONSOLE("Failed to initialize command line selected Win32 WSI context");
-                    return_code = -1;
-                }
-            }
-#endif
-#else
-#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
-            if (wsi_platform == WsiPlatform::kWayland)
-            {
-                application->InitializeWsiContext(VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME);
-                if (!application->GetWsiContext())
-                {
-                    GFXRECON_WRITE_CONSOLE("Failed to initialize command line selected Wayland WSI context");
-                    return_code = -1;
-                }
-            }
-#endif
-#if defined(VK_USE_PLATFORM_XCB_KHR)
-            if (wsi_platform == WsiPlatform::kXcb)
-            {
-                application->InitializeWsiContext(VK_KHR_XCB_SURFACE_EXTENSION_NAME);
-                if (!application->GetWsiContext())
-                {
-                    GFXRECON_WRITE_CONSOLE("Failed to initialize command line selected XCB WSI context");
-                    return_code = -1;
-                }
-            }
-#endif
-#if defined(VK_USE_PLATFORM_XLIB_KHR)
-            if (wsi_platform == WsiPlatform::kXlib)
-            {
-                application->InitializeWsiContext(VK_KHR_XLIB_SURFACE_EXTENSION_NAME);
-                if (!application->GetWsiContext())
-                {
-                    GFXRECON_WRITE_CONSOLE("Failed to initialize command line selected Xlib WSI context");
-                    return_code = -1;
-                }
-            }
-#endif
-#if defined(VK_USE_PLATFORM_DISPLAY_KHR)
-            if (wsi_platform == WsiPlatform::kDisplay)
-            {
-                application->InitializeWsiContext(VK_KHR_DISPLAY_EXTENSION_NAME);
-                if (!application->GetWsiContext())
-                {
-                    GFXRECON_WRITE_CONSOLE("Failed to initialize command line selected Direct Display context");
-                    return_code = -1;
-                }
-            }
-#endif
-#endif
-#if defined(VK_USE_PLATFORM_HEADLESS)
-            if (wsi_platform == WsiPlatform::kHeadless)
-            {
-                application->InitializeWsiContext(VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME);
-                if (!application->GetWsiContext())
-                {
-                    GFXRECON_WRITE_CONSOLE("Failed to initialize command line selected Headless WSI context");
-                    return_code = -1;
-                }
-            }
-#endif
+            // Select WSI context based on CLI
+            std::string wsi_extension = GetWsiExtensionName(GetWsiPlatform(arg_parser));
+            auto        application =
+                std::make_shared<gfxrecon::application::Application>(kApplicationName, wsi_extension, &file_processor);
 
             gfxrecon::graphics::FpsInfo                    fps_info;
             gfxrecon::decode::VulkanTrackedObjectInfoTable tracked_object_info_table;

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -310,6 +310,47 @@ static WsiPlatform GetWsiPlatform(const gfxrecon::util::ArgumentParser& arg_pars
     return wsi_platform;
 }
 
+static std::string GetWsiExtensionName(WsiPlatform wsi_platform)
+{
+    switch (wsi_platform)
+    {
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+        case WsiPlatform::kWin32:
+        {
+            return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
+        }
+#endif
+#if defined(VK_USE_PLATFORM_XLIB_KHR)
+        case WsiPlatform::kXlib:
+        {
+            return VK_KHR_XLIB_SURFACE_EXTENSION_NAME;
+        }
+#endif
+#if defined(VK_USE_PLATFORM_XCB_KHR)
+        case WsiPlatform::kXcb:
+        {
+            return VK_KHR_XCB_SURFACE_EXTENSION_NAME;
+        }
+#endif
+#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+        case WsiPlatform::kWayland:
+        {
+            return VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME;
+        }
+#endif
+#if defined(VK_USE_PLATFORM_HEADLESS)
+        case WsiPlatform::kHeadless:
+        {
+            return VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME;
+        }
+#endif
+        default:
+        {
+            return std::string();
+        }
+    }
+}
+
 static std::string GetWsiArgString()
 {
     std::string wsi_args = kWsiPlatformAuto;


### PR DESCRIPTION
This PR enables fallback WSI selection for gfxr replay.

The logic in this PR results in the following behavior...

If there is a WSI selection on the CLI, gfxr-replay will attempt to use that extension.
If the CLI WSI selection fails, gfxr-replay will attempt to fallback to the WSI extension used at capture time.
If the capture time WSI selection fails, gfxr-replay will attempt to fallback to an available WSI extension.

Note that there is no guarantee that WSI configuration will be successful if the playback WSI selection is different from the capture time selection.

This should address issue #583 