### PR TITLE
exit with failure if FileProcessor can't be initialized

### DIFF
--- a/tools/compress/main.cpp
+++ b/tools/compress/main.cpp
@@ -141,8 +141,6 @@ static std::string GetCompressionTypeName(uint32_t type)
 
 int main(int argc, const char** argv)
 {
-    int return_code = 0;
-
     gfxrecon::util::Log::Init();
 
     gfxrecon::util::ArgumentParser arg_parser(argc, argv, kOptions, "");
@@ -249,16 +247,18 @@ int main(int argc, const char** argv)
         else
         {
             GFXRECON_WRITE_CONSOLE("Capture file %s could not be converted.", input_filename.c_str());
-            return_code = -1;
+            gfxrecon::util::Log::Release();
+            exit(-1);
         }
     }
     else
     {
         GFXRECON_WRITE_CONSOLE("CompressionConverter could not be initialized.");
+        gfxrecon::util::Log::Release();
         exit(-1);
     }
 
     gfxrecon::util::Log::Release();
 
-    return return_code;
+    return 0;
 }

--- a/tools/compress/main.cpp
+++ b/tools/compress/main.cpp
@@ -254,7 +254,7 @@ int main(int argc, const char** argv)
     }
     else
     {
-        GFXRECON_WRITE_CONSOLE("CompressionCoverter could not be initialized.");
+        GFXRECON_WRITE_CONSOLE("CompressionConverter could not be initialized.");
         exit(-1);
     }
 

--- a/tools/compress/main.cpp
+++ b/tools/compress/main.cpp
@@ -251,7 +251,9 @@ int main(int argc, const char** argv)
             GFXRECON_WRITE_CONSOLE("Capture file %s could not be converted.", input_filename.c_str());
             return_code = -1;
         }
-    } else {
+    }
+    else
+    {
         GFXRECON_WRITE_CONSOLE("CompressionCoverter could not be initialized.");
         exit(-1);
     }

--- a/tools/compress/main.cpp
+++ b/tools/compress/main.cpp
@@ -251,6 +251,9 @@ int main(int argc, const char** argv)
             GFXRECON_WRITE_CONSOLE("Capture file %s could not be converted.", input_filename.c_str());
             return_code = -1;
         }
+    } else {
+        GFXRECON_WRITE_CONSOLE("CompressionCoverter could not be initialized.");
+        exit(-1);
     }
 
     gfxrecon::util::Log::Release();


### PR DESCRIPTION
Fixes #567 for the narrow case of a non-zero error code when `gfxrecon-compress` fails, see #627 for an extended task to review exit codes.