### PR TITLE
Trimming replay SurfaceCapabilities

### DIFF
--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -293,9 +293,9 @@ struct BufferInfo : public VulkanObjectInfo<VkBuffer>
     VulkanResourceAllocator::ResourceData allocator_data{ 0 };
 
     // The following values are only used when loading the initial state for trimmed files.
-    VkMemoryPropertyFlags               memory_property_flags{ 0 };
-    VkBufferUsageFlags                  usage{ 0 };
-    uint32_t                            queue_family_index{ 0 };
+    VkMemoryPropertyFlags memory_property_flags{ 0 };
+    VkBufferUsageFlags    usage{ 0 };
+    uint32_t              queue_family_index{ 0 };
 };
 
 struct ImageInfo : public VulkanObjectInfo<VkImage>
@@ -357,11 +357,14 @@ struct SurfaceKHRInfo : public VulkanObjectInfo<VkSurfaceKHR>
 {
     Window*                              window{ nullptr };
     std::unordered_map<uint32_t, size_t> array_counts;
+
+    std::unordered_map<VkPhysicalDevice, VkSurfaceCapabilitiesKHR> surface_capabilities;
 };
 
 struct SwapchainKHRInfo : public VulkanObjectInfo<VkSwapchainKHR>
 {
     VkSurfaceKHR                         surface{ VK_NULL_HANDLE };
+    format::HandleId                     surface_id{ format::kNullHandleId };
     DeviceInfo*                          device_info{ nullptr };
     uint32_t                             width{ 0 };
     uint32_t                             height{ 0 };

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -451,6 +451,20 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         PhysicalDeviceInfo*                                              physical_device_info,
         StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties);
 
+    VkResult OverrideGetPhysicalDeviceSurfaceCapabilitiesKHR(
+        PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR           func,
+        VkResult                                                original_result,
+        PhysicalDeviceInfo*                                     physical_device_info,
+        SurfaceKHRInfo*                                         surface_info,
+        StructPointerDecoder<Decoded_VkSurfaceCapabilitiesKHR>* pSurfaceCapabilities);
+
+    VkResult OverrideGetPhysicalDeviceSurfaceCapabilities2KHR(
+        PFN_vkGetPhysicalDeviceSurfaceCapabilities2KHR                 func,
+        VkResult                                                       original_result,
+        PhysicalDeviceInfo*                                            physical_device_info,
+        StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
+        StructPointerDecoder<Decoded_VkSurfaceCapabilities2KHR>*       pSurfaceCapabilities);
+
     VkResult OverrideWaitForFences(PFN_vkWaitForFences                  func,
                                    VkResult                             original_result,
                                    const DeviceInfo*                    device_info,

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -2485,12 +2485,11 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
     format::HandleId                            surface,
     StructPointerDecoder<Decoded_VkSurfaceCapabilitiesKHR>* pSurfaceCapabilities)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    VkSurfaceKHR in_surface = MapHandle<SurfaceKHRInfo>(surface, &VulkanObjectInfoTable::GetSurfaceKHRInfo);
-    if (in_surface == VK_NULL_HANDLE) { return; }
-    VkSurfaceCapabilitiesKHR* out_pSurfaceCapabilities = pSurfaceCapabilities->IsNull() ? nullptr : pSurfaceCapabilities->AllocateOutputData(1);
+    auto in_physicalDevice = GetObjectInfoTable().GetPhysicalDeviceInfo(physicalDevice);
+    auto in_surface = GetObjectInfoTable().GetSurfaceKHRInfo(surface);
+    pSurfaceCapabilities->IsNull() ? nullptr : pSurfaceCapabilities->AllocateOutputData(1);
 
-    VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceCapabilitiesKHR(in_physicalDevice, in_surface, out_pSurfaceCapabilities);
+    VkResult replay_result = OverrideGetPhysicalDeviceSurfaceCapabilitiesKHR(GetInstanceTable(in_physicalDevice->handle)->GetPhysicalDeviceSurfaceCapabilitiesKHR, returnValue, in_physicalDevice, in_surface, pSurfaceCapabilities);
     CheckResult("vkGetPhysicalDeviceSurfaceCapabilitiesKHR", returnValue, replay_result);
 }
 
@@ -3520,12 +3519,12 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
     StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
     StructPointerDecoder<Decoded_VkSurfaceCapabilities2KHR>* pSurfaceCapabilities)
 {
-    VkPhysicalDevice in_physicalDevice = MapHandle<PhysicalDeviceInfo>(physicalDevice, &VulkanObjectInfoTable::GetPhysicalDeviceInfo);
-    const VkPhysicalDeviceSurfaceInfo2KHR* in_pSurfaceInfo = pSurfaceInfo->GetPointer();
-    MapStructHandles(pSurfaceInfo->GetMetaStructPointer(), GetObjectInfoTable());
-    VkSurfaceCapabilities2KHR* out_pSurfaceCapabilities = pSurfaceCapabilities->IsNull() ? nullptr : pSurfaceCapabilities->AllocateOutputData(1, { VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR, nullptr });
+    auto in_physicalDevice = GetObjectInfoTable().GetPhysicalDeviceInfo(physicalDevice);
 
-    VkResult replay_result = GetInstanceTable(in_physicalDevice)->GetPhysicalDeviceSurfaceCapabilities2KHR(in_physicalDevice, in_pSurfaceInfo, out_pSurfaceCapabilities);
+    MapStructHandles(pSurfaceInfo->GetMetaStructPointer(), GetObjectInfoTable());
+    pSurfaceCapabilities->IsNull() ? nullptr : pSurfaceCapabilities->AllocateOutputData(1, { VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR, nullptr });
+
+    VkResult replay_result = OverrideGetPhysicalDeviceSurfaceCapabilities2KHR(GetInstanceTable(in_physicalDevice->handle)->GetPhysicalDeviceSurfaceCapabilities2KHR, returnValue, in_physicalDevice, pSurfaceInfo, pSurfaceCapabilities);
     CheckResult("vkGetPhysicalDeviceSurfaceCapabilities2KHR", returnValue, replay_result);
 }
 

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -12,6 +12,8 @@
     "vkGetPhysicalDeviceMemoryProperties": "OverrideGetPhysicalDeviceMemoryProperties",
     "vkGetPhysicalDeviceMemoryProperties2": "OverrideGetPhysicalDeviceMemoryProperties2",
     "vkGetPhysicalDeviceMemoryProperties2KHR": "OverrideGetPhysicalDeviceMemoryProperties2",
+    "vkGetPhysicalDeviceSurfaceCapabilitiesKHR": "OverrideGetPhysicalDeviceSurfaceCapabilitiesKHR",
+    "vkGetPhysicalDeviceSurfaceCapabilities2KHR": "OverrideGetPhysicalDeviceSurfaceCapabilities2KHR",
     "vkWaitForFences": "OverrideWaitForFences",
     "vkGetFenceStatus": "OverrideGetFenceStatus",
     "vkGetEventStatus": "OverrideGetEventStatus",


### PR DESCRIPTION
This's for `VK_EXT_full_screen_exclusive`. `vkGetPhysicalDeviceSurfaceCapabilities2KHR` could affect `VulkanReplayConsumerBase::ProcessSetSwapchainImageStateCommand` that's for replaying trimming `format::MetaDataType::kSetSwapchainImageStateCommand`.

In the previous commt, `Trimming: VK_EXT_full_screen_exclusive`, it recorded `vkGetPhysicalDeviceSurfacePresentModes2EXT`,  `vkGetDeviceGroupSurfacePresentModesKHR` and `vkGetDeviceGroupSurfacePresentModes2EXT`. But they might be not necessary.  The `presentMode` has been recorded in `vkCreateSwapchainKHR`. But I think it's ok to keep those code.
