### PR TITLE
WIP - Add option for measurement frame range

### DIFF
--- a/framework/application/application.h
+++ b/framework/application/application.h
@@ -34,6 +34,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <functional>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
@@ -57,7 +58,10 @@ class Application final
 
     bool IsRunning() const { return running_; }
 
-    void Run();
+    // Note that FileProcessor::FrameNumber() will be N at the time of pre_frame_callback and
+    // N+1 at the time of post_frame_callback.
+    void Run(std::function<bool(Application*)> pre_frame_callback = nullptr,
+             std::function<bool(Application*)> post_frame_allback = nullptr);
 
     void StopRunning() { running_ = false; }
 

--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -45,6 +45,7 @@ class ApiDecoder
   public:
     virtual ~ApiDecoder() {}
 
+    virtual void WaitIdle()                            = 0;
     virtual bool SupportsApiCall(format::ApiCallId id) = 0;
 
     virtual bool SupportsMetaDataId(format::MetaDataId meta_data_id) = 0;

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -56,6 +56,13 @@ FileProcessor::~FileProcessor()
     DecodeAllocator::DestroyInstance();
 }
 
+void FileProcessor::WaitDecodersIdle()
+{
+    for (auto decoder : decoders_)
+    {
+        decoder->WaitIdle();
+    }
+};
 bool FileProcessor::Initialize(const std::string& filename)
 {
     bool success = false;

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -62,6 +62,8 @@ class FileProcessor
 
     ~FileProcessor();
 
+    void WaitDecodersIdle();
+
     void SetAnnotationProcessor(AnnotationHandler* handler) { annotation_handler_ = handler; }
 
     void AddDecoder(ApiDecoder* decoder) { decoders_.push_back(decoder); }

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -46,6 +46,8 @@ class VulkanConsumerBase
 
     virtual ~VulkanConsumerBase() {}
 
+    virtual void WaitDevicesIdle() {}
+
     virtual void ProcessStateBeginMarker(uint64_t frame_number) {}
 
     virtual void ProcessStateEndMarker(uint64_t frame_number) {}

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -30,6 +30,14 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
+void VulkanDecoderBase::WaitIdle()
+{
+    for (auto consumer : consumers_)
+    {
+        consumer->WaitDevicesIdle();
+    }
+}
+
 void VulkanDecoderBase::DispatchStateBeginMarker(uint64_t frame_number)
 {
     for (auto consumer : consumers_)

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -53,6 +53,8 @@ class VulkanDecoderBase : public ApiDecoder
         consumers_.erase(std::remove(consumers_.begin(), consumers_.end(), consumer));
     }
 
+    virtual void WaitIdle() override;
+
     virtual bool SupportsApiCall(format::ApiCallId call_id) override
     {
         return (format::GetApiCallFamily(call_id) == format::ApiFamilyId::ApiFamily_Vulkan);

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -164,15 +164,16 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
                              create_surface_count_);
     }
 
-    // Idle all devices before destroying other resources, and cleanup screenshot resources before destroying device.
+    // Idle all devices before destroying other resources.
+    WaitDevicesIdle();
+
+    // Cleanup screenshot resources before destroying device.
     object_info_table_.VisitDeviceInfo([this](const DeviceInfo* info) {
         assert(info != nullptr);
         VkDevice device = info->handle;
 
         auto device_table = GetDeviceTable(device);
         assert(device_table != nullptr);
-
-        device_table->DeviceWaitIdle(device);
 
         if (screenshot_handler_ != nullptr)
         {
@@ -202,6 +203,18 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
     }
 }
 
+void VulkanReplayConsumerBase::WaitDevicesIdle()
+{
+    object_info_table_.VisitDeviceInfo([this](const DeviceInfo* info) {
+        assert(info != nullptr);
+        VkDevice device = info->handle;
+
+        auto device_table = GetDeviceTable(device);
+        assert(device_table != nullptr);
+
+        device_table->DeviceWaitIdle(device);
+    });
+}
 void VulkanReplayConsumerBase::ProcessStateBeginMarker(uint64_t frame_number)
 {
     GFXRECON_LOG_INFO("Loading state for captured frame %" PRId64, frame_number);

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -72,6 +72,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     virtual ~VulkanReplayConsumerBase() override;
 
+    virtual void WaitDevicesIdle() override;
+
     void SetFatalErrorHandler(std::function<void(const char*)> handler) { fatal_error_handler_ = handler; }
 
     void SetFpsInfo(graphics::FpsInfo* fps_info) { fps_info_ = fps_info; }

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -47,6 +47,8 @@ struct VulkanReplayOptions : public ReplayOptions
     bool                         skip_failed_allocations{ false };
     bool                         omit_pipeline_cache_data{ false };
     bool                         remove_unsupported_features{ false };
+    bool                         quit_after_measurement_frame_range{ false };
+    bool                         flush_measurement_frame_range{ false };
     int32_t                      override_gpu_index{ -1 };
     int32_t                      surface_index{ -1 };
     CreateResourceAllocator      create_resource_allocator;

--- a/framework/graphics/fps_info.cpp
+++ b/framework/graphics/fps_info.cpp
@@ -54,12 +54,17 @@ WriteFpsToConsole(const char* prefix, uint64_t start_frame, uint64_t end_frame, 
                            end_frame);
 }
 
+void FpsInfo::SetStartTime()
+{
+    start_time_ = util::datetime::GetTimestamp();
+}
+
 void FpsInfo::Begin(uint64_t start_frame)
 {
     // Save the start frame/time information for the FPS result.
     replay_start_frame_ = start_frame;
-    start_time_         = util::datetime::GetTimestamp();
-    replay_start_time_  = start_time_;
+    begin_frame_        = start_frame;
+    replay_start_time_  = util::datetime::GetTimestamp();
 }
 
 void FpsInfo::EndAndLog(uint64_t end_frame)
@@ -67,14 +72,22 @@ void FpsInfo::EndAndLog(uint64_t end_frame)
     // Get the end frame/time information and calculate FPS.
     int64_t end_time = util::datetime::GetTimestamp();
 
-    if (replay_start_time_ != start_time_)
-    {
-        GFXRECON_WRITE_CONSOLE("Load time:  %f seconds", GetElapsedSeconds(start_time_, replay_start_time_));
-    }
-    GFXRECON_WRITE_CONSOLE("Total time: %f seconds", GetElapsedSeconds(start_time_, end_time));
+    bool include_load = begin_frame_ == 1;
 
-    WriteFpsToConsole(
-        "Replay FPS:", replay_start_frame_, end_frame + replay_start_frame_ - 1, replay_start_time_, end_time);
+    if (include_load)
+    {
+        if (replay_start_time_ != start_time_)
+        {
+            GFXRECON_WRITE_CONSOLE("Load time:  %f seconds", GetElapsedSeconds(start_time_, replay_start_time_));
+        }
+        GFXRECON_WRITE_CONSOLE("Total time: %f seconds", GetElapsedSeconds(start_time_, end_time));
+        WriteFpsToConsole(
+            "Replay FPS:", replay_start_frame_, end_frame + replay_start_frame_ - 1, replay_start_time_, end_time);
+    }
+    else
+    {
+        WriteFpsToConsole("Measurement range FPS:", begin_frame_, end_frame - 1, replay_start_time_, end_time);
+    }
 }
 
 void FpsInfo::ProcessStateEndMarker(uint64_t frame)

--- a/framework/graphics/fps_info.h
+++ b/framework/graphics/fps_info.h
@@ -34,6 +34,7 @@ GFXRECON_BEGIN_NAMESPACE(graphics)
 class FpsInfo
 {
   public:
+    void SetStartTime();
     void Begin(uint64_t start_frame = 1);
     void EndAndLog(uint64_t current_frame);
 
@@ -43,6 +44,7 @@ class FpsInfo
     int64_t  start_time_;
     uint64_t replay_start_frame_;
     int64_t  replay_start_time_;
+    uint64_t begin_frame_;
 };
 
 GFXRECON_END_NAMESPACE(graphics)

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -28,10 +28,10 @@
 const char kOptions[] =
     "-h|--help,--version,--log-debugview,--no-debug-popup,--paused,--sync,--sfa|--skip-failed-allocations,--"
     "opcd|--omit-pipeline-cache-data,--remove-unsupported,--validate,--debug-device-lost,--create-dummy-allocations,--"
-    "screenshot-all,--dcp,--discard-cached-psos";
+    "screenshot-all,--dcp,--discard-cached-psos,--qamr|--quit-after-measurement-range,--fmr|--flush-measurement-range";
 const char kArguments[] = "--log-level,--log-file,--gpu,--pause-frame,--wsi,--surface-index,-m|--memory-translation,--"
                           "replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
-                          "screenshot-dir,--screenshot-prefix";
+                          "screenshot-dir,--screenshot-prefix,--mfr|--measurement-frame-range";
 
 static void PrintUsage(const char* exe_name)
 {
@@ -77,6 +77,21 @@ static void PrintUsage(const char* exe_name)
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("  --log-debugview\tLog messages with OutputDebugStringA.");
 #endif
+    GFXRECON_WRITE_CONSOLE("  --measurement-frame-range <start_frame>-<end_frame>");
+    GFXRECON_WRITE_CONSOLE("          \t\tCustom framerange to measure FPS for.");
+    GFXRECON_WRITE_CONSOLE("          \t\tThis range will include the start frame but not the end frame.");
+    GFXRECON_WRITE_CONSOLE("          \t\tThe measurement frame range defaults to all frames except the loading");
+    GFXRECON_WRITE_CONSOLE("          \t\tframe but can be configured for any range. If the end frame is past the");
+    GFXRECON_WRITE_CONSOLE("          \t\tlast frame in the trace it will be clamped to the frame after the last");
+    GFXRECON_WRITE_CONSOLE("          \t\t(so in that case the results would include the last frame).");
+    GFXRECON_WRITE_CONSOLE("  --quit-after-measurement-range");
+    GFXRECON_WRITE_CONSOLE("          \t\tIf this is specified the replayer will abort");
+    GFXRECON_WRITE_CONSOLE("          \t\twhen it reaches the <end_frame> specified in");
+    GFXRECON_WRITE_CONSOLE("          \t\tthe --measurement-frame-range argument.");
+    GFXRECON_WRITE_CONSOLE("  --flush-measurement-range");
+    GFXRECON_WRITE_CONSOLE("          \t\tIf this is specified the replayer will flush")
+    GFXRECON_WRITE_CONSOLE("          \t\tand wait for all current GPU work to finish at the");
+    GFXRECON_WRITE_CONSOLE("          \t\tstart and end of the measurement range.");
     GFXRECON_WRITE_CONSOLE("  --gpu <index>\t\tUse the specified device for replay, where index");
     GFXRECON_WRITE_CONSOLE("          \t\tis the zero-based index to the array of physical devices");
     GFXRECON_WRITE_CONSOLE("          \t\treturned by vkEnumeratePhysicalDevices.  Replay may fail");

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -84,6 +84,9 @@ const char kScreenshotRangeArgument[]          = "--screenshots";
 const char kScreenshotFormatArgument[]         = "--screenshot-format";
 const char kScreenshotDirArgument[]            = "--screenshot-dir";
 const char kScreenshotFilePrefixArgument[]     = "--screenshot-prefix";
+const char kMeasurementRangeArgument[]         = "--measurement-frame-range";
+const char kQuitAfterMeasurementRangeOption[]  = "--quit-after-measurement-range";
+const char kFlushMeasurementRangeOption[]      = "--flush-measurement-range";
 const char kOutput[]                           = "--output";
 #if defined(WIN32)
 const char kApiFamilyOption[] = "--api";
@@ -469,6 +472,89 @@ GetScreenshotRanges(const gfxrecon::util::ArgumentParser& arg_parser)
     return ranges;
 }
 
+static std::pair<uint32_t, uint32_t> GetMeasurementFrameRange(const gfxrecon::util::ArgumentParser& arg_parser)
+{
+    std::pair<uint32_t, uint32_t> measurement_frame_range(1, std::numeric_limits<uint32_t>::max());
+
+    const auto& value = arg_parser.GetArgumentValue(kMeasurementRangeArgument);
+    if (!value.empty())
+    {
+        std::string range = value;
+
+        if (std::count(range.begin(), range.end(), '-') != 1)
+        {
+            GFXRECON_LOG_WARNING(
+                "Ignoring invalid measurement frame range \"%s\". Must have format: <start_frame>-<end_frame>",
+                range.c_str());
+            return measurement_frame_range;
+        }
+
+        // Remove whitespace.
+        range.erase(std::remove_if(range.begin(), range.end(), ::isspace), range.end());
+
+        // Split string on '-' delimiter.
+        bool                     invalid = false;
+        std::vector<std::string> values;
+        std::istringstream       range_input;
+        range_input.str(range);
+
+        for (std::string token; std::getline(range_input, token, '-');)
+        {
+            if (token.empty())
+            {
+                break;
+            }
+
+            // Check that the range string only contains numbers.
+            size_t count = std::count_if(token.begin(), token.end(), ::isdigit);
+            if (count == token.length())
+            {
+                values.push_back(token);
+            }
+            else
+            {
+                GFXRECON_LOG_WARNING(
+                    "Ignoring invalid measurement frame range \"%s\", which contains non-numeric values",
+                    range.c_str());
+                invalid = true;
+                break;
+            }
+        }
+
+        if (values.size() < 2)
+        {
+            GFXRECON_LOG_WARNING("Ignoring invalid measurement frame range \"%s\", does not have two values.",
+                                 range.c_str());
+
+            invalid = true;
+        }
+
+        if (!invalid)
+        {
+            uint32_t start_frame = std::stoi(values[0]);
+            uint32_t end_frame   = std::stoi(values[1]);
+
+            if (start_frame >= end_frame)
+            {
+                GFXRECON_LOG_WARNING("Ignoring invalid measurement frame range \"%s\", where first frame is "
+                                     "greater than or equal to the last frame",
+                                     range.c_str());
+
+                return measurement_frame_range;
+            }
+
+            measurement_frame_range.first  = start_frame;
+            measurement_frame_range.second = end_frame;
+        }
+        else
+        {
+            GFXRECON_LOG_WARNING("Ignoring invalid measurement frame range \"%s\".", range.c_str());
+        }
+    }
+
+    return measurement_frame_range;
+}
+
 static gfxrecon::decode::CreateResourceAllocator
 GetCreateResourceAllocatorFunc(const gfxrecon::util::ArgumentParser&           arg_parser,
                                const std::string&                              filename,
@@ -606,6 +692,16 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
     if (arg_parser.IsOptionSet(kRemoveUnsupportedOption))
     {
         replay_options.remove_unsupported_features = true;
+    }
+
+    if (arg_parser.IsOptionSet(kQuitAfterMeasurementRangeOption))
+    {
+        replay_options.quit_after_measurement_frame_range = true;
+    }
+
+    if (arg_parser.IsOptionSet(kFlushMeasurementRangeOption))
+    {
+        replay_options.flush_measurement_frame_range = true;
     }
 
     if (arg_parser.IsOptionSet(kSkipFailedAllocationLongOption) ||


### PR DESCRIPTION
Refactor #553 to elevate logic from FpsInfo and bring up to date with `dev`.  From @tomped01's original PR:

> This patch adds the option to specify start and stop frames for
> secondary FPS measurements. In addition, options for aborting replay
> after the end of the measurement range is reached and for flushing all
> work at range boundaries have been added.
> 
> The framerange support is very useful when investigating performance for
> large traces as creating new trimmed variants for every scene in the
> trace can be very time consuming (and quickly becomes unmaintainable for
> large sets of traces).
> The abort option is very handy on slower development platforms where
> replay of relatively small traces can take hours, this allows for
> skipping work one might not be interested in for a particular run.

Still in-progress.  Need to add flush, quit, and Android functionality.