### PR TITLE
Trimming Ray Tracing(deferred operation)

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -6125,16 +6125,6 @@ void VulkanReplayConsumerBase::OverrideGetDeferredOperationMaxConcurrencyKHR(
 }
 
 VkResult
-VulkanReplayConsumerBase::OverrideDeferredOperationJoinKHR(PFN_vkDeferredOperationJoinKHR  func,
-                                                           VkResult                        original_result,
-                                                           const DeviceInfo*               device_info,
-                                                           const DeferredOperationKHRInfo* deferred_operation_info)
-{
-    // Replay this in VulkanReplayConsumerBase::ProcessDeferredOperation
-    return original_result;
-}
-
-VkResult
 VulkanReplayConsumerBase::OverrideGetDeferredOperationResultKHR(PFN_vkGetDeferredOperationResultKHR func,
                                                                 VkResult                            original_result,
                                                                 const DeviceInfo*                   device_info,

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -41,6 +41,7 @@
 #include <cstdint>
 #include <limits>
 #include <unordered_set>
+#include <future>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -5920,6 +5921,10 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesKHR(
     }
     else
     {
+        GFXRECON_LOG_ERROR_ONCE(
+            "The replayed application used vkCreateRayTracingPipelinesKHR, which may require the "
+            "rayTracingPipelineShaderGroupHandleCaptureReplay feature for accurate capture and replay. The replay "
+            "device does not support this feature, so replay may fail.");
         result = device_table->CreateRayTracingPipelinesKHR(device,
                                                             in_deferredOperation,
                                                             in_pipelineCache,
@@ -5929,7 +5934,68 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesKHR(
                                                             out_pPipelines);
     }
 
+    if ((in_deferredOperation != VK_NULL_HANDLE) &&
+        ((result == VK_OPERATION_DEFERRED_KHR) || (result == VK_OPERATION_NOT_DEFERRED_KHR)))
+    {
+        // Before running vkDeferredOperationJoinKHR, CreateRayTracingPipelinesKHR won't be processed. It means if any
+        // parameters are be modified before running vkDeferredOperationJoinKHR, it will fail. So processing deferred
+        // operation immediately after CreateRayTracingPipelinesKHR will be safer.
+        ProcessDeferredOperation(*device_info, in_deferredOperation);
+    }
     return result;
+}
+
+void VulkanReplayConsumerBase::ProcessDeferredOperation(const DeviceInfo&      device_info,
+                                                        VkDeferredOperationKHR deferred_operation)
+{
+    if (!device_info.property_feature_info.feature_rayTracingPipelineShaderGroupHandleCaptureReplay)
+    {
+        GFXRECON_LOG_ERROR_ONCE("The replayed application used VkDeferredOperationKHR. It might fail for rendering "
+                                "incorrect or VK_ERROR_DEVICE_LOST. The reason might be the device doesn't support "
+                                "rayTracingPipelineShaderGroupHandleCaptureReplay feature.");
+    }
+    VkDevice                                    device = device_info.handle;
+    PFN_vkGetDeferredOperationMaxConcurrencyKHR vkGetDeferredOperationMaxConcurrencyKHR =
+        GetDeviceTable(device)->GetDeferredOperationMaxConcurrencyKHR;
+
+    uint32_t max_threads  = std::thread::hardware_concurrency();
+    uint32_t thread_count = std::min(vkGetDeferredOperationMaxConcurrencyKHR(device, deferred_operation), max_threads);
+    PFN_vkDeferredOperationJoinKHR vkDeferredOperationJoinKHR   = GetDeviceTable(device)->DeferredOperationJoinKHR;
+    bool                           deferred_operation_completed = false;
+    std::vector<std::future<void>> deferred_operation_joins;
+
+    for (uint32_t i = 0; i < thread_count; i++)
+    {
+        // At least one vkDeferredOperationJoinKHR in a thread has to get VK_SUCCESS.
+        deferred_operation_joins.emplace_back(std::async(
+            std::launch::async,
+            [vkDeferredOperationJoinKHR, device, deferred_operation, &deferred_operation_completed]() {
+                VkResult result = VK_ERROR_UNKNOWN;
+                while (result != VK_SUCCESS && !deferred_operation_completed)
+                {
+                    result = vkDeferredOperationJoinKHR(device, deferred_operation);
+                    assert(result == VK_SUCCESS || result == VK_THREAD_DONE_KHR || result == VK_THREAD_IDLE_KHR);
+                    if (result == VK_SUCCESS)
+                    {
+                        deferred_operation_completed = true;
+                    }
+                }
+            }));
+    }
+
+    for (auto& j : deferred_operation_joins)
+    {
+        j.get();
+    }
+    PFN_vkGetDeferredOperationResultKHR vkGetDeferredOperationResultKHR =
+        GetDeviceTable(device)->GetDeferredOperationResultKHR;
+
+    VkResult result = VK_NOT_READY;
+    while (result != VK_SUCCESS)
+    {
+        result = vkGetDeferredOperationResultKHR(device, deferred_operation);
+        assert(result == VK_SUCCESS || result == VK_NOT_READY);
+    }
 }
 
 VkDeviceAddress VulkanReplayConsumerBase::OverrideGetBufferDeviceAddress(
@@ -6002,7 +6068,7 @@ VulkanReplayConsumerBase::OverrideGetRayTracingShaderGroupHandlesKHR(PFN_vkGetRa
     if (!device_info->property_feature_info.feature_rayTracingPipelineShaderGroupHandleCaptureReplay)
     {
         GFXRECON_LOG_WARNING_ONCE(
-            "The captured application used vkGetRayTracingShaderGroupHandlesKHR, which may require the "
+            "The replayed application used vkGetRayTracingShaderGroupHandlesKHR, which may require the "
             "rayTracingPipelineShaderGroupHandleCaptureReplay feature for accurate capture and replay. The replay "
             "device does not support this feature, so replay may fail.");
     }
@@ -6046,6 +6112,34 @@ VkResult VulkanReplayConsumerBase::OverrideGetAndroidHardwareBufferPropertiesAND
 
         return func(device, hardware_buffer, output_properties);
     }
+}
+
+void VulkanReplayConsumerBase::OverrideGetDeferredOperationMaxConcurrencyKHR(
+    PFN_vkGetDeferredOperationMaxConcurrencyKHR func,
+    const DeviceInfo*                           device_info,
+    const DeferredOperationKHRInfo*             deferred_operation_info)
+{
+    // Replay this in VulkanReplayConsumerBase::ProcessDeferredOperation
+}
+
+VkResult
+VulkanReplayConsumerBase::OverrideDeferredOperationJoinKHR(PFN_vkDeferredOperationJoinKHR  func,
+                                                           VkResult                        original_result,
+                                                           const DeviceInfo*               device_info,
+                                                           const DeferredOperationKHRInfo* deferred_operation_info)
+{
+    // Replay this in VulkanReplayConsumerBase::ProcessDeferredOperation
+    return original_result;
+}
+
+VkResult
+VulkanReplayConsumerBase::OverrideGetDeferredOperationResultKHR(PFN_vkGetDeferredOperationResultKHR func,
+                                                                VkResult                            original_result,
+                                                                const DeviceInfo*                   device_info,
+                                                                const DeferredOperationKHRInfo* deferred_operation_info)
+{
+    // Replay this in VulkanReplayConsumerBase::ProcessDeferredOperation
+    return original_result;
 }
 
 void VulkanReplayConsumerBase::MapDescriptorUpdateTemplateHandles(

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -5855,11 +5855,13 @@ VkResult VulkanReplayConsumerBase::OverrideCreateRayTracingPipelinesKHR(
         (deferred_operation_info != nullptr) ? deferred_operation_info->handle : VK_NULL_HANDLE;
     VkPipelineCache in_pipelineCache = (pipeline_cache_info != nullptr) ? pipeline_cache_info->handle : VK_NULL_HANDLE;
 
+    // These data couldn't be released before running vkDeferredOperationJoinKHR.
+    std::vector<VkRayTracingPipelineCreateInfoKHR>                 modified_create_infos;
+    std::vector<std::vector<VkRayTracingShaderGroupCreateInfoKHR>> modified_pgroups;
+
     if (device_info->property_feature_info.feature_rayTracingPipelineShaderGroupHandleCaptureReplay)
     {
         // Modify pipeline create infos with capture replay flag and data.
-        std::vector<VkRayTracingPipelineCreateInfoKHR>                 modified_create_infos;
-        std::vector<std::vector<VkRayTracingShaderGroupCreateInfoKHR>> modified_pgroups;
         modified_create_infos.reserve(createInfoCount);
         modified_pgroups.resize(createInfoCount);
         for (uint32_t create_info_i = 0; create_info_i < createInfoCount; ++create_info_i)

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -876,6 +876,20 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         const struct AHardwareBuffer*                                           hardware_buffer,
         StructPointerDecoder<Decoded_VkAndroidHardwareBufferPropertiesANDROID>* pProperties);
 
+    void OverrideGetDeferredOperationMaxConcurrencyKHR(PFN_vkGetDeferredOperationMaxConcurrencyKHR func,
+                                                       const DeviceInfo*                           device_info,
+                                                       const DeferredOperationKHRInfo* deferred_operation_info);
+
+    VkResult OverrideDeferredOperationJoinKHR(PFN_vkDeferredOperationJoinKHR  func,
+                                              VkResult                        original_result,
+                                              const DeviceInfo*               device_info,
+                                              const DeferredOperationKHRInfo* deferred_operation_info);
+
+    VkResult OverrideGetDeferredOperationResultKHR(PFN_vkGetDeferredOperationResultKHR func,
+                                                   VkResult                            original_result,
+                                                   const DeviceInfo*                   device_info,
+                                                   const DeferredOperationKHRInfo*     deferred_operation_info);
+
   private:
     void RaiseFatalError(const char* message) const;
 
@@ -982,6 +996,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     void ProcessSwapchainFullScreenExclusiveInfo(const Decoded_VkSwapchainCreateInfoKHR* swapchain_info);
 
     void ProcessImportAndroidHardwareBufferInfo(const Decoded_VkMemoryAllocateInfo* allocate_info);
+
+    void ProcessDeferredOperation(const DeviceInfo& device_info, VkDeferredOperationKHR deferred_operation);
 
     void SetSwapchainWindowSize(const Decoded_VkSwapchainCreateInfoKHR* swapchain_info);
 

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -880,11 +880,6 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                                        const DeviceInfo*                           device_info,
                                                        const DeferredOperationKHRInfo* deferred_operation_info);
 
-    VkResult OverrideDeferredOperationJoinKHR(PFN_vkDeferredOperationJoinKHR  func,
-                                              VkResult                        original_result,
-                                              const DeviceInfo*               device_info,
-                                              const DeferredOperationKHRInfo* deferred_operation_info);
-
     VkResult OverrideGetDeferredOperationResultKHR(PFN_vkGetDeferredOperationResultKHR func,
                                                    VkResult                            original_result,
                                                    const DeviceInfo*                   device_info,

--- a/framework/encode/custom_vulkan_api_call_encoders.cpp
+++ b/framework/encode/custom_vulkan_api_call_encoders.cpp
@@ -348,5 +348,11 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureKHR(VkDevice            
     return GetDeviceTable(device)->CopyAccelerationStructureKHR(device, deferredOperation, pInfo);
 }
 
+VKAPI_ATTR VkResult VKAPI_CALL DeferredOperationJoinKHR(VkDevice device, VkDeferredOperationKHR operation)
+{
+    // It doesn't need capturing and it runs in VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR.
+    return VK_SUCCESS;
+}
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/custom_vulkan_api_call_encoders.h
+++ b/framework/encode/custom_vulkan_api_call_encoders.h
@@ -58,6 +58,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CopyAccelerationStructureKHR(VkDevice            
                                                             VkDeferredOperationKHR                    deferredOperation,
                                                             const VkCopyAccelerationStructureInfoKHR* pInfo);
 
+VKAPI_ATTR VkResult VKAPI_CALL DeferredOperationJoinKHR(VkDevice device, VkDeferredOperationKHR operation);
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -135,7 +135,9 @@ class VulkanCaptureManager : public CaptureManager
                                       typename Wrapper::HandleType* handles,
                                       const CreateInfo*             create_infos)
     {
-        if (((GetCaptureMode() & kModeTrack) == kModeTrack) && ((result == VK_SUCCESS) || (result == VK_INCOMPLETE)) &&
+        if (((GetCaptureMode() & kModeTrack) == kModeTrack) &&
+            ((result == VK_SUCCESS) || (result == VK_OPERATION_DEFERRED_KHR) ||
+             (result == VK_OPERATION_NOT_DEFERRED_KHR) || (result == VK_INCOMPLETE)) &&
             (handles != nullptr))
         {
             assert(state_tracker_ != nullptr);

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -286,6 +286,8 @@ class VulkanCaptureManager : public CaptureManager
                                                   const VkAllocationCallbacks*             pAllocator,
                                                   VkPipeline*                              pPipelines);
 
+    void ProcessDeferredOperation(const VkDevice device, const VkDeferredOperationKHR deferred_operation);
+
     void PostProcess_vkEnumeratePhysicalDevices(VkResult          result,
                                                 VkInstance        instance,
                                                 uint32_t*         pPhysicalDeviceCount,

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -78,7 +78,6 @@ struct DebugUtilsMessengerEXTWrapper        : public HandleWrapper<VkDebugUtilsM
 struct ValidationCacheEXTWrapper            : public HandleWrapper<VkValidationCacheEXT> {};
 struct IndirectCommandsLayoutNVWrapper      : public HandleWrapper<VkIndirectCommandsLayoutNV> {};
 struct PerformanceConfigurationINTELWrapper : public HandleWrapper<VkPerformanceConfigurationINTEL> {};
-struct DeferredOperationKHRWrapper          : public HandleWrapper<VkDeferredOperationKHR> {};
 struct PrivateDataSlotEXTWrapper            : public HandleWrapper<VkPrivateDataSlotEXT> {};
 
 // This handle type has a create function, but no destroy function. The handle wrapper will be owned by its parent VkDisplayKHR
@@ -434,6 +433,13 @@ struct AccelerationStructureKHRWrapper : public HandleWrapper<VkAccelerationStru
 struct AccelerationStructureNVWrapper : public HandleWrapper<VkAccelerationStructureNV>
 {
     // TODO: Determine what additional state tracking is needed.
+};
+
+struct DeferredOperationKHRWrapper : public HandleWrapper<VkDeferredOperationKHR>
+{
+    // Save data for CreateRayTracingPipelinesKHR
+    std::vector<VkRayTracingPipelineCreateInfoKHR> recored_modified_create_infos;
+    std::vector<VkPipeline>                        recored_original_pipelines;
 };
 
 // Handle alias types for extension handle types that have been promoted to core types.

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -78,6 +78,7 @@ struct DebugUtilsMessengerEXTWrapper        : public HandleWrapper<VkDebugUtilsM
 struct ValidationCacheEXTWrapper            : public HandleWrapper<VkValidationCacheEXT> {};
 struct IndirectCommandsLayoutNVWrapper      : public HandleWrapper<VkIndirectCommandsLayoutNV> {};
 struct PerformanceConfigurationINTELWrapper : public HandleWrapper<VkPerformanceConfigurationINTEL> {};
+struct DeferredOperationKHRWrapper          : public HandleWrapper<VkDeferredOperationKHR> {};
 struct PrivateDataSlotEXTWrapper            : public HandleWrapper<VkPrivateDataSlotEXT> {};
 
 // This handle type has a create function, but no destroy function. The handle wrapper will be owned by its parent VkDisplayKHR
@@ -433,13 +434,6 @@ struct AccelerationStructureKHRWrapper : public HandleWrapper<VkAccelerationStru
 struct AccelerationStructureNVWrapper : public HandleWrapper<VkAccelerationStructureNV>
 {
     // TODO: Determine what additional state tracking is needed.
-};
-
-struct DeferredOperationKHRWrapper : public HandleWrapper<VkDeferredOperationKHR>
-{
-    // Save data for CreateRayTracingPipelinesKHR
-    std::vector<VkRayTracingPipelineCreateInfoKHR> recored_modified_create_infos;
-    std::vector<VkPipeline>                        recored_original_pipelines;
 };
 
 // Handle alias types for extension handle types that have been promoted to core types.

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -312,6 +312,7 @@ struct PipelineWrapper : public HandleWrapper<VkPipeline>
     // Ray tracing pipeline's shader group handle data
     format::HandleId     device_id{ format::kNullHandleId };
     std::vector<uint8_t> shader_group_handle_data;
+    CreateDependencyInfo deferred_operation;
 
     // TODO: Base pipeline
     // TODO: Pipeline cache

--- a/framework/encode/vulkan_state_info.h
+++ b/framework/encode/vulkan_state_info.h
@@ -68,6 +68,7 @@ struct DescriptorInfo
     VkDescriptorType                              type;
     const void*                                   write_pnext{ nullptr };
     HandleUnwrapMemory                            write_pnext_memory;
+    std::vector<VkAccelerationStructureKHR>       record_write_set_accel_structs;
     uint32_t                                      count{ 0 };
     bool                                          immutable_samplers{ 0 };
     std::unique_ptr<bool[]>                       written;

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -9556,33 +9556,6 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeferredOperationResultKHR(
     return result;
 }
 
-VKAPI_ATTR VkResult VKAPI_CALL DeferredOperationJoinKHR(
-    VkDevice                                    device,
-    VkDeferredOperationKHR                      operation)
-{
-    auto state_lock = VulkanCaptureManager::Get()->AcquireSharedStateLock();
-
-    CustomEncoderPreCall<format::ApiCallId::ApiCall_vkDeferredOperationJoinKHR>::Dispatch(VulkanCaptureManager::Get(), device, operation);
-
-    VkDevice device_unwrapped = GetWrappedHandle<VkDevice>(device);
-    VkDeferredOperationKHR operation_unwrapped = GetWrappedHandle<VkDeferredOperationKHR>(operation);
-
-    VkResult result = GetDeviceTable(device)->DeferredOperationJoinKHR(device_unwrapped, operation_unwrapped);
-
-    auto encoder = VulkanCaptureManager::Get()->BeginApiCallCapture(format::ApiCallId::ApiCall_vkDeferredOperationJoinKHR);
-    if (encoder)
-    {
-        encoder->EncodeHandleValue(device);
-        encoder->EncodeHandleValue(operation);
-        encoder->EncodeEnumValue(result);
-        VulkanCaptureManager::Get()->EndApiCallCapture();
-    }
-
-    CustomEncoderPostCall<format::ApiCallId::ApiCall_vkDeferredOperationJoinKHR>::Dispatch(VulkanCaptureManager::Get(), result, device, operation);
-
-    return result;
-}
-
 VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutablePropertiesKHR(
     VkDevice                                    device,
     const VkPipelineInfoKHR*                    pPipelineInfo,

--- a/framework/generated/generated_vulkan_api_call_encoders.h
+++ b/framework/generated/generated_vulkan_api_call_encoders.h
@@ -1725,10 +1725,6 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDeferredOperationResultKHR(
     VkDevice                                    device,
     VkDeferredOperationKHR                      operation);
 
-VKAPI_ATTR VkResult VKAPI_CALL DeferredOperationJoinKHR(
-    VkDevice                                    device,
-    VkDeferredOperationKHR                      operation);
-
 VKAPI_ATTR VkResult VKAPI_CALL GetPipelineExecutablePropertiesKHR(
     VkDevice                                    device,
     const VkPipelineInfoKHR*                    pPipelineInfo,

--- a/framework/generated/generated_vulkan_ascii_consumer.cpp
+++ b/framework/generated/generated_vulkan_ascii_consumer.cpp
@@ -6718,26 +6718,6 @@ void VulkanAsciiConsumer::Process_vkGetDeferredOperationResultKHR(
     );
 }
 
-void VulkanAsciiConsumer::Process_vkDeferredOperationJoinKHR(
-    const ApiCallInfo&                          call_info,
-    VkResult                                    returnValue,
-    format::HandleId                            device,
-    format::HandleId                            operation)
-{
-    using namespace gfxrecon::util;
-    ToStringFlags toStringFlags = kToString_Default;
-    uint32_t tabCount = 0;
-    uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDeferredOperationJoinKHR", toStringFlags, tabCount, tabSize,
-        [&](std::stringstream& strStrm)
-        {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
-            FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
-        }
-    );
-}
-
 void VulkanAsciiConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
     const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,

--- a/framework/generated/generated_vulkan_ascii_consumer.h
+++ b/framework/generated/generated_vulkan_ascii_consumer.h
@@ -2175,12 +2175,6 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            device,
         format::HandleId                            operation) override;
 
-    virtual void Process_vkDeferredOperationJoinKHR(
-        const ApiCallInfo&                          call_info,
-        VkResult                                    returnValue,
-        format::HandleId                            device,
-        format::HandleId                            operation) override;
-
     virtual void Process_vkGetPipelineExecutablePropertiesKHR(
         const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,

--- a/framework/generated/generated_vulkan_consumer.h
+++ b/framework/generated/generated_vulkan_consumer.h
@@ -2175,12 +2175,6 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            device,
         format::HandleId                            operation) {}
 
-    virtual void Process_vkDeferredOperationJoinKHR(
-        const ApiCallInfo&                          call_info,
-        VkResult                                    returnValue,
-        format::HandleId                            device,
-        format::HandleId                            operation) {}
-
     virtual void Process_vkGetPipelineExecutablePropertiesKHR(
         const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,

--- a/framework/generated/generated_vulkan_decoder.cpp
+++ b/framework/generated/generated_vulkan_decoder.cpp
@@ -6770,26 +6770,6 @@ size_t VulkanDecoder::Decode_vkGetDeferredOperationResultKHR(const ApiCallInfo& 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDeferredOperationJoinKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
-{
-    size_t bytes_read = 0;
-
-    format::HandleId device;
-    format::HandleId operation;
-    VkResult return_value;
-
-    bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &device);
-    bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &operation);
-    bytes_read += ValueDecoder::DecodeEnumValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &return_value);
-
-    for (auto consumer : GetConsumers())
-    {
-        consumer->Process_vkDeferredOperationJoinKHR(call_info, return_value, device, operation);
-    }
-
-    return bytes_read;
-}
-
 size_t VulkanDecoder::Decode_vkGetPipelineExecutablePropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
@@ -12207,9 +12187,6 @@ void VulkanDecoder::DecodeFunctionCall(format::ApiCallId             call_id,
         break;
     case format::ApiCallId::ApiCall_vkGetDeferredOperationResultKHR:
         Decode_vkGetDeferredOperationResultKHR(call_info, parameter_buffer, buffer_size);
-        break;
-    case format::ApiCallId::ApiCall_vkDeferredOperationJoinKHR:
-        Decode_vkDeferredOperationJoinKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPipelineExecutablePropertiesKHR:
         Decode_vkGetPipelineExecutablePropertiesKHR(call_info, parameter_buffer, buffer_size);

--- a/framework/generated/generated_vulkan_decoder.h
+++ b/framework/generated/generated_vulkan_decoder.h
@@ -666,8 +666,6 @@ class VulkanDecoder : public VulkanDecoderBase
 
     size_t Decode_vkGetDeferredOperationResultKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDeferredOperationJoinKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
-
     size_t Decode_vkGetPipelineExecutablePropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
     size_t Decode_vkGetPipelineExecutableStatisticsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -4667,10 +4667,10 @@ void VulkanReplayConsumer::Process_vkGetDeferredOperationMaxConcurrencyKHR(
     format::HandleId                            device,
     format::HandleId                            operation)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkDeferredOperationKHR in_operation = MapHandle<DeferredOperationKHRInfo>(operation, &VulkanObjectInfoTable::GetDeferredOperationKHRInfo);
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
+    auto in_operation = GetObjectInfoTable().GetDeferredOperationKHRInfo(operation);
 
-    GetDeviceTable(in_device)->GetDeferredOperationMaxConcurrencyKHR(in_device, in_operation);
+    OverrideGetDeferredOperationMaxConcurrencyKHR(GetDeviceTable(in_device->handle)->GetDeferredOperationMaxConcurrencyKHR, in_device, in_operation);
 }
 
 void VulkanReplayConsumer::Process_vkGetDeferredOperationResultKHR(
@@ -4679,10 +4679,10 @@ void VulkanReplayConsumer::Process_vkGetDeferredOperationResultKHR(
     format::HandleId                            device,
     format::HandleId                            operation)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkDeferredOperationKHR in_operation = MapHandle<DeferredOperationKHRInfo>(operation, &VulkanObjectInfoTable::GetDeferredOperationKHRInfo);
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
+    auto in_operation = GetObjectInfoTable().GetDeferredOperationKHRInfo(operation);
 
-    VkResult replay_result = GetDeviceTable(in_device)->GetDeferredOperationResultKHR(in_device, in_operation);
+    VkResult replay_result = OverrideGetDeferredOperationResultKHR(GetDeviceTable(in_device->handle)->GetDeferredOperationResultKHR, returnValue, in_device, in_operation);
     CheckResult("vkGetDeferredOperationResultKHR", returnValue, replay_result);
 }
 
@@ -4692,10 +4692,10 @@ void VulkanReplayConsumer::Process_vkDeferredOperationJoinKHR(
     format::HandleId                            device,
     format::HandleId                            operation)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkDeferredOperationKHR in_operation = MapHandle<DeferredOperationKHRInfo>(operation, &VulkanObjectInfoTable::GetDeferredOperationKHRInfo);
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
+    auto in_operation = GetObjectInfoTable().GetDeferredOperationKHRInfo(operation);
 
-    VkResult replay_result = GetDeviceTable(in_device)->DeferredOperationJoinKHR(in_device, in_operation);
+    VkResult replay_result = OverrideDeferredOperationJoinKHR(GetDeviceTable(in_device->handle)->DeferredOperationJoinKHR, returnValue, in_device, in_operation);
     CheckResult("vkDeferredOperationJoinKHR", returnValue, replay_result);
 }
 

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -4686,19 +4686,6 @@ void VulkanReplayConsumer::Process_vkGetDeferredOperationResultKHR(
     CheckResult("vkGetDeferredOperationResultKHR", returnValue, replay_result);
 }
 
-void VulkanReplayConsumer::Process_vkDeferredOperationJoinKHR(
-    const ApiCallInfo&                          call_info,
-    VkResult                                    returnValue,
-    format::HandleId                            device,
-    format::HandleId                            operation)
-{
-    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
-    auto in_operation = GetObjectInfoTable().GetDeferredOperationKHRInfo(operation);
-
-    VkResult replay_result = OverrideDeferredOperationJoinKHR(GetDeviceTable(in_device->handle)->DeferredOperationJoinKHR, returnValue, in_device, in_operation);
-    CheckResult("vkDeferredOperationJoinKHR", returnValue, replay_result);
-}
-
 void VulkanReplayConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
     const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,

--- a/framework/generated/generated_vulkan_replay_consumer.h
+++ b/framework/generated/generated_vulkan_replay_consumer.h
@@ -2175,12 +2175,6 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            device,
         format::HandleId                            operation) override;
 
-    virtual void Process_vkDeferredOperationJoinKHR(
-        const ApiCallInfo&                          call_info,
-        VkResult                                    returnValue,
-        format::HandleId                            device,
-        format::HandleId                            operation) override;
-
     virtual void Process_vkGetPipelineExecutablePropertiesKHR(
         const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,

--- a/framework/generated/vulkan_generators/blacklists.json
+++ b/framework/generated/vulkan_generators/blacklists.json
@@ -11,7 +11,8 @@
     "vkUpdateDescriptorSetWithTemplateKHR",
     "vkCmdPushDescriptorSetWithTemplateKHR",
     "vkBuildAccelerationStructuresKHR",
-    "vkCopyAccelerationStructureKHR"
+    "vkCopyAccelerationStructureKHR",
+    "vkDeferredOperationJoinKHR"
   ],
   "structures": [
     "VkBaseOutStructure",

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -80,6 +80,9 @@
     "vkGetBufferDeviceAddressKHR": "OverrideGetBufferDeviceAddress",
     "vkGetAccelerationStructureDeviceAddressKHR": "OverrideGetAccelerationStructureDeviceAddressKHR",
     "vkGetRayTracingShaderGroupHandlesKHR": "OverrideGetRayTracingShaderGroupHandlesKHR",
-    "vkGetAndroidHardwareBufferPropertiesANDROID": "OverrideGetAndroidHardwareBufferPropertiesANDROID"
+    "vkGetAndroidHardwareBufferPropertiesANDROID": "OverrideGetAndroidHardwareBufferPropertiesANDROID",
+    "vkGetDeferredOperationMaxConcurrencyKHR": "OverrideGetDeferredOperationMaxConcurrencyKHR",
+    "vkDeferredOperationJoinKHR": "OverrideDeferredOperationJoinKHR",
+    "vkGetDeferredOperationResultKHR": "OverrideGetDeferredOperationResultKHR"
   }
 }

--- a/framework/graphics/vulkan_device_util.cpp
+++ b/framework/graphics/vulkan_device_util.cpp
@@ -192,23 +192,22 @@ VulkanDeviceUtil::EnableRequiredPhysicalDeviceFeatures(uint32_t                 
                     GetPhysicalDeviceFeatures(
                         instance_api_version, instance_table, physical_device, supported_features);
 
-                    if (supported_features.rayTracingPipelineShaderGroupHandleCaptureReplay)
-                    {
-                        rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay = VK_TRUE;
-
-                        VkPhysicalDeviceRayTracingPipelinePropertiesKHR rt_properties{
-                            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR, nullptr
-                        };
-                        GetPhysicalDeviceProperties(
-                            instance_api_version, instance_table, physical_device, rt_properties);
-
-                        result.property_shaderGroupHandleCaptureReplaySize =
-                            rt_properties.shaderGroupHandleCaptureReplaySize;
-                    }
+                    rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay =
+                        supported_features.rayTracingPipelineShaderGroupHandleCaptureReplay;
                 }
 
                 result.feature_rayTracingPipelineShaderGroupHandleCaptureReplay =
                     rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay;
+                if (result.feature_rayTracingPipelineShaderGroupHandleCaptureReplay)
+                {
+                    VkPhysicalDeviceRayTracingPipelinePropertiesKHR rt_properties{
+                        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR, nullptr
+                    };
+                    GetPhysicalDeviceProperties(instance_api_version, instance_table, physical_device, rt_properties);
+
+                    result.property_shaderGroupHandleCaptureReplaySize =
+                        rt_properties.shaderGroupHandleCaptureReplaySize;
+                }
             }
             break;
             default:


### PR DESCRIPTION
https://github.com/nvpro-samples/vk_raytracing_tutorial_KHR
This PR could run trimming for these samples. AMD GPU might not support these samples.

`vk_ray_tracing_animation` and `vk_ray_tracing_instances` take very long for capturing because they loads many models. 

`vk_ray_tracing_advanced_compilation` is a complex case. It work well for replay and trimming. It just needs to wait for deferred operations. It uses `std::future` for waiting. It referred to `vk_ray_tracing_advanced_compilation` . But after waiting, it still has low chance to happen the rendering problem during replaying. Also
`[gfxrecon] FATAL - API call vkQueueSubmit returned error value VK_ERROR_DEVICE_LOST that does not match the result from the capture file: VK_SUCCESS.  Replay cannot continue.` or 
`[gfxrecon] FATAL - API call vkWaitForFences returned error value VK_ERROR_DEVICE_LOST that does not match the result from the capture file: VK_SUCCESS.  Replay cannot continue.` sometimes happen randomly during replaying.