### PR TITLE
Add API call index and plumb ApiCallInfo down to consumers

### DIFF
--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -37,6 +37,7 @@ GFXRECON_BEGIN_NAMESPACE(decode)
 
 struct ApiCallInfo
 {
+    uint64_t         index{ 0 };
     format::ThreadId thread_id{ 0 };
 };
 

--- a/framework/decode/custom_vulkan_ascii_consumer.cpp
+++ b/framework/decode/custom_vulkan_ascii_consumer.cpp
@@ -27,24 +27,29 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 void VulkanAsciiConsumer::Process_vkAllocateCommandBuffers(
+    const ApiCallInfo&                                         call_info,
     VkResult                                                   returnValue,
     format::HandleId                                           device,
     StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
     HandlePointerDecoder<VkCommandBuffer>*                     pCommandBuffers)
 {
-    VulkanAsciiConsumerBase::Process_vkAllocateCommandBuffers(returnValue, device, pAllocateInfo, pCommandBuffers);
+    VulkanAsciiConsumerBase::Process_vkAllocateCommandBuffers(
+        call_info, returnValue, device, pAllocateInfo, pCommandBuffers);
 }
 
 void VulkanAsciiConsumer::Process_vkAllocateDescriptorSets(
+    const ApiCallInfo&                                         call_info,
     VkResult                                                   returnValue,
     format::HandleId                                           device,
     StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
     HandlePointerDecoder<VkDescriptorSet>*                     pDescriptorSets)
 {
-    VulkanAsciiConsumerBase::Process_vkAllocateDescriptorSets(returnValue, device, pAllocateInfo, pDescriptorSets);
+    VulkanAsciiConsumerBase::Process_vkAllocateDescriptorSets(
+        call_info, returnValue, device, pAllocateInfo, pDescriptorSets);
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBuildAccelerationStructuresIndirectKHR(
+    const ApiCallInfo&                                                         call_info,
     format::HandleId                                                           commandBuffer,
     uint32_t                                                                   infoCount,
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
@@ -53,20 +58,22 @@ void VulkanAsciiConsumer::Process_vkCmdBuildAccelerationStructuresIndirectKHR(
     PointerDecoder<uint32_t*>*                                                 ppMaxPrimitiveCounts)
 {
     VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresIndirectKHR(
-        commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts);
+        call_info, commandBuffer, infoCount, pInfos, pIndirectDeviceAddresses, pIndirectStrides, ppMaxPrimitiveCounts);
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBuildAccelerationStructuresKHR(
+    const ApiCallInfo&                                                         call_info,
     format::HandleId                                                           commandBuffer,
     uint32_t                                                                   infoCount,
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>*   ppBuildRangeInfos)
 {
     VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresKHR(
-        commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
+        call_info, commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
 }
 
 void VulkanAsciiConsumer::Process_vkGetAccelerationStructureBuildSizesKHR(
+    const ApiCallInfo&                                                         call_info,
     format::HandleId                                                           device,
     VkAccelerationStructureBuildTypeKHR                                        buildType,
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pBuildInfo,
@@ -74,7 +81,7 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureBuildSizesKHR(
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildSizesInfoKHR>*    pSizeInfo)
 {
     VulkanAsciiConsumerBase::Process_vkGetAccelerationStructureBuildSizesKHR(
-        device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo);
+        call_info, device, buildType, pBuildInfo, pMaxPrimitiveCounts, pSizeInfo);
 }
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -137,6 +137,7 @@ class FileProcessor
     std::vector<uint8_t>                parameter_buffer_;
     std::vector<uint8_t>                compressed_parameter_buffer_;
     util::Compressor*                   compressor_;
+    uint64_t                            call_index_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_ascii_consumer_base.cpp
+++ b/framework/decode/vulkan_ascii_consumer_base.cpp
@@ -58,6 +58,7 @@ void VulkanAsciiConsumerBase::Destroy()
 //  validation to interpret correctly, etc...
 
 void VulkanAsciiConsumerBase::Process_vkAllocateCommandBuffers(
+    const ApiCallInfo&               call_info,
     VkResult returnValue,
     format::HandleId device,
     StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
@@ -68,7 +69,7 @@ void VulkanAsciiConsumerBase::Process_vkAllocateCommandBuffers(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkAllocateCommandBuffers", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkAllocateCommandBuffers", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -82,6 +83,7 @@ void VulkanAsciiConsumerBase::Process_vkAllocateCommandBuffers(
 }
 
 void VulkanAsciiConsumerBase::Process_vkAllocateDescriptorSets(
+    const ApiCallInfo&               call_info,
     VkResult returnValue,
     format::HandleId device,
     StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
@@ -92,7 +94,7 @@ void VulkanAsciiConsumerBase::Process_vkAllocateDescriptorSets(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkAllocateDescriptorSets", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkAllocateDescriptorSets", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -106,6 +108,7 @@ void VulkanAsciiConsumerBase::Process_vkAllocateDescriptorSets(
 }
 
 void VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresIndirectKHR(
+    const ApiCallInfo&               call_info,
     format::HandleId commandBuffer,
     uint32_t infoCount,
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
@@ -118,7 +121,7 @@ void VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresIndirectKH
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBuildAccelerationStructuresIndirectKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBuildAccelerationStructuresIndirectKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -145,6 +148,7 @@ void VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresIndirectKH
 }
 
 void VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresKHR(
+    const ApiCallInfo&               call_info,
     format::HandleId commandBuffer,
     uint32_t infoCount,
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
@@ -155,7 +159,7 @@ void VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBuildAccelerationStructuresKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBuildAccelerationStructuresKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -180,6 +184,7 @@ void VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresKHR(
 }
 
 void VulkanAsciiConsumerBase::Process_vkGetAccelerationStructureBuildSizesKHR(
+    const ApiCallInfo&               call_info,
     format::HandleId device,
     VkAccelerationStructureBuildTypeKHR buildType,
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pBuildInfo,
@@ -191,7 +196,7 @@ void VulkanAsciiConsumerBase::Process_vkGetAccelerationStructureBuildSizesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetAccelerationStructureBuildSizesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetAccelerationStructureBuildSizesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -207,6 +212,7 @@ void VulkanAsciiConsumerBase::Process_vkGetAccelerationStructureBuildSizesKHR(
 }
 
 void VulkanAsciiConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(
+    const ApiCallInfo&               call_info,
     format::HandleId commandBuffer,
     format::HandleId descriptorUpdateTemplate,
     format::HandleId layout,
@@ -218,7 +224,7 @@ void VulkanAsciiConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdPushDescriptorSetWithTemplateKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdPushDescriptorSetWithTemplateKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -230,6 +236,7 @@ void VulkanAsciiConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(
 }
 
 void VulkanAsciiConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(
+    const ApiCallInfo&               call_info,
     format::HandleId device,
     format::HandleId descriptorSet,
     format::HandleId descriptorUpdateTemplate,
@@ -240,7 +247,7 @@ void VulkanAsciiConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkUpdateDescriptorSetWithTemplate", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkUpdateDescriptorSetWithTemplate", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -252,6 +259,7 @@ void VulkanAsciiConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(
 }
 
 void VulkanAsciiConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(
+    const ApiCallInfo&               call_info,
     format::HandleId device,
     format::HandleId descriptorSet,
     format::HandleId descriptorUpdateTemplate,
@@ -262,7 +270,7 @@ void VulkanAsciiConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkUpdateDescriptorSetWithTemplateKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkUpdateDescriptorSetWithTemplateKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));

--- a/framework/decode/vulkan_ascii_consumer_base.h
+++ b/framework/decode/vulkan_ascii_consumer_base.h
@@ -51,18 +51,21 @@ class VulkanAsciiConsumerBase : public VulkanConsumer
     bool IsValid() const { return (file_ != nullptr); }
 
     virtual void
-    Process_vkAllocateCommandBuffers(VkResult                                                   returnValue,
+    Process_vkAllocateCommandBuffers(const ApiCallInfo&                                         call_info,
+                                     VkResult                                                   returnValue,
                                      format::HandleId                                           device,
                                      StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
                                      HandlePointerDecoder<VkCommandBuffer>* pCommandBuffers) override;
 
     virtual void
-    Process_vkAllocateDescriptorSets(VkResult                                                   returnValue,
+    Process_vkAllocateDescriptorSets(const ApiCallInfo&                                         call_info,
+                                     VkResult                                                   returnValue,
                                      format::HandleId                                           device,
                                      StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
                                      HandlePointerDecoder<VkDescriptorSet>* pDescriptorSets) override;
 
     virtual void Process_vkCmdBuildAccelerationStructuresIndirectKHR(
+        const ApiCallInfo&                                                         call_info,
         format::HandleId                                                           commandBuffer,
         uint32_t                                                                   infoCount,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
@@ -71,52 +74,57 @@ class VulkanAsciiConsumerBase : public VulkanConsumer
         PointerDecoder<uint32_t*>*                                                 ppMaxPrimitiveCounts) override;
 
     virtual void Process_vkCmdBuildAccelerationStructuresKHR(
+        const ApiCallInfo&                                                         call_info,
         format::HandleId                                                           commandBuffer,
         uint32_t                                                                   infoCount,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>*   ppBuildRangeInfos) override;
 
-    virtual void Process_vkCmdPushDescriptorSetWithTemplateKHR(format::HandleId commandBuffer,
-                                                               format::HandleId descriptorUpdateTemplate,
-                                                               format::HandleId layout,
-                                                               uint32_t         set,
+    virtual void Process_vkCmdPushDescriptorSetWithTemplateKHR(const ApiCallInfo& call_info,
+                                                               format::HandleId   commandBuffer,
+                                                               format::HandleId   descriptorUpdateTemplate,
+                                                               format::HandleId   layout,
+                                                               uint32_t           set,
                                                                DescriptorUpdateTemplateDecoder* pData) override;
 
     virtual void Process_vkGetAccelerationStructureBuildSizesKHR(
+        const ApiCallInfo&                                                         call_info,
         format::HandleId                                                           device,
         VkAccelerationStructureBuildTypeKHR                                        buildType,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pBuildInfo,
         PointerDecoder<uint32_t>*                                                  pMaxPrimitiveCounts,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildSizesInfoKHR>*    pSizeInfo) override;
 
-    virtual void Process_vkUpdateDescriptorSetWithTemplate(format::HandleId                 device,
+    virtual void Process_vkUpdateDescriptorSetWithTemplate(const ApiCallInfo&               call_info,
+                                                           format::HandleId                 device,
                                                            format::HandleId                 descriptorSet,
                                                            format::HandleId                 descriptorUpdateTemplate,
                                                            DescriptorUpdateTemplateDecoder* pData) override;
 
-    virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(format::HandleId                 device,
+    virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(const ApiCallInfo&               call_info,
+                                                              format::HandleId                 device,
                                                               format::HandleId                 descriptorSet,
                                                               format::HandleId                 descriptorUpdateTemplate,
                                                               DescriptorUpdateTemplateDecoder* pData) override;
 
   protected:
     template <typename ToStringFunctionType>
-    inline void WriteApiCallToFile(const std::string&   functionName,
+    inline void WriteApiCallToFile(const ApiCallInfo&   call_info,
+                                   const std::string&   functionName,
                                    util::ToStringFlags  toStringFlags,
                                    uint32_t&            tabCount,
                                    uint32_t             tabSize,
                                    ToStringFunctionType toStringFunction)
     {
         using namespace util;
-        fprintf(file_, "%s\n", (api_call_count_ ? "," : ""));
-        fprintf(file_, "\"[%s]%s\":", std::to_string(api_call_count_++).c_str(), functionName.c_str());
+        fprintf(file_, "%s\n", (call_info.index ? "," : ""));
+        fprintf(file_, "\"[%s]%s\":", std::to_string(call_info.index).c_str(), functionName.c_str());
         fprintf(file_, "%s", GetWhitespaceString(toStringFlags).c_str());
         fprintf(file_, "%s", ObjectToString(toStringFlags, tabCount, tabSize, toStringFunction).c_str());
     }
 
   private:
-    FILE*    file_{ nullptr };
-    uint64_t api_call_count_{ 0 };
+    FILE* file_{ nullptr };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -25,6 +25,7 @@
 #define GFXRECON_DECODE_VULKAN_CONSUMER_BASE_H
 
 #include "format/platform_types.h"
+#include "decode/api_decoder.h"
 #include "decode/custom_vulkan_struct_decoders.h"
 #include "decode/descriptor_update_template_decoder.h"
 #include "decode/handle_pointer_decoder.h"
@@ -125,20 +126,23 @@ class VulkanConsumerBase
                                          const uint8_t*               data)
     {}
 
-    virtual void Process_vkUpdateDescriptorSetWithTemplate(format::HandleId                 device,
+    virtual void Process_vkUpdateDescriptorSetWithTemplate(const ApiCallInfo&               call_info,
+                                                           format::HandleId                 device,
                                                            format::HandleId                 descriptorSet,
                                                            format::HandleId                 descriptorUpdateTemplate,
                                                            DescriptorUpdateTemplateDecoder* pData)
     {}
 
-    virtual void Process_vkCmdPushDescriptorSetWithTemplateKHR(format::HandleId commandBuffer,
-                                                               format::HandleId descriptorUpdateTemplate,
-                                                               format::HandleId layout,
-                                                               uint32_t         set,
+    virtual void Process_vkCmdPushDescriptorSetWithTemplateKHR(const ApiCallInfo& call_info,
+                                                               format::HandleId   commandBuffer,
+                                                               format::HandleId   descriptorUpdateTemplate,
+                                                               format::HandleId   layout,
+                                                               uint32_t           set,
                                                                DescriptorUpdateTemplateDecoder* pData)
     {}
 
-    virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(format::HandleId                 device,
+    virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(const ApiCallInfo&               call_info,
+                                                              format::HandleId                 device,
                                                               format::HandleId                 descriptorSet,
                                                               format::HandleId                 descriptorUpdateTemplate,
                                                               DescriptorUpdateTemplateDecoder* pData)

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -257,7 +257,9 @@ void VulkanDecoderBase::DispatchInitImageCommand(format::ThreadId             th
     }
 }
 
-size_t VulkanDecoderBase::Decode_vkUpdateDescriptorSetWithTemplate(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoderBase::Decode_vkUpdateDescriptorSetWithTemplate(const ApiCallInfo& call_info,
+                                                                   const uint8_t*     parameter_buffer,
+                                                                   size_t             buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -276,14 +278,16 @@ size_t VulkanDecoderBase::Decode_vkUpdateDescriptorSetWithTemplate(const uint8_t
 
     for (auto consumer : consumers_)
     {
-        consumer->Process_vkUpdateDescriptorSetWithTemplate(device, descriptorSet, descriptorUpdateTemplate, &pData);
+        consumer->Process_vkUpdateDescriptorSetWithTemplate(
+            call_info, device, descriptorSet, descriptorUpdateTemplate, &pData);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoderBase::Decode_vkCmdPushDescriptorSetWithTemplateKHR(const uint8_t* parameter_buffer,
-                                                                       size_t         buffer_size)
+size_t VulkanDecoderBase::Decode_vkCmdPushDescriptorSetWithTemplateKHR(const ApiCallInfo& call_info,
+                                                                       const uint8_t*     parameter_buffer,
+                                                                       size_t             buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -305,14 +309,15 @@ size_t VulkanDecoderBase::Decode_vkCmdPushDescriptorSetWithTemplateKHR(const uin
     for (auto consumer : consumers_)
     {
         consumer->Process_vkCmdPushDescriptorSetWithTemplateKHR(
-            commandBuffer, descriptorUpdateTemplate, layout, set, &pData);
+            call_info, commandBuffer, descriptorUpdateTemplate, layout, set, &pData);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoderBase::Decode_vkUpdateDescriptorSetWithTemplateKHR(const uint8_t* parameter_buffer,
-                                                                      size_t         buffer_size)
+size_t VulkanDecoderBase::Decode_vkUpdateDescriptorSetWithTemplateKHR(const ApiCallInfo& call_info,
+                                                                      const uint8_t*     parameter_buffer,
+                                                                      size_t             buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -331,7 +336,8 @@ size_t VulkanDecoderBase::Decode_vkUpdateDescriptorSetWithTemplateKHR(const uint
 
     for (auto consumer : consumers_)
     {
-        consumer->Process_vkUpdateDescriptorSetWithTemplateKHR(device, descriptorSet, descriptorUpdateTemplate, &pData);
+        consumer->Process_vkUpdateDescriptorSetWithTemplateKHR(
+            call_info, device, descriptorSet, descriptorUpdateTemplate, &pData);
     }
 
     return bytes_read;
@@ -347,13 +353,13 @@ void VulkanDecoderBase::DecodeFunctionCall(format::ApiCallId  call_id,
     switch (call_id)
     {
         case format::ApiCallId::ApiCall_vkUpdateDescriptorSetWithTemplate:
-            Decode_vkUpdateDescriptorSetWithTemplate(parameter_buffer, buffer_size);
+            Decode_vkUpdateDescriptorSetWithTemplate(call_info, parameter_buffer, buffer_size);
             break;
         case format::ApiCallId::ApiCall_vkCmdPushDescriptorSetWithTemplateKHR:
-            Decode_vkCmdPushDescriptorSetWithTemplateKHR(parameter_buffer, buffer_size);
+            Decode_vkCmdPushDescriptorSetWithTemplateKHR(call_info, parameter_buffer, buffer_size);
             break;
         case format::ApiCallId::ApiCall_vkUpdateDescriptorSetWithTemplateKHR:
-            Decode_vkUpdateDescriptorSetWithTemplateKHR(parameter_buffer, buffer_size);
+            Decode_vkUpdateDescriptorSetWithTemplateKHR(call_info, parameter_buffer, buffer_size);
             break;
         default:
             break;

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -164,11 +164,17 @@ class VulkanDecoderBase : public ApiDecoder
     const std::vector<VulkanConsumer*>& GetConsumers() const { return consumers_; }
 
   private:
-    size_t Decode_vkUpdateDescriptorSetWithTemplate(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkUpdateDescriptorSetWithTemplate(const ApiCallInfo& call_info,
+                                                    const uint8_t*     parameter_buffer,
+                                                    size_t             buffer_size);
 
-    size_t Decode_vkCmdPushDescriptorSetWithTemplateKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdPushDescriptorSetWithTemplateKHR(const ApiCallInfo& call_info,
+                                                        const uint8_t*     parameter_buffer,
+                                                        size_t             buffer_size);
 
-    size_t Decode_vkUpdateDescriptorSetWithTemplateKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkUpdateDescriptorSetWithTemplateKHR(const ApiCallInfo& call_info,
+                                                       const uint8_t*     parameter_buffer,
+                                                       size_t             buffer_size);
 
   private:
     std::vector<VulkanConsumer*> consumers_;

--- a/framework/decode/vulkan_referenced_resource_consumer_base.cpp
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.cpp
@@ -34,9 +34,10 @@ VulkanReferencedResourceConsumerBase::VulkanReferencedResourceConsumerBase() :
     loading_state_(false), loaded_state_(false)
 {}
 
-void VulkanReferencedResourceConsumerBase::Process_vkQueueSubmit(VkResult         returnValue,
-                                                                 format::HandleId queue,
-                                                                 uint32_t         submitCount,
+void VulkanReferencedResourceConsumerBase::Process_vkQueueSubmit(const ApiCallInfo& call_info,
+                                                                 VkResult           returnValue,
+                                                                 format::HandleId   queue,
+                                                                 uint32_t           submitCount,
                                                                  StructPointerDecoder<Decoded_VkSubmitInfo>* pSubmits,
                                                                  format::HandleId                            fence)
 {
@@ -66,6 +67,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkQueueSubmit(VkResult       
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkCreateBuffer(
+    const ApiCallInfo&                                   call_info,
     VkResult                                             returnValue,
     format::HandleId                                     device,
     StructPointerDecoder<Decoded_VkBufferCreateInfo>*    pCreateInfo,
@@ -100,6 +102,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkCreateBuffer(
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkCreateBufferView(
+    const ApiCallInfo&                                    call_info,
     VkResult                                              returnValue,
     format::HandleId                                      device,
     StructPointerDecoder<Decoded_VkBufferViewCreateInfo>* pCreateInfo,
@@ -120,6 +123,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkCreateBufferView(
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkCreateImage(
+    const ApiCallInfo&                                   call_info,
     VkResult                                             returnValue,
     format::HandleId                                     device,
     StructPointerDecoder<Decoded_VkImageCreateInfo>*     pCreateInfo,
@@ -154,6 +158,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkCreateImage(
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkCreateImageView(
+    const ApiCallInfo&                                   call_info,
     VkResult                                             returnValue,
     format::HandleId                                     device,
     StructPointerDecoder<Decoded_VkImageViewCreateInfo>* pCreateInfo,
@@ -174,6 +179,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkCreateImageView(
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkCreateFramebuffer(
+    const ApiCallInfo&                                     call_info,
     VkResult                                               returnValue,
     format::HandleId                                       device,
     StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* pCreateInfo,
@@ -197,6 +203,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkCreateFramebuffer(
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkCreateDescriptorSetLayout(
+    const ApiCallInfo&                                             call_info,
     VkResult                                                       returnValue,
     format::HandleId                                               device,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
@@ -224,6 +231,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkCreateDescriptorSetLayout(
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkCreateDescriptorUpdateTemplate(
+    const ApiCallInfo&                                                  call_info,
     VkResult                                                            returnValue,
     format::HandleId                                                    device,
     StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
@@ -238,6 +246,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkCreateDescriptorUpdateTempl
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkCreateDescriptorUpdateTemplateKHR(
+    const ApiCallInfo&                                                  call_info,
     VkResult                                                            returnValue,
     format::HandleId                                                    device,
     StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
@@ -252,6 +261,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkCreateDescriptorUpdateTempl
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkDestroyDescriptorPool(
+    const ApiCallInfo&                                   call_info,
     format::HandleId                                     device,
     format::HandleId                                     descriptorPool,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -262,7 +272,8 @@ void VulkanReferencedResourceConsumerBase::Process_vkDestroyDescriptorPool(
     table_.ClearContainers(descriptorPool);
 }
 
-void VulkanReferencedResourceConsumerBase::Process_vkResetDescriptorPool(VkResult                   returnValue,
+void VulkanReferencedResourceConsumerBase::Process_vkResetDescriptorPool(const ApiCallInfo&         call_info,
+                                                                         VkResult                   returnValue,
                                                                          format::HandleId           device,
                                                                          format::HandleId           descriptorPool,
                                                                          VkDescriptorPoolResetFlags flags)
@@ -275,6 +286,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkResetDescriptorPool(VkResul
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkAllocateDescriptorSets(
+    const ApiCallInfo&                                         call_info,
     VkResult                                                   returnValue,
     format::HandleId                                           device,
     StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
@@ -307,6 +319,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkAllocateDescriptorSets(
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkFreeDescriptorSets(
+    const ApiCallInfo&                     call_info,
     VkResult                               returnValue,
     format::HandleId                       device,
     format::HandleId                       descriptorPool,
@@ -331,6 +344,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkFreeDescriptorSets(
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkUpdateDescriptorSets(
+    const ApiCallInfo&                                  call_info,
     format::HandleId                                    device,
     uint32_t                                            descriptorWriteCount,
     StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites,
@@ -466,6 +480,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkUpdateDescriptorSets(
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(
+    const ApiCallInfo&               call_info,
     format::HandleId                 device,
     format::HandleId                 descriptorSet,
     format::HandleId                 descriptorUpdateTemplate,
@@ -477,6 +492,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkUpdateDescriptorSetWithTemp
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(
+    const ApiCallInfo&               call_info,
     format::HandleId                 commandBuffer,
     format::HandleId                 descriptorUpdateTemplate,
     format::HandleId                 layout,
@@ -490,6 +506,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkCmdPushDescriptorSetWithTem
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(
+    const ApiCallInfo&               call_info,
     format::HandleId                 device,
     format::HandleId                 descriptorSet,
     format::HandleId                 descriptorUpdateTemplate,
@@ -501,6 +518,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkUpdateDescriptorSetWithTemp
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkDestroyCommandPool(
+    const ApiCallInfo&                                   call_info,
     format::HandleId                                     device,
     format::HandleId                                     commandPool,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -511,7 +529,8 @@ void VulkanReferencedResourceConsumerBase::Process_vkDestroyCommandPool(
     table_.ClearUsers(commandPool);
 }
 
-void VulkanReferencedResourceConsumerBase::Process_vkResetCommandPool(VkResult                returnValue,
+void VulkanReferencedResourceConsumerBase::Process_vkResetCommandPool(const ApiCallInfo&      call_info,
+                                                                      VkResult                returnValue,
                                                                       format::HandleId        device,
                                                                       format::HandleId        commandPool,
                                                                       VkCommandPoolResetFlags flags)
@@ -524,6 +543,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkResetCommandPool(VkResult  
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkAllocateCommandBuffers(
+    const ApiCallInfo&                                         call_info,
     VkResult                                                   returnValue,
     format::HandleId                                           device,
     StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
@@ -551,6 +571,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkAllocateCommandBuffers(
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkFreeCommandBuffers(
+    const ApiCallInfo&                     call_info,
     format::HandleId                       device,
     format::HandleId                       commandPool,
     uint32_t                               commandBufferCount,
@@ -573,6 +594,7 @@ void VulkanReferencedResourceConsumerBase::Process_vkFreeCommandBuffers(
 }
 
 void VulkanReferencedResourceConsumerBase::Process_vkBeginCommandBuffer(
+    const ApiCallInfo&                                      call_info,
     VkResult                                                returnValue,
     format::HandleId                                        commandBuffer,
     StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo)
@@ -583,7 +605,8 @@ void VulkanReferencedResourceConsumerBase::Process_vkBeginCommandBuffer(
     table_.ResetUser(commandBuffer);
 }
 
-void VulkanReferencedResourceConsumerBase::Process_vkResetCommandBuffer(VkResult                  returnValue,
+void VulkanReferencedResourceConsumerBase::Process_vkResetCommandBuffer(const ApiCallInfo&        call_info,
+                                                                        VkResult                  returnValue,
                                                                         format::HandleId          commandBuffer,
                                                                         VkCommandBufferResetFlags flags)
 {

--- a/framework/decode/vulkan_referenced_resource_consumer_base.h
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.h
@@ -56,50 +56,58 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
         loaded_state_  = true;
     }
 
-    virtual void Process_vkQueueSubmit(VkResult                                    returnValue,
+    virtual void Process_vkQueueSubmit(const ApiCallInfo&                          call_info,
+                                       VkResult                                    returnValue,
                                        format::HandleId                            queue,
                                        uint32_t                                    submitCount,
                                        StructPointerDecoder<Decoded_VkSubmitInfo>* pSubmits,
                                        format::HandleId                            fence) override;
 
-    virtual void Process_vkCreateBuffer(VkResult                                             returnValue,
+    virtual void Process_vkCreateBuffer(const ApiCallInfo&                                   call_info,
+                                        VkResult                                             returnValue,
                                         format::HandleId                                     device,
                                         StructPointerDecoder<Decoded_VkBufferCreateInfo>*    pCreateInfo,
                                         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                         HandlePointerDecoder<VkBuffer>*                      pBuffer) override;
 
-    virtual void Process_vkCreateBufferView(VkResult                                              returnValue,
+    virtual void Process_vkCreateBufferView(const ApiCallInfo&                                    call_info,
+                                            VkResult                                              returnValue,
                                             format::HandleId                                      device,
                                             StructPointerDecoder<Decoded_VkBufferViewCreateInfo>* pCreateInfo,
                                             StructPointerDecoder<Decoded_VkAllocationCallbacks>*  pAllocator,
                                             HandlePointerDecoder<VkBufferView>*                   pView) override;
 
-    virtual void Process_vkCreateImage(VkResult                                             returnValue,
+    virtual void Process_vkCreateImage(const ApiCallInfo&                                   call_info,
+                                       VkResult                                             returnValue,
                                        format::HandleId                                     device,
                                        StructPointerDecoder<Decoded_VkImageCreateInfo>*     pCreateInfo,
                                        StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                        HandlePointerDecoder<VkImage>*                       pImage) override;
 
-    virtual void Process_vkCreateImageView(VkResult                                             returnValue,
+    virtual void Process_vkCreateImageView(const ApiCallInfo&                                   call_info,
+                                           VkResult                                             returnValue,
                                            format::HandleId                                     device,
                                            StructPointerDecoder<Decoded_VkImageViewCreateInfo>* pCreateInfo,
                                            StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                            HandlePointerDecoder<VkImageView>*                   pView) override;
 
-    virtual void Process_vkCreateFramebuffer(VkResult                                               returnValue,
+    virtual void Process_vkCreateFramebuffer(const ApiCallInfo&                                     call_info,
+                                             VkResult                                               returnValue,
                                              format::HandleId                                       device,
                                              StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* pCreateInfo,
                                              StructPointerDecoder<Decoded_VkAllocationCallbacks>*   pAllocator,
                                              HandlePointerDecoder<VkFramebuffer>* pFramebuffer) override;
 
     virtual void
-    Process_vkCreateDescriptorSetLayout(VkResult                                                       returnValue,
+    Process_vkCreateDescriptorSetLayout(const ApiCallInfo&                                             call_info,
+                                        VkResult                                                       returnValue,
                                         format::HandleId                                               device,
                                         StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
                                         StructPointerDecoder<Decoded_VkAllocationCallbacks>*           pAllocator,
                                         HandlePointerDecoder<VkDescriptorSetLayout>* pSetLayout) override;
 
     virtual void Process_vkCreateDescriptorUpdateTemplate(
+        const ApiCallInfo&                                                  call_info,
         VkResult                                                            returnValue,
         format::HandleId                                                    device,
         StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
@@ -107,6 +115,7 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
         HandlePointerDecoder<VkDescriptorUpdateTemplate>*                   pDescriptorUpdateTemplate) override;
 
     virtual void Process_vkCreateDescriptorUpdateTemplateKHR(
+        const ApiCallInfo&                                                  call_info,
         VkResult                                                            returnValue,
         format::HandleId                                                    device,
         StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
@@ -114,76 +123,90 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
         HandlePointerDecoder<VkDescriptorUpdateTemplate>*                   pDescriptorUpdateTemplate) override;
 
     virtual void
-    Process_vkDestroyDescriptorPool(format::HandleId                                     device,
+    Process_vkDestroyDescriptorPool(const ApiCallInfo&                                   call_info,
+                                    format::HandleId                                     device,
                                     format::HandleId                                     descriptorPool,
                                     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
-    virtual void Process_vkResetDescriptorPool(VkResult                   returnValue,
+    virtual void Process_vkResetDescriptorPool(const ApiCallInfo&         call_info,
+                                               VkResult                   returnValue,
                                                format::HandleId           device,
                                                format::HandleId           descriptorPool,
                                                VkDescriptorPoolResetFlags flags) override;
 
     virtual void
-    Process_vkAllocateDescriptorSets(VkResult                                                   returnValue,
+    Process_vkAllocateDescriptorSets(const ApiCallInfo&                                         call_info,
+                                     VkResult                                                   returnValue,
                                      format::HandleId                                           device,
                                      StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
                                      HandlePointerDecoder<VkDescriptorSet>* pDescriptorSets) override;
 
-    virtual void Process_vkFreeDescriptorSets(VkResult                               returnValue,
+    virtual void Process_vkFreeDescriptorSets(const ApiCallInfo&                     call_info,
+                                              VkResult                               returnValue,
                                               format::HandleId                       device,
                                               format::HandleId                       descriptorPool,
                                               uint32_t                               descriptorSetCount,
                                               HandlePointerDecoder<VkDescriptorSet>* pDescriptorSets) override;
 
     virtual void
-    Process_vkUpdateDescriptorSets(format::HandleId                                    device,
+    Process_vkUpdateDescriptorSets(const ApiCallInfo&                                  call_info,
+                                   format::HandleId                                    device,
                                    uint32_t                                            descriptorWriteCount,
                                    StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites,
                                    uint32_t                                            descriptorCopyCount,
                                    StructPointerDecoder<Decoded_VkCopyDescriptorSet>*  pDescriptorCopies) override;
 
-    virtual void Process_vkUpdateDescriptorSetWithTemplate(format::HandleId                 device,
+    virtual void Process_vkUpdateDescriptorSetWithTemplate(const ApiCallInfo&               call_info,
+                                                           format::HandleId                 device,
                                                            format::HandleId                 descriptorSet,
                                                            format::HandleId                 descriptorUpdateTemplate,
                                                            DescriptorUpdateTemplateDecoder* pData) override;
 
-    virtual void Process_vkCmdPushDescriptorSetWithTemplateKHR(format::HandleId commandBuffer,
-                                                               format::HandleId descriptorUpdateTemplate,
-                                                               format::HandleId layout,
-                                                               uint32_t         set,
+    virtual void Process_vkCmdPushDescriptorSetWithTemplateKHR(const ApiCallInfo& call_info,
+                                                               format::HandleId   commandBuffer,
+                                                               format::HandleId   descriptorUpdateTemplate,
+                                                               format::HandleId   layout,
+                                                               uint32_t           set,
                                                                DescriptorUpdateTemplateDecoder* pData) override;
 
-    virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(format::HandleId                 device,
+    virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(const ApiCallInfo&               call_info,
+                                                              format::HandleId                 device,
                                                               format::HandleId                 descriptorSet,
                                                               format::HandleId                 descriptorUpdateTemplate,
                                                               DescriptorUpdateTemplateDecoder* pData) override;
 
-    virtual void Process_vkDestroyCommandPool(format::HandleId                                     device,
+    virtual void Process_vkDestroyCommandPool(const ApiCallInfo&                                   call_info,
+                                              format::HandleId                                     device,
                                               format::HandleId                                     commandPool,
                                               StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
-    virtual void Process_vkResetCommandPool(VkResult                returnValue,
+    virtual void Process_vkResetCommandPool(const ApiCallInfo&      call_info,
+                                            VkResult                returnValue,
                                             format::HandleId        device,
                                             format::HandleId        commandPool,
                                             VkCommandPoolResetFlags flags) override;
 
     virtual void
-    Process_vkAllocateCommandBuffers(VkResult                                                   returnValue,
+    Process_vkAllocateCommandBuffers(const ApiCallInfo&                                         call_info,
+                                     VkResult                                                   returnValue,
                                      format::HandleId                                           device,
                                      StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
                                      HandlePointerDecoder<VkCommandBuffer>* pCommandBuffers) override;
 
-    virtual void Process_vkFreeCommandBuffers(format::HandleId                       device,
+    virtual void Process_vkFreeCommandBuffers(const ApiCallInfo&                     call_info,
+                                              format::HandleId                       device,
                                               format::HandleId                       commandPool,
                                               uint32_t                               commandBufferCount,
                                               HandlePointerDecoder<VkCommandBuffer>* pCommandBuffers) override;
 
     virtual void
-    Process_vkBeginCommandBuffer(VkResult                                                returnValue,
+    Process_vkBeginCommandBuffer(const ApiCallInfo&                                      call_info,
+                                 VkResult                                                returnValue,
                                  format::HandleId                                        commandBuffer,
                                  StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo) override;
 
-    virtual void Process_vkResetCommandBuffer(VkResult                  returnValue,
+    virtual void Process_vkResetCommandBuffer(const ApiCallInfo&        call_info,
+                                              VkResult                  returnValue,
                                               format::HandleId          commandBuffer,
                                               VkCommandBufferResetFlags flags) override;
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -6085,9 +6085,10 @@ VkResult VulkanReplayConsumerBase::CreateSwapchainImage(const DeviceInfo*       
     return result;
 }
 
-void VulkanReplayConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(format::HandleId device,
-                                                                         format::HandleId descriptorSet,
-                                                                         format::HandleId descriptorUpdateTemplate,
+void VulkanReplayConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(const ApiCallInfo& call_info,
+                                                                         format::HandleId   device,
+                                                                         format::HandleId   descriptorSet,
+                                                                         format::HandleId   descriptorUpdateTemplate,
                                                                          DescriptorUpdateTemplateDecoder* pData)
 {
     assert(pData != nullptr);
@@ -6109,7 +6110,8 @@ void VulkanReplayConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(format:
         in_device, in_descriptorSet, in_descriptorUpdateTemplate, pData->GetPointer());
 }
 
-void VulkanReplayConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(format::HandleId commandBuffer,
+void VulkanReplayConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(const ApiCallInfo& call_info,
+                                                                             format::HandleId   commandBuffer,
                                                                              format::HandleId descriptorUpdateTemplate,
                                                                              format::HandleId layout,
                                                                              uint32_t         set,
@@ -6135,9 +6137,10 @@ void VulkanReplayConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(for
             in_commandBuffer, in_descriptorUpdateTemplate, in_layout, set, pData->GetPointer());
 }
 
-void VulkanReplayConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(format::HandleId device,
-                                                                            format::HandleId descriptorSet,
-                                                                            format::HandleId descriptorUpdateTemplate,
+void VulkanReplayConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(const ApiCallInfo& call_info,
+                                                                            format::HandleId   device,
+                                                                            format::HandleId   descriptorSet,
+                                                                            format::HandleId   descriptorUpdateTemplate,
                                                                             DescriptorUpdateTemplateDecoder* pData)
 {
     assert(pData != nullptr);

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -152,18 +152,21 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                          const std::vector<uint64_t>& level_sizes,
                                          const uint8_t*               data) override;
 
-    virtual void Process_vkUpdateDescriptorSetWithTemplate(format::HandleId                 device,
+    virtual void Process_vkUpdateDescriptorSetWithTemplate(const ApiCallInfo&               call_info,
+                                                           format::HandleId                 device,
                                                            format::HandleId                 descriptorSet,
                                                            format::HandleId                 descriptorUpdateTemplate,
                                                            DescriptorUpdateTemplateDecoder* pData) override;
 
-    virtual void Process_vkCmdPushDescriptorSetWithTemplateKHR(format::HandleId commandBuffer,
-                                                               format::HandleId descriptorUpdateTemplate,
-                                                               format::HandleId layout,
-                                                               uint32_t         set,
+    virtual void Process_vkCmdPushDescriptorSetWithTemplateKHR(const ApiCallInfo& call_info,
+                                                               format::HandleId   commandBuffer,
+                                                               format::HandleId   descriptorUpdateTemplate,
+                                                               format::HandleId   layout,
+                                                               uint32_t           set,
                                                                DescriptorUpdateTemplateDecoder* pData) override;
 
-    virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(format::HandleId                 device,
+    virtual void Process_vkUpdateDescriptorSetWithTemplateKHR(const ApiCallInfo&               call_info,
+                                                              format::HandleId                 device,
                                                               format::HandleId                 descriptorSet,
                                                               format::HandleId                 descriptorUpdateTemplate,
                                                               DescriptorUpdateTemplateDecoder* pData) override;

--- a/framework/decode/vulkan_resource_tracking_consumer.cpp
+++ b/framework/decode/vulkan_resource_tracking_consumer.cpp
@@ -125,6 +125,7 @@ const encode::DeviceTable* VulkanResourceTrackingConsumer::GetDeviceTable(const 
 }
 
 void VulkanResourceTrackingConsumer::Process_vkCreateInstance(
+    const ApiCallInfo&                                   call_info,
     VkResult                                             returnValue,
     StructPointerDecoder<Decoded_VkInstanceCreateInfo>*  pCreateInfo,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
@@ -165,6 +166,7 @@ void VulkanResourceTrackingConsumer::Process_vkCreateInstance(
 }
 
 void VulkanResourceTrackingConsumer::Process_vkCreateDevice(
+    const ApiCallInfo&                                   call_info,
     VkResult                                             returnValue,
     format::HandleId                                     physicalDevice,
     StructPointerDecoder<Decoded_VkDeviceCreateInfo>*    pCreateInfo,
@@ -233,6 +235,7 @@ void VulkanResourceTrackingConsumer::Process_vkCreateDevice(
 }
 
 void VulkanResourceTrackingConsumer::Process_vkEnumeratePhysicalDevices(
+    const ApiCallInfo&                      call_info,
     VkResult                                returnValue,
     format::HandleId                        instance,
     PointerDecoder<uint32_t>*               pPhysicalDeviceCount,
@@ -285,6 +288,7 @@ void VulkanResourceTrackingConsumer::Process_vkEnumeratePhysicalDevices(
 }
 
 void VulkanResourceTrackingConsumer::Process_vkCreateBuffer(
+    const ApiCallInfo&                                   call_info,
     VkResult                                             returnValue,
     format::HandleId                                     device,
     StructPointerDecoder<Decoded_VkBufferCreateInfo>*    create_info,
@@ -331,6 +335,7 @@ void VulkanResourceTrackingConsumer::Process_vkCreateBuffer(
 }
 
 void VulkanResourceTrackingConsumer::Process_vkCreateImage(
+    const ApiCallInfo&                                   call_info,
     VkResult                                             returnValue,
     format::HandleId                                     device,
     StructPointerDecoder<Decoded_VkImageCreateInfo>*     create_info,
@@ -378,6 +383,7 @@ void VulkanResourceTrackingConsumer::Process_vkCreateImage(
 }
 
 void VulkanResourceTrackingConsumer::Process_vkAllocateMemory(
+    const ApiCallInfo&                                   call_info,
     VkResult                                             returnValue,
     format::HandleId                                     device,
     StructPointerDecoder<Decoded_VkMemoryAllocateInfo>*  allocate_info,
@@ -422,11 +428,12 @@ void VulkanResourceTrackingConsumer::Process_vkAllocateMemory(
     GetTrackedObjectInfoTable()->AddTrackedDeviceMemoryInfo(std::move(memory_info));
 }
 
-void VulkanResourceTrackingConsumer::Process_vkBindBufferMemory(VkResult         returnValue,
-                                                                format::HandleId device,
-                                                                format::HandleId buffer,
-                                                                format::HandleId memory,
-                                                                VkDeviceSize     memory_offset)
+void VulkanResourceTrackingConsumer::Process_vkBindBufferMemory(const ApiCallInfo& call_info,
+                                                                VkResult           returnValue,
+                                                                format::HandleId   device,
+                                                                format::HandleId   buffer,
+                                                                format::HandleId   memory,
+                                                                VkDeviceSize       memory_offset)
 {
     GFXRECON_UNREFERENCED_PARAMETER(returnValue);
 
@@ -442,17 +449,18 @@ void VulkanResourceTrackingConsumer::Process_vkBindBufferMemory(VkResult        
     // make the getbuffermemoryrequirement call to get the replay size.
     if (buffer_info->GetReplayResourceSize() == 0)
     {
-        Process_vkGetBufferMemoryRequirements(device, buffer, nullptr);
+        Process_vkGetBufferMemoryRequirements(call_info, device, buffer, nullptr);
     }
 
     memory_info->InsertBoundResourcesList(buffer_info);
 }
 
-void VulkanResourceTrackingConsumer::Process_vkBindImageMemory(VkResult         returnValue,
-                                                               format::HandleId device,
-                                                               format::HandleId image,
-                                                               format::HandleId memory,
-                                                               VkDeviceSize     memory_offset)
+void VulkanResourceTrackingConsumer::Process_vkBindImageMemory(const ApiCallInfo& call_info,
+                                                               VkResult           returnValue,
+                                                               format::HandleId   device,
+                                                               format::HandleId   image,
+                                                               format::HandleId   memory,
+                                                               VkDeviceSize       memory_offset)
 {
     GFXRECON_UNREFERENCED_PARAMETER(returnValue);
 
@@ -468,13 +476,14 @@ void VulkanResourceTrackingConsumer::Process_vkBindImageMemory(VkResult         
     // make the getimagememoryrequirement call to get the replay size.
     if (image_info->GetReplayResourceSize() == 0)
     {
-        Process_vkGetImageMemoryRequirements(device, image, nullptr);
+        Process_vkGetImageMemoryRequirements(call_info, device, image, nullptr);
     }
 
     memory_info->InsertBoundResourcesList(image_info);
 }
 
 void VulkanResourceTrackingConsumer::Process_vkBindBufferMemory2(
+    const ApiCallInfo&                                    call_info,
     VkResult                                              returnValue,
     format::HandleId                                      device,
     uint32_t                                              bindInfoCount,
@@ -506,7 +515,7 @@ void VulkanResourceTrackingConsumer::Process_vkBindBufferMemory2(
         // make the getbuffermemoryrequirement call to get the replay size.
         if (buffer_info->GetReplayResourceSize() == 0)
         {
-            Process_vkGetBufferMemoryRequirements(device, bind_meta_info->buffer, nullptr);
+            Process_vkGetBufferMemoryRequirements(call_info, device, bind_meta_info->buffer, nullptr);
         }
 
         memory_info->InsertBoundResourcesList(buffer_info);
@@ -514,6 +523,7 @@ void VulkanResourceTrackingConsumer::Process_vkBindBufferMemory2(
 }
 
 void VulkanResourceTrackingConsumer::Process_vkBindImageMemory2(
+    const ApiCallInfo&                                   call_info,
     VkResult                                             returnValue,
     format::HandleId                                     device,
     uint32_t                                             bindInfoCount,
@@ -545,14 +555,15 @@ void VulkanResourceTrackingConsumer::Process_vkBindImageMemory2(
         // make the getimagememoryrequirement call to get the replay size.
         if (image_info->GetReplayResourceSize() == 0)
         {
-            Process_vkGetImageMemoryRequirements(device, bind_meta_info->image, nullptr);
+            Process_vkGetImageMemoryRequirements(call_info, device, bind_meta_info->image, nullptr);
         }
 
         memory_info->InsertBoundResourcesList(image_info);
     }
 }
 
-void VulkanResourceTrackingConsumer::Process_vkMapMemory(VkResult                         returnValue,
+void VulkanResourceTrackingConsumer::Process_vkMapMemory(const ApiCallInfo&               call_info,
+                                                         VkResult                         returnValue,
                                                          format::HandleId                 device,
                                                          format::HandleId                 memory,
                                                          VkDeviceSize                     offset,
@@ -571,6 +582,7 @@ void VulkanResourceTrackingConsumer::Process_vkMapMemory(VkResult               
 }
 
 void VulkanResourceTrackingConsumer::Process_vkGetBufferMemoryRequirements(
+    const ApiCallInfo&                                  call_info,
     format::HandleId                                    device,
     format::HandleId                                    buffer,
     StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements)
@@ -619,6 +631,7 @@ void VulkanResourceTrackingConsumer::Process_vkGetBufferMemoryRequirements(
 }
 
 void VulkanResourceTrackingConsumer::Process_vkGetImageMemoryRequirements(
+    const ApiCallInfo&                                  call_info,
     format::HandleId                                    device,
     format::HandleId                                    image,
     StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements)
@@ -667,7 +680,9 @@ void VulkanResourceTrackingConsumer::Process_vkGetImageMemoryRequirements(
 }
 
 void VulkanResourceTrackingConsumer::Process_vkDestroyInstance(
-    format::HandleId instance, StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
+    const ApiCallInfo&                                   call_info,
+    format::HandleId                                     instance,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     auto       instance_info = GetTrackedObjectInfoTable()->GetTrackedInstanceInfo(instance);
     VkInstance in_instance   = instance_info->GetHandleId();
@@ -676,7 +691,9 @@ void VulkanResourceTrackingConsumer::Process_vkDestroyInstance(
 }
 
 void VulkanResourceTrackingConsumer::Process_vkDestroyDevice(
-    format::HandleId device, StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
+    const ApiCallInfo&                                   call_info,
+    format::HandleId                                     device,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     auto     device_info = GetTrackedObjectInfoTable()->GetTrackedDeviceInfo(device);
     VkDevice in_device   = device_info->GetHandleId();
@@ -685,7 +702,10 @@ void VulkanResourceTrackingConsumer::Process_vkDestroyDevice(
 }
 
 void VulkanResourceTrackingConsumer::Process_vkDestroyBuffer(
-    format::HandleId device, format::HandleId buffer, StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
+    const ApiCallInfo&                                   call_info,
+    format::HandleId                                     device,
+    format::HandleId                                     buffer,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     auto     device_info = GetTrackedObjectInfoTable()->GetTrackedDeviceInfo(device);
     auto     buffer_info = GetTrackedObjectInfoTable()->GetTrackedResourceInfo(buffer);
@@ -696,7 +716,10 @@ void VulkanResourceTrackingConsumer::Process_vkDestroyBuffer(
 }
 
 void VulkanResourceTrackingConsumer::Process_vkDestroyImage(
-    format::HandleId device, format::HandleId image, StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
+    const ApiCallInfo&                                   call_info,
+    format::HandleId                                     device,
+    format::HandleId                                     image,
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
     auto     device_info = GetTrackedObjectInfoTable()->GetTrackedDeviceInfo(device);
     auto     image_info  = GetTrackedObjectInfoTable()->GetTrackedResourceInfo(image);

--- a/framework/decode/vulkan_resource_tracking_consumer.h
+++ b/framework/decode/vulkan_resource_tracking_consumer.h
@@ -62,63 +62,74 @@ class VulkanResourceTrackingConsumer : public VulkanConsumer
 
     const encode::DeviceTable* GetDeviceTable(const void* handle) const;
 
-    virtual void Process_vkCreateInstance(VkResult                                             returnValue,
+    virtual void Process_vkCreateInstance(const ApiCallInfo&                                   call_info,
+                                          VkResult                                             returnValue,
                                           StructPointerDecoder<Decoded_VkInstanceCreateInfo>*  pCreateInfo,
                                           StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                           HandlePointerDecoder<VkInstance>*                    pInstance) override;
 
-    virtual void Process_vkCreateDevice(VkResult                                             returnValue,
+    virtual void Process_vkCreateDevice(const ApiCallInfo&                                   call_info,
+                                        VkResult                                             returnValue,
                                         format::HandleId                                     physicalDevice,
                                         StructPointerDecoder<Decoded_VkDeviceCreateInfo>*    pCreateInfo,
                                         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
                                         HandlePointerDecoder<VkDevice>*                      pDevice) override;
 
-    virtual void Process_vkEnumeratePhysicalDevices(VkResult                                returnValue,
+    virtual void Process_vkEnumeratePhysicalDevices(const ApiCallInfo&                      call_info,
+                                                    VkResult                                returnValue,
                                                     format::HandleId                        instance,
                                                     PointerDecoder<uint32_t>*               pPhysicalDeviceCount,
                                                     HandlePointerDecoder<VkPhysicalDevice>* pPhysicalDevices) override;
 
-    virtual void Process_vkCreateBuffer(VkResult                                             returnValue,
+    virtual void Process_vkCreateBuffer(const ApiCallInfo&                                   call_info,
+                                        VkResult                                             returnValue,
                                         format::HandleId                                     device,
                                         StructPointerDecoder<Decoded_VkBufferCreateInfo>*    create_info,
                                         StructPointerDecoder<Decoded_VkAllocationCallbacks>* allocator,
                                         HandlePointerDecoder<VkBuffer>*                      buffer) override;
 
-    virtual void Process_vkCreateImage(VkResult                                             returnValue,
+    virtual void Process_vkCreateImage(const ApiCallInfo&                                   call_info,
+                                       VkResult                                             returnValue,
                                        format::HandleId                                     device,
                                        StructPointerDecoder<Decoded_VkImageCreateInfo>*     create_info,
                                        StructPointerDecoder<Decoded_VkAllocationCallbacks>* allocator,
                                        HandlePointerDecoder<VkImage>*                       image) override;
 
-    virtual void Process_vkAllocateMemory(VkResult                                             returnValue,
+    virtual void Process_vkAllocateMemory(const ApiCallInfo&                                   call_info,
+                                          VkResult                                             returnValue,
                                           format::HandleId                                     device,
                                           StructPointerDecoder<Decoded_VkMemoryAllocateInfo>*  allocate_info,
                                           StructPointerDecoder<Decoded_VkAllocationCallbacks>* allocator,
                                           HandlePointerDecoder<VkDeviceMemory>*                memory) override;
 
-    virtual void Process_vkBindBufferMemory(VkResult         returnValue,
-                                            format::HandleId device,
-                                            format::HandleId buffer,
-                                            format::HandleId memory,
-                                            VkDeviceSize     memory_offset) override;
+    virtual void Process_vkBindBufferMemory(const ApiCallInfo& call_info,
+                                            VkResult           returnValue,
+                                            format::HandleId   device,
+                                            format::HandleId   buffer,
+                                            format::HandleId   memory,
+                                            VkDeviceSize       memory_offset) override;
 
-    virtual void Process_vkBindImageMemory(VkResult         returnValue,
-                                           format::HandleId device,
-                                           format::HandleId image,
-                                           format::HandleId memory,
-                                           VkDeviceSize     memory_offset) override;
+    virtual void Process_vkBindImageMemory(const ApiCallInfo& call_info,
+                                           VkResult           returnValue,
+                                           format::HandleId   device,
+                                           format::HandleId   image,
+                                           format::HandleId   memory,
+                                           VkDeviceSize       memory_offset) override;
 
-    virtual void Process_vkBindBufferMemory2(VkResult                                              returnValue,
+    virtual void Process_vkBindBufferMemory2(const ApiCallInfo&                                    call_info,
+                                             VkResult                                              returnValue,
                                              format::HandleId                                      device,
                                              uint32_t                                              bindInfoCount,
                                              StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos) override;
 
-    virtual void Process_vkBindImageMemory2(VkResult                                             returnValue,
+    virtual void Process_vkBindImageMemory2(const ApiCallInfo&                                   call_info,
+                                            VkResult                                             returnValue,
                                             format::HandleId                                     device,
                                             uint32_t                                             bindInfoCount,
                                             StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos) override;
 
-    virtual void Process_vkMapMemory(VkResult                         returnValue,
+    virtual void Process_vkMapMemory(const ApiCallInfo&               call_info,
+                                     VkResult                         returnValue,
                                      format::HandleId                 device,
                                      format::HandleId                 memory,
                                      VkDeviceSize                     offset,
@@ -127,26 +138,32 @@ class VulkanResourceTrackingConsumer : public VulkanConsumer
                                      PointerDecoder<uint64_t, void*>* data_pointer) override;
 
     virtual void Process_vkGetBufferMemoryRequirements(
+        const ApiCallInfo&                                  call_info,
         format::HandleId                                    device,
         format::HandleId                                    buffer,
         StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements) override;
 
     virtual void Process_vkGetImageMemoryRequirements(
+        const ApiCallInfo&                                  call_info,
         format::HandleId                                    device,
         format::HandleId                                    image,
         StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements) override;
 
-    virtual void Process_vkDestroyInstance(format::HandleId                                     instance,
+    virtual void Process_vkDestroyInstance(const ApiCallInfo&                                   call_info,
+                                           format::HandleId                                     instance,
                                            StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
-    virtual void Process_vkDestroyDevice(format::HandleId                                     device,
+    virtual void Process_vkDestroyDevice(const ApiCallInfo&                                   call_info,
+                                         format::HandleId                                     device,
                                          StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
-    virtual void Process_vkDestroyBuffer(format::HandleId                                     device,
+    virtual void Process_vkDestroyBuffer(const ApiCallInfo&                                   call_info,
+                                         format::HandleId                                     device,
                                          format::HandleId                                     buffer,
                                          StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
-    virtual void Process_vkDestroyImage(format::HandleId                                     device,
+    virtual void Process_vkDestroyImage(const ApiCallInfo&                                   call_info,
+                                        format::HandleId                                     device,
                                         format::HandleId                                     image,
                                         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 

--- a/framework/generated/base_generators/base_decoder_body_generator.py
+++ b/framework/generated/base_generators/base_decoder_body_generator.py
@@ -42,7 +42,7 @@ class BaseDecoderBodyGenerator():
             values = info[2]
 
             cmddef = '' if first else '\n'
-            cmddef += 'size_t {}Decoder::Decode_{}(const uint8_t* parameter_buffer, size_t buffer_size)\n'.format(
+            cmddef += 'size_t {}Decoder::Decode_{}(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)\n'.format(
                 platform_type, cmd
             )
             cmddef += '{\n'
@@ -137,6 +137,7 @@ class BaseDecoderBodyGenerator():
 
         if arglist[-2:] == ', ':
             arglist = arglist[:-2]
+        arglist = 'call_info, ' + arglist
 
         body += '    for (auto consumer : GetConsumers())\n'
         body += '    {\n'
@@ -247,7 +248,7 @@ class BaseDecoderBodyGenerator():
 
         for cmd in self.cmd_names:
             cmddef = '    case format::ApiCallId::ApiCall_{}:\n'.format(cmd)
-            cmddef += '        Decode_{}(parameter_buffer, buffer_size);\n'.format(
+            cmddef += '        Decode_{}(call_info, parameter_buffer, buffer_size);\n'.format(
                 cmd
             )
             cmddef += '        break;'

--- a/framework/generated/generated_vulkan_ascii_consumer.cpp
+++ b/framework/generated/generated_vulkan_ascii_consumer.cpp
@@ -37,6 +37,7 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 void VulkanAsciiConsumer::Process_vkCreateInstance(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     StructPointerDecoder<Decoded_VkInstanceCreateInfo>* pCreateInfo,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
@@ -46,7 +47,7 @@ void VulkanAsciiConsumer::Process_vkCreateInstance(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateInstance", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateInstance", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -58,6 +59,7 @@ void VulkanAsciiConsumer::Process_vkCreateInstance(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyInstance(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
@@ -65,7 +67,7 @@ void VulkanAsciiConsumer::Process_vkDestroyInstance(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyInstance", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyInstance", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
@@ -75,6 +77,7 @@ void VulkanAsciiConsumer::Process_vkDestroyInstance(
 }
 
 void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDevices(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     PointerDecoder<uint32_t>*                   pPhysicalDeviceCount,
@@ -84,7 +87,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDevices(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkEnumeratePhysicalDevices", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkEnumeratePhysicalDevices", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -96,6 +99,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDevices(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFeatures(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures>* pFeatures)
 {
@@ -103,7 +107,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFeatures(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceFeatures", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceFeatures", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -113,6 +117,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFeatures(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     VkFormat                                    format,
     StructPointerDecoder<Decoded_VkFormatProperties>* pFormatProperties)
@@ -121,7 +126,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceFormatProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceFormatProperties", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -132,6 +137,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     VkFormat                                    format,
@@ -145,7 +151,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceImageFormatProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceImageFormatProperties", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -161,6 +167,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceProperties(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceProperties>* pProperties)
 {
@@ -168,7 +175,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceProperties(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceProperties", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -178,6 +185,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceProperties(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
     StructPointerDecoder<Decoded_VkQueueFamilyProperties>* pQueueFamilyProperties)
@@ -186,7 +194,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceQueueFamilyProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceQueueFamilyProperties", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -197,6 +205,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties>* pMemoryProperties)
 {
@@ -204,7 +213,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceMemoryProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceMemoryProperties", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -214,6 +223,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateDevice(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkDeviceCreateInfo>* pCreateInfo,
@@ -224,7 +234,7 @@ void VulkanAsciiConsumer::Process_vkCreateDevice(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateDevice", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateDevice", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -237,6 +247,7 @@ void VulkanAsciiConsumer::Process_vkCreateDevice(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyDevice(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
@@ -244,7 +255,7 @@ void VulkanAsciiConsumer::Process_vkDestroyDevice(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyDevice", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyDevice", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -254,6 +265,7 @@ void VulkanAsciiConsumer::Process_vkDestroyDevice(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceQueue(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     uint32_t                                    queueFamilyIndex,
     uint32_t                                    queueIndex,
@@ -263,7 +275,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceQueue(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceQueue", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceQueue", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -275,6 +287,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceQueue(
 }
 
 void VulkanAsciiConsumer::Process_vkQueueSubmit(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            queue,
     uint32_t                                    submitCount,
@@ -285,7 +298,7 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkQueueSubmit", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkQueueSubmit", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -298,6 +311,7 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit(
 }
 
 void VulkanAsciiConsumer::Process_vkQueueWaitIdle(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            queue)
 {
@@ -305,7 +319,7 @@ void VulkanAsciiConsumer::Process_vkQueueWaitIdle(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkQueueWaitIdle", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkQueueWaitIdle", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -315,6 +329,7 @@ void VulkanAsciiConsumer::Process_vkQueueWaitIdle(
 }
 
 void VulkanAsciiConsumer::Process_vkDeviceWaitIdle(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device)
 {
@@ -322,7 +337,7 @@ void VulkanAsciiConsumer::Process_vkDeviceWaitIdle(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDeviceWaitIdle", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDeviceWaitIdle", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -332,6 +347,7 @@ void VulkanAsciiConsumer::Process_vkDeviceWaitIdle(
 }
 
 void VulkanAsciiConsumer::Process_vkAllocateMemory(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkMemoryAllocateInfo>* pAllocateInfo,
@@ -342,7 +358,7 @@ void VulkanAsciiConsumer::Process_vkAllocateMemory(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkAllocateMemory", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkAllocateMemory", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -355,6 +371,7 @@ void VulkanAsciiConsumer::Process_vkAllocateMemory(
 }
 
 void VulkanAsciiConsumer::Process_vkFreeMemory(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            memory,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -363,7 +380,7 @@ void VulkanAsciiConsumer::Process_vkFreeMemory(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkFreeMemory", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkFreeMemory", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -374,6 +391,7 @@ void VulkanAsciiConsumer::Process_vkFreeMemory(
 }
 
 void VulkanAsciiConsumer::Process_vkMapMemory(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            memory,
@@ -386,7 +404,7 @@ void VulkanAsciiConsumer::Process_vkMapMemory(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkMapMemory", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkMapMemory", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -401,6 +419,7 @@ void VulkanAsciiConsumer::Process_vkMapMemory(
 }
 
 void VulkanAsciiConsumer::Process_vkUnmapMemory(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            memory)
 {
@@ -408,7 +427,7 @@ void VulkanAsciiConsumer::Process_vkUnmapMemory(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkUnmapMemory", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkUnmapMemory", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -418,6 +437,7 @@ void VulkanAsciiConsumer::Process_vkUnmapMemory(
 }
 
 void VulkanAsciiConsumer::Process_vkFlushMappedMemoryRanges(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    memoryRangeCount,
@@ -427,7 +447,7 @@ void VulkanAsciiConsumer::Process_vkFlushMappedMemoryRanges(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkFlushMappedMemoryRanges", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkFlushMappedMemoryRanges", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -439,6 +459,7 @@ void VulkanAsciiConsumer::Process_vkFlushMappedMemoryRanges(
 }
 
 void VulkanAsciiConsumer::Process_vkInvalidateMappedMemoryRanges(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    memoryRangeCount,
@@ -448,7 +469,7 @@ void VulkanAsciiConsumer::Process_vkInvalidateMappedMemoryRanges(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkInvalidateMappedMemoryRanges", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkInvalidateMappedMemoryRanges", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -460,6 +481,7 @@ void VulkanAsciiConsumer::Process_vkInvalidateMappedMemoryRanges(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceMemoryCommitment(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            memory,
     PointerDecoder<VkDeviceSize>*               pCommittedMemoryInBytes)
@@ -468,7 +490,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryCommitment(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceMemoryCommitment", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceMemoryCommitment", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -479,6 +501,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryCommitment(
 }
 
 void VulkanAsciiConsumer::Process_vkBindBufferMemory(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            buffer,
@@ -489,7 +512,7 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkBindBufferMemory", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkBindBufferMemory", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -502,6 +525,7 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory(
 }
 
 void VulkanAsciiConsumer::Process_vkBindImageMemory(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            image,
@@ -512,7 +536,7 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkBindImageMemory", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkBindImageMemory", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -525,6 +549,7 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory(
 }
 
 void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            buffer,
     StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements)
@@ -533,7 +558,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetBufferMemoryRequirements", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetBufferMemoryRequirements", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -544,6 +569,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements(
 }
 
 void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            image,
     StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements)
@@ -552,7 +578,7 @@ void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetImageMemoryRequirements", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetImageMemoryRequirements", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -563,6 +589,7 @@ void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements(
 }
 
 void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            image,
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
@@ -572,7 +599,7 @@ void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetImageSparseMemoryRequirements", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetImageSparseMemoryRequirements", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -584,6 +611,7 @@ void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     VkFormat                                    format,
     VkImageType                                 type,
@@ -597,7 +625,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceSparseImageFormatProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSparseImageFormatProperties", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -613,6 +641,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties
 }
 
 void VulkanAsciiConsumer::Process_vkQueueBindSparse(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            queue,
     uint32_t                                    bindInfoCount,
@@ -623,7 +652,7 @@ void VulkanAsciiConsumer::Process_vkQueueBindSparse(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkQueueBindSparse", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkQueueBindSparse", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -636,6 +665,7 @@ void VulkanAsciiConsumer::Process_vkQueueBindSparse(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateFence(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkFenceCreateInfo>* pCreateInfo,
@@ -646,7 +676,7 @@ void VulkanAsciiConsumer::Process_vkCreateFence(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateFence", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateFence", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -659,6 +689,7 @@ void VulkanAsciiConsumer::Process_vkCreateFence(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyFence(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            fence,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -667,7 +698,7 @@ void VulkanAsciiConsumer::Process_vkDestroyFence(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyFence", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyFence", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -678,6 +709,7 @@ void VulkanAsciiConsumer::Process_vkDestroyFence(
 }
 
 void VulkanAsciiConsumer::Process_vkResetFences(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    fenceCount,
@@ -687,7 +719,7 @@ void VulkanAsciiConsumer::Process_vkResetFences(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkResetFences", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkResetFences", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -699,6 +731,7 @@ void VulkanAsciiConsumer::Process_vkResetFences(
 }
 
 void VulkanAsciiConsumer::Process_vkGetFenceStatus(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            fence)
@@ -707,7 +740,7 @@ void VulkanAsciiConsumer::Process_vkGetFenceStatus(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetFenceStatus", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetFenceStatus", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -718,6 +751,7 @@ void VulkanAsciiConsumer::Process_vkGetFenceStatus(
 }
 
 void VulkanAsciiConsumer::Process_vkWaitForFences(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    fenceCount,
@@ -729,7 +763,7 @@ void VulkanAsciiConsumer::Process_vkWaitForFences(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkWaitForFences", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkWaitForFences", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -743,6 +777,7 @@ void VulkanAsciiConsumer::Process_vkWaitForFences(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateSemaphore(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreCreateInfo>* pCreateInfo,
@@ -753,7 +788,7 @@ void VulkanAsciiConsumer::Process_vkCreateSemaphore(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateSemaphore", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateSemaphore", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -766,6 +801,7 @@ void VulkanAsciiConsumer::Process_vkCreateSemaphore(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroySemaphore(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            semaphore,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -774,7 +810,7 @@ void VulkanAsciiConsumer::Process_vkDestroySemaphore(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroySemaphore", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroySemaphore", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -785,6 +821,7 @@ void VulkanAsciiConsumer::Process_vkDestroySemaphore(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateEvent(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkEventCreateInfo>* pCreateInfo,
@@ -795,7 +832,7 @@ void VulkanAsciiConsumer::Process_vkCreateEvent(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateEvent", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateEvent", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -808,6 +845,7 @@ void VulkanAsciiConsumer::Process_vkCreateEvent(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyEvent(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            event,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -816,7 +854,7 @@ void VulkanAsciiConsumer::Process_vkDestroyEvent(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyEvent", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyEvent", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -827,6 +865,7 @@ void VulkanAsciiConsumer::Process_vkDestroyEvent(
 }
 
 void VulkanAsciiConsumer::Process_vkGetEventStatus(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            event)
@@ -835,7 +874,7 @@ void VulkanAsciiConsumer::Process_vkGetEventStatus(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetEventStatus", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetEventStatus", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -846,6 +885,7 @@ void VulkanAsciiConsumer::Process_vkGetEventStatus(
 }
 
 void VulkanAsciiConsumer::Process_vkSetEvent(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            event)
@@ -854,7 +894,7 @@ void VulkanAsciiConsumer::Process_vkSetEvent(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkSetEvent", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkSetEvent", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -865,6 +905,7 @@ void VulkanAsciiConsumer::Process_vkSetEvent(
 }
 
 void VulkanAsciiConsumer::Process_vkResetEvent(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            event)
@@ -873,7 +914,7 @@ void VulkanAsciiConsumer::Process_vkResetEvent(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkResetEvent", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkResetEvent", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -884,6 +925,7 @@ void VulkanAsciiConsumer::Process_vkResetEvent(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateQueryPool(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkQueryPoolCreateInfo>* pCreateInfo,
@@ -894,7 +936,7 @@ void VulkanAsciiConsumer::Process_vkCreateQueryPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateQueryPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateQueryPool", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -907,6 +949,7 @@ void VulkanAsciiConsumer::Process_vkCreateQueryPool(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyQueryPool(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            queryPool,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -915,7 +958,7 @@ void VulkanAsciiConsumer::Process_vkDestroyQueryPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyQueryPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyQueryPool", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -926,6 +969,7 @@ void VulkanAsciiConsumer::Process_vkDestroyQueryPool(
 }
 
 void VulkanAsciiConsumer::Process_vkGetQueryPoolResults(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            queryPool,
@@ -940,7 +984,7 @@ void VulkanAsciiConsumer::Process_vkGetQueryPoolResults(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetQueryPoolResults", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetQueryPoolResults", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -957,6 +1001,7 @@ void VulkanAsciiConsumer::Process_vkGetQueryPoolResults(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateBuffer(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferCreateInfo>* pCreateInfo,
@@ -967,7 +1012,7 @@ void VulkanAsciiConsumer::Process_vkCreateBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateBuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -980,6 +1025,7 @@ void VulkanAsciiConsumer::Process_vkCreateBuffer(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            buffer,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -988,7 +1034,7 @@ void VulkanAsciiConsumer::Process_vkDestroyBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyBuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -999,6 +1045,7 @@ void VulkanAsciiConsumer::Process_vkDestroyBuffer(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateBufferView(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferViewCreateInfo>* pCreateInfo,
@@ -1009,7 +1056,7 @@ void VulkanAsciiConsumer::Process_vkCreateBufferView(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateBufferView", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateBufferView", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1022,6 +1069,7 @@ void VulkanAsciiConsumer::Process_vkCreateBufferView(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyBufferView(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            bufferView,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1030,7 +1078,7 @@ void VulkanAsciiConsumer::Process_vkDestroyBufferView(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyBufferView", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyBufferView", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1041,6 +1089,7 @@ void VulkanAsciiConsumer::Process_vkDestroyBufferView(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateImage(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImageCreateInfo>* pCreateInfo,
@@ -1051,7 +1100,7 @@ void VulkanAsciiConsumer::Process_vkCreateImage(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateImage", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateImage", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1064,6 +1113,7 @@ void VulkanAsciiConsumer::Process_vkCreateImage(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            image,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1072,7 +1122,7 @@ void VulkanAsciiConsumer::Process_vkDestroyImage(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyImage", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyImage", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1083,6 +1133,7 @@ void VulkanAsciiConsumer::Process_vkDestroyImage(
 }
 
 void VulkanAsciiConsumer::Process_vkGetImageSubresourceLayout(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            image,
     StructPointerDecoder<Decoded_VkImageSubresource>* pSubresource,
@@ -1092,7 +1143,7 @@ void VulkanAsciiConsumer::Process_vkGetImageSubresourceLayout(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetImageSubresourceLayout", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetImageSubresourceLayout", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1104,6 +1155,7 @@ void VulkanAsciiConsumer::Process_vkGetImageSubresourceLayout(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateImageView(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImageViewCreateInfo>* pCreateInfo,
@@ -1114,7 +1166,7 @@ void VulkanAsciiConsumer::Process_vkCreateImageView(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateImageView", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateImageView", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1127,6 +1179,7 @@ void VulkanAsciiConsumer::Process_vkCreateImageView(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyImageView(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            imageView,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1135,7 +1188,7 @@ void VulkanAsciiConsumer::Process_vkDestroyImageView(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyImageView", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyImageView", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1146,6 +1199,7 @@ void VulkanAsciiConsumer::Process_vkDestroyImageView(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateShaderModule(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>* pCreateInfo,
@@ -1156,7 +1210,7 @@ void VulkanAsciiConsumer::Process_vkCreateShaderModule(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateShaderModule", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateShaderModule", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1169,6 +1223,7 @@ void VulkanAsciiConsumer::Process_vkCreateShaderModule(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyShaderModule(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            shaderModule,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1177,7 +1232,7 @@ void VulkanAsciiConsumer::Process_vkDestroyShaderModule(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyShaderModule", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyShaderModule", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1188,6 +1243,7 @@ void VulkanAsciiConsumer::Process_vkDestroyShaderModule(
 }
 
 void VulkanAsciiConsumer::Process_vkCreatePipelineCache(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>* pCreateInfo,
@@ -1198,7 +1254,7 @@ void VulkanAsciiConsumer::Process_vkCreatePipelineCache(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreatePipelineCache", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreatePipelineCache", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1211,6 +1267,7 @@ void VulkanAsciiConsumer::Process_vkCreatePipelineCache(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyPipelineCache(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            pipelineCache,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1219,7 +1276,7 @@ void VulkanAsciiConsumer::Process_vkDestroyPipelineCache(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyPipelineCache", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyPipelineCache", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1230,6 +1287,7 @@ void VulkanAsciiConsumer::Process_vkDestroyPipelineCache(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPipelineCacheData(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipelineCache,
@@ -1240,7 +1298,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineCacheData(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPipelineCacheData", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPipelineCacheData", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1253,6 +1311,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineCacheData(
 }
 
 void VulkanAsciiConsumer::Process_vkMergePipelineCaches(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            dstCache,
@@ -1263,7 +1322,7 @@ void VulkanAsciiConsumer::Process_vkMergePipelineCaches(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkMergePipelineCaches", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkMergePipelineCaches", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1276,6 +1335,7 @@ void VulkanAsciiConsumer::Process_vkMergePipelineCaches(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateGraphicsPipelines(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipelineCache,
@@ -1288,7 +1348,7 @@ void VulkanAsciiConsumer::Process_vkCreateGraphicsPipelines(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateGraphicsPipelines", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateGraphicsPipelines", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1303,6 +1363,7 @@ void VulkanAsciiConsumer::Process_vkCreateGraphicsPipelines(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateComputePipelines(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipelineCache,
@@ -1315,7 +1376,7 @@ void VulkanAsciiConsumer::Process_vkCreateComputePipelines(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateComputePipelines", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateComputePipelines", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1330,6 +1391,7 @@ void VulkanAsciiConsumer::Process_vkCreateComputePipelines(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyPipeline(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            pipeline,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1338,7 +1400,7 @@ void VulkanAsciiConsumer::Process_vkDestroyPipeline(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyPipeline", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyPipeline", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1349,6 +1411,7 @@ void VulkanAsciiConsumer::Process_vkDestroyPipeline(
 }
 
 void VulkanAsciiConsumer::Process_vkCreatePipelineLayout(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPipelineLayoutCreateInfo>* pCreateInfo,
@@ -1359,7 +1422,7 @@ void VulkanAsciiConsumer::Process_vkCreatePipelineLayout(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreatePipelineLayout", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreatePipelineLayout", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1372,6 +1435,7 @@ void VulkanAsciiConsumer::Process_vkCreatePipelineLayout(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyPipelineLayout(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            pipelineLayout,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1380,7 +1444,7 @@ void VulkanAsciiConsumer::Process_vkDestroyPipelineLayout(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyPipelineLayout", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyPipelineLayout", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1391,6 +1455,7 @@ void VulkanAsciiConsumer::Process_vkDestroyPipelineLayout(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateSampler(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSamplerCreateInfo>* pCreateInfo,
@@ -1401,7 +1466,7 @@ void VulkanAsciiConsumer::Process_vkCreateSampler(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateSampler", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateSampler", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1414,6 +1479,7 @@ void VulkanAsciiConsumer::Process_vkCreateSampler(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroySampler(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            sampler,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1422,7 +1488,7 @@ void VulkanAsciiConsumer::Process_vkDestroySampler(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroySampler", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroySampler", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1433,6 +1499,7 @@ void VulkanAsciiConsumer::Process_vkDestroySampler(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateDescriptorSetLayout(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
@@ -1443,7 +1510,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorSetLayout(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateDescriptorSetLayout", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateDescriptorSetLayout", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1456,6 +1523,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorSetLayout(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyDescriptorSetLayout(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            descriptorSetLayout,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1464,7 +1532,7 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorSetLayout(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyDescriptorSetLayout", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyDescriptorSetLayout", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1475,6 +1543,7 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorSetLayout(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateDescriptorPool(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>* pCreateInfo,
@@ -1485,7 +1554,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateDescriptorPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateDescriptorPool", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1498,6 +1567,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorPool(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyDescriptorPool(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            descriptorPool,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1506,7 +1576,7 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyDescriptorPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyDescriptorPool", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1517,6 +1587,7 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorPool(
 }
 
 void VulkanAsciiConsumer::Process_vkResetDescriptorPool(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            descriptorPool,
@@ -1526,7 +1597,7 @@ void VulkanAsciiConsumer::Process_vkResetDescriptorPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkResetDescriptorPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkResetDescriptorPool", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1538,6 +1609,7 @@ void VulkanAsciiConsumer::Process_vkResetDescriptorPool(
 }
 
 void VulkanAsciiConsumer::Process_vkFreeDescriptorSets(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            descriptorPool,
@@ -1548,7 +1620,7 @@ void VulkanAsciiConsumer::Process_vkFreeDescriptorSets(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkFreeDescriptorSets", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkFreeDescriptorSets", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1561,6 +1633,7 @@ void VulkanAsciiConsumer::Process_vkFreeDescriptorSets(
 }
 
 void VulkanAsciiConsumer::Process_vkUpdateDescriptorSets(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     uint32_t                                    descriptorWriteCount,
     StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites,
@@ -1571,7 +1644,7 @@ void VulkanAsciiConsumer::Process_vkUpdateDescriptorSets(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkUpdateDescriptorSets", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkUpdateDescriptorSets", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1584,6 +1657,7 @@ void VulkanAsciiConsumer::Process_vkUpdateDescriptorSets(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateFramebuffer(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* pCreateInfo,
@@ -1594,7 +1668,7 @@ void VulkanAsciiConsumer::Process_vkCreateFramebuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateFramebuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateFramebuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1607,6 +1681,7 @@ void VulkanAsciiConsumer::Process_vkCreateFramebuffer(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyFramebuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            framebuffer,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1615,7 +1690,7 @@ void VulkanAsciiConsumer::Process_vkDestroyFramebuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyFramebuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyFramebuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1626,6 +1701,7 @@ void VulkanAsciiConsumer::Process_vkDestroyFramebuffer(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateRenderPass(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkRenderPassCreateInfo>* pCreateInfo,
@@ -1636,7 +1712,7 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateRenderPass", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateRenderPass", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1649,6 +1725,7 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyRenderPass(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            renderPass,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1657,7 +1734,7 @@ void VulkanAsciiConsumer::Process_vkDestroyRenderPass(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyRenderPass", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyRenderPass", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1668,6 +1745,7 @@ void VulkanAsciiConsumer::Process_vkDestroyRenderPass(
 }
 
 void VulkanAsciiConsumer::Process_vkGetRenderAreaGranularity(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            renderPass,
     StructPointerDecoder<Decoded_VkExtent2D>*   pGranularity)
@@ -1676,7 +1754,7 @@ void VulkanAsciiConsumer::Process_vkGetRenderAreaGranularity(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetRenderAreaGranularity", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetRenderAreaGranularity", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1687,6 +1765,7 @@ void VulkanAsciiConsumer::Process_vkGetRenderAreaGranularity(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateCommandPool(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>* pCreateInfo,
@@ -1697,7 +1776,7 @@ void VulkanAsciiConsumer::Process_vkCreateCommandPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateCommandPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateCommandPool", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1710,6 +1789,7 @@ void VulkanAsciiConsumer::Process_vkCreateCommandPool(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyCommandPool(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            commandPool,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1718,7 +1798,7 @@ void VulkanAsciiConsumer::Process_vkDestroyCommandPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyCommandPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyCommandPool", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1729,6 +1809,7 @@ void VulkanAsciiConsumer::Process_vkDestroyCommandPool(
 }
 
 void VulkanAsciiConsumer::Process_vkResetCommandPool(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            commandPool,
@@ -1738,7 +1819,7 @@ void VulkanAsciiConsumer::Process_vkResetCommandPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkResetCommandPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkResetCommandPool", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1750,6 +1831,7 @@ void VulkanAsciiConsumer::Process_vkResetCommandPool(
 }
 
 void VulkanAsciiConsumer::Process_vkFreeCommandBuffers(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            commandPool,
     uint32_t                                    commandBufferCount,
@@ -1759,7 +1841,7 @@ void VulkanAsciiConsumer::Process_vkFreeCommandBuffers(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkFreeCommandBuffers", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkFreeCommandBuffers", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -1771,6 +1853,7 @@ void VulkanAsciiConsumer::Process_vkFreeCommandBuffers(
 }
 
 void VulkanAsciiConsumer::Process_vkBeginCommandBuffer(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo)
@@ -1779,7 +1862,7 @@ void VulkanAsciiConsumer::Process_vkBeginCommandBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkBeginCommandBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkBeginCommandBuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1790,6 +1873,7 @@ void VulkanAsciiConsumer::Process_vkBeginCommandBuffer(
 }
 
 void VulkanAsciiConsumer::Process_vkEndCommandBuffer(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer)
 {
@@ -1797,7 +1881,7 @@ void VulkanAsciiConsumer::Process_vkEndCommandBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkEndCommandBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkEndCommandBuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1807,6 +1891,7 @@ void VulkanAsciiConsumer::Process_vkEndCommandBuffer(
 }
 
 void VulkanAsciiConsumer::Process_vkResetCommandBuffer(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer,
     VkCommandBufferResetFlags                   flags)
@@ -1815,7 +1900,7 @@ void VulkanAsciiConsumer::Process_vkResetCommandBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkResetCommandBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkResetCommandBuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -1826,6 +1911,7 @@ void VulkanAsciiConsumer::Process_vkResetCommandBuffer(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBindPipeline(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineBindPoint                         pipelineBindPoint,
     format::HandleId                            pipeline)
@@ -1834,7 +1920,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindPipeline(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBindPipeline", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBindPipeline", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -1845,6 +1931,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindPipeline(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetViewport(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstViewport,
     uint32_t                                    viewportCount,
@@ -1854,7 +1941,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewport(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetViewport", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetViewport", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -1866,6 +1953,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewport(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetScissor(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstScissor,
     uint32_t                                    scissorCount,
@@ -1875,7 +1963,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetScissor(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetScissor", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetScissor", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -1887,6 +1975,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetScissor(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetLineWidth(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     float                                       lineWidth)
 {
@@ -1894,7 +1983,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetLineWidth(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetLineWidth", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetLineWidth", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -1904,6 +1993,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetLineWidth(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetDepthBias(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     float                                       depthBiasConstantFactor,
     float                                       depthBiasClamp,
@@ -1913,7 +2003,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBias(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetDepthBias", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetDepthBias", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -1925,6 +2015,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBias(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetBlendConstants(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     PointerDecoder<float>*                      blendConstants)
 {
@@ -1932,7 +2023,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetBlendConstants(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetBlendConstants", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetBlendConstants", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -1942,6 +2033,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetBlendConstants(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetDepthBounds(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     float                                       minDepthBounds,
     float                                       maxDepthBounds)
@@ -1950,7 +2042,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBounds(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetDepthBounds", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetDepthBounds", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -1961,6 +2053,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBounds(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetStencilCompareMask(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkStencilFaceFlags                          faceMask,
     uint32_t                                    compareMask)
@@ -1969,7 +2062,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilCompareMask(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetStencilCompareMask", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetStencilCompareMask", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -1980,6 +2073,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilCompareMask(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetStencilWriteMask(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkStencilFaceFlags                          faceMask,
     uint32_t                                    writeMask)
@@ -1988,7 +2082,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilWriteMask(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetStencilWriteMask", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetStencilWriteMask", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -1999,6 +2093,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilWriteMask(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetStencilReference(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkStencilFaceFlags                          faceMask,
     uint32_t                                    reference)
@@ -2007,7 +2102,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilReference(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetStencilReference", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetStencilReference", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2018,6 +2113,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilReference(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBindDescriptorSets(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineBindPoint                         pipelineBindPoint,
     format::HandleId                            layout,
@@ -2031,7 +2127,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindDescriptorSets(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBindDescriptorSets", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBindDescriptorSets", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2047,6 +2143,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindDescriptorSets(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBindIndexBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -2056,7 +2153,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindIndexBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBindIndexBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBindIndexBuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2068,6 +2165,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindIndexBuffer(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstBinding,
     uint32_t                                    bindingCount,
@@ -2078,7 +2176,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBindVertexBuffers", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBindVertexBuffers", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2091,6 +2189,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDraw(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    vertexCount,
     uint32_t                                    instanceCount,
@@ -2101,7 +2200,7 @@ void VulkanAsciiConsumer::Process_vkCmdDraw(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDraw", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDraw", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2114,6 +2213,7 @@ void VulkanAsciiConsumer::Process_vkCmdDraw(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDrawIndexed(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    indexCount,
     uint32_t                                    instanceCount,
@@ -2125,7 +2225,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexed(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDrawIndexed", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDrawIndexed", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2139,6 +2239,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexed(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDrawIndirect(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -2149,7 +2250,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirect(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDrawIndirect", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDrawIndirect", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2162,6 +2263,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirect(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirect(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -2172,7 +2274,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirect(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDrawIndexedIndirect", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDrawIndexedIndirect", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2185,6 +2287,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirect(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDispatch(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    groupCountX,
     uint32_t                                    groupCountY,
@@ -2194,7 +2297,7 @@ void VulkanAsciiConsumer::Process_vkCmdDispatch(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDispatch", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDispatch", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2206,6 +2309,7 @@ void VulkanAsciiConsumer::Process_vkCmdDispatch(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDispatchIndirect(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset)
@@ -2214,7 +2318,7 @@ void VulkanAsciiConsumer::Process_vkCmdDispatchIndirect(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDispatchIndirect", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDispatchIndirect", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2225,6 +2329,7 @@ void VulkanAsciiConsumer::Process_vkCmdDispatchIndirect(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcBuffer,
     format::HandleId                            dstBuffer,
@@ -2235,7 +2340,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyBuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2248,6 +2353,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBuffer(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcImage,
     VkImageLayout                               srcImageLayout,
@@ -2260,7 +2366,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImage(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyImage", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyImage", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2275,6 +2381,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImage(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBlitImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcImage,
     VkImageLayout                               srcImageLayout,
@@ -2288,7 +2395,7 @@ void VulkanAsciiConsumer::Process_vkCmdBlitImage(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBlitImage", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBlitImage", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2304,6 +2411,7 @@ void VulkanAsciiConsumer::Process_vkCmdBlitImage(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyBufferToImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcBuffer,
     format::HandleId                            dstImage,
@@ -2315,7 +2423,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBufferToImage(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyBufferToImage", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyBufferToImage", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2329,6 +2437,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBufferToImage(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyImageToBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcImage,
     VkImageLayout                               srcImageLayout,
@@ -2340,7 +2449,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImageToBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyImageToBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyImageToBuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2354,6 +2463,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImageToBuffer(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdUpdateBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            dstBuffer,
     VkDeviceSize                                dstOffset,
@@ -2364,7 +2474,7 @@ void VulkanAsciiConsumer::Process_vkCmdUpdateBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdUpdateBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdUpdateBuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2377,6 +2487,7 @@ void VulkanAsciiConsumer::Process_vkCmdUpdateBuffer(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdFillBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            dstBuffer,
     VkDeviceSize                                dstOffset,
@@ -2387,7 +2498,7 @@ void VulkanAsciiConsumer::Process_vkCmdFillBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdFillBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdFillBuffer", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2400,6 +2511,7 @@ void VulkanAsciiConsumer::Process_vkCmdFillBuffer(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdClearColorImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            image,
     VkImageLayout                               imageLayout,
@@ -2411,7 +2523,7 @@ void VulkanAsciiConsumer::Process_vkCmdClearColorImage(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdClearColorImage", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdClearColorImage", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2425,6 +2537,7 @@ void VulkanAsciiConsumer::Process_vkCmdClearColorImage(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdClearDepthStencilImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            image,
     VkImageLayout                               imageLayout,
@@ -2436,7 +2549,7 @@ void VulkanAsciiConsumer::Process_vkCmdClearDepthStencilImage(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdClearDepthStencilImage", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdClearDepthStencilImage", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2450,6 +2563,7 @@ void VulkanAsciiConsumer::Process_vkCmdClearDepthStencilImage(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdClearAttachments(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    attachmentCount,
     StructPointerDecoder<Decoded_VkClearAttachment>* pAttachments,
@@ -2460,7 +2574,7 @@ void VulkanAsciiConsumer::Process_vkCmdClearAttachments(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdClearAttachments", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdClearAttachments", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2473,6 +2587,7 @@ void VulkanAsciiConsumer::Process_vkCmdClearAttachments(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdResolveImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcImage,
     VkImageLayout                               srcImageLayout,
@@ -2485,7 +2600,7 @@ void VulkanAsciiConsumer::Process_vkCmdResolveImage(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdResolveImage", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdResolveImage", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2500,6 +2615,7 @@ void VulkanAsciiConsumer::Process_vkCmdResolveImage(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetEvent(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            event,
     VkPipelineStageFlags                        stageMask)
@@ -2508,7 +2624,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetEvent(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetEvent", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetEvent", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2519,6 +2635,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetEvent(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdResetEvent(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            event,
     VkPipelineStageFlags                        stageMask)
@@ -2527,7 +2644,7 @@ void VulkanAsciiConsumer::Process_vkCmdResetEvent(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdResetEvent", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdResetEvent", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2538,6 +2655,7 @@ void VulkanAsciiConsumer::Process_vkCmdResetEvent(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdWaitEvents(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    eventCount,
     HandlePointerDecoder<VkEvent>*              pEvents,
@@ -2554,7 +2672,7 @@ void VulkanAsciiConsumer::Process_vkCmdWaitEvents(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdWaitEvents", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdWaitEvents", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2573,6 +2691,7 @@ void VulkanAsciiConsumer::Process_vkCmdWaitEvents(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineStageFlags                        srcStageMask,
     VkPipelineStageFlags                        dstStageMask,
@@ -2588,7 +2707,7 @@ void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdPipelineBarrier", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdPipelineBarrier", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2606,6 +2725,7 @@ void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBeginQuery(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            queryPool,
     uint32_t                                    query,
@@ -2615,7 +2735,7 @@ void VulkanAsciiConsumer::Process_vkCmdBeginQuery(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBeginQuery", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBeginQuery", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2627,6 +2747,7 @@ void VulkanAsciiConsumer::Process_vkCmdBeginQuery(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdEndQuery(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            queryPool,
     uint32_t                                    query)
@@ -2635,7 +2756,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndQuery(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdEndQuery", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdEndQuery", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2646,6 +2767,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndQuery(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdResetQueryPool(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            queryPool,
     uint32_t                                    firstQuery,
@@ -2655,7 +2777,7 @@ void VulkanAsciiConsumer::Process_vkCmdResetQueryPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdResetQueryPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdResetQueryPool", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2667,6 +2789,7 @@ void VulkanAsciiConsumer::Process_vkCmdResetQueryPool(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdWriteTimestamp(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineStageFlagBits                     pipelineStage,
     format::HandleId                            queryPool,
@@ -2676,7 +2799,7 @@ void VulkanAsciiConsumer::Process_vkCmdWriteTimestamp(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdWriteTimestamp", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdWriteTimestamp", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2688,6 +2811,7 @@ void VulkanAsciiConsumer::Process_vkCmdWriteTimestamp(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyQueryPoolResults(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            queryPool,
     uint32_t                                    firstQuery,
@@ -2701,7 +2825,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyQueryPoolResults(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyQueryPoolResults", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyQueryPoolResults", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2717,6 +2841,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyQueryPoolResults(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdPushConstants(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            layout,
     VkShaderStageFlags                          stageFlags,
@@ -2728,7 +2853,7 @@ void VulkanAsciiConsumer::Process_vkCmdPushConstants(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdPushConstants", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdPushConstants", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2742,6 +2867,7 @@ void VulkanAsciiConsumer::Process_vkCmdPushConstants(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
     VkSubpassContents                           contents)
@@ -2750,7 +2876,7 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBeginRenderPass", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBeginRenderPass", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2761,6 +2887,7 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdNextSubpass(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkSubpassContents                           contents)
 {
@@ -2768,7 +2895,7 @@ void VulkanAsciiConsumer::Process_vkCmdNextSubpass(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdNextSubpass", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdNextSubpass", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2778,13 +2905,14 @@ void VulkanAsciiConsumer::Process_vkCmdNextSubpass(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdEndRenderPass(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
     using namespace gfxrecon::util;
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdEndRenderPass", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdEndRenderPass", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2793,6 +2921,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndRenderPass(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdExecuteCommands(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    commandBufferCount,
     HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers)
@@ -2801,7 +2930,7 @@ void VulkanAsciiConsumer::Process_vkCmdExecuteCommands(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdExecuteCommands", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdExecuteCommands", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2812,6 +2941,7 @@ void VulkanAsciiConsumer::Process_vkCmdExecuteCommands(
 }
 
 void VulkanAsciiConsumer::Process_vkBindBufferMemory2(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    bindInfoCount,
@@ -2821,7 +2951,7 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkBindBufferMemory2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkBindBufferMemory2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -2833,6 +2963,7 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory2(
 }
 
 void VulkanAsciiConsumer::Process_vkBindImageMemory2(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    bindInfoCount,
@@ -2842,7 +2973,7 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkBindImageMemory2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkBindImageMemory2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -2854,6 +2985,7 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory2(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceGroupPeerMemoryFeatures(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     uint32_t                                    heapIndex,
     uint32_t                                    localDeviceIndex,
@@ -2864,7 +2996,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupPeerMemoryFeatures(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceGroupPeerMemoryFeatures", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceGroupPeerMemoryFeatures", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -2877,6 +3009,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupPeerMemoryFeatures(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetDeviceMask(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    deviceMask)
 {
@@ -2884,7 +3017,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDeviceMask(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetDeviceMask", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetDeviceMask", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2894,6 +3027,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDeviceMask(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDispatchBase(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    baseGroupX,
     uint32_t                                    baseGroupY,
@@ -2906,7 +3040,7 @@ void VulkanAsciiConsumer::Process_vkCmdDispatchBase(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDispatchBase", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDispatchBase", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -2921,6 +3055,7 @@ void VulkanAsciiConsumer::Process_vkCmdDispatchBase(
 }
 
 void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroups(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     PointerDecoder<uint32_t>*                   pPhysicalDeviceGroupCount,
@@ -2930,7 +3065,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroups(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkEnumeratePhysicalDeviceGroups", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkEnumeratePhysicalDeviceGroups", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -2942,6 +3077,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroups(
 }
 
 void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -2950,7 +3086,7 @@ void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetImageMemoryRequirements2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetImageMemoryRequirements2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -2961,6 +3097,7 @@ void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements2(
 }
 
 void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -2969,7 +3106,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetBufferMemoryRequirements2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetBufferMemoryRequirements2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -2980,6 +3117,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements2(
 }
 
 void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
@@ -2989,7 +3127,7 @@ void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetImageSparseMemoryRequirements2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetImageSparseMemoryRequirements2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -3001,6 +3139,7 @@ void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements2(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFeatures2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures)
 {
@@ -3008,7 +3147,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFeatures2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceFeatures2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceFeatures2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -3018,6 +3157,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFeatures2(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceProperties2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties)
 {
@@ -3025,7 +3165,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceProperties2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceProperties2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceProperties2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -3035,6 +3175,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceProperties2(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     VkFormat                                    format,
     StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties)
@@ -3043,7 +3184,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceFormatProperties2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceFormatProperties2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -3054,6 +3195,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties2(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
@@ -3063,7 +3205,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceImageFormatProperties2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceImageFormatProperties2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -3075,6 +3217,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
     StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties)
@@ -3083,7 +3226,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceQueueFamilyProperties2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceQueueFamilyProperties2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -3094,6 +3237,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties)
 {
@@ -3101,7 +3245,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceMemoryProperties2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceMemoryProperties2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -3111,6 +3255,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties2(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
     PointerDecoder<uint32_t>*                   pPropertyCount,
@@ -3120,7 +3265,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceSparseImageFormatProperties2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSparseImageFormatProperties2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -3132,6 +3277,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties
 }
 
 void VulkanAsciiConsumer::Process_vkTrimCommandPool(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            commandPool,
     VkCommandPoolTrimFlags                      flags)
@@ -3140,7 +3286,7 @@ void VulkanAsciiConsumer::Process_vkTrimCommandPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkTrimCommandPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkTrimCommandPool", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -3151,6 +3297,7 @@ void VulkanAsciiConsumer::Process_vkTrimCommandPool(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceQueue2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceQueueInfo2>* pQueueInfo,
     HandlePointerDecoder<VkQueue>*              pQueue)
@@ -3159,7 +3306,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceQueue2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceQueue2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceQueue2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -3170,6 +3317,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceQueue2(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversion(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
@@ -3180,7 +3328,7 @@ void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversion(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateSamplerYcbcrConversion", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateSamplerYcbcrConversion", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -3193,6 +3341,7 @@ void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversion(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroySamplerYcbcrConversion(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            ycbcrConversion,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -3201,7 +3350,7 @@ void VulkanAsciiConsumer::Process_vkDestroySamplerYcbcrConversion(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroySamplerYcbcrConversion", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroySamplerYcbcrConversion", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -3212,6 +3361,7 @@ void VulkanAsciiConsumer::Process_vkDestroySamplerYcbcrConversion(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplate(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
@@ -3222,7 +3372,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplate(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateDescriptorUpdateTemplate", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateDescriptorUpdateTemplate", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -3235,6 +3385,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplate(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyDescriptorUpdateTemplate(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            descriptorUpdateTemplate,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -3243,7 +3394,7 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorUpdateTemplate(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyDescriptorUpdateTemplate", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyDescriptorUpdateTemplate", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -3254,6 +3405,7 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorUpdateTemplate(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalBufferProperties(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
     StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties)
@@ -3262,7 +3414,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalBufferProperties(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceExternalBufferProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceExternalBufferProperties", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -3273,6 +3425,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalBufferProperties(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalFenceProperties(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
     StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties)
@@ -3281,7 +3434,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalFenceProperties(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceExternalFenceProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceExternalFenceProperties", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -3292,6 +3445,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalFenceProperties(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalSemaphoreProperties(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
     StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties)
@@ -3300,7 +3454,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalSemaphoreProperties
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceExternalSemaphoreProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceExternalSemaphoreProperties", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -3311,6 +3465,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalSemaphoreProperties
 }
 
 void VulkanAsciiConsumer::Process_vkGetDescriptorSetLayoutSupport(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport)
@@ -3319,7 +3474,7 @@ void VulkanAsciiConsumer::Process_vkGetDescriptorSetLayoutSupport(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDescriptorSetLayoutSupport", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDescriptorSetLayoutSupport", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -3330,6 +3485,7 @@ void VulkanAsciiConsumer::Process_vkGetDescriptorSetLayoutSupport(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCount(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -3342,7 +3498,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCount(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDrawIndirectCount", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDrawIndirectCount", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3357,6 +3513,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCount(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCount(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -3369,7 +3526,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCount(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDrawIndexedIndirectCount", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDrawIndexedIndirectCount", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3384,6 +3541,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCount(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateRenderPass2(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkRenderPassCreateInfo2>* pCreateInfo,
@@ -3394,7 +3552,7 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateRenderPass2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateRenderPass2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -3407,6 +3565,7 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass2(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
     StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo)
@@ -3415,7 +3574,7 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBeginRenderPass2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBeginRenderPass2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3426,6 +3585,7 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass2(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdNextSubpass2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo,
     StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo)
@@ -3434,7 +3594,7 @@ void VulkanAsciiConsumer::Process_vkCmdNextSubpass2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdNextSubpass2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdNextSubpass2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3445,6 +3605,7 @@ void VulkanAsciiConsumer::Process_vkCmdNextSubpass2(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdEndRenderPass2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo)
 {
@@ -3452,7 +3613,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndRenderPass2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdEndRenderPass2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdEndRenderPass2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3462,6 +3623,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndRenderPass2(
 }
 
 void VulkanAsciiConsumer::Process_vkResetQueryPool(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            queryPool,
     uint32_t                                    firstQuery,
@@ -3471,7 +3633,7 @@ void VulkanAsciiConsumer::Process_vkResetQueryPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkResetQueryPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkResetQueryPool", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -3483,6 +3645,7 @@ void VulkanAsciiConsumer::Process_vkResetQueryPool(
 }
 
 void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValue(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            semaphore,
@@ -3492,7 +3655,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValue(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetSemaphoreCounterValue", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetSemaphoreCounterValue", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -3504,6 +3667,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValue(
 }
 
 void VulkanAsciiConsumer::Process_vkWaitSemaphores(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreWaitInfo>* pWaitInfo,
@@ -3513,7 +3677,7 @@ void VulkanAsciiConsumer::Process_vkWaitSemaphores(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkWaitSemaphores", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkWaitSemaphores", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -3525,6 +3689,7 @@ void VulkanAsciiConsumer::Process_vkWaitSemaphores(
 }
 
 void VulkanAsciiConsumer::Process_vkSignalSemaphore(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreSignalInfo>* pSignalInfo)
@@ -3533,7 +3698,7 @@ void VulkanAsciiConsumer::Process_vkSignalSemaphore(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkSignalSemaphore", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkSignalSemaphore", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -3544,6 +3709,7 @@ void VulkanAsciiConsumer::Process_vkSignalSemaphore(
 }
 
 void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddress(
+    const ApiCallInfo&                          call_info,
     VkDeviceAddress                             returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
@@ -3552,7 +3718,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddress(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetBufferDeviceAddress", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetBufferDeviceAddress", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -3563,6 +3729,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddress(
 }
 
 void VulkanAsciiConsumer::Process_vkGetBufferOpaqueCaptureAddress(
+    const ApiCallInfo&                          call_info,
     uint64_t                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
@@ -3571,7 +3738,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferOpaqueCaptureAddress(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetBufferOpaqueCaptureAddress", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetBufferOpaqueCaptureAddress", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -3582,6 +3749,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferOpaqueCaptureAddress(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddress(
+    const ApiCallInfo&                          call_info,
     uint64_t                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo>* pInfo)
@@ -3590,7 +3758,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddress(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceMemoryOpaqueCaptureAddress", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceMemoryOpaqueCaptureAddress", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -3601,6 +3769,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddress(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceToolProperties(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pToolCount,
@@ -3610,7 +3779,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceToolProperties(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceToolProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceToolProperties", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -3622,6 +3791,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceToolProperties(
 }
 
 void VulkanAsciiConsumer::Process_vkCreatePrivateDataSlot(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPrivateDataSlotCreateInfo>* pCreateInfo,
@@ -3632,7 +3802,7 @@ void VulkanAsciiConsumer::Process_vkCreatePrivateDataSlot(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreatePrivateDataSlot", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreatePrivateDataSlot", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -3645,6 +3815,7 @@ void VulkanAsciiConsumer::Process_vkCreatePrivateDataSlot(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyPrivateDataSlot(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            privateDataSlot,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -3653,7 +3824,7 @@ void VulkanAsciiConsumer::Process_vkDestroyPrivateDataSlot(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyPrivateDataSlot", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyPrivateDataSlot", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -3664,6 +3835,7 @@ void VulkanAsciiConsumer::Process_vkDestroyPrivateDataSlot(
 }
 
 void VulkanAsciiConsumer::Process_vkSetPrivateData(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     VkObjectType                                objectType,
@@ -3675,7 +3847,7 @@ void VulkanAsciiConsumer::Process_vkSetPrivateData(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkSetPrivateData", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkSetPrivateData", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -3689,6 +3861,7 @@ void VulkanAsciiConsumer::Process_vkSetPrivateData(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPrivateData(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     VkObjectType                                objectType,
     uint64_t                                    objectHandle,
@@ -3699,7 +3872,7 @@ void VulkanAsciiConsumer::Process_vkGetPrivateData(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPrivateData", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPrivateData", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -3712,6 +3885,7 @@ void VulkanAsciiConsumer::Process_vkGetPrivateData(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetEvent2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            event,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo)
@@ -3720,7 +3894,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetEvent2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetEvent2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetEvent2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3731,6 +3905,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetEvent2(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdResetEvent2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            event,
     VkPipelineStageFlags2                       stageMask)
@@ -3739,7 +3914,7 @@ void VulkanAsciiConsumer::Process_vkCmdResetEvent2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdResetEvent2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdResetEvent2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3750,6 +3925,7 @@ void VulkanAsciiConsumer::Process_vkCmdResetEvent2(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdWaitEvents2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    eventCount,
     HandlePointerDecoder<VkEvent>*              pEvents,
@@ -3759,7 +3935,7 @@ void VulkanAsciiConsumer::Process_vkCmdWaitEvents2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdWaitEvents2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdWaitEvents2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3771,6 +3947,7 @@ void VulkanAsciiConsumer::Process_vkCmdWaitEvents2(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo)
 {
@@ -3778,7 +3955,7 @@ void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdPipelineBarrier2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdPipelineBarrier2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3788,6 +3965,7 @@ void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier2(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdWriteTimestamp2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineStageFlags2                       stage,
     format::HandleId                            queryPool,
@@ -3797,7 +3975,7 @@ void VulkanAsciiConsumer::Process_vkCmdWriteTimestamp2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdWriteTimestamp2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdWriteTimestamp2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3809,6 +3987,7 @@ void VulkanAsciiConsumer::Process_vkCmdWriteTimestamp2(
 }
 
 void VulkanAsciiConsumer::Process_vkQueueSubmit2(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            queue,
     uint32_t                                    submitCount,
@@ -3819,7 +3998,7 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkQueueSubmit2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkQueueSubmit2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -3832,6 +4011,7 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit2(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyBuffer2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyBufferInfo2>* pCopyBufferInfo)
 {
@@ -3839,7 +4019,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBuffer2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyBuffer2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyBuffer2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3849,6 +4029,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBuffer2(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyImage2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyImageInfo2>* pCopyImageInfo)
 {
@@ -3856,7 +4037,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImage2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyImage2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyImage2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3866,6 +4047,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImage2(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyBufferToImage2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2>* pCopyBufferToImageInfo)
 {
@@ -3873,7 +4055,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBufferToImage2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyBufferToImage2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyBufferToImage2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3883,6 +4065,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBufferToImage2(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyImageToBuffer2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2>* pCopyImageToBufferInfo)
 {
@@ -3890,7 +4073,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImageToBuffer2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyImageToBuffer2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyImageToBuffer2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3900,6 +4083,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImageToBuffer2(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBlitImage2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkBlitImageInfo2>* pBlitImageInfo)
 {
@@ -3907,7 +4091,7 @@ void VulkanAsciiConsumer::Process_vkCmdBlitImage2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBlitImage2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBlitImage2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3917,6 +4101,7 @@ void VulkanAsciiConsumer::Process_vkCmdBlitImage2(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdResolveImage2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkResolveImageInfo2>* pResolveImageInfo)
 {
@@ -3924,7 +4109,7 @@ void VulkanAsciiConsumer::Process_vkCmdResolveImage2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdResolveImage2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdResolveImage2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3934,6 +4119,7 @@ void VulkanAsciiConsumer::Process_vkCmdResolveImage2(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBeginRendering(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo)
 {
@@ -3941,7 +4127,7 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRendering(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBeginRendering", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBeginRendering", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3951,13 +4137,14 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRendering(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdEndRendering(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
     using namespace gfxrecon::util;
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdEndRendering", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdEndRendering", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3966,6 +4153,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndRendering(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetCullMode(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkCullModeFlags                             cullMode)
 {
@@ -3973,7 +4161,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetCullMode(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetCullMode", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetCullMode", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -3983,6 +4171,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetCullMode(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetFrontFace(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkFrontFace                                 frontFace)
 {
@@ -3990,7 +4179,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetFrontFace(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetFrontFace", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetFrontFace", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -4000,6 +4189,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetFrontFace(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveTopology(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPrimitiveTopology                         primitiveTopology)
 {
@@ -4007,7 +4197,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveTopology(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetPrimitiveTopology", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetPrimitiveTopology", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -4017,6 +4207,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveTopology(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetViewportWithCount(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    viewportCount,
     StructPointerDecoder<Decoded_VkViewport>*   pViewports)
@@ -4025,7 +4216,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportWithCount(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetViewportWithCount", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetViewportWithCount", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -4036,6 +4227,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportWithCount(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetScissorWithCount(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    scissorCount,
     StructPointerDecoder<Decoded_VkRect2D>*     pScissors)
@@ -4044,7 +4236,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetScissorWithCount(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetScissorWithCount", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetScissorWithCount", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -4055,6 +4247,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetScissorWithCount(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstBinding,
     uint32_t                                    bindingCount,
@@ -4067,7 +4260,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBindVertexBuffers2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBindVertexBuffers2", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -4082,6 +4275,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers2(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetDepthTestEnable(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    depthTestEnable)
 {
@@ -4089,7 +4283,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthTestEnable(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetDepthTestEnable", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetDepthTestEnable", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -4099,6 +4293,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthTestEnable(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetDepthWriteEnable(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    depthWriteEnable)
 {
@@ -4106,7 +4301,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthWriteEnable(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetDepthWriteEnable", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetDepthWriteEnable", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -4116,6 +4311,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthWriteEnable(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetDepthCompareOp(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkCompareOp                                 depthCompareOp)
 {
@@ -4123,7 +4319,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthCompareOp(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetDepthCompareOp", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetDepthCompareOp", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -4133,6 +4329,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthCompareOp(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetDepthBoundsTestEnable(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    depthBoundsTestEnable)
 {
@@ -4140,7 +4337,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBoundsTestEnable(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetDepthBoundsTestEnable", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetDepthBoundsTestEnable", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -4150,6 +4347,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBoundsTestEnable(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetStencilTestEnable(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    stencilTestEnable)
 {
@@ -4157,7 +4355,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilTestEnable(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetStencilTestEnable", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetStencilTestEnable", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -4167,6 +4365,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilTestEnable(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetStencilOp(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkStencilFaceFlags                          faceMask,
     VkStencilOp                                 failOp,
@@ -4178,7 +4377,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilOp(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetStencilOp", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetStencilOp", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -4192,6 +4391,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilOp(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetRasterizerDiscardEnable(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    rasterizerDiscardEnable)
 {
@@ -4199,7 +4399,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetRasterizerDiscardEnable(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetRasterizerDiscardEnable", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetRasterizerDiscardEnable", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -4209,6 +4409,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetRasterizerDiscardEnable(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetDepthBiasEnable(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    depthBiasEnable)
 {
@@ -4216,7 +4417,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBiasEnable(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetDepthBiasEnable", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetDepthBiasEnable", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -4226,6 +4427,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBiasEnable(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveRestartEnable(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    primitiveRestartEnable)
 {
@@ -4233,7 +4435,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveRestartEnable(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetPrimitiveRestartEnable", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetPrimitiveRestartEnable", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -4243,6 +4445,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveRestartEnable(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceBufferMemoryRequirements(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceBufferMemoryRequirements>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -4251,7 +4454,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceBufferMemoryRequirements(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceBufferMemoryRequirements", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceBufferMemoryRequirements", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -4262,6 +4465,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceBufferMemoryRequirements(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceImageMemoryRequirements(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -4270,7 +4474,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceImageMemoryRequirements(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceImageMemoryRequirements", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceImageMemoryRequirements", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -4281,6 +4485,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceImageMemoryRequirements(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceImageSparseMemoryRequirements(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
@@ -4290,7 +4495,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceImageSparseMemoryRequirements(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceImageSparseMemoryRequirements", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceImageSparseMemoryRequirements", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -4302,6 +4507,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceImageSparseMemoryRequirements(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroySurfaceKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            instance,
     format::HandleId                            surface,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -4310,7 +4516,7 @@ void VulkanAsciiConsumer::Process_vkDestroySurfaceKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroySurfaceKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroySurfaceKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
@@ -4321,6 +4527,7 @@ void VulkanAsciiConsumer::Process_vkDestroySurfaceKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceSupportKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    queueFamilyIndex,
@@ -4331,7 +4538,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceSupportKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceSurfaceSupportKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceSupportKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4344,6 +4551,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceSupportKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            surface,
@@ -4353,7 +4561,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceSurfaceCapabilitiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4365,6 +4573,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            surface,
@@ -4375,7 +4584,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceSurfaceFormatsKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceFormatsKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4388,6 +4597,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            surface,
@@ -4398,7 +4608,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceSurfacePresentModesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfacePresentModesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4411,6 +4621,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateSwapchainKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfo,
@@ -4421,7 +4632,7 @@ void VulkanAsciiConsumer::Process_vkCreateSwapchainKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateSwapchainKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateSwapchainKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4434,6 +4645,7 @@ void VulkanAsciiConsumer::Process_vkCreateSwapchainKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroySwapchainKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            swapchain,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -4442,7 +4654,7 @@ void VulkanAsciiConsumer::Process_vkDestroySwapchainKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroySwapchainKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroySwapchainKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -4453,6 +4665,7 @@ void VulkanAsciiConsumer::Process_vkDestroySwapchainKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetSwapchainImagesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain,
@@ -4463,7 +4676,7 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainImagesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetSwapchainImagesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetSwapchainImagesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4476,6 +4689,7 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainImagesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkAcquireNextImageKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain,
@@ -4488,7 +4702,7 @@ void VulkanAsciiConsumer::Process_vkAcquireNextImageKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkAcquireNextImageKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkAcquireNextImageKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4503,6 +4717,7 @@ void VulkanAsciiConsumer::Process_vkAcquireNextImageKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkQueuePresentKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            queue,
     StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo)
@@ -4511,7 +4726,7 @@ void VulkanAsciiConsumer::Process_vkQueuePresentKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkQueuePresentKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkQueuePresentKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4522,6 +4737,7 @@ void VulkanAsciiConsumer::Process_vkQueuePresentKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceGroupPresentCapabilitiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceGroupPresentCapabilitiesKHR>* pDeviceGroupPresentCapabilities)
@@ -4530,7 +4746,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupPresentCapabilitiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceGroupPresentCapabilitiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceGroupPresentCapabilitiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4541,6 +4757,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupPresentCapabilitiesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            surface,
@@ -4550,7 +4767,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceGroupSurfacePresentModesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceGroupSurfacePresentModesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4562,6 +4779,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            surface,
@@ -4572,7 +4790,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDevicePresentRectanglesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDevicePresentRectanglesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4585,6 +4803,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkAcquireNextImage2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>* pAcquireInfo,
@@ -4594,7 +4813,7 @@ void VulkanAsciiConsumer::Process_vkAcquireNextImage2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkAcquireNextImage2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkAcquireNextImage2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4606,6 +4825,7 @@ void VulkanAsciiConsumer::Process_vkAcquireNextImage2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pPropertyCount,
@@ -4615,7 +4835,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceDisplayPropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceDisplayPropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4627,6 +4847,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pPropertyCount,
@@ -4636,7 +4857,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceDisplayPlanePropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceDisplayPlanePropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4648,6 +4869,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    planeIndex,
@@ -4658,7 +4880,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDisplayPlaneSupportedDisplaysKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDisplayPlaneSupportedDisplaysKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4671,6 +4893,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDisplayModePropertiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            display,
@@ -4681,7 +4904,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayModePropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDisplayModePropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDisplayModePropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4694,6 +4917,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayModePropertiesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateDisplayModeKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            display,
@@ -4705,7 +4929,7 @@ void VulkanAsciiConsumer::Process_vkCreateDisplayModeKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateDisplayModeKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateDisplayModeKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4719,6 +4943,7 @@ void VulkanAsciiConsumer::Process_vkCreateDisplayModeKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilitiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            mode,
@@ -4729,7 +4954,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilitiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDisplayPlaneCapabilitiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDisplayPlaneCapabilitiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4742,6 +4967,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilitiesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateDisplayPlaneSurfaceKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkDisplaySurfaceCreateInfoKHR>* pCreateInfo,
@@ -4752,7 +4978,7 @@ void VulkanAsciiConsumer::Process_vkCreateDisplayPlaneSurfaceKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateDisplayPlaneSurfaceKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateDisplayPlaneSurfaceKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4765,6 +4991,7 @@ void VulkanAsciiConsumer::Process_vkCreateDisplayPlaneSurfaceKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateSharedSwapchainsKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    swapchainCount,
@@ -4776,7 +5003,7 @@ void VulkanAsciiConsumer::Process_vkCreateSharedSwapchainsKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateSharedSwapchainsKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateSharedSwapchainsKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4790,6 +5017,7 @@ void VulkanAsciiConsumer::Process_vkCreateSharedSwapchainsKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateXlibSurfaceKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>* pCreateInfo,
@@ -4800,7 +5028,7 @@ void VulkanAsciiConsumer::Process_vkCreateXlibSurfaceKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateXlibSurfaceKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateXlibSurfaceKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4813,6 +5041,7 @@ void VulkanAsciiConsumer::Process_vkCreateXlibSurfaceKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
+    const ApiCallInfo&                          call_info,
     VkBool32                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    queueFamilyIndex,
@@ -4823,7 +5052,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceXlibPresentationSupportKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceXlibPresentationSupportKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4836,6 +5065,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateXcbSurfaceKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>* pCreateInfo,
@@ -4846,7 +5076,7 @@ void VulkanAsciiConsumer::Process_vkCreateXcbSurfaceKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateXcbSurfaceKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateXcbSurfaceKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4859,6 +5089,7 @@ void VulkanAsciiConsumer::Process_vkCreateXcbSurfaceKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
+    const ApiCallInfo&                          call_info,
     VkBool32                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    queueFamilyIndex,
@@ -4869,7 +5100,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceXcbPresentationSupportKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceXcbPresentationSupportKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4882,6 +5113,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateWaylandSurfaceKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>* pCreateInfo,
@@ -4892,7 +5124,7 @@ void VulkanAsciiConsumer::Process_vkCreateWaylandSurfaceKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateWaylandSurfaceKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateWaylandSurfaceKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4905,6 +5137,7 @@ void VulkanAsciiConsumer::Process_vkCreateWaylandSurfaceKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWaylandPresentationSupportKHR(
+    const ApiCallInfo&                          call_info,
     VkBool32                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    queueFamilyIndex,
@@ -4914,7 +5147,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWaylandPresentationSupportK
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceWaylandPresentationSupportKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceWaylandPresentationSupportKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4926,6 +5159,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWaylandPresentationSupportK
 }
 
 void VulkanAsciiConsumer::Process_vkCreateAndroidSurfaceKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>* pCreateInfo,
@@ -4936,7 +5170,7 @@ void VulkanAsciiConsumer::Process_vkCreateAndroidSurfaceKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateAndroidSurfaceKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateAndroidSurfaceKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4949,6 +5183,7 @@ void VulkanAsciiConsumer::Process_vkCreateAndroidSurfaceKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateWin32SurfaceKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>* pCreateInfo,
@@ -4959,7 +5194,7 @@ void VulkanAsciiConsumer::Process_vkCreateWin32SurfaceKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateWin32SurfaceKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateWin32SurfaceKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4972,6 +5207,7 @@ void VulkanAsciiConsumer::Process_vkCreateWin32SurfaceKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWin32PresentationSupportKHR(
+    const ApiCallInfo&                          call_info,
     VkBool32                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    queueFamilyIndex)
@@ -4980,7 +5216,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWin32PresentationSupportKHR
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceWin32PresentationSupportKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceWin32PresentationSupportKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -4991,6 +5227,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWin32PresentationSupportKHR
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBeginRenderingKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo)
 {
@@ -4998,7 +5235,7 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRenderingKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBeginRenderingKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBeginRenderingKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -5008,13 +5245,14 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRenderingKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdEndRenderingKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
     using namespace gfxrecon::util;
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdEndRenderingKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdEndRenderingKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -5023,6 +5261,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndRenderingKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFeatures2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures)
 {
@@ -5030,7 +5269,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFeatures2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceFeatures2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceFeatures2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -5040,6 +5279,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFeatures2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceProperties2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties)
 {
@@ -5047,7 +5287,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceProperties2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceProperties2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -5057,6 +5297,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceProperties2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     VkFormat                                    format,
     StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties)
@@ -5065,7 +5306,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceFormatProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceFormatProperties2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -5076,6 +5317,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
@@ -5085,7 +5327,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceImageFormatProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceImageFormatProperties2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5097,6 +5339,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
     StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties)
@@ -5105,7 +5348,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceQueueFamilyProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceQueueFamilyProperties2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -5116,6 +5359,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties)
 {
@@ -5123,7 +5367,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceMemoryProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceMemoryProperties2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -5133,6 +5377,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
     PointerDecoder<uint32_t>*                   pPropertyCount,
@@ -5142,7 +5387,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceSparseImageFormatProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSparseImageFormatProperties2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -5154,6 +5399,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     uint32_t                                    heapIndex,
     uint32_t                                    localDeviceIndex,
@@ -5164,7 +5410,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceGroupPeerMemoryFeaturesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceGroupPeerMemoryFeaturesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -5177,6 +5423,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetDeviceMaskKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    deviceMask)
 {
@@ -5184,7 +5431,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDeviceMaskKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetDeviceMaskKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetDeviceMaskKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -5194,6 +5441,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDeviceMaskKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDispatchBaseKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    baseGroupX,
     uint32_t                                    baseGroupY,
@@ -5206,7 +5454,7 @@ void VulkanAsciiConsumer::Process_vkCmdDispatchBaseKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDispatchBaseKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDispatchBaseKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -5221,6 +5469,7 @@ void VulkanAsciiConsumer::Process_vkCmdDispatchBaseKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkTrimCommandPoolKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            commandPool,
     VkCommandPoolTrimFlags                      flags)
@@ -5229,7 +5478,7 @@ void VulkanAsciiConsumer::Process_vkTrimCommandPoolKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkTrimCommandPoolKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkTrimCommandPoolKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -5240,6 +5489,7 @@ void VulkanAsciiConsumer::Process_vkTrimCommandPoolKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     PointerDecoder<uint32_t>*                   pPhysicalDeviceGroupCount,
@@ -5249,7 +5499,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkEnumeratePhysicalDeviceGroupsKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkEnumeratePhysicalDeviceGroupsKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5261,6 +5511,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
     StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties)
@@ -5269,7 +5520,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceExternalBufferPropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceExternalBufferPropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -5280,6 +5531,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR
 }
 
 void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkMemoryGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
@@ -5289,7 +5541,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetMemoryWin32HandleKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetMemoryWin32HandleKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5301,6 +5553,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandlePropertiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -5311,7 +5564,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandlePropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetMemoryWin32HandlePropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetMemoryWin32HandlePropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5324,6 +5577,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandlePropertiesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetMemoryFdKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkMemoryGetFdInfoKHR>* pGetFdInfo,
@@ -5333,7 +5587,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryFdKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetMemoryFdKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetMemoryFdKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5345,6 +5599,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryFdKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetMemoryFdPropertiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -5355,7 +5610,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryFdPropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetMemoryFdPropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetMemoryFdPropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5368,6 +5623,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryFdPropertiesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
     StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties)
@@ -5376,7 +5632,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalSemaphoreProperties
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceExternalSemaphorePropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -5387,6 +5643,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalSemaphoreProperties
 }
 
 void VulkanAsciiConsumer::Process_vkImportSemaphoreWin32HandleKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>* pImportSemaphoreWin32HandleInfo)
@@ -5395,7 +5652,7 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreWin32HandleKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkImportSemaphoreWin32HandleKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkImportSemaphoreWin32HandleKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5406,6 +5663,7 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreWin32HandleKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetSemaphoreWin32HandleKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
@@ -5415,7 +5673,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreWin32HandleKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetSemaphoreWin32HandleKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetSemaphoreWin32HandleKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5427,6 +5685,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreWin32HandleKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkImportSemaphoreFdKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>* pImportSemaphoreFdInfo)
@@ -5435,7 +5694,7 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreFdKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkImportSemaphoreFdKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkImportSemaphoreFdKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5446,6 +5705,7 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreFdKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetSemaphoreFdKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreGetFdInfoKHR>* pGetFdInfo,
@@ -5455,7 +5715,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreFdKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetSemaphoreFdKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetSemaphoreFdKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5467,6 +5727,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreFdKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdPushDescriptorSetKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineBindPoint                         pipelineBindPoint,
     format::HandleId                            layout,
@@ -5478,7 +5739,7 @@ void VulkanAsciiConsumer::Process_vkCmdPushDescriptorSetKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdPushDescriptorSetKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdPushDescriptorSetKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -5492,6 +5753,7 @@ void VulkanAsciiConsumer::Process_vkCmdPushDescriptorSetKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplateKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
@@ -5502,7 +5764,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplateKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateDescriptorUpdateTemplateKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateDescriptorUpdateTemplateKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5515,6 +5777,7 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplateKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyDescriptorUpdateTemplateKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            descriptorUpdateTemplate,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -5523,7 +5786,7 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorUpdateTemplateKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyDescriptorUpdateTemplateKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyDescriptorUpdateTemplateKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -5534,6 +5797,7 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorUpdateTemplateKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateRenderPass2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkRenderPassCreateInfo2>* pCreateInfo,
@@ -5544,7 +5808,7 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateRenderPass2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateRenderPass2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5557,6 +5821,7 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
     StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo)
@@ -5565,7 +5830,7 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBeginRenderPass2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBeginRenderPass2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -5576,6 +5841,7 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdNextSubpass2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo,
     StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo)
@@ -5584,7 +5850,7 @@ void VulkanAsciiConsumer::Process_vkCmdNextSubpass2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdNextSubpass2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdNextSubpass2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -5595,6 +5861,7 @@ void VulkanAsciiConsumer::Process_vkCmdNextSubpass2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdEndRenderPass2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo)
 {
@@ -5602,7 +5869,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndRenderPass2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdEndRenderPass2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdEndRenderPass2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -5612,6 +5879,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndRenderPass2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetSwapchainStatusKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain)
@@ -5620,7 +5888,7 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainStatusKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetSwapchainStatusKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetSwapchainStatusKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5631,6 +5899,7 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainStatusKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
     StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties)
@@ -5639,7 +5908,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceExternalFencePropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceExternalFencePropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -5650,6 +5919,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkImportFenceWin32HandleKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImportFenceWin32HandleInfoKHR>* pImportFenceWin32HandleInfo)
@@ -5658,7 +5928,7 @@ void VulkanAsciiConsumer::Process_vkImportFenceWin32HandleKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkImportFenceWin32HandleKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkImportFenceWin32HandleKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5669,6 +5939,7 @@ void VulkanAsciiConsumer::Process_vkImportFenceWin32HandleKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetFenceWin32HandleKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkFenceGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
@@ -5678,7 +5949,7 @@ void VulkanAsciiConsumer::Process_vkGetFenceWin32HandleKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetFenceWin32HandleKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetFenceWin32HandleKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5690,6 +5961,7 @@ void VulkanAsciiConsumer::Process_vkGetFenceWin32HandleKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkImportFenceFdKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImportFenceFdInfoKHR>* pImportFenceFdInfo)
@@ -5698,7 +5970,7 @@ void VulkanAsciiConsumer::Process_vkImportFenceFdKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkImportFenceFdKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkImportFenceFdKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5709,6 +5981,7 @@ void VulkanAsciiConsumer::Process_vkImportFenceFdKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetFenceFdKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkFenceGetFdInfoKHR>* pGetFdInfo,
@@ -5718,7 +5991,7 @@ void VulkanAsciiConsumer::Process_vkGetFenceFdKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetFenceFdKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetFenceFdKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5730,6 +6003,7 @@ void VulkanAsciiConsumer::Process_vkGetFenceFdKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    queueFamilyIndex,
@@ -5741,7 +6015,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceQueueFamilyPerformanc
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5755,6 +6029,7 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceQueueFamilyPerformanc
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkQueryPoolPerformanceCreateInfoKHR>* pPerformanceQueryCreateInfo,
     PointerDecoder<uint32_t>*                   pNumPasses)
@@ -5763,7 +6038,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyPerformanceQuery
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -5774,6 +6049,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyPerformanceQuery
 }
 
 void VulkanAsciiConsumer::Process_vkAcquireProfilingLockKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAcquireProfilingLockInfoKHR>* pInfo)
@@ -5782,7 +6058,7 @@ void VulkanAsciiConsumer::Process_vkAcquireProfilingLockKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkAcquireProfilingLockKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkAcquireProfilingLockKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5793,13 +6069,14 @@ void VulkanAsciiConsumer::Process_vkAcquireProfilingLockKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkReleaseProfilingLockKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device)
 {
     using namespace gfxrecon::util;
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkReleaseProfilingLockKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkReleaseProfilingLockKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -5808,6 +6085,7 @@ void VulkanAsciiConsumer::Process_vkReleaseProfilingLockKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
@@ -5817,7 +6095,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceSurfaceCapabilities2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceCapabilities2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5829,6 +6107,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
@@ -5839,7 +6118,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceSurfaceFormats2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceFormats2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5852,6 +6131,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pPropertyCount,
@@ -5861,7 +6141,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceDisplayProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceDisplayProperties2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5873,6 +6153,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pPropertyCount,
@@ -5882,7 +6163,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceDisplayPlaneProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceDisplayPlaneProperties2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5894,6 +6175,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDisplayModeProperties2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            display,
@@ -5904,7 +6186,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayModeProperties2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDisplayModeProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDisplayModeProperties2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5917,6 +6199,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayModeProperties2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkDisplayPlaneInfo2KHR>* pDisplayPlaneInfo,
@@ -5926,7 +6209,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDisplayPlaneCapabilities2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDisplayPlaneCapabilities2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -5938,6 +6221,7 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -5946,7 +6230,7 @@ void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetImageMemoryRequirements2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetImageMemoryRequirements2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -5957,6 +6241,7 @@ void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -5965,7 +6250,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetBufferMemoryRequirements2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetBufferMemoryRequirements2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -5976,6 +6261,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
@@ -5985,7 +6271,7 @@ void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetImageSparseMemoryRequirements2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetImageSparseMemoryRequirements2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -5997,6 +6283,7 @@ void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
@@ -6007,7 +6294,7 @@ void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateSamplerYcbcrConversionKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateSamplerYcbcrConversionKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6020,6 +6307,7 @@ void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroySamplerYcbcrConversionKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            ycbcrConversion,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -6028,7 +6316,7 @@ void VulkanAsciiConsumer::Process_vkDestroySamplerYcbcrConversionKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroySamplerYcbcrConversionKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroySamplerYcbcrConversionKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -6039,6 +6327,7 @@ void VulkanAsciiConsumer::Process_vkDestroySamplerYcbcrConversionKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkBindBufferMemory2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    bindInfoCount,
@@ -6048,7 +6337,7 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkBindBufferMemory2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkBindBufferMemory2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6060,6 +6349,7 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkBindImageMemory2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    bindInfoCount,
@@ -6069,7 +6359,7 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkBindImageMemory2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkBindImageMemory2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6081,6 +6371,7 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDescriptorSetLayoutSupportKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport)
@@ -6089,7 +6380,7 @@ void VulkanAsciiConsumer::Process_vkGetDescriptorSetLayoutSupportKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDescriptorSetLayoutSupportKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDescriptorSetLayoutSupportKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -6100,6 +6391,7 @@ void VulkanAsciiConsumer::Process_vkGetDescriptorSetLayoutSupportKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCountKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -6112,7 +6404,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCountKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDrawIndirectCountKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDrawIndirectCountKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6127,6 +6419,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCountKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCountKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -6139,7 +6432,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCountKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDrawIndexedIndirectCountKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDrawIndexedIndirectCountKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6154,6 +6447,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCountKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValueKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            semaphore,
@@ -6163,7 +6457,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValueKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetSemaphoreCounterValueKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetSemaphoreCounterValueKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6175,6 +6469,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValueKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkWaitSemaphoresKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreWaitInfo>* pWaitInfo,
@@ -6184,7 +6479,7 @@ void VulkanAsciiConsumer::Process_vkWaitSemaphoresKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkWaitSemaphoresKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkWaitSemaphoresKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6196,6 +6491,7 @@ void VulkanAsciiConsumer::Process_vkWaitSemaphoresKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkSignalSemaphoreKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreSignalInfo>* pSignalInfo)
@@ -6204,7 +6500,7 @@ void VulkanAsciiConsumer::Process_vkSignalSemaphoreKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkSignalSemaphoreKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkSignalSemaphoreKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6215,6 +6511,7 @@ void VulkanAsciiConsumer::Process_vkSignalSemaphoreKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pFragmentShadingRateCount,
@@ -6224,7 +6521,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceFragmentShadingRatesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceFragmentShadingRatesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6236,6 +6533,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetFragmentShadingRateKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkExtent2D>*   pFragmentSize,
     PointerDecoder<VkFragmentShadingRateCombinerOpKHR>* combinerOps)
@@ -6244,7 +6542,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetFragmentShadingRateKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetFragmentShadingRateKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetFragmentShadingRateKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6255,6 +6553,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetFragmentShadingRateKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkWaitForPresentKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain,
@@ -6265,7 +6564,7 @@ void VulkanAsciiConsumer::Process_vkWaitForPresentKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkWaitForPresentKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkWaitForPresentKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6278,6 +6577,7 @@ void VulkanAsciiConsumer::Process_vkWaitForPresentKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressKHR(
+    const ApiCallInfo&                          call_info,
     VkDeviceAddress                             returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
@@ -6286,7 +6586,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetBufferDeviceAddressKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetBufferDeviceAddressKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6297,6 +6597,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetBufferOpaqueCaptureAddressKHR(
+    const ApiCallInfo&                          call_info,
     uint64_t                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
@@ -6305,7 +6606,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferOpaqueCaptureAddressKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetBufferOpaqueCaptureAddressKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetBufferOpaqueCaptureAddressKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6316,6 +6617,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferOpaqueCaptureAddressKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddressKHR(
+    const ApiCallInfo&                          call_info,
     uint64_t                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo>* pInfo)
@@ -6324,7 +6626,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddressKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceMemoryOpaqueCaptureAddressKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceMemoryOpaqueCaptureAddressKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6335,6 +6637,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddressKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateDeferredOperationKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
@@ -6344,7 +6647,7 @@ void VulkanAsciiConsumer::Process_vkCreateDeferredOperationKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateDeferredOperationKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateDeferredOperationKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6356,6 +6659,7 @@ void VulkanAsciiConsumer::Process_vkCreateDeferredOperationKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyDeferredOperationKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            operation,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -6364,7 +6668,7 @@ void VulkanAsciiConsumer::Process_vkDestroyDeferredOperationKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyDeferredOperationKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyDeferredOperationKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -6375,6 +6679,7 @@ void VulkanAsciiConsumer::Process_vkDestroyDeferredOperationKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeferredOperationMaxConcurrencyKHR(
+    const ApiCallInfo&                          call_info,
     uint32_t                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            operation)
@@ -6383,7 +6688,7 @@ void VulkanAsciiConsumer::Process_vkGetDeferredOperationMaxConcurrencyKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeferredOperationMaxConcurrencyKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeferredOperationMaxConcurrencyKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6394,6 +6699,7 @@ void VulkanAsciiConsumer::Process_vkGetDeferredOperationMaxConcurrencyKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeferredOperationResultKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            operation)
@@ -6402,7 +6708,7 @@ void VulkanAsciiConsumer::Process_vkGetDeferredOperationResultKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeferredOperationResultKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeferredOperationResultKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6413,6 +6719,7 @@ void VulkanAsciiConsumer::Process_vkGetDeferredOperationResultKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkDeferredOperationJoinKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            operation)
@@ -6421,7 +6728,7 @@ void VulkanAsciiConsumer::Process_vkDeferredOperationJoinKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDeferredOperationJoinKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDeferredOperationJoinKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6432,6 +6739,7 @@ void VulkanAsciiConsumer::Process_vkDeferredOperationJoinKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPipelineInfoKHR>* pPipelineInfo,
@@ -6442,7 +6750,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPipelineExecutablePropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPipelineExecutablePropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6455,6 +6763,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
@@ -6465,7 +6774,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPipelineExecutableStatisticsKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPipelineExecutableStatisticsKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6478,6 +6787,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPipelineExecutableInternalRepresentationsKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
@@ -6488,7 +6798,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutableInternalRepresentations
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPipelineExecutableInternalRepresentationsKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPipelineExecutableInternalRepresentationsKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6501,6 +6811,7 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutableInternalRepresentations
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetEvent2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            event,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo)
@@ -6509,7 +6820,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetEvent2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetEvent2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetEvent2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6520,6 +6831,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetEvent2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdResetEvent2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            event,
     VkPipelineStageFlags2                       stageMask)
@@ -6528,7 +6840,7 @@ void VulkanAsciiConsumer::Process_vkCmdResetEvent2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdResetEvent2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdResetEvent2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6539,6 +6851,7 @@ void VulkanAsciiConsumer::Process_vkCmdResetEvent2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdWaitEvents2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    eventCount,
     HandlePointerDecoder<VkEvent>*              pEvents,
@@ -6548,7 +6861,7 @@ void VulkanAsciiConsumer::Process_vkCmdWaitEvents2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdWaitEvents2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdWaitEvents2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6560,6 +6873,7 @@ void VulkanAsciiConsumer::Process_vkCmdWaitEvents2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo)
 {
@@ -6567,7 +6881,7 @@ void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdPipelineBarrier2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdPipelineBarrier2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6577,6 +6891,7 @@ void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdWriteTimestamp2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineStageFlags2                       stage,
     format::HandleId                            queryPool,
@@ -6586,7 +6901,7 @@ void VulkanAsciiConsumer::Process_vkCmdWriteTimestamp2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdWriteTimestamp2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdWriteTimestamp2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6598,6 +6913,7 @@ void VulkanAsciiConsumer::Process_vkCmdWriteTimestamp2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkQueueSubmit2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            queue,
     uint32_t                                    submitCount,
@@ -6608,7 +6924,7 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkQueueSubmit2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkQueueSubmit2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6621,6 +6937,7 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdWriteBufferMarker2AMD(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineStageFlags2                       stage,
     format::HandleId                            dstBuffer,
@@ -6631,7 +6948,7 @@ void VulkanAsciiConsumer::Process_vkCmdWriteBufferMarker2AMD(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdWriteBufferMarker2AMD", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdWriteBufferMarker2AMD", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6644,6 +6961,7 @@ void VulkanAsciiConsumer::Process_vkCmdWriteBufferMarker2AMD(
 }
 
 void VulkanAsciiConsumer::Process_vkGetQueueCheckpointData2NV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            queue,
     PointerDecoder<uint32_t>*                   pCheckpointDataCount,
     StructPointerDecoder<Decoded_VkCheckpointData2NV>* pCheckpointData)
@@ -6652,7 +6970,7 @@ void VulkanAsciiConsumer::Process_vkGetQueueCheckpointData2NV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetQueueCheckpointData2NV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetQueueCheckpointData2NV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
@@ -6663,6 +6981,7 @@ void VulkanAsciiConsumer::Process_vkGetQueueCheckpointData2NV(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyBuffer2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyBufferInfo2>* pCopyBufferInfo)
 {
@@ -6670,7 +6989,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBuffer2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyBuffer2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyBuffer2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6680,6 +6999,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBuffer2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyImage2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyImageInfo2>* pCopyImageInfo)
 {
@@ -6687,7 +7007,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImage2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyImage2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyImage2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6697,6 +7017,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImage2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyBufferToImage2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2>* pCopyBufferToImageInfo)
 {
@@ -6704,7 +7025,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBufferToImage2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyBufferToImage2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyBufferToImage2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6714,6 +7035,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBufferToImage2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyImageToBuffer2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2>* pCopyImageToBufferInfo)
 {
@@ -6721,7 +7043,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImageToBuffer2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyImageToBuffer2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyImageToBuffer2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6731,6 +7053,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImageToBuffer2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBlitImage2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkBlitImageInfo2>* pBlitImageInfo)
 {
@@ -6738,7 +7061,7 @@ void VulkanAsciiConsumer::Process_vkCmdBlitImage2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBlitImage2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBlitImage2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6748,6 +7071,7 @@ void VulkanAsciiConsumer::Process_vkCmdBlitImage2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdResolveImage2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkResolveImageInfo2>* pResolveImageInfo)
 {
@@ -6755,7 +7079,7 @@ void VulkanAsciiConsumer::Process_vkCmdResolveImage2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdResolveImage2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdResolveImage2KHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6765,6 +7089,7 @@ void VulkanAsciiConsumer::Process_vkCmdResolveImage2KHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceBufferMemoryRequirementsKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceBufferMemoryRequirements>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -6773,7 +7098,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceBufferMemoryRequirementsKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceBufferMemoryRequirementsKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceBufferMemoryRequirementsKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -6784,6 +7109,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceBufferMemoryRequirementsKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceImageMemoryRequirementsKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -6792,7 +7118,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceImageMemoryRequirementsKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceImageMemoryRequirementsKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceImageMemoryRequirementsKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -6803,6 +7129,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceImageMemoryRequirementsKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceImageSparseMemoryRequirementsKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
@@ -6812,7 +7139,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceImageSparseMemoryRequirementsKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceImageSparseMemoryRequirementsKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceImageSparseMemoryRequirementsKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -6824,6 +7151,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceImageSparseMemoryRequirementsKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateDebugReportCallbackEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>* pCreateInfo,
@@ -6834,7 +7162,7 @@ void VulkanAsciiConsumer::Process_vkCreateDebugReportCallbackEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateDebugReportCallbackEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateDebugReportCallbackEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6847,6 +7175,7 @@ void VulkanAsciiConsumer::Process_vkCreateDebugReportCallbackEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyDebugReportCallbackEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            instance,
     format::HandleId                            callback,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -6855,7 +7184,7 @@ void VulkanAsciiConsumer::Process_vkDestroyDebugReportCallbackEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyDebugReportCallbackEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyDebugReportCallbackEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
@@ -6866,6 +7195,7 @@ void VulkanAsciiConsumer::Process_vkDestroyDebugReportCallbackEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkDebugReportMessageEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            instance,
     VkDebugReportFlagsEXT                       flags,
     VkDebugReportObjectTypeEXT                  objectType,
@@ -6879,7 +7209,7 @@ void VulkanAsciiConsumer::Process_vkDebugReportMessageEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDebugReportMessageEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDebugReportMessageEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
@@ -6895,6 +7225,7 @@ void VulkanAsciiConsumer::Process_vkDebugReportMessageEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectTagEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDebugMarkerObjectTagInfoEXT>* pTagInfo)
@@ -6903,7 +7234,7 @@ void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectTagEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDebugMarkerSetObjectTagEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDebugMarkerSetObjectTagEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6914,6 +7245,7 @@ void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectTagEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectNameEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDebugMarkerObjectNameInfoEXT>* pNameInfo)
@@ -6922,7 +7254,7 @@ void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectNameEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDebugMarkerSetObjectNameEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDebugMarkerSetObjectNameEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -6933,6 +7265,7 @@ void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectNameEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDebugMarkerBeginEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo)
 {
@@ -6940,7 +7273,7 @@ void VulkanAsciiConsumer::Process_vkCmdDebugMarkerBeginEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDebugMarkerBeginEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDebugMarkerBeginEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6950,13 +7283,14 @@ void VulkanAsciiConsumer::Process_vkCmdDebugMarkerBeginEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDebugMarkerEndEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
     using namespace gfxrecon::util;
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDebugMarkerEndEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDebugMarkerEndEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6965,6 +7299,7 @@ void VulkanAsciiConsumer::Process_vkCmdDebugMarkerEndEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDebugMarkerInsertEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo)
 {
@@ -6972,7 +7307,7 @@ void VulkanAsciiConsumer::Process_vkCmdDebugMarkerInsertEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDebugMarkerInsertEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDebugMarkerInsertEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -6982,6 +7317,7 @@ void VulkanAsciiConsumer::Process_vkCmdDebugMarkerInsertEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBindTransformFeedbackBuffersEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstBinding,
     uint32_t                                    bindingCount,
@@ -6993,7 +7329,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindTransformFeedbackBuffersEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBindTransformFeedbackBuffersEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBindTransformFeedbackBuffersEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -7007,6 +7343,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindTransformFeedbackBuffersEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBeginTransformFeedbackEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstCounterBuffer,
     uint32_t                                    counterBufferCount,
@@ -7017,7 +7354,7 @@ void VulkanAsciiConsumer::Process_vkCmdBeginTransformFeedbackEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBeginTransformFeedbackEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBeginTransformFeedbackEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -7030,6 +7367,7 @@ void VulkanAsciiConsumer::Process_vkCmdBeginTransformFeedbackEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdEndTransformFeedbackEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstCounterBuffer,
     uint32_t                                    counterBufferCount,
@@ -7040,7 +7378,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndTransformFeedbackEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdEndTransformFeedbackEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdEndTransformFeedbackEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -7053,6 +7391,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndTransformFeedbackEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBeginQueryIndexedEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            queryPool,
     uint32_t                                    query,
@@ -7063,7 +7402,7 @@ void VulkanAsciiConsumer::Process_vkCmdBeginQueryIndexedEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBeginQueryIndexedEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBeginQueryIndexedEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -7076,6 +7415,7 @@ void VulkanAsciiConsumer::Process_vkCmdBeginQueryIndexedEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdEndQueryIndexedEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            queryPool,
     uint32_t                                    query,
@@ -7085,7 +7425,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndQueryIndexedEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdEndQueryIndexedEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdEndQueryIndexedEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -7097,6 +7437,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndQueryIndexedEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDrawIndirectByteCountEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    instanceCount,
     uint32_t                                    firstInstance,
@@ -7109,7 +7450,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectByteCountEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDrawIndirectByteCountEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDrawIndirectByteCountEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -7124,6 +7465,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectByteCountEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetImageViewHandleNVX(
+    const ApiCallInfo&                          call_info,
     uint32_t                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>* pInfo)
@@ -7132,7 +7474,7 @@ void VulkanAsciiConsumer::Process_vkGetImageViewHandleNVX(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetImageViewHandleNVX", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetImageViewHandleNVX", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7143,6 +7485,7 @@ void VulkanAsciiConsumer::Process_vkGetImageViewHandleNVX(
 }
 
 void VulkanAsciiConsumer::Process_vkGetImageViewAddressNVX(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            imageView,
@@ -7152,7 +7495,7 @@ void VulkanAsciiConsumer::Process_vkGetImageViewAddressNVX(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetImageViewAddressNVX", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetImageViewAddressNVX", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7164,6 +7507,7 @@ void VulkanAsciiConsumer::Process_vkGetImageViewAddressNVX(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCountAMD(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -7176,7 +7520,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCountAMD(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDrawIndirectCountAMD", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDrawIndirectCountAMD", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -7191,6 +7535,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCountAMD(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCountAMD(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -7203,7 +7548,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCountAMD(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDrawIndexedIndirectCountAMD", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDrawIndexedIndirectCountAMD", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -7218,6 +7563,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCountAMD(
 }
 
 void VulkanAsciiConsumer::Process_vkGetShaderInfoAMD(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipeline,
@@ -7230,7 +7576,7 @@ void VulkanAsciiConsumer::Process_vkGetShaderInfoAMD(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetShaderInfoAMD", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetShaderInfoAMD", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7245,6 +7591,7 @@ void VulkanAsciiConsumer::Process_vkGetShaderInfoAMD(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkStreamDescriptorSurfaceCreateInfoGGP>* pCreateInfo,
@@ -7255,7 +7602,7 @@ void VulkanAsciiConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateStreamDescriptorSurfaceGGP", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateStreamDescriptorSurfaceGGP", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7268,6 +7615,7 @@ void VulkanAsciiConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     VkFormat                                    format,
@@ -7282,7 +7630,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalImageFormatProperti
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceExternalImageFormatPropertiesNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceExternalImageFormatPropertiesNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7299,6 +7647,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalImageFormatProperti
 }
 
 void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            memory,
@@ -7309,7 +7658,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetMemoryWin32HandleNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetMemoryWin32HandleNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7322,6 +7671,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateViSurfaceNN(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkViSurfaceCreateInfoNN>* pCreateInfo,
@@ -7332,7 +7682,7 @@ void VulkanAsciiConsumer::Process_vkCreateViSurfaceNN(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateViSurfaceNN", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateViSurfaceNN", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7345,6 +7695,7 @@ void VulkanAsciiConsumer::Process_vkCreateViSurfaceNN(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBeginConditionalRenderingEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>* pConditionalRenderingBegin)
 {
@@ -7352,7 +7703,7 @@ void VulkanAsciiConsumer::Process_vkCmdBeginConditionalRenderingEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBeginConditionalRenderingEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBeginConditionalRenderingEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -7362,13 +7713,14 @@ void VulkanAsciiConsumer::Process_vkCmdBeginConditionalRenderingEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdEndConditionalRenderingEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
     using namespace gfxrecon::util;
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdEndConditionalRenderingEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdEndConditionalRenderingEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -7377,6 +7729,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndConditionalRenderingEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetViewportWScalingNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstViewport,
     uint32_t                                    viewportCount,
@@ -7386,7 +7739,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportWScalingNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetViewportWScalingNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetViewportWScalingNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -7398,6 +7751,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportWScalingNV(
 }
 
 void VulkanAsciiConsumer::Process_vkReleaseDisplayEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            display)
@@ -7406,7 +7760,7 @@ void VulkanAsciiConsumer::Process_vkReleaseDisplayEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkReleaseDisplayEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkReleaseDisplayEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7417,6 +7771,7 @@ void VulkanAsciiConsumer::Process_vkReleaseDisplayEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkAcquireXlibDisplayEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     uint64_t                                    dpy,
@@ -7426,7 +7781,7 @@ void VulkanAsciiConsumer::Process_vkAcquireXlibDisplayEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkAcquireXlibDisplayEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkAcquireXlibDisplayEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7438,6 +7793,7 @@ void VulkanAsciiConsumer::Process_vkAcquireXlibDisplayEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetRandROutputDisplayEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     uint64_t                                    dpy,
@@ -7448,7 +7804,7 @@ void VulkanAsciiConsumer::Process_vkGetRandROutputDisplayEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetRandROutputDisplayEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetRandROutputDisplayEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7461,6 +7817,7 @@ void VulkanAsciiConsumer::Process_vkGetRandROutputDisplayEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            surface,
@@ -7470,7 +7827,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceSurfaceCapabilities2EXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceCapabilities2EXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7482,6 +7839,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
 }
 
 void VulkanAsciiConsumer::Process_vkDisplayPowerControlEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            display,
@@ -7491,7 +7849,7 @@ void VulkanAsciiConsumer::Process_vkDisplayPowerControlEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDisplayPowerControlEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDisplayPowerControlEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7503,6 +7861,7 @@ void VulkanAsciiConsumer::Process_vkDisplayPowerControlEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkRegisterDeviceEventEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceEventInfoEXT>* pDeviceEventInfo,
@@ -7513,7 +7872,7 @@ void VulkanAsciiConsumer::Process_vkRegisterDeviceEventEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkRegisterDeviceEventEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkRegisterDeviceEventEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7526,6 +7885,7 @@ void VulkanAsciiConsumer::Process_vkRegisterDeviceEventEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkRegisterDisplayEventEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            display,
@@ -7537,7 +7897,7 @@ void VulkanAsciiConsumer::Process_vkRegisterDisplayEventEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkRegisterDisplayEventEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkRegisterDisplayEventEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7551,6 +7911,7 @@ void VulkanAsciiConsumer::Process_vkRegisterDisplayEventEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetSwapchainCounterEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain,
@@ -7561,7 +7922,7 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainCounterEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetSwapchainCounterEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetSwapchainCounterEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7574,6 +7935,7 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainCounterEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetRefreshCycleDurationGOOGLE(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain,
@@ -7583,7 +7945,7 @@ void VulkanAsciiConsumer::Process_vkGetRefreshCycleDurationGOOGLE(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetRefreshCycleDurationGOOGLE", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetRefreshCycleDurationGOOGLE", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7595,6 +7957,7 @@ void VulkanAsciiConsumer::Process_vkGetRefreshCycleDurationGOOGLE(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPastPresentationTimingGOOGLE(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain,
@@ -7605,7 +7968,7 @@ void VulkanAsciiConsumer::Process_vkGetPastPresentationTimingGOOGLE(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPastPresentationTimingGOOGLE", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPastPresentationTimingGOOGLE", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7618,6 +7981,7 @@ void VulkanAsciiConsumer::Process_vkGetPastPresentationTimingGOOGLE(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetDiscardRectangleEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstDiscardRectangle,
     uint32_t                                    discardRectangleCount,
@@ -7627,7 +7991,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDiscardRectangleEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetDiscardRectangleEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetDiscardRectangleEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -7639,6 +8003,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDiscardRectangleEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkSetHdrMetadataEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     uint32_t                                    swapchainCount,
     HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains,
@@ -7648,7 +8013,7 @@ void VulkanAsciiConsumer::Process_vkSetHdrMetadataEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkSetHdrMetadataEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkSetHdrMetadataEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -7660,6 +8025,7 @@ void VulkanAsciiConsumer::Process_vkSetHdrMetadataEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateIOSSurfaceMVK(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkIOSSurfaceCreateInfoMVK>* pCreateInfo,
@@ -7670,7 +8036,7 @@ void VulkanAsciiConsumer::Process_vkCreateIOSSurfaceMVK(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateIOSSurfaceMVK", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateIOSSurfaceMVK", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7683,6 +8049,7 @@ void VulkanAsciiConsumer::Process_vkCreateIOSSurfaceMVK(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateMacOSSurfaceMVK(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkMacOSSurfaceCreateInfoMVK>* pCreateInfo,
@@ -7693,7 +8060,7 @@ void VulkanAsciiConsumer::Process_vkCreateMacOSSurfaceMVK(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateMacOSSurfaceMVK", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateMacOSSurfaceMVK", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7706,6 +8073,7 @@ void VulkanAsciiConsumer::Process_vkCreateMacOSSurfaceMVK(
 }
 
 void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectNameEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* pNameInfo)
@@ -7714,7 +8082,7 @@ void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectNameEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkSetDebugUtilsObjectNameEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkSetDebugUtilsObjectNameEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7725,6 +8093,7 @@ void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectNameEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectTagEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>* pTagInfo)
@@ -7733,7 +8102,7 @@ void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectTagEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkSetDebugUtilsObjectTagEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkSetDebugUtilsObjectTagEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7744,6 +8113,7 @@ void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectTagEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkQueueBeginDebugUtilsLabelEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            queue,
     StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo)
 {
@@ -7751,7 +8121,7 @@ void VulkanAsciiConsumer::Process_vkQueueBeginDebugUtilsLabelEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkQueueBeginDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkQueueBeginDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
@@ -7761,13 +8131,14 @@ void VulkanAsciiConsumer::Process_vkQueueBeginDebugUtilsLabelEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkQueueEndDebugUtilsLabelEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            queue)
 {
     using namespace gfxrecon::util;
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkQueueEndDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkQueueEndDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
@@ -7776,6 +8147,7 @@ void VulkanAsciiConsumer::Process_vkQueueEndDebugUtilsLabelEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkQueueInsertDebugUtilsLabelEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            queue,
     StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo)
 {
@@ -7783,7 +8155,7 @@ void VulkanAsciiConsumer::Process_vkQueueInsertDebugUtilsLabelEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkQueueInsertDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkQueueInsertDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
@@ -7793,6 +8165,7 @@ void VulkanAsciiConsumer::Process_vkQueueInsertDebugUtilsLabelEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBeginDebugUtilsLabelEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo)
 {
@@ -7800,7 +8173,7 @@ void VulkanAsciiConsumer::Process_vkCmdBeginDebugUtilsLabelEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBeginDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBeginDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -7810,13 +8183,14 @@ void VulkanAsciiConsumer::Process_vkCmdBeginDebugUtilsLabelEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdEndDebugUtilsLabelEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
     using namespace gfxrecon::util;
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdEndDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdEndDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -7825,6 +8199,7 @@ void VulkanAsciiConsumer::Process_vkCmdEndDebugUtilsLabelEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdInsertDebugUtilsLabelEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo)
 {
@@ -7832,7 +8207,7 @@ void VulkanAsciiConsumer::Process_vkCmdInsertDebugUtilsLabelEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdInsertDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdInsertDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -7842,6 +8217,7 @@ void VulkanAsciiConsumer::Process_vkCmdInsertDebugUtilsLabelEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateDebugUtilsMessengerEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>* pCreateInfo,
@@ -7852,7 +8228,7 @@ void VulkanAsciiConsumer::Process_vkCreateDebugUtilsMessengerEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateDebugUtilsMessengerEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateDebugUtilsMessengerEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7865,6 +8241,7 @@ void VulkanAsciiConsumer::Process_vkCreateDebugUtilsMessengerEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyDebugUtilsMessengerEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            instance,
     format::HandleId                            messenger,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -7873,7 +8250,7 @@ void VulkanAsciiConsumer::Process_vkDestroyDebugUtilsMessengerEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyDebugUtilsMessengerEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyDebugUtilsMessengerEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
@@ -7884,6 +8261,7 @@ void VulkanAsciiConsumer::Process_vkDestroyDebugUtilsMessengerEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkSubmitDebugUtilsMessageEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            instance,
     VkDebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,
     VkDebugUtilsMessageTypeFlagsEXT             messageTypes,
@@ -7893,7 +8271,7 @@ void VulkanAsciiConsumer::Process_vkSubmitDebugUtilsMessageEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkSubmitDebugUtilsMessageEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkSubmitDebugUtilsMessageEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
@@ -7905,6 +8283,7 @@ void VulkanAsciiConsumer::Process_vkSubmitDebugUtilsMessageEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetAndroidHardwareBufferPropertiesANDROID(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint64_t                                    buffer,
@@ -7914,7 +8293,7 @@ void VulkanAsciiConsumer::Process_vkGetAndroidHardwareBufferPropertiesANDROID(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetAndroidHardwareBufferPropertiesANDROID", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetAndroidHardwareBufferPropertiesANDROID", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7926,6 +8305,7 @@ void VulkanAsciiConsumer::Process_vkGetAndroidHardwareBufferPropertiesANDROID(
 }
 
 void VulkanAsciiConsumer::Process_vkGetMemoryAndroidHardwareBufferANDROID(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID>* pInfo,
@@ -7935,7 +8315,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryAndroidHardwareBufferANDROID(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetMemoryAndroidHardwareBufferANDROID", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetMemoryAndroidHardwareBufferANDROID", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -7947,6 +8327,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryAndroidHardwareBufferANDROID(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetSampleLocationsEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkSampleLocationsInfoEXT>* pSampleLocationsInfo)
 {
@@ -7954,7 +8335,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetSampleLocationsEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetSampleLocationsEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetSampleLocationsEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -7964,6 +8345,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetSampleLocationsEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     VkSampleCountFlagBits                       samples,
     StructPointerDecoder<Decoded_VkMultisamplePropertiesEXT>* pMultisampleProperties)
@@ -7972,7 +8354,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceMultisamplePropertiesEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceMultisamplePropertiesEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
@@ -7983,6 +8365,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetImageDrmFormatModifierPropertiesEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            image,
@@ -7992,7 +8375,7 @@ void VulkanAsciiConsumer::Process_vkGetImageDrmFormatModifierPropertiesEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetImageDrmFormatModifierPropertiesEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetImageDrmFormatModifierPropertiesEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8004,6 +8387,7 @@ void VulkanAsciiConsumer::Process_vkGetImageDrmFormatModifierPropertiesEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateValidationCacheEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkValidationCacheCreateInfoEXT>* pCreateInfo,
@@ -8014,7 +8398,7 @@ void VulkanAsciiConsumer::Process_vkCreateValidationCacheEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateValidationCacheEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateValidationCacheEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8027,6 +8411,7 @@ void VulkanAsciiConsumer::Process_vkCreateValidationCacheEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyValidationCacheEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            validationCache,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -8035,7 +8420,7 @@ void VulkanAsciiConsumer::Process_vkDestroyValidationCacheEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyValidationCacheEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyValidationCacheEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -8046,6 +8431,7 @@ void VulkanAsciiConsumer::Process_vkDestroyValidationCacheEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkMergeValidationCachesEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            dstCache,
@@ -8056,7 +8442,7 @@ void VulkanAsciiConsumer::Process_vkMergeValidationCachesEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkMergeValidationCachesEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkMergeValidationCachesEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8069,6 +8455,7 @@ void VulkanAsciiConsumer::Process_vkMergeValidationCachesEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetValidationCacheDataEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            validationCache,
@@ -8079,7 +8466,7 @@ void VulkanAsciiConsumer::Process_vkGetValidationCacheDataEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetValidationCacheDataEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetValidationCacheDataEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8092,6 +8479,7 @@ void VulkanAsciiConsumer::Process_vkGetValidationCacheDataEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBindShadingRateImageNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            imageView,
     VkImageLayout                               imageLayout)
@@ -8100,7 +8488,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindShadingRateImageNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBindShadingRateImageNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBindShadingRateImageNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -8111,6 +8499,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindShadingRateImageNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetViewportShadingRatePaletteNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstViewport,
     uint32_t                                    viewportCount,
@@ -8120,7 +8509,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportShadingRatePaletteNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetViewportShadingRatePaletteNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetViewportShadingRatePaletteNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -8132,6 +8521,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportShadingRatePaletteNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetCoarseSampleOrderNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkCoarseSampleOrderTypeNV                   sampleOrderType,
     uint32_t                                    customSampleOrderCount,
@@ -8141,7 +8531,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetCoarseSampleOrderNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetCoarseSampleOrderNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetCoarseSampleOrderNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -8153,6 +8543,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetCoarseSampleOrderNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoNV>* pCreateInfo,
@@ -8163,7 +8554,7 @@ void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateAccelerationStructureNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateAccelerationStructureNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8176,6 +8567,7 @@ void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureNV(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyAccelerationStructureNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            accelerationStructure,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -8184,7 +8576,7 @@ void VulkanAsciiConsumer::Process_vkDestroyAccelerationStructureNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyAccelerationStructureNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyAccelerationStructureNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -8195,6 +8587,7 @@ void VulkanAsciiConsumer::Process_vkDestroyAccelerationStructureNV(
 }
 
 void VulkanAsciiConsumer::Process_vkGetAccelerationStructureMemoryRequirementsNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAccelerationStructureMemoryRequirementsInfoNV>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2KHR>* pMemoryRequirements)
@@ -8203,7 +8596,7 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureMemoryRequirementsNV
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetAccelerationStructureMemoryRequirementsNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetAccelerationStructureMemoryRequirementsNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -8214,6 +8607,7 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureMemoryRequirementsNV
 }
 
 void VulkanAsciiConsumer::Process_vkBindAccelerationStructureMemoryNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    bindInfoCount,
@@ -8223,7 +8617,7 @@ void VulkanAsciiConsumer::Process_vkBindAccelerationStructureMemoryNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkBindAccelerationStructureMemoryNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkBindAccelerationStructureMemoryNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8235,6 +8629,7 @@ void VulkanAsciiConsumer::Process_vkBindAccelerationStructureMemoryNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBuildAccelerationStructureNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>* pInfo,
     format::HandleId                            instanceData,
@@ -8249,7 +8644,7 @@ void VulkanAsciiConsumer::Process_vkCmdBuildAccelerationStructureNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBuildAccelerationStructureNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBuildAccelerationStructureNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -8266,6 +8661,7 @@ void VulkanAsciiConsumer::Process_vkCmdBuildAccelerationStructureNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyAccelerationStructureNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            dst,
     format::HandleId                            src,
@@ -8275,7 +8671,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyAccelerationStructureNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyAccelerationStructureNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyAccelerationStructureNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -8287,6 +8683,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyAccelerationStructureNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdTraceRaysNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            raygenShaderBindingTableBuffer,
     VkDeviceSize                                raygenShaderBindingOffset,
@@ -8307,7 +8704,7 @@ void VulkanAsciiConsumer::Process_vkCmdTraceRaysNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdTraceRaysNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdTraceRaysNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -8330,6 +8727,7 @@ void VulkanAsciiConsumer::Process_vkCmdTraceRaysNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipelineCache,
@@ -8342,7 +8740,7 @@ void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateRayTracingPipelinesNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateRayTracingPipelinesNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8357,6 +8755,7 @@ void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesNV(
 }
 
 void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupHandlesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipeline,
@@ -8369,7 +8768,7 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupHandlesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetRayTracingShaderGroupHandlesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetRayTracingShaderGroupHandlesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8384,6 +8783,7 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupHandlesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupHandlesNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipeline,
@@ -8396,7 +8796,7 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupHandlesNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetRayTracingShaderGroupHandlesNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetRayTracingShaderGroupHandlesNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8411,6 +8811,7 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupHandlesNV(
 }
 
 void VulkanAsciiConsumer::Process_vkGetAccelerationStructureHandleNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            accelerationStructure,
@@ -8421,7 +8822,7 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureHandleNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetAccelerationStructureHandleNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetAccelerationStructureHandleNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8434,6 +8835,7 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureHandleNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    accelerationStructureCount,
     HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructures,
@@ -8445,7 +8847,7 @@ void VulkanAsciiConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdWriteAccelerationStructuresPropertiesNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdWriteAccelerationStructuresPropertiesNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -8459,6 +8861,7 @@ void VulkanAsciiConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCompileDeferredNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipeline,
@@ -8468,7 +8871,7 @@ void VulkanAsciiConsumer::Process_vkCompileDeferredNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCompileDeferredNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCompileDeferredNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8480,6 +8883,7 @@ void VulkanAsciiConsumer::Process_vkCompileDeferredNV(
 }
 
 void VulkanAsciiConsumer::Process_vkGetMemoryHostPointerPropertiesEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -8490,7 +8894,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryHostPointerPropertiesEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetMemoryHostPointerPropertiesEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetMemoryHostPointerPropertiesEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8503,6 +8907,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryHostPointerPropertiesEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdWriteBufferMarkerAMD(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineStageFlagBits                     pipelineStage,
     format::HandleId                            dstBuffer,
@@ -8513,7 +8918,7 @@ void VulkanAsciiConsumer::Process_vkCmdWriteBufferMarkerAMD(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdWriteBufferMarkerAMD", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdWriteBufferMarkerAMD", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -8526,6 +8931,7 @@ void VulkanAsciiConsumer::Process_vkCmdWriteBufferMarkerAMD(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pTimeDomainCount,
@@ -8535,7 +8941,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8547,6 +8953,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT
 }
 
 void VulkanAsciiConsumer::Process_vkGetCalibratedTimestampsEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    timestampCount,
@@ -8558,7 +8965,7 @@ void VulkanAsciiConsumer::Process_vkGetCalibratedTimestampsEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetCalibratedTimestampsEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetCalibratedTimestampsEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8572,6 +8979,7 @@ void VulkanAsciiConsumer::Process_vkGetCalibratedTimestampsEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDrawMeshTasksNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    taskCount,
     uint32_t                                    firstTask)
@@ -8580,7 +8988,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMeshTasksNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDrawMeshTasksNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDrawMeshTasksNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -8591,6 +8999,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMeshTasksNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDrawMeshTasksIndirectNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -8601,7 +9010,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMeshTasksIndirectNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDrawMeshTasksIndirectNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDrawMeshTasksIndirectNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -8614,6 +9023,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMeshTasksIndirectNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDrawMeshTasksIndirectCountNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -8626,7 +9036,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMeshTasksIndirectCountNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDrawMeshTasksIndirectCountNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDrawMeshTasksIndirectCountNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -8641,6 +9051,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMeshTasksIndirectCountNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetExclusiveScissorNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstExclusiveScissor,
     uint32_t                                    exclusiveScissorCount,
@@ -8650,7 +9061,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetExclusiveScissorNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetExclusiveScissorNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetExclusiveScissorNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -8662,6 +9073,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetExclusiveScissorNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetCheckpointNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint64_t                                    pCheckpointMarker)
 {
@@ -8669,7 +9081,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetCheckpointNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetCheckpointNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetCheckpointNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -8679,6 +9091,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetCheckpointNV(
 }
 
 void VulkanAsciiConsumer::Process_vkGetQueueCheckpointDataNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            queue,
     PointerDecoder<uint32_t>*                   pCheckpointDataCount,
     StructPointerDecoder<Decoded_VkCheckpointDataNV>* pCheckpointData)
@@ -8687,7 +9100,7 @@ void VulkanAsciiConsumer::Process_vkGetQueueCheckpointDataNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetQueueCheckpointDataNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetQueueCheckpointDataNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
@@ -8698,6 +9111,7 @@ void VulkanAsciiConsumer::Process_vkGetQueueCheckpointDataNV(
 }
 
 void VulkanAsciiConsumer::Process_vkInitializePerformanceApiINTEL(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkInitializePerformanceApiInfoINTEL>* pInitializeInfo)
@@ -8706,7 +9120,7 @@ void VulkanAsciiConsumer::Process_vkInitializePerformanceApiINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkInitializePerformanceApiINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkInitializePerformanceApiINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8717,13 +9131,14 @@ void VulkanAsciiConsumer::Process_vkInitializePerformanceApiINTEL(
 }
 
 void VulkanAsciiConsumer::Process_vkUninitializePerformanceApiINTEL(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device)
 {
     using namespace gfxrecon::util;
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkUninitializePerformanceApiINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkUninitializePerformanceApiINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -8732,6 +9147,7 @@ void VulkanAsciiConsumer::Process_vkUninitializePerformanceApiINTEL(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetPerformanceMarkerINTEL(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkPerformanceMarkerInfoINTEL>* pMarkerInfo)
@@ -8740,7 +9156,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceMarkerINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetPerformanceMarkerINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetPerformanceMarkerINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8751,6 +9167,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceMarkerINTEL(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkPerformanceStreamMarkerInfoINTEL>* pMarkerInfo)
@@ -8759,7 +9176,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetPerformanceStreamMarkerINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetPerformanceStreamMarkerINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8770,6 +9187,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkPerformanceOverrideInfoINTEL>* pOverrideInfo)
@@ -8778,7 +9196,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetPerformanceOverrideINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetPerformanceOverrideINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8789,6 +9207,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
 }
 
 void VulkanAsciiConsumer::Process_vkAcquirePerformanceConfigurationINTEL(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPerformanceConfigurationAcquireInfoINTEL>* pAcquireInfo,
@@ -8798,7 +9217,7 @@ void VulkanAsciiConsumer::Process_vkAcquirePerformanceConfigurationINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkAcquirePerformanceConfigurationINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkAcquirePerformanceConfigurationINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8810,6 +9229,7 @@ void VulkanAsciiConsumer::Process_vkAcquirePerformanceConfigurationINTEL(
 }
 
 void VulkanAsciiConsumer::Process_vkReleasePerformanceConfigurationINTEL(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            configuration)
@@ -8818,7 +9238,7 @@ void VulkanAsciiConsumer::Process_vkReleasePerformanceConfigurationINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkReleasePerformanceConfigurationINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkReleasePerformanceConfigurationINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8829,6 +9249,7 @@ void VulkanAsciiConsumer::Process_vkReleasePerformanceConfigurationINTEL(
 }
 
 void VulkanAsciiConsumer::Process_vkQueueSetPerformanceConfigurationINTEL(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            queue,
     format::HandleId                            configuration)
@@ -8837,7 +9258,7 @@ void VulkanAsciiConsumer::Process_vkQueueSetPerformanceConfigurationINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkQueueSetPerformanceConfigurationINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkQueueSetPerformanceConfigurationINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8848,6 +9269,7 @@ void VulkanAsciiConsumer::Process_vkQueueSetPerformanceConfigurationINTEL(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPerformanceParameterINTEL(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     VkPerformanceParameterTypeINTEL             parameter,
@@ -8857,7 +9279,7 @@ void VulkanAsciiConsumer::Process_vkGetPerformanceParameterINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPerformanceParameterINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPerformanceParameterINTEL", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8869,6 +9291,7 @@ void VulkanAsciiConsumer::Process_vkGetPerformanceParameterINTEL(
 }
 
 void VulkanAsciiConsumer::Process_vkSetLocalDimmingAMD(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            swapChain,
     VkBool32                                    localDimmingEnable)
@@ -8877,7 +9300,7 @@ void VulkanAsciiConsumer::Process_vkSetLocalDimmingAMD(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkSetLocalDimmingAMD", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkSetLocalDimmingAMD", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -8888,6 +9311,7 @@ void VulkanAsciiConsumer::Process_vkSetLocalDimmingAMD(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA>* pCreateInfo,
@@ -8898,7 +9322,7 @@ void VulkanAsciiConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateImagePipeSurfaceFUCHSIA", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateImagePipeSurfaceFUCHSIA", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8911,6 +9335,7 @@ void VulkanAsciiConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateMetalSurfaceEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>* pCreateInfo,
@@ -8921,7 +9346,7 @@ void VulkanAsciiConsumer::Process_vkCreateMetalSurfaceEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateMetalSurfaceEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateMetalSurfaceEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8934,6 +9359,7 @@ void VulkanAsciiConsumer::Process_vkCreateMetalSurfaceEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressEXT(
+    const ApiCallInfo&                          call_info,
     VkDeviceAddress                             returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
@@ -8942,7 +9368,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetBufferDeviceAddressEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetBufferDeviceAddressEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8953,6 +9379,7 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceToolPropertiesEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pToolCount,
@@ -8962,7 +9389,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceToolPropertiesEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceToolPropertiesEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceToolPropertiesEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8974,6 +9401,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceToolPropertiesEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pPropertyCount,
@@ -8983,7 +9411,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixProperties
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -8995,6 +9423,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixProperties
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pCombinationCount,
@@ -9004,7 +9433,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedSa
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9016,6 +9445,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedSa
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
@@ -9026,7 +9456,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceSurfacePresentModes2EXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfacePresentModes2EXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9039,6 +9469,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
 }
 
 void VulkanAsciiConsumer::Process_vkAcquireFullScreenExclusiveModeEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain)
@@ -9047,7 +9478,7 @@ void VulkanAsciiConsumer::Process_vkAcquireFullScreenExclusiveModeEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkAcquireFullScreenExclusiveModeEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkAcquireFullScreenExclusiveModeEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9058,6 +9489,7 @@ void VulkanAsciiConsumer::Process_vkAcquireFullScreenExclusiveModeEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkReleaseFullScreenExclusiveModeEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain)
@@ -9066,7 +9498,7 @@ void VulkanAsciiConsumer::Process_vkReleaseFullScreenExclusiveModeEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkReleaseFullScreenExclusiveModeEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkReleaseFullScreenExclusiveModeEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9077,6 +9509,7 @@ void VulkanAsciiConsumer::Process_vkReleaseFullScreenExclusiveModeEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModes2EXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
@@ -9086,7 +9519,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModes2EXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceGroupSurfacePresentModes2EXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceGroupSurfacePresentModes2EXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9098,6 +9531,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModes2EXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateHeadlessSurfaceEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkHeadlessSurfaceCreateInfoEXT>* pCreateInfo,
@@ -9108,7 +9542,7 @@ void VulkanAsciiConsumer::Process_vkCreateHeadlessSurfaceEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateHeadlessSurfaceEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateHeadlessSurfaceEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9121,6 +9555,7 @@ void VulkanAsciiConsumer::Process_vkCreateHeadlessSurfaceEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetLineStippleEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    lineStippleFactor,
     uint16_t                                    lineStipplePattern)
@@ -9129,7 +9564,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetLineStippleEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetLineStippleEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetLineStippleEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9140,6 +9575,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetLineStippleEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkResetQueryPoolEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            queryPool,
     uint32_t                                    firstQuery,
@@ -9149,7 +9585,7 @@ void VulkanAsciiConsumer::Process_vkResetQueryPoolEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkResetQueryPoolEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkResetQueryPoolEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -9161,6 +9597,7 @@ void VulkanAsciiConsumer::Process_vkResetQueryPoolEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetCullModeEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkCullModeFlags                             cullMode)
 {
@@ -9168,7 +9605,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetCullModeEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetCullModeEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetCullModeEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9178,6 +9615,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetCullModeEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetFrontFaceEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkFrontFace                                 frontFace)
 {
@@ -9185,7 +9623,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetFrontFaceEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetFrontFaceEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetFrontFaceEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9195,6 +9633,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetFrontFaceEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveTopologyEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPrimitiveTopology                         primitiveTopology)
 {
@@ -9202,7 +9641,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveTopologyEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetPrimitiveTopologyEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetPrimitiveTopologyEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9212,6 +9651,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveTopologyEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetViewportWithCountEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    viewportCount,
     StructPointerDecoder<Decoded_VkViewport>*   pViewports)
@@ -9220,7 +9660,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportWithCountEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetViewportWithCountEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetViewportWithCountEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9231,6 +9671,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportWithCountEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetScissorWithCountEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    scissorCount,
     StructPointerDecoder<Decoded_VkRect2D>*     pScissors)
@@ -9239,7 +9680,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetScissorWithCountEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetScissorWithCountEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetScissorWithCountEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9250,6 +9691,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetScissorWithCountEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers2EXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstBinding,
     uint32_t                                    bindingCount,
@@ -9262,7 +9704,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers2EXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBindVertexBuffers2EXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBindVertexBuffers2EXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9277,6 +9719,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers2EXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetDepthTestEnableEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    depthTestEnable)
 {
@@ -9284,7 +9727,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthTestEnableEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetDepthTestEnableEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetDepthTestEnableEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9294,6 +9737,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthTestEnableEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetDepthWriteEnableEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    depthWriteEnable)
 {
@@ -9301,7 +9745,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthWriteEnableEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetDepthWriteEnableEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetDepthWriteEnableEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9311,6 +9755,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthWriteEnableEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetDepthCompareOpEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkCompareOp                                 depthCompareOp)
 {
@@ -9318,7 +9763,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthCompareOpEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetDepthCompareOpEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetDepthCompareOpEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9328,6 +9773,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthCompareOpEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetDepthBoundsTestEnableEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    depthBoundsTestEnable)
 {
@@ -9335,7 +9781,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBoundsTestEnableEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetDepthBoundsTestEnableEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetDepthBoundsTestEnableEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9345,6 +9791,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBoundsTestEnableEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetStencilTestEnableEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    stencilTestEnable)
 {
@@ -9352,7 +9799,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilTestEnableEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetStencilTestEnableEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetStencilTestEnableEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9362,6 +9809,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilTestEnableEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetStencilOpEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkStencilFaceFlags                          faceMask,
     VkStencilOp                                 failOp,
@@ -9373,7 +9821,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilOpEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetStencilOpEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetStencilOpEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9387,6 +9835,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilOpEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetGeneratedCommandsMemoryRequirementsNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkGeneratedCommandsMemoryRequirementsInfoNV>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -9395,7 +9844,7 @@ void VulkanAsciiConsumer::Process_vkGetGeneratedCommandsMemoryRequirementsNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetGeneratedCommandsMemoryRequirementsNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetGeneratedCommandsMemoryRequirementsNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -9406,6 +9855,7 @@ void VulkanAsciiConsumer::Process_vkGetGeneratedCommandsMemoryRequirementsNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdPreprocessGeneratedCommandsNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo)
 {
@@ -9413,7 +9863,7 @@ void VulkanAsciiConsumer::Process_vkCmdPreprocessGeneratedCommandsNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdPreprocessGeneratedCommandsNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdPreprocessGeneratedCommandsNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9423,6 +9873,7 @@ void VulkanAsciiConsumer::Process_vkCmdPreprocessGeneratedCommandsNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdExecuteGeneratedCommandsNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    isPreprocessed,
     StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo)
@@ -9431,7 +9882,7 @@ void VulkanAsciiConsumer::Process_vkCmdExecuteGeneratedCommandsNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdExecuteGeneratedCommandsNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdExecuteGeneratedCommandsNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9442,6 +9893,7 @@ void VulkanAsciiConsumer::Process_vkCmdExecuteGeneratedCommandsNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBindPipelineShaderGroupNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineBindPoint                         pipelineBindPoint,
     format::HandleId                            pipeline,
@@ -9451,7 +9903,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindPipelineShaderGroupNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBindPipelineShaderGroupNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBindPipelineShaderGroupNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9463,6 +9915,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindPipelineShaderGroupNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateIndirectCommandsLayoutNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkIndirectCommandsLayoutCreateInfoNV>* pCreateInfo,
@@ -9473,7 +9926,7 @@ void VulkanAsciiConsumer::Process_vkCreateIndirectCommandsLayoutNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateIndirectCommandsLayoutNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateIndirectCommandsLayoutNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9486,6 +9939,7 @@ void VulkanAsciiConsumer::Process_vkCreateIndirectCommandsLayoutNV(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyIndirectCommandsLayoutNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            indirectCommandsLayout,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -9494,7 +9948,7 @@ void VulkanAsciiConsumer::Process_vkDestroyIndirectCommandsLayoutNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyIndirectCommandsLayoutNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyIndirectCommandsLayoutNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -9505,6 +9959,7 @@ void VulkanAsciiConsumer::Process_vkDestroyIndirectCommandsLayoutNV(
 }
 
 void VulkanAsciiConsumer::Process_vkAcquireDrmDisplayEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     int32_t                                     drmFd,
@@ -9514,7 +9969,7 @@ void VulkanAsciiConsumer::Process_vkAcquireDrmDisplayEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkAcquireDrmDisplayEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkAcquireDrmDisplayEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9526,6 +9981,7 @@ void VulkanAsciiConsumer::Process_vkAcquireDrmDisplayEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDrmDisplayEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     int32_t                                     drmFd,
@@ -9536,7 +9992,7 @@ void VulkanAsciiConsumer::Process_vkGetDrmDisplayEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDrmDisplayEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDrmDisplayEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9549,6 +10005,7 @@ void VulkanAsciiConsumer::Process_vkGetDrmDisplayEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCreatePrivateDataSlotEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPrivateDataSlotCreateInfo>* pCreateInfo,
@@ -9559,7 +10016,7 @@ void VulkanAsciiConsumer::Process_vkCreatePrivateDataSlotEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreatePrivateDataSlotEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreatePrivateDataSlotEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9572,6 +10029,7 @@ void VulkanAsciiConsumer::Process_vkCreatePrivateDataSlotEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyPrivateDataSlotEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            privateDataSlot,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -9580,7 +10038,7 @@ void VulkanAsciiConsumer::Process_vkDestroyPrivateDataSlotEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyPrivateDataSlotEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyPrivateDataSlotEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -9591,6 +10049,7 @@ void VulkanAsciiConsumer::Process_vkDestroyPrivateDataSlotEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkSetPrivateDataEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     VkObjectType                                objectType,
@@ -9602,7 +10061,7 @@ void VulkanAsciiConsumer::Process_vkSetPrivateDataEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkSetPrivateDataEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkSetPrivateDataEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9616,6 +10075,7 @@ void VulkanAsciiConsumer::Process_vkSetPrivateDataEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPrivateDataEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     VkObjectType                                objectType,
     uint64_t                                    objectHandle,
@@ -9626,7 +10086,7 @@ void VulkanAsciiConsumer::Process_vkGetPrivateDataEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPrivateDataEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPrivateDataEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -9639,6 +10099,7 @@ void VulkanAsciiConsumer::Process_vkGetPrivateDataEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetFragmentShadingRateEnumNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkFragmentShadingRateNV                     shadingRate,
     PointerDecoder<VkFragmentShadingRateCombinerOpKHR>* combinerOps)
@@ -9647,7 +10108,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetFragmentShadingRateEnumNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetFragmentShadingRateEnumNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetFragmentShadingRateEnumNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9658,6 +10119,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetFragmentShadingRateEnumNV(
 }
 
 void VulkanAsciiConsumer::Process_vkAcquireWinrtDisplayNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            display)
@@ -9666,7 +10128,7 @@ void VulkanAsciiConsumer::Process_vkAcquireWinrtDisplayNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkAcquireWinrtDisplayNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkAcquireWinrtDisplayNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9677,6 +10139,7 @@ void VulkanAsciiConsumer::Process_vkAcquireWinrtDisplayNV(
 }
 
 void VulkanAsciiConsumer::Process_vkGetWinrtDisplayNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    deviceRelativeId,
@@ -9686,7 +10149,7 @@ void VulkanAsciiConsumer::Process_vkGetWinrtDisplayNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetWinrtDisplayNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetWinrtDisplayNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9698,6 +10161,7 @@ void VulkanAsciiConsumer::Process_vkGetWinrtDisplayNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateDirectFBSurfaceEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkDirectFBSurfaceCreateInfoEXT>* pCreateInfo,
@@ -9708,7 +10172,7 @@ void VulkanAsciiConsumer::Process_vkCreateDirectFBSurfaceEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateDirectFBSurfaceEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateDirectFBSurfaceEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9721,6 +10185,7 @@ void VulkanAsciiConsumer::Process_vkCreateDirectFBSurfaceEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDirectFBPresentationSupportEXT(
+    const ApiCallInfo&                          call_info,
     VkBool32                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    queueFamilyIndex,
@@ -9730,7 +10195,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDirectFBPresentationSupport
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceDirectFBPresentationSupportEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceDirectFBPresentationSupportEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9742,6 +10207,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDirectFBPresentationSupport
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetVertexInputEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    vertexBindingDescriptionCount,
     StructPointerDecoder<Decoded_VkVertexInputBindingDescription2EXT>* pVertexBindingDescriptions,
@@ -9752,7 +10218,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetVertexInputEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetVertexInputEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetVertexInputEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9765,6 +10231,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetVertexInputEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkGetMemoryZirconHandleFUCHSIA(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkMemoryGetZirconHandleInfoFUCHSIA>* pGetZirconHandleInfo,
@@ -9774,7 +10241,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryZirconHandleFUCHSIA(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetMemoryZirconHandleFUCHSIA", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetMemoryZirconHandleFUCHSIA", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9786,6 +10253,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryZirconHandleFUCHSIA(
 }
 
 void VulkanAsciiConsumer::Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -9796,7 +10264,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetMemoryZirconHandlePropertiesFUCHSIA", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetMemoryZirconHandlePropertiesFUCHSIA", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9809,6 +10277,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(
 }
 
 void VulkanAsciiConsumer::Process_vkImportSemaphoreZirconHandleFUCHSIA(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImportSemaphoreZirconHandleInfoFUCHSIA>* pImportSemaphoreZirconHandleInfo)
@@ -9817,7 +10286,7 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreZirconHandleFUCHSIA(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkImportSemaphoreZirconHandleFUCHSIA", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkImportSemaphoreZirconHandleFUCHSIA", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9828,6 +10297,7 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreZirconHandleFUCHSIA(
 }
 
 void VulkanAsciiConsumer::Process_vkGetSemaphoreZirconHandleFUCHSIA(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreGetZirconHandleInfoFUCHSIA>* pGetZirconHandleInfo,
@@ -9837,7 +10307,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreZirconHandleFUCHSIA(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetSemaphoreZirconHandleFUCHSIA", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetSemaphoreZirconHandleFUCHSIA", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9849,6 +10319,7 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreZirconHandleFUCHSIA(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdBindInvocationMaskHUAWEI(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            imageView,
     VkImageLayout                               imageLayout)
@@ -9857,7 +10328,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindInvocationMaskHUAWEI(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdBindInvocationMaskHUAWEI", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdBindInvocationMaskHUAWEI", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9868,6 +10339,7 @@ void VulkanAsciiConsumer::Process_vkCmdBindInvocationMaskHUAWEI(
 }
 
 void VulkanAsciiConsumer::Process_vkGetMemoryRemoteAddressNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkMemoryGetRemoteAddressInfoNV>* pMemoryGetRemoteAddressInfo,
@@ -9877,7 +10349,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryRemoteAddressNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetMemoryRemoteAddressNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetMemoryRemoteAddressNV", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9889,6 +10361,7 @@ void VulkanAsciiConsumer::Process_vkGetMemoryRemoteAddressNV(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetPatchControlPointsEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    patchControlPoints)
 {
@@ -9896,7 +10369,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPatchControlPointsEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetPatchControlPointsEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetPatchControlPointsEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9906,6 +10379,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPatchControlPointsEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetRasterizerDiscardEnableEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    rasterizerDiscardEnable)
 {
@@ -9913,7 +10387,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetRasterizerDiscardEnableEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetRasterizerDiscardEnableEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetRasterizerDiscardEnableEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9923,6 +10397,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetRasterizerDiscardEnableEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetDepthBiasEnableEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    depthBiasEnable)
 {
@@ -9930,7 +10405,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBiasEnableEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetDepthBiasEnableEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetDepthBiasEnableEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9940,6 +10415,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBiasEnableEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetLogicOpEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkLogicOp                                   logicOp)
 {
@@ -9947,7 +10423,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetLogicOpEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetLogicOpEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetLogicOpEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9957,6 +10433,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetLogicOpEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveRestartEnableEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    primitiveRestartEnable)
 {
@@ -9964,7 +10441,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveRestartEnableEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetPrimitiveRestartEnableEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetPrimitiveRestartEnableEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -9974,6 +10451,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveRestartEnableEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateScreenSurfaceQNX(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkScreenSurfaceCreateInfoQNX>* pCreateInfo,
@@ -9984,7 +10462,7 @@ void VulkanAsciiConsumer::Process_vkCreateScreenSurfaceQNX(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateScreenSurfaceQNX", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateScreenSurfaceQNX", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -9997,6 +10475,7 @@ void VulkanAsciiConsumer::Process_vkCreateScreenSurfaceQNX(
 }
 
 void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceScreenPresentationSupportQNX(
+    const ApiCallInfo&                          call_info,
     VkBool32                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    queueFamilyIndex,
@@ -10006,7 +10485,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceScreenPresentationSupportQN
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetPhysicalDeviceScreenPresentationSupportQNX", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceScreenPresentationSupportQNX", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -10018,6 +10497,7 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceScreenPresentationSupportQN
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetColorWriteEnableEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    attachmentCount,
     PointerDecoder<VkBool32>*                   pColorWriteEnables)
@@ -10026,7 +10506,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetColorWriteEnableEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetColorWriteEnableEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetColorWriteEnableEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -10037,6 +10517,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetColorWriteEnableEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDrawMultiEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    drawCount,
     StructPointerDecoder<Decoded_VkMultiDrawInfoEXT>* pVertexInfo,
@@ -10048,7 +10529,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMultiEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDrawMultiEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDrawMultiEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -10062,6 +10543,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMultiEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdDrawMultiIndexedEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    drawCount,
     StructPointerDecoder<Decoded_VkMultiDrawIndexedInfoEXT>* pIndexInfo,
@@ -10074,7 +10556,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMultiIndexedEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdDrawMultiIndexedEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdDrawMultiIndexedEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -10089,6 +10571,7 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMultiIndexedEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkSetDeviceMemoryPriorityEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            memory,
     float                                       priority)
@@ -10097,7 +10580,7 @@ void VulkanAsciiConsumer::Process_vkSetDeviceMemoryPriorityEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkSetDeviceMemoryPriorityEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkSetDeviceMemoryPriorityEXT", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -10108,6 +10591,7 @@ void VulkanAsciiConsumer::Process_vkSetDeviceMemoryPriorityEXT(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoKHR>* pCreateInfo,
@@ -10118,7 +10602,7 @@ void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -10131,6 +10615,7 @@ void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkDestroyAccelerationStructureKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            accelerationStructure,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -10139,7 +10624,7 @@ void VulkanAsciiConsumer::Process_vkDestroyAccelerationStructureKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkDestroyAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkDestroyAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -10150,6 +10635,7 @@ void VulkanAsciiConsumer::Process_vkDestroyAccelerationStructureKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCopyAccelerationStructureToMemoryKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            deferredOperation,
@@ -10159,7 +10645,7 @@ void VulkanAsciiConsumer::Process_vkCopyAccelerationStructureToMemoryKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCopyAccelerationStructureToMemoryKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCopyAccelerationStructureToMemoryKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -10171,6 +10657,7 @@ void VulkanAsciiConsumer::Process_vkCopyAccelerationStructureToMemoryKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCopyMemoryToAccelerationStructureKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            deferredOperation,
@@ -10180,7 +10667,7 @@ void VulkanAsciiConsumer::Process_vkCopyMemoryToAccelerationStructureKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCopyMemoryToAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCopyMemoryToAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -10192,6 +10679,7 @@ void VulkanAsciiConsumer::Process_vkCopyMemoryToAccelerationStructureKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkWriteAccelerationStructuresPropertiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    accelerationStructureCount,
@@ -10205,7 +10693,7 @@ void VulkanAsciiConsumer::Process_vkWriteAccelerationStructuresPropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkWriteAccelerationStructuresPropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkWriteAccelerationStructuresPropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -10221,6 +10709,7 @@ void VulkanAsciiConsumer::Process_vkWriteAccelerationStructuresPropertiesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyAccelerationStructureKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo)
 {
@@ -10228,7 +10717,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyAccelerationStructureKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -10238,6 +10727,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyAccelerationStructureKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyAccelerationStructureToMemoryKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyAccelerationStructureToMemoryInfoKHR>* pInfo)
 {
@@ -10245,7 +10735,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyAccelerationStructureToMemoryKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyAccelerationStructureToMemoryKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyAccelerationStructureToMemoryKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -10255,6 +10745,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyAccelerationStructureToMemoryKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdCopyMemoryToAccelerationStructureKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyMemoryToAccelerationStructureInfoKHR>* pInfo)
 {
@@ -10262,7 +10753,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyMemoryToAccelerationStructureKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdCopyMemoryToAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdCopyMemoryToAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -10272,6 +10763,7 @@ void VulkanAsciiConsumer::Process_vkCmdCopyMemoryToAccelerationStructureKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetAccelerationStructureDeviceAddressKHR(
+    const ApiCallInfo&                          call_info,
     VkDeviceAddress                             returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAccelerationStructureDeviceAddressInfoKHR>* pInfo)
@@ -10280,7 +10772,7 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureDeviceAddressKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetAccelerationStructureDeviceAddressKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetAccelerationStructureDeviceAddressKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -10291,6 +10783,7 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureDeviceAddressKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    accelerationStructureCount,
     HandlePointerDecoder<VkAccelerationStructureKHR>* pAccelerationStructures,
@@ -10302,7 +10795,7 @@ void VulkanAsciiConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdWriteAccelerationStructuresPropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdWriteAccelerationStructuresPropertiesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -10316,6 +10809,7 @@ void VulkanAsciiConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetDeviceAccelerationStructureCompatibilityKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAccelerationStructureVersionInfoKHR>* pVersionInfo,
     PointerDecoder<VkAccelerationStructureCompatibilityKHR>* pCompatibility)
@@ -10324,7 +10818,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceAccelerationStructureCompatibilityK
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetDeviceAccelerationStructureCompatibilityKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetDeviceAccelerationStructureCompatibilityKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
@@ -10335,6 +10829,7 @@ void VulkanAsciiConsumer::Process_vkGetDeviceAccelerationStructureCompatibilityK
 }
 
 void VulkanAsciiConsumer::Process_vkCmdTraceRaysKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pRaygenShaderBindingTable,
     StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pMissShaderBindingTable,
@@ -10348,7 +10843,7 @@ void VulkanAsciiConsumer::Process_vkCmdTraceRaysKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdTraceRaysKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdTraceRaysKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -10364,6 +10859,7 @@ void VulkanAsciiConsumer::Process_vkCmdTraceRaysKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            deferredOperation,
@@ -10377,7 +10873,7 @@ void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCreateRayTracingPipelinesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCreateRayTracingPipelinesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -10393,6 +10889,7 @@ void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipeline,
@@ -10405,7 +10902,7 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingCaptureReplayShaderGroupHandles
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetRayTracingCaptureReplayShaderGroupHandlesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetRayTracingCaptureReplayShaderGroupHandlesKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -10420,6 +10917,7 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingCaptureReplayShaderGroupHandles
 }
 
 void VulkanAsciiConsumer::Process_vkCmdTraceRaysIndirectKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pRaygenShaderBindingTable,
     StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pMissShaderBindingTable,
@@ -10431,7 +10929,7 @@ void VulkanAsciiConsumer::Process_vkCmdTraceRaysIndirectKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdTraceRaysIndirectKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdTraceRaysIndirectKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
@@ -10445,6 +10943,7 @@ void VulkanAsciiConsumer::Process_vkCmdTraceRaysIndirectKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupStackSizeKHR(
+    const ApiCallInfo&                          call_info,
     VkDeviceSize                                returnValue,
     format::HandleId                            device,
     format::HandleId                            pipeline,
@@ -10455,7 +10954,7 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupStackSizeKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkGetRayTracingShaderGroupStackSizeKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkGetRayTracingShaderGroupStackSizeKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
@@ -10468,6 +10967,7 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupStackSizeKHR(
 }
 
 void VulkanAsciiConsumer::Process_vkCmdSetRayTracingPipelineStackSizeKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    pipelineStackSize)
 {
@@ -10475,7 +10975,7 @@ void VulkanAsciiConsumer::Process_vkCmdSetRayTracingPipelineStackSizeKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile("vkCmdSetRayTracingPipelineStackSizeKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(call_info, "vkCmdSetRayTracingPipelineStackSizeKHR", toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));

--- a/framework/generated/generated_vulkan_ascii_consumer.h
+++ b/framework/generated/generated_vulkan_ascii_consumer.h
@@ -45,31 +45,37 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
     virtual ~VulkanAsciiConsumer() override { }
 
     virtual void Process_vkCreateInstance(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         StructPointerDecoder<Decoded_VkInstanceCreateInfo>* pCreateInfo,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkInstance>*           pInstance) override;
 
     virtual void Process_vkDestroyInstance(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkEnumeratePhysicalDevices(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         PointerDecoder<uint32_t>*                   pPhysicalDeviceCount,
         HandlePointerDecoder<VkPhysicalDevice>*     pPhysicalDevices) override;
 
     virtual void Process_vkGetPhysicalDeviceFeatures(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures>* pFeatures) override;
 
     virtual void Process_vkGetPhysicalDeviceFormatProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
         StructPointerDecoder<Decoded_VkFormatProperties>* pFormatProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
@@ -80,19 +86,23 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkImageFormatProperties>* pImageFormatProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceProperties>* pProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
         StructPointerDecoder<Decoded_VkQueueFamilyProperties>* pQueueFamilyProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceMemoryProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties>* pMemoryProperties) override;
 
     virtual void Process_vkCreateDevice(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkDeviceCreateInfo>* pCreateInfo,
@@ -100,16 +110,19 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkDevice>*             pDevice) override;
 
     virtual void Process_vkDestroyDevice(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetDeviceQueue(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         uint32_t                                    queueFamilyIndex,
         uint32_t                                    queueIndex,
         HandlePointerDecoder<VkQueue>*              pQueue) override;
 
     virtual void Process_vkQueueSubmit(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    submitCount,
@@ -117,14 +130,17 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            fence) override;
 
     virtual void Process_vkQueueWaitIdle(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue) override;
 
     virtual void Process_vkDeviceWaitIdle(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device) override;
 
     virtual void Process_vkAllocateMemory(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryAllocateInfo>* pAllocateInfo,
@@ -132,11 +148,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkDeviceMemory>*       pMemory) override;
 
     virtual void Process_vkFreeMemory(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            memory,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkMapMemory(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            memory,
@@ -146,27 +164,32 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint64_t, void*>*            ppData) override;
 
     virtual void Process_vkUnmapMemory(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            memory) override;
 
     virtual void Process_vkFlushMappedMemoryRanges(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    memoryRangeCount,
         StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges) override;
 
     virtual void Process_vkInvalidateMappedMemoryRanges(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    memoryRangeCount,
         StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges) override;
 
     virtual void Process_vkGetDeviceMemoryCommitment(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            memory,
         PointerDecoder<VkDeviceSize>*               pCommittedMemoryInBytes) override;
 
     virtual void Process_vkBindBufferMemory(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            buffer,
@@ -174,6 +197,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkDeviceSize                                memoryOffset) override;
 
     virtual void Process_vkBindImageMemory(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            image,
@@ -181,22 +205,26 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkDeviceSize                                memoryOffset) override;
 
     virtual void Process_vkGetBufferMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            buffer,
         StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements) override;
 
     virtual void Process_vkGetImageMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            image,
         StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements) override;
 
     virtual void Process_vkGetImageSparseMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            image,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements>* pSparseMemoryRequirements) override;
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
         VkImageType                                 type,
@@ -207,6 +235,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkSparseImageFormatProperties>* pProperties) override;
 
     virtual void Process_vkQueueBindSparse(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    bindInfoCount,
@@ -214,6 +243,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            fence) override;
 
     virtual void Process_vkCreateFence(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkFenceCreateInfo>* pCreateInfo,
@@ -221,22 +251,26 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkFence>*              pFence) override;
 
     virtual void Process_vkDestroyFence(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            fence,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkResetFences(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    fenceCount,
         HandlePointerDecoder<VkFence>*              pFences) override;
 
     virtual void Process_vkGetFenceStatus(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            fence) override;
 
     virtual void Process_vkWaitForFences(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    fenceCount,
@@ -245,6 +279,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint64_t                                    timeout) override;
 
     virtual void Process_vkCreateSemaphore(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreCreateInfo>* pCreateInfo,
@@ -252,11 +287,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSemaphore>*          pSemaphore) override;
 
     virtual void Process_vkDestroySemaphore(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            semaphore,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateEvent(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkEventCreateInfo>* pCreateInfo,
@@ -264,26 +301,31 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkEvent>*              pEvent) override;
 
     virtual void Process_vkDestroyEvent(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            event,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetEventStatus(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            event) override;
 
     virtual void Process_vkSetEvent(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            event) override;
 
     virtual void Process_vkResetEvent(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            event) override;
 
     virtual void Process_vkCreateQueryPool(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkQueryPoolCreateInfo>* pCreateInfo,
@@ -291,11 +333,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkQueryPool>*          pQueryPool) override;
 
     virtual void Process_vkDestroyQueryPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            queryPool,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetQueryPoolResults(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            queryPool,
@@ -307,6 +351,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkQueryResultFlags                          flags) override;
 
     virtual void Process_vkCreateBuffer(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferCreateInfo>* pCreateInfo,
@@ -314,11 +359,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkBuffer>*             pBuffer) override;
 
     virtual void Process_vkDestroyBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            buffer,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateBufferView(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferViewCreateInfo>* pCreateInfo,
@@ -326,11 +373,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkBufferView>*         pView) override;
 
     virtual void Process_vkDestroyBufferView(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            bufferView,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateImage(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageCreateInfo>* pCreateInfo,
@@ -338,17 +387,20 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkImage>*              pImage) override;
 
     virtual void Process_vkDestroyImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            image,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetImageSubresourceLayout(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            image,
         StructPointerDecoder<Decoded_VkImageSubresource>* pSubresource,
         StructPointerDecoder<Decoded_VkSubresourceLayout>* pLayout) override;
 
     virtual void Process_vkCreateImageView(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageViewCreateInfo>* pCreateInfo,
@@ -356,11 +408,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkImageView>*          pView) override;
 
     virtual void Process_vkDestroyImageView(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            imageView,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateShaderModule(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>* pCreateInfo,
@@ -368,11 +422,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkShaderModule>*       pShaderModule) override;
 
     virtual void Process_vkDestroyShaderModule(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            shaderModule,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreatePipelineCache(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>* pCreateInfo,
@@ -380,11 +436,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkPipelineCache>*      pPipelineCache) override;
 
     virtual void Process_vkDestroyPipelineCache(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetPipelineCacheData(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
@@ -392,6 +450,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkMergePipelineCaches(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            dstCache,
@@ -399,6 +458,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkPipelineCache>*      pSrcCaches) override;
 
     virtual void Process_vkCreateGraphicsPipelines(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
@@ -408,6 +468,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkPipeline>*           pPipelines) override;
 
     virtual void Process_vkCreateComputePipelines(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
@@ -417,11 +478,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkPipeline>*           pPipelines) override;
 
     virtual void Process_vkDestroyPipeline(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            pipeline,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreatePipelineLayout(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPipelineLayoutCreateInfo>* pCreateInfo,
@@ -429,11 +492,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkPipelineLayout>*     pPipelineLayout) override;
 
     virtual void Process_vkDestroyPipelineLayout(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            pipelineLayout,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateSampler(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSamplerCreateInfo>* pCreateInfo,
@@ -441,11 +506,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSampler>*            pSampler) override;
 
     virtual void Process_vkDestroySampler(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            sampler,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateDescriptorSetLayout(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
@@ -453,11 +520,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkDescriptorSetLayout>* pSetLayout) override;
 
     virtual void Process_vkDestroyDescriptorSetLayout(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            descriptorSetLayout,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateDescriptorPool(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>* pCreateInfo,
@@ -465,23 +534,27 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkDescriptorPool>*     pDescriptorPool) override;
 
     virtual void Process_vkDestroyDescriptorPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkResetDescriptorPool(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
         VkDescriptorPoolResetFlags                  flags) override;
 
     virtual void Process_vkAllocateDescriptorSets(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
         HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) override;
 
     virtual void Process_vkFreeDescriptorSets(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
@@ -489,6 +562,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) override;
 
     virtual void Process_vkUpdateDescriptorSets(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         uint32_t                                    descriptorWriteCount,
         StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites,
@@ -496,6 +570,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkCopyDescriptorSet>* pDescriptorCopies) override;
 
     virtual void Process_vkCreateFramebuffer(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* pCreateInfo,
@@ -503,11 +578,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkFramebuffer>*        pFramebuffer) override;
 
     virtual void Process_vkDestroyFramebuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            framebuffer,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateRenderPass(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkRenderPassCreateInfo>* pCreateInfo,
@@ -515,16 +592,19 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkRenderPass>*         pRenderPass) override;
 
     virtual void Process_vkDestroyRenderPass(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            renderPass,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetRenderAreaGranularity(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            renderPass,
         StructPointerDecoder<Decoded_VkExtent2D>*   pGranularity) override;
 
     virtual void Process_vkCreateCommandPool(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>* pCreateInfo,
@@ -532,94 +612,112 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkCommandPool>*        pCommandPool) override;
 
     virtual void Process_vkDestroyCommandPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            commandPool,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkResetCommandPool(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            commandPool,
         VkCommandPoolResetFlags                     flags) override;
 
     virtual void Process_vkAllocateCommandBuffers(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
         HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) override;
 
     virtual void Process_vkFreeCommandBuffers(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            commandPool,
         uint32_t                                    commandBufferCount,
         HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) override;
 
     virtual void Process_vkBeginCommandBuffer(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo) override;
 
     virtual void Process_vkEndCommandBuffer(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkResetCommandBuffer(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
         VkCommandBufferResetFlags                   flags) override;
 
     virtual void Process_vkCmdBindPipeline(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineBindPoint                         pipelineBindPoint,
         format::HandleId                            pipeline) override;
 
     virtual void Process_vkCmdSetViewport(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
         StructPointerDecoder<Decoded_VkViewport>*   pViewports) override;
 
     virtual void Process_vkCmdSetScissor(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstScissor,
         uint32_t                                    scissorCount,
         StructPointerDecoder<Decoded_VkRect2D>*     pScissors) override;
 
     virtual void Process_vkCmdSetLineWidth(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         float                                       lineWidth) override;
 
     virtual void Process_vkCmdSetDepthBias(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         float                                       depthBiasConstantFactor,
         float                                       depthBiasClamp,
         float                                       depthBiasSlopeFactor) override;
 
     virtual void Process_vkCmdSetBlendConstants(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         PointerDecoder<float>*                      blendConstants) override;
 
     virtual void Process_vkCmdSetDepthBounds(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         float                                       minDepthBounds,
         float                                       maxDepthBounds) override;
 
     virtual void Process_vkCmdSetStencilCompareMask(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
         uint32_t                                    compareMask) override;
 
     virtual void Process_vkCmdSetStencilWriteMask(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
         uint32_t                                    writeMask) override;
 
     virtual void Process_vkCmdSetStencilReference(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
         uint32_t                                    reference) override;
 
     virtual void Process_vkCmdBindDescriptorSets(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineBindPoint                         pipelineBindPoint,
         format::HandleId                            layout,
@@ -630,12 +728,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint32_t>*                   pDynamicOffsets) override;
 
     virtual void Process_vkCmdBindIndexBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
         VkIndexType                                 indexType) override;
 
     virtual void Process_vkCmdBindVertexBuffers(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
@@ -643,6 +743,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<VkDeviceSize>*               pOffsets) override;
 
     virtual void Process_vkCmdDraw(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    vertexCount,
         uint32_t                                    instanceCount,
@@ -650,6 +751,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    firstInstance) override;
 
     virtual void Process_vkCmdDrawIndexed(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    indexCount,
         uint32_t                                    instanceCount,
@@ -658,6 +760,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    firstInstance) override;
 
     virtual void Process_vkCmdDrawIndirect(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -665,6 +768,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawIndexedIndirect(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -672,17 +776,20 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDispatch(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    groupCountX,
         uint32_t                                    groupCountY,
         uint32_t                                    groupCountZ) override;
 
     virtual void Process_vkCmdDispatchIndirect(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset) override;
 
     virtual void Process_vkCmdCopyBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcBuffer,
         format::HandleId                            dstBuffer,
@@ -690,6 +797,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkBufferCopy>* pRegions) override;
 
     virtual void Process_vkCmdCopyImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcImage,
         VkImageLayout                               srcImageLayout,
@@ -699,6 +807,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkImageCopy>*  pRegions) override;
 
     virtual void Process_vkCmdBlitImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcImage,
         VkImageLayout                               srcImageLayout,
@@ -709,6 +818,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkFilter                                    filter) override;
 
     virtual void Process_vkCmdCopyBufferToImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcBuffer,
         format::HandleId                            dstImage,
@@ -717,6 +827,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions) override;
 
     virtual void Process_vkCmdCopyImageToBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcImage,
         VkImageLayout                               srcImageLayout,
@@ -725,6 +836,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions) override;
 
     virtual void Process_vkCmdUpdateBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            dstBuffer,
         VkDeviceSize                                dstOffset,
@@ -732,6 +844,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkCmdFillBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            dstBuffer,
         VkDeviceSize                                dstOffset,
@@ -739,6 +852,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    data) override;
 
     virtual void Process_vkCmdClearColorImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            image,
         VkImageLayout                               imageLayout,
@@ -747,6 +861,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges) override;
 
     virtual void Process_vkCmdClearDepthStencilImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            image,
         VkImageLayout                               imageLayout,
@@ -755,6 +870,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges) override;
 
     virtual void Process_vkCmdClearAttachments(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    attachmentCount,
         StructPointerDecoder<Decoded_VkClearAttachment>* pAttachments,
@@ -762,6 +878,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkClearRect>*  pRects) override;
 
     virtual void Process_vkCmdResolveImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcImage,
         VkImageLayout                               srcImageLayout,
@@ -771,16 +888,19 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkImageResolve>* pRegions) override;
 
     virtual void Process_vkCmdSetEvent(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         VkPipelineStageFlags                        stageMask) override;
 
     virtual void Process_vkCmdResetEvent(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         VkPipelineStageFlags                        stageMask) override;
 
     virtual void Process_vkCmdWaitEvents(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    eventCount,
         HandlePointerDecoder<VkEvent>*              pEvents,
@@ -794,6 +914,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers) override;
 
     virtual void Process_vkCmdPipelineBarrier(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlags                        srcStageMask,
         VkPipelineStageFlags                        dstStageMask,
@@ -806,29 +927,34 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers) override;
 
     virtual void Process_vkCmdBeginQuery(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    query,
         VkQueryControlFlags                         flags) override;
 
     virtual void Process_vkCmdEndQuery(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    query) override;
 
     virtual void Process_vkCmdResetQueryPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery,
         uint32_t                                    queryCount) override;
 
     virtual void Process_vkCmdWriteTimestamp(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlagBits                     pipelineStage,
         format::HandleId                            queryPool,
         uint32_t                                    query) override;
 
     virtual void Process_vkCmdCopyQueryPoolResults(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery,
@@ -839,6 +965,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkQueryResultFlags                          flags) override;
 
     virtual void Process_vkCmdPushConstants(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            layout,
         VkShaderStageFlags                          stageFlags,
@@ -847,35 +974,42 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint8_t>*                    pValues) override;
 
     virtual void Process_vkCmdBeginRenderPass(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
         VkSubpassContents                           contents) override;
 
     virtual void Process_vkCmdNextSubpass(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkSubpassContents                           contents) override;
 
     virtual void Process_vkCmdEndRenderPass(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkCmdExecuteCommands(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    commandBufferCount,
         HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) override;
 
     virtual void Process_vkBindBufferMemory2(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
         StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos) override;
 
     virtual void Process_vkBindImageMemory2(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
         StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos) override;
 
     virtual void Process_vkGetDeviceGroupPeerMemoryFeatures(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         uint32_t                                    heapIndex,
         uint32_t                                    localDeviceIndex,
@@ -883,10 +1017,12 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<VkPeerMemoryFeatureFlags>*   pPeerMemoryFeatures) override;
 
     virtual void Process_vkCmdSetDeviceMask(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    deviceMask) override;
 
     virtual void Process_vkCmdDispatchBase(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    baseGroupX,
         uint32_t                                    baseGroupY,
@@ -896,72 +1032,86 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    groupCountZ) override;
 
     virtual void Process_vkEnumeratePhysicalDeviceGroups(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         PointerDecoder<uint32_t>*                   pPhysicalDeviceGroupCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties) override;
 
     virtual void Process_vkGetImageMemoryRequirements2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetBufferMemoryRequirements2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetImageSparseMemoryRequirements2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) override;
 
     virtual void Process_vkGetPhysicalDeviceFeatures2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures) override;
 
     virtual void Process_vkGetPhysicalDeviceProperties2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceFormatProperties2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
         StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties2(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
         StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
         StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceMemoryProperties2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties) override;
 
     virtual void Process_vkTrimCommandPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            commandPool,
         VkCommandPoolTrimFlags                      flags) override;
 
     virtual void Process_vkGetDeviceQueue2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceQueueInfo2>* pQueueInfo,
         HandlePointerDecoder<VkQueue>*              pQueue) override;
 
     virtual void Process_vkCreateSamplerYcbcrConversion(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
@@ -969,11 +1119,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion) override;
 
     virtual void Process_vkDestroySamplerYcbcrConversion(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            ycbcrConversion,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateDescriptorUpdateTemplate(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
@@ -981,31 +1133,37 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate) override;
 
     virtual void Process_vkDestroyDescriptorUpdateTemplate(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            descriptorUpdateTemplate,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalBufferProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
         StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalFenceProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
         StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalSemaphoreProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
         StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties) override;
 
     virtual void Process_vkGetDescriptorSetLayoutSupport(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport) override;
 
     virtual void Process_vkCmdDrawIndirectCount(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -1015,6 +1173,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawIndexedIndirectCount(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -1024,6 +1183,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCreateRenderPass2(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkRenderPassCreateInfo2>* pCreateInfo,
@@ -1031,64 +1191,76 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkRenderPass>*         pRenderPass) override;
 
     virtual void Process_vkCmdBeginRenderPass2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
         StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo) override;
 
     virtual void Process_vkCmdNextSubpass2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo,
         StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo) override;
 
     virtual void Process_vkCmdEndRenderPass2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo) override;
 
     virtual void Process_vkResetQueryPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery,
         uint32_t                                    queryCount) override;
 
     virtual void Process_vkGetSemaphoreCounterValue(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            semaphore,
         PointerDecoder<uint64_t>*                   pValue) override;
 
     virtual void Process_vkWaitSemaphores(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreWaitInfo>* pWaitInfo,
         uint64_t                                    timeout) override;
 
     virtual void Process_vkSignalSemaphore(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreSignalInfo>* pSignalInfo) override;
 
     virtual void Process_vkGetBufferDeviceAddress(
+        const ApiCallInfo&                          call_info,
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) override;
 
     virtual void Process_vkGetBufferOpaqueCaptureAddress(
+        const ApiCallInfo&                          call_info,
         uint64_t                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) override;
 
     virtual void Process_vkGetDeviceMemoryOpaqueCaptureAddress(
+        const ApiCallInfo&                          call_info,
         uint64_t                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo>* pInfo) override;
 
     virtual void Process_vkGetPhysicalDeviceToolProperties(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pToolCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceToolProperties>* pToolProperties) override;
 
     virtual void Process_vkCreatePrivateDataSlot(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPrivateDataSlotCreateInfo>* pCreateInfo,
@@ -1096,11 +1268,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkPrivateDataSlot>*    pPrivateDataSlot) override;
 
     virtual void Process_vkDestroyPrivateDataSlot(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            privateDataSlot,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkSetPrivateData(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkObjectType                                objectType,
@@ -1109,6 +1283,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint64_t                                    data) override;
 
     virtual void Process_vkGetPrivateData(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         VkObjectType                                objectType,
         uint64_t                                    objectHandle,
@@ -1116,32 +1291,38 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint64_t>*                   pData) override;
 
     virtual void Process_vkCmdSetEvent2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo) override;
 
     virtual void Process_vkCmdResetEvent2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         VkPipelineStageFlags2                       stageMask) override;
 
     virtual void Process_vkCmdWaitEvents2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    eventCount,
         HandlePointerDecoder<VkEvent>*              pEvents,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfos) override;
 
     virtual void Process_vkCmdPipelineBarrier2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo) override;
 
     virtual void Process_vkCmdWriteTimestamp2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlags2                       stage,
         format::HandleId                            queryPool,
         uint32_t                                    query) override;
 
     virtual void Process_vkQueueSubmit2(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    submitCount,
@@ -1149,59 +1330,73 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            fence) override;
 
     virtual void Process_vkCmdCopyBuffer2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyBufferInfo2>* pCopyBufferInfo) override;
 
     virtual void Process_vkCmdCopyImage2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyImageInfo2>* pCopyImageInfo) override;
 
     virtual void Process_vkCmdCopyBufferToImage2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2>* pCopyBufferToImageInfo) override;
 
     virtual void Process_vkCmdCopyImageToBuffer2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2>* pCopyImageToBufferInfo) override;
 
     virtual void Process_vkCmdBlitImage2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkBlitImageInfo2>* pBlitImageInfo) override;
 
     virtual void Process_vkCmdResolveImage2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkResolveImageInfo2>* pResolveImageInfo) override;
 
     virtual void Process_vkCmdBeginRendering(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo) override;
 
     virtual void Process_vkCmdEndRendering(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkCmdSetCullMode(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkCullModeFlags                             cullMode) override;
 
     virtual void Process_vkCmdSetFrontFace(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkFrontFace                                 frontFace) override;
 
     virtual void Process_vkCmdSetPrimitiveTopology(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPrimitiveTopology                         primitiveTopology) override;
 
     virtual void Process_vkCmdSetViewportWithCount(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    viewportCount,
         StructPointerDecoder<Decoded_VkViewport>*   pViewports) override;
 
     virtual void Process_vkCmdSetScissorWithCount(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    scissorCount,
         StructPointerDecoder<Decoded_VkRect2D>*     pScissors) override;
 
     virtual void Process_vkCmdBindVertexBuffers2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
@@ -1211,26 +1406,32 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<VkDeviceSize>*               pStrides) override;
 
     virtual void Process_vkCmdSetDepthTestEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthTestEnable) override;
 
     virtual void Process_vkCmdSetDepthWriteEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthWriteEnable) override;
 
     virtual void Process_vkCmdSetDepthCompareOp(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkCompareOp                                 depthCompareOp) override;
 
     virtual void Process_vkCmdSetDepthBoundsTestEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthBoundsTestEnable) override;
 
     virtual void Process_vkCmdSetStencilTestEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    stencilTestEnable) override;
 
     virtual void Process_vkCmdSetStencilOp(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
         VkStencilOp                                 failOp,
@@ -1239,39 +1440,47 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkCompareOp                                 compareOp) override;
 
     virtual void Process_vkCmdSetRasterizerDiscardEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    rasterizerDiscardEnable) override;
 
     virtual void Process_vkCmdSetDepthBiasEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthBiasEnable) override;
 
     virtual void Process_vkCmdSetPrimitiveRestartEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    primitiveRestartEnable) override;
 
     virtual void Process_vkGetDeviceBufferMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceBufferMemoryRequirements>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetDeviceImageMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetDeviceImageSparseMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) override;
 
     virtual void Process_vkDestroySurfaceKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         format::HandleId                            surface,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceSupportKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
@@ -1279,12 +1488,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<VkBool32>*                   pSupported) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
         StructPointerDecoder<Decoded_VkSurfaceCapabilitiesKHR>* pSurfaceCapabilities) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
@@ -1292,6 +1503,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkSurfaceFormatKHR>* pSurfaceFormats) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
@@ -1299,6 +1511,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<VkPresentModeKHR>*           pPresentModes) override;
 
     virtual void Process_vkCreateSwapchainKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfo,
@@ -1306,11 +1519,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSwapchainKHR>*       pSwapchain) override;
 
     virtual void Process_vkDestroySwapchainKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            swapchain,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetSwapchainImagesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
@@ -1318,6 +1533,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkImage>*              pSwapchainImages) override;
 
     virtual void Process_vkAcquireNextImageKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
@@ -1327,22 +1543,26 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint32_t>*                   pImageIndex) override;
 
     virtual void Process_vkQueuePresentKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo) override;
 
     virtual void Process_vkGetDeviceGroupPresentCapabilitiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceGroupPresentCapabilitiesKHR>* pDeviceGroupPresentCapabilities) override;
 
     virtual void Process_vkGetDeviceGroupSurfacePresentModesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            surface,
         PointerDecoder<VkDeviceGroupPresentModeFlagsKHR>* pModes) override;
 
     virtual void Process_vkGetPhysicalDevicePresentRectanglesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
@@ -1350,24 +1570,28 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkRect2D>*     pRects) override;
 
     virtual void Process_vkAcquireNextImage2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>* pAcquireInfo,
         PointerDecoder<uint32_t>*                   pImageIndex) override;
 
     virtual void Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkDisplayPropertiesKHR>* pProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkDisplayPlanePropertiesKHR>* pProperties) override;
 
     virtual void Process_vkGetDisplayPlaneSupportedDisplaysKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    planeIndex,
@@ -1375,6 +1599,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkDisplayKHR>*         pDisplays) override;
 
     virtual void Process_vkGetDisplayModePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display,
@@ -1382,6 +1607,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkDisplayModePropertiesKHR>* pProperties) override;
 
     virtual void Process_vkCreateDisplayModeKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display,
@@ -1390,6 +1616,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkDisplayModeKHR>*     pMode) override;
 
     virtual void Process_vkGetDisplayPlaneCapabilitiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            mode,
@@ -1397,6 +1624,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkDisplayPlaneCapabilitiesKHR>* pCapabilities) override;
 
     virtual void Process_vkCreateDisplayPlaneSurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkDisplaySurfaceCreateInfoKHR>* pCreateInfo,
@@ -1404,6 +1632,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCreateSharedSwapchainsKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    swapchainCount,
@@ -1412,6 +1641,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains) override;
 
     virtual void Process_vkCreateXlibSurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>* pCreateInfo,
@@ -1419,6 +1649,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
@@ -1426,6 +1657,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         size_t                                      visualID) override;
 
     virtual void Process_vkCreateXcbSurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>* pCreateInfo,
@@ -1433,6 +1665,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
@@ -1440,6 +1673,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    visual_id) override;
 
     virtual void Process_vkCreateWaylandSurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>* pCreateInfo,
@@ -1447,12 +1681,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceWaylandPresentationSupportKHR(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
         uint64_t                                    display) override;
 
     virtual void Process_vkCreateAndroidSurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>* pCreateInfo,
@@ -1460,6 +1696,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCreateWin32SurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>* pCreateInfo,
@@ -1467,52 +1704,63 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceWin32PresentationSupportKHR(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex) override;
 
     virtual void Process_vkCmdBeginRenderingKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo) override;
 
     virtual void Process_vkCmdEndRenderingKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkGetPhysicalDeviceFeatures2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures) override;
 
     virtual void Process_vkGetPhysicalDeviceProperties2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceFormatProperties2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
         StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
         StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
         StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceMemoryProperties2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties) override;
 
     virtual void Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         uint32_t                                    heapIndex,
         uint32_t                                    localDeviceIndex,
@@ -1520,10 +1768,12 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<VkPeerMemoryFeatureFlags>*   pPeerMemoryFeatures) override;
 
     virtual void Process_vkCmdSetDeviceMaskKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    deviceMask) override;
 
     virtual void Process_vkCmdDispatchBaseKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    baseGroupX,
         uint32_t                                    baseGroupY,
@@ -1533,28 +1783,33 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    groupCountZ) override;
 
     virtual void Process_vkTrimCommandPoolKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            commandPool,
         VkCommandPoolTrimFlags                      flags) override;
 
     virtual void Process_vkEnumeratePhysicalDeviceGroupsKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         PointerDecoder<uint32_t>*                   pPhysicalDeviceGroupCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
         StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties) override;
 
     virtual void Process_vkGetMemoryWin32HandleKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) override;
 
     virtual void Process_vkGetMemoryWin32HandlePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -1562,12 +1817,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkMemoryWin32HandlePropertiesKHR>* pMemoryWin32HandleProperties) override;
 
     virtual void Process_vkGetMemoryFdKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) override;
 
     virtual void Process_vkGetMemoryFdPropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -1575,33 +1832,39 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkMemoryFdPropertiesKHR>* pMemoryFdProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
         StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties) override;
 
     virtual void Process_vkImportSemaphoreWin32HandleKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>* pImportSemaphoreWin32HandleInfo) override;
 
     virtual void Process_vkGetSemaphoreWin32HandleKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) override;
 
     virtual void Process_vkImportSemaphoreFdKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>* pImportSemaphoreFdInfo) override;
 
     virtual void Process_vkGetSemaphoreFdKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) override;
 
     virtual void Process_vkCmdPushDescriptorSetKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineBindPoint                         pipelineBindPoint,
         format::HandleId                            layout,
@@ -1610,6 +1873,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites) override;
 
     virtual void Process_vkCreateDescriptorUpdateTemplateKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
@@ -1617,11 +1881,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate) override;
 
     virtual void Process_vkDestroyDescriptorUpdateTemplateKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            descriptorUpdateTemplate,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateRenderPass2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkRenderPassCreateInfo2>* pCreateInfo,
@@ -1629,52 +1895,62 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkRenderPass>*         pRenderPass) override;
 
     virtual void Process_vkCmdBeginRenderPass2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
         StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo) override;
 
     virtual void Process_vkCmdNextSubpass2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo,
         StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo) override;
 
     virtual void Process_vkCmdEndRenderPass2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo) override;
 
     virtual void Process_vkGetSwapchainStatusKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
         StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties) override;
 
     virtual void Process_vkImportFenceWin32HandleKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImportFenceWin32HandleInfoKHR>* pImportFenceWin32HandleInfo) override;
 
     virtual void Process_vkGetFenceWin32HandleKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkFenceGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) override;
 
     virtual void Process_vkImportFenceFdKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImportFenceFdInfoKHR>* pImportFenceFdInfo) override;
 
     virtual void Process_vkGetFenceFdKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkFenceGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) override;
 
     virtual void Process_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
@@ -1683,25 +1959,30 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkPerformanceCounterDescriptionKHR>* pCounterDescriptions) override;
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkQueryPoolPerformanceCreateInfoKHR>* pPerformanceQueryCreateInfo,
         PointerDecoder<uint32_t>*                   pNumPasses) override;
 
     virtual void Process_vkAcquireProfilingLockKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAcquireProfilingLockInfoKHR>* pInfo) override;
 
     virtual void Process_vkReleaseProfilingLockKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         StructPointerDecoder<Decoded_VkSurfaceCapabilities2KHR>* pSurfaceCapabilities) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
@@ -1709,18 +1990,21 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkSurfaceFormat2KHR>* pSurfaceFormats) override;
 
     virtual void Process_vkGetPhysicalDeviceDisplayProperties2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkDisplayProperties2KHR>* pProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkDisplayPlaneProperties2KHR>* pProperties) override;
 
     virtual void Process_vkGetDisplayModeProperties2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display,
@@ -1728,28 +2012,33 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkDisplayModeProperties2KHR>* pProperties) override;
 
     virtual void Process_vkGetDisplayPlaneCapabilities2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkDisplayPlaneInfo2KHR>* pDisplayPlaneInfo,
         StructPointerDecoder<Decoded_VkDisplayPlaneCapabilities2KHR>* pCapabilities) override;
 
     virtual void Process_vkGetImageMemoryRequirements2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetBufferMemoryRequirements2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetImageSparseMemoryRequirements2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) override;
 
     virtual void Process_vkCreateSamplerYcbcrConversionKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
@@ -1757,28 +2046,33 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion) override;
 
     virtual void Process_vkDestroySamplerYcbcrConversionKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            ycbcrConversion,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkBindBufferMemory2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
         StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos) override;
 
     virtual void Process_vkBindImageMemory2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
         StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos) override;
 
     virtual void Process_vkGetDescriptorSetLayoutSupportKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport) override;
 
     virtual void Process_vkCmdDrawIndirectCountKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -1788,6 +2082,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawIndexedIndirectCountKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -1797,34 +2092,40 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkGetSemaphoreCounterValueKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            semaphore,
         PointerDecoder<uint64_t>*                   pValue) override;
 
     virtual void Process_vkWaitSemaphoresKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreWaitInfo>* pWaitInfo,
         uint64_t                                    timeout) override;
 
     virtual void Process_vkSignalSemaphoreKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreSignalInfo>* pSignalInfo) override;
 
     virtual void Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pFragmentShadingRateCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceFragmentShadingRateKHR>* pFragmentShadingRates) override;
 
     virtual void Process_vkCmdSetFragmentShadingRateKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkExtent2D>*   pFragmentSize,
         PointerDecoder<VkFragmentShadingRateCombinerOpKHR>* combinerOps) override;
 
     virtual void Process_vkWaitForPresentKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
@@ -1832,47 +2133,56 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint64_t                                    timeout) override;
 
     virtual void Process_vkGetBufferDeviceAddressKHR(
+        const ApiCallInfo&                          call_info,
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) override;
 
     virtual void Process_vkGetBufferOpaqueCaptureAddressKHR(
+        const ApiCallInfo&                          call_info,
         uint64_t                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) override;
 
     virtual void Process_vkGetDeviceMemoryOpaqueCaptureAddressKHR(
+        const ApiCallInfo&                          call_info,
         uint64_t                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo>* pInfo) override;
 
     virtual void Process_vkCreateDeferredOperationKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDeferredOperationKHR>* pDeferredOperation) override;
 
     virtual void Process_vkDestroyDeferredOperationKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            operation,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetDeferredOperationMaxConcurrencyKHR(
+        const ApiCallInfo&                          call_info,
         uint32_t                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            operation) override;
 
     virtual void Process_vkGetDeferredOperationResultKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            operation) override;
 
     virtual void Process_vkDeferredOperationJoinKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            operation) override;
 
     virtual void Process_vkGetPipelineExecutablePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPipelineInfoKHR>* pPipelineInfo,
@@ -1880,6 +2190,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkPipelineExecutablePropertiesKHR>* pProperties) override;
 
     virtual void Process_vkGetPipelineExecutableStatisticsKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
@@ -1887,6 +2198,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkPipelineExecutableStatisticKHR>* pStatistics) override;
 
     virtual void Process_vkGetPipelineExecutableInternalRepresentationsKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
@@ -1894,32 +2206,38 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkPipelineExecutableInternalRepresentationKHR>* pInternalRepresentations) override;
 
     virtual void Process_vkCmdSetEvent2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo) override;
 
     virtual void Process_vkCmdResetEvent2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         VkPipelineStageFlags2                       stageMask) override;
 
     virtual void Process_vkCmdWaitEvents2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    eventCount,
         HandlePointerDecoder<VkEvent>*              pEvents,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfos) override;
 
     virtual void Process_vkCmdPipelineBarrier2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo) override;
 
     virtual void Process_vkCmdWriteTimestamp2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlags2                       stage,
         format::HandleId                            queryPool,
         uint32_t                                    query) override;
 
     virtual void Process_vkQueueSubmit2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    submitCount,
@@ -1927,6 +2245,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         format::HandleId                            fence) override;
 
     virtual void Process_vkCmdWriteBufferMarker2AMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlags2                       stage,
         format::HandleId                            dstBuffer,
@@ -1934,51 +2253,62 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    marker) override;
 
     virtual void Process_vkGetQueueCheckpointData2NV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            queue,
         PointerDecoder<uint32_t>*                   pCheckpointDataCount,
         StructPointerDecoder<Decoded_VkCheckpointData2NV>* pCheckpointData) override;
 
     virtual void Process_vkCmdCopyBuffer2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyBufferInfo2>* pCopyBufferInfo) override;
 
     virtual void Process_vkCmdCopyImage2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyImageInfo2>* pCopyImageInfo) override;
 
     virtual void Process_vkCmdCopyBufferToImage2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2>* pCopyBufferToImageInfo) override;
 
     virtual void Process_vkCmdCopyImageToBuffer2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2>* pCopyImageToBufferInfo) override;
 
     virtual void Process_vkCmdBlitImage2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkBlitImageInfo2>* pBlitImageInfo) override;
 
     virtual void Process_vkCmdResolveImage2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkResolveImageInfo2>* pResolveImageInfo) override;
 
     virtual void Process_vkGetDeviceBufferMemoryRequirementsKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceBufferMemoryRequirements>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetDeviceImageMemoryRequirementsKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetDeviceImageSparseMemoryRequirementsKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) override;
 
     virtual void Process_vkCreateDebugReportCallbackEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>* pCreateInfo,
@@ -1986,11 +2316,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkDebugReportCallbackEXT>* pCallback) override;
 
     virtual void Process_vkDestroyDebugReportCallbackEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         format::HandleId                            callback,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkDebugReportMessageEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         VkDebugReportFlagsEXT                       flags,
         VkDebugReportObjectTypeEXT                  objectType,
@@ -2001,27 +2333,33 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StringDecoder*                              pMessage) override;
 
     virtual void Process_vkDebugMarkerSetObjectTagEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDebugMarkerObjectTagInfoEXT>* pTagInfo) override;
 
     virtual void Process_vkDebugMarkerSetObjectNameEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDebugMarkerObjectNameInfoEXT>* pNameInfo) override;
 
     virtual void Process_vkCmdDebugMarkerBeginEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo) override;
 
     virtual void Process_vkCmdDebugMarkerEndEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkCmdDebugMarkerInsertEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo) override;
 
     virtual void Process_vkCmdBindTransformFeedbackBuffersEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
@@ -2030,6 +2368,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<VkDeviceSize>*               pSizes) override;
 
     virtual void Process_vkCmdBeginTransformFeedbackEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstCounterBuffer,
         uint32_t                                    counterBufferCount,
@@ -2037,6 +2376,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets) override;
 
     virtual void Process_vkCmdEndTransformFeedbackEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstCounterBuffer,
         uint32_t                                    counterBufferCount,
@@ -2044,6 +2384,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets) override;
 
     virtual void Process_vkCmdBeginQueryIndexedEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    query,
@@ -2051,12 +2392,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    index) override;
 
     virtual void Process_vkCmdEndQueryIndexedEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    query,
         uint32_t                                    index) override;
 
     virtual void Process_vkCmdDrawIndirectByteCountEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    instanceCount,
         uint32_t                                    firstInstance,
@@ -2066,17 +2409,20 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    vertexStride) override;
 
     virtual void Process_vkGetImageViewHandleNVX(
+        const ApiCallInfo&                          call_info,
         uint32_t                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>* pInfo) override;
 
     virtual void Process_vkGetImageViewAddressNVX(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            imageView,
         StructPointerDecoder<Decoded_VkImageViewAddressPropertiesNVX>* pProperties) override;
 
     virtual void Process_vkCmdDrawIndirectCountAMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -2086,6 +2432,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawIndexedIndirectCountAMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -2095,6 +2442,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkGetShaderInfoAMD(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
@@ -2104,6 +2452,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint8_t>*                    pInfo) override;
 
     virtual void Process_vkCreateStreamDescriptorSurfaceGGP(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkStreamDescriptorSurfaceCreateInfoGGP>* pCreateInfo,
@@ -2111,6 +2460,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
@@ -2122,6 +2472,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkExternalImageFormatPropertiesNV>* pExternalImageFormatProperties) override;
 
     virtual void Process_vkGetMemoryWin32HandleNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            memory,
@@ -2129,6 +2480,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint64_t, void*>*            pHandle) override;
 
     virtual void Process_vkCreateViSurfaceNN(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkViSurfaceCreateInfoNN>* pCreateInfo,
@@ -2136,30 +2488,36 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCmdBeginConditionalRenderingEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>* pConditionalRenderingBegin) override;
 
     virtual void Process_vkCmdEndConditionalRenderingEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkCmdSetViewportWScalingNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
         StructPointerDecoder<Decoded_VkViewportWScalingNV>* pViewportWScalings) override;
 
     virtual void Process_vkReleaseDisplayEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display) override;
 
     virtual void Process_vkAcquireXlibDisplayEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint64_t                                    dpy,
         format::HandleId                            display) override;
 
     virtual void Process_vkGetRandROutputDisplayEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint64_t                                    dpy,
@@ -2167,18 +2525,21 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkDisplayKHR>*         pDisplay) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
         StructPointerDecoder<Decoded_VkSurfaceCapabilities2EXT>* pSurfaceCapabilities) override;
 
     virtual void Process_vkDisplayPowerControlEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            display,
         StructPointerDecoder<Decoded_VkDisplayPowerInfoEXT>* pDisplayPowerInfo) override;
 
     virtual void Process_vkRegisterDeviceEventEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceEventInfoEXT>* pDeviceEventInfo,
@@ -2186,6 +2547,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkFence>*              pFence) override;
 
     virtual void Process_vkRegisterDisplayEventEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            display,
@@ -2194,6 +2556,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkFence>*              pFence) override;
 
     virtual void Process_vkGetSwapchainCounterEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
@@ -2201,12 +2564,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint64_t>*                   pCounterValue) override;
 
     virtual void Process_vkGetRefreshCycleDurationGOOGLE(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
         StructPointerDecoder<Decoded_VkRefreshCycleDurationGOOGLE>* pDisplayTimingProperties) override;
 
     virtual void Process_vkGetPastPresentationTimingGOOGLE(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
@@ -2214,18 +2579,21 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkPastPresentationTimingGOOGLE>* pPresentationTimings) override;
 
     virtual void Process_vkCmdSetDiscardRectangleEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstDiscardRectangle,
         uint32_t                                    discardRectangleCount,
         StructPointerDecoder<Decoded_VkRect2D>*     pDiscardRectangles) override;
 
     virtual void Process_vkSetHdrMetadataEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         uint32_t                                    swapchainCount,
         HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains,
         StructPointerDecoder<Decoded_VkHdrMetadataEXT>* pMetadata) override;
 
     virtual void Process_vkCreateIOSSurfaceMVK(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkIOSSurfaceCreateInfoMVK>* pCreateInfo,
@@ -2233,6 +2601,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCreateMacOSSurfaceMVK(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkMacOSSurfaceCreateInfoMVK>* pCreateInfo,
@@ -2240,38 +2609,47 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkSetDebugUtilsObjectNameEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* pNameInfo) override;
 
     virtual void Process_vkSetDebugUtilsObjectTagEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>* pTagInfo) override;
 
     virtual void Process_vkQueueBeginDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            queue,
         StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) override;
 
     virtual void Process_vkQueueEndDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            queue) override;
 
     virtual void Process_vkQueueInsertDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            queue,
         StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) override;
 
     virtual void Process_vkCmdBeginDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) override;
 
     virtual void Process_vkCmdEndDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkCmdInsertDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) override;
 
     virtual void Process_vkCreateDebugUtilsMessengerEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>* pCreateInfo,
@@ -2279,44 +2657,52 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkDebugUtilsMessengerEXT>* pMessenger) override;
 
     virtual void Process_vkDestroyDebugUtilsMessengerEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         format::HandleId                            messenger,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkSubmitDebugUtilsMessageEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         VkDebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,
         VkDebugUtilsMessageTypeFlagsEXT             messageTypes,
         StructPointerDecoder<Decoded_VkDebugUtilsMessengerCallbackDataEXT>* pCallbackData) override;
 
     virtual void Process_vkGetAndroidHardwareBufferPropertiesANDROID(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint64_t                                    buffer,
         StructPointerDecoder<Decoded_VkAndroidHardwareBufferPropertiesANDROID>* pProperties) override;
 
     virtual void Process_vkGetMemoryAndroidHardwareBufferANDROID(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID>* pInfo,
         PointerDecoder<uint64_t, void*>*            pBuffer) override;
 
     virtual void Process_vkCmdSetSampleLocationsEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkSampleLocationsInfoEXT>* pSampleLocationsInfo) override;
 
     virtual void Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         VkSampleCountFlagBits                       samples,
         StructPointerDecoder<Decoded_VkMultisamplePropertiesEXT>* pMultisampleProperties) override;
 
     virtual void Process_vkGetImageDrmFormatModifierPropertiesEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            image,
         StructPointerDecoder<Decoded_VkImageDrmFormatModifierPropertiesEXT>* pProperties) override;
 
     virtual void Process_vkCreateValidationCacheEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkValidationCacheCreateInfoEXT>* pCreateInfo,
@@ -2324,11 +2710,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkValidationCacheEXT>* pValidationCache) override;
 
     virtual void Process_vkDestroyValidationCacheEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            validationCache,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkMergeValidationCachesEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            dstCache,
@@ -2336,6 +2724,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkValidationCacheEXT>* pSrcCaches) override;
 
     virtual void Process_vkGetValidationCacheDataEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            validationCache,
@@ -2343,23 +2732,27 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkCmdBindShadingRateImageNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            imageView,
         VkImageLayout                               imageLayout) override;
 
     virtual void Process_vkCmdSetViewportShadingRatePaletteNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
         StructPointerDecoder<Decoded_VkShadingRatePaletteNV>* pShadingRatePalettes) override;
 
     virtual void Process_vkCmdSetCoarseSampleOrderNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkCoarseSampleOrderTypeNV                   sampleOrderType,
         uint32_t                                    customSampleOrderCount,
         StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>* pCustomSampleOrders) override;
 
     virtual void Process_vkCreateAccelerationStructureNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoNV>* pCreateInfo,
@@ -2367,22 +2760,26 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructure) override;
 
     virtual void Process_vkDestroyAccelerationStructureNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            accelerationStructure,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetAccelerationStructureMemoryRequirementsNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAccelerationStructureMemoryRequirementsInfoNV>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2KHR>* pMemoryRequirements) override;
 
     virtual void Process_vkBindAccelerationStructureMemoryNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
         StructPointerDecoder<Decoded_VkBindAccelerationStructureMemoryInfoNV>* pBindInfos) override;
 
     virtual void Process_vkCmdBuildAccelerationStructureNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>* pInfo,
         format::HandleId                            instanceData,
@@ -2394,12 +2791,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkDeviceSize                                scratchOffset) override;
 
     virtual void Process_vkCmdCopyAccelerationStructureNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            dst,
         format::HandleId                            src,
         VkCopyAccelerationStructureModeKHR          mode) override;
 
     virtual void Process_vkCmdTraceRaysNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            raygenShaderBindingTableBuffer,
         VkDeviceSize                                raygenShaderBindingOffset,
@@ -2417,6 +2816,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    depth) override;
 
     virtual void Process_vkCreateRayTracingPipelinesNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
@@ -2426,6 +2826,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkPipeline>*           pPipelines) override;
 
     virtual void Process_vkGetRayTracingShaderGroupHandlesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
@@ -2435,6 +2836,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkGetRayTracingShaderGroupHandlesNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
@@ -2444,6 +2846,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkGetAccelerationStructureHandleNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            accelerationStructure,
@@ -2451,6 +2854,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkCmdWriteAccelerationStructuresPropertiesNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    accelerationStructureCount,
         HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructures,
@@ -2459,12 +2863,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    firstQuery) override;
 
     virtual void Process_vkCompileDeferredNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
         uint32_t                                    shader) override;
 
     virtual void Process_vkGetMemoryHostPointerPropertiesEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -2472,6 +2878,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkMemoryHostPointerPropertiesEXT>* pMemoryHostPointerProperties) override;
 
     virtual void Process_vkCmdWriteBufferMarkerAMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlagBits                     pipelineStage,
         format::HandleId                            dstBuffer,
@@ -2479,12 +2886,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    marker) override;
 
     virtual void Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pTimeDomainCount,
         PointerDecoder<VkTimeDomainEXT>*            pTimeDomains) override;
 
     virtual void Process_vkGetCalibratedTimestampsEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    timestampCount,
@@ -2493,11 +2902,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint64_t>*                   pMaxDeviation) override;
 
     virtual void Process_vkCmdDrawMeshTasksNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    taskCount,
         uint32_t                                    firstTask) override;
 
     virtual void Process_vkCmdDrawMeshTasksIndirectNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -2505,6 +2916,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawMeshTasksIndirectCountNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -2514,71 +2926,85 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdSetExclusiveScissorNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstExclusiveScissor,
         uint32_t                                    exclusiveScissorCount,
         StructPointerDecoder<Decoded_VkRect2D>*     pExclusiveScissors) override;
 
     virtual void Process_vkCmdSetCheckpointNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint64_t                                    pCheckpointMarker) override;
 
     virtual void Process_vkGetQueueCheckpointDataNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            queue,
         PointerDecoder<uint32_t>*                   pCheckpointDataCount,
         StructPointerDecoder<Decoded_VkCheckpointDataNV>* pCheckpointData) override;
 
     virtual void Process_vkInitializePerformanceApiINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkInitializePerformanceApiInfoINTEL>* pInitializeInfo) override;
 
     virtual void Process_vkUninitializePerformanceApiINTEL(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device) override;
 
     virtual void Process_vkCmdSetPerformanceMarkerINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkPerformanceMarkerInfoINTEL>* pMarkerInfo) override;
 
     virtual void Process_vkCmdSetPerformanceStreamMarkerINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkPerformanceStreamMarkerInfoINTEL>* pMarkerInfo) override;
 
     virtual void Process_vkCmdSetPerformanceOverrideINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkPerformanceOverrideInfoINTEL>* pOverrideInfo) override;
 
     virtual void Process_vkAcquirePerformanceConfigurationINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPerformanceConfigurationAcquireInfoINTEL>* pAcquireInfo,
         HandlePointerDecoder<VkPerformanceConfigurationINTEL>* pConfiguration) override;
 
     virtual void Process_vkReleasePerformanceConfigurationINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            configuration) override;
 
     virtual void Process_vkQueueSetPerformanceConfigurationINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         format::HandleId                            configuration) override;
 
     virtual void Process_vkGetPerformanceParameterINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkPerformanceParameterTypeINTEL             parameter,
         StructPointerDecoder<Decoded_VkPerformanceValueINTEL>* pValue) override;
 
     virtual void Process_vkSetLocalDimmingAMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            swapChain,
         VkBool32                                    localDimmingEnable) override;
 
     virtual void Process_vkCreateImagePipeSurfaceFUCHSIA(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA>* pCreateInfo,
@@ -2586,6 +3012,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCreateMetalSurfaceEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>* pCreateInfo,
@@ -2593,29 +3020,34 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetBufferDeviceAddressEXT(
+        const ApiCallInfo&                          call_info,
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) override;
 
     virtual void Process_vkGetPhysicalDeviceToolPropertiesEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pToolCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceToolProperties>* pToolProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkCooperativeMatrixPropertiesNV>* pProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pCombinationCount,
         StructPointerDecoder<Decoded_VkFramebufferMixedSamplesCombinationNV>* pCombinations) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
@@ -2623,22 +3055,26 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<VkPresentModeKHR>*           pPresentModes) override;
 
     virtual void Process_vkAcquireFullScreenExclusiveModeEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain) override;
 
     virtual void Process_vkReleaseFullScreenExclusiveModeEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain) override;
 
     virtual void Process_vkGetDeviceGroupSurfacePresentModes2EXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         PointerDecoder<VkDeviceGroupPresentModeFlagsKHR>* pModes) override;
 
     virtual void Process_vkCreateHeadlessSurfaceEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkHeadlessSurfaceCreateInfoEXT>* pCreateInfo,
@@ -2646,39 +3082,47 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCmdSetLineStippleEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    lineStippleFactor,
         uint16_t                                    lineStipplePattern) override;
 
     virtual void Process_vkResetQueryPoolEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery,
         uint32_t                                    queryCount) override;
 
     virtual void Process_vkCmdSetCullModeEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkCullModeFlags                             cullMode) override;
 
     virtual void Process_vkCmdSetFrontFaceEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkFrontFace                                 frontFace) override;
 
     virtual void Process_vkCmdSetPrimitiveTopologyEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPrimitiveTopology                         primitiveTopology) override;
 
     virtual void Process_vkCmdSetViewportWithCountEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    viewportCount,
         StructPointerDecoder<Decoded_VkViewport>*   pViewports) override;
 
     virtual void Process_vkCmdSetScissorWithCountEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    scissorCount,
         StructPointerDecoder<Decoded_VkRect2D>*     pScissors) override;
 
     virtual void Process_vkCmdBindVertexBuffers2EXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
@@ -2688,26 +3132,32 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<VkDeviceSize>*               pStrides) override;
 
     virtual void Process_vkCmdSetDepthTestEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthTestEnable) override;
 
     virtual void Process_vkCmdSetDepthWriteEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthWriteEnable) override;
 
     virtual void Process_vkCmdSetDepthCompareOpEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkCompareOp                                 depthCompareOp) override;
 
     virtual void Process_vkCmdSetDepthBoundsTestEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthBoundsTestEnable) override;
 
     virtual void Process_vkCmdSetStencilTestEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    stencilTestEnable) override;
 
     virtual void Process_vkCmdSetStencilOpEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
         VkStencilOp                                 failOp,
@@ -2716,26 +3166,31 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkCompareOp                                 compareOp) override;
 
     virtual void Process_vkGetGeneratedCommandsMemoryRequirementsNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkGeneratedCommandsMemoryRequirementsInfoNV>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkCmdPreprocessGeneratedCommandsNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo) override;
 
     virtual void Process_vkCmdExecuteGeneratedCommandsNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    isPreprocessed,
         StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo) override;
 
     virtual void Process_vkCmdBindPipelineShaderGroupNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineBindPoint                         pipelineBindPoint,
         format::HandleId                            pipeline,
         uint32_t                                    groupIndex) override;
 
     virtual void Process_vkCreateIndirectCommandsLayoutNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkIndirectCommandsLayoutCreateInfoNV>* pCreateInfo,
@@ -2743,17 +3198,20 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkIndirectCommandsLayoutNV>* pIndirectCommandsLayout) override;
 
     virtual void Process_vkDestroyIndirectCommandsLayoutNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            indirectCommandsLayout,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkAcquireDrmDisplayEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         int32_t                                     drmFd,
         format::HandleId                            display) override;
 
     virtual void Process_vkGetDrmDisplayEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         int32_t                                     drmFd,
@@ -2761,6 +3219,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkDisplayKHR>*         display) override;
 
     virtual void Process_vkCreatePrivateDataSlotEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPrivateDataSlotCreateInfo>* pCreateInfo,
@@ -2768,11 +3227,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkPrivateDataSlot>*    pPrivateDataSlot) override;
 
     virtual void Process_vkDestroyPrivateDataSlotEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            privateDataSlot,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkSetPrivateDataEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkObjectType                                objectType,
@@ -2781,6 +3242,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint64_t                                    data) override;
 
     virtual void Process_vkGetPrivateDataEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         VkObjectType                                objectType,
         uint64_t                                    objectHandle,
@@ -2788,22 +3250,26 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint64_t>*                   pData) override;
 
     virtual void Process_vkCmdSetFragmentShadingRateEnumNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkFragmentShadingRateNV                     shadingRate,
         PointerDecoder<VkFragmentShadingRateCombinerOpKHR>* combinerOps) override;
 
     virtual void Process_vkAcquireWinrtDisplayNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display) override;
 
     virtual void Process_vkGetWinrtDisplayNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    deviceRelativeId,
         HandlePointerDecoder<VkDisplayKHR>*         pDisplay) override;
 
     virtual void Process_vkCreateDirectFBSurfaceEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkDirectFBSurfaceCreateInfoEXT>* pCreateInfo,
@@ -2811,12 +3277,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceDirectFBPresentationSupportEXT(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
         uint64_t                                    dfb) override;
 
     virtual void Process_vkCmdSetVertexInputEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    vertexBindingDescriptionCount,
         StructPointerDecoder<Decoded_VkVertexInputBindingDescription2EXT>* pVertexBindingDescriptions,
@@ -2824,12 +3292,14 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkVertexInputAttributeDescription2EXT>* pVertexAttributeDescriptions) override;
 
     virtual void Process_vkGetMemoryZirconHandleFUCHSIA(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryGetZirconHandleInfoFUCHSIA>* pGetZirconHandleInfo,
         PointerDecoder<uint32_t>*                   pZirconHandle) override;
 
     virtual void Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -2837,48 +3307,58 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkMemoryZirconHandlePropertiesFUCHSIA>* pMemoryZirconHandleProperties) override;
 
     virtual void Process_vkImportSemaphoreZirconHandleFUCHSIA(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImportSemaphoreZirconHandleInfoFUCHSIA>* pImportSemaphoreZirconHandleInfo) override;
 
     virtual void Process_vkGetSemaphoreZirconHandleFUCHSIA(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreGetZirconHandleInfoFUCHSIA>* pGetZirconHandleInfo,
         PointerDecoder<uint32_t>*                   pZirconHandle) override;
 
     virtual void Process_vkCmdBindInvocationMaskHUAWEI(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            imageView,
         VkImageLayout                               imageLayout) override;
 
     virtual void Process_vkGetMemoryRemoteAddressNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryGetRemoteAddressInfoNV>* pMemoryGetRemoteAddressInfo,
         PointerDecoder<uint64_t, void*>*            pAddress) override;
 
     virtual void Process_vkCmdSetPatchControlPointsEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    patchControlPoints) override;
 
     virtual void Process_vkCmdSetRasterizerDiscardEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    rasterizerDiscardEnable) override;
 
     virtual void Process_vkCmdSetDepthBiasEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthBiasEnable) override;
 
     virtual void Process_vkCmdSetLogicOpEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkLogicOp                                   logicOp) override;
 
     virtual void Process_vkCmdSetPrimitiveRestartEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    primitiveRestartEnable) override;
 
     virtual void Process_vkCreateScreenSurfaceQNX(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkScreenSurfaceCreateInfoQNX>* pCreateInfo,
@@ -2886,17 +3366,20 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceScreenPresentationSupportQNX(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
         uint64_t                                    window) override;
 
     virtual void Process_vkCmdSetColorWriteEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    attachmentCount,
         PointerDecoder<VkBool32>*                   pColorWriteEnables) override;
 
     virtual void Process_vkCmdDrawMultiEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    drawCount,
         StructPointerDecoder<Decoded_VkMultiDrawInfoEXT>* pVertexInfo,
@@ -2905,6 +3388,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawMultiIndexedEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    drawCount,
         StructPointerDecoder<Decoded_VkMultiDrawIndexedInfoEXT>* pIndexInfo,
@@ -2914,11 +3398,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<int32_t>*                    pVertexOffset) override;
 
     virtual void Process_vkSetDeviceMemoryPriorityEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            memory,
         float                                       priority) override;
 
     virtual void Process_vkCreateAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoKHR>* pCreateInfo,
@@ -2926,17 +3412,20 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkAccelerationStructureKHR>* pAccelerationStructure) override;
 
     virtual void Process_vkDestroyAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            accelerationStructure,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCmdBuildAccelerationStructuresKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    infoCount,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>* ppBuildRangeInfos) override;
 
     virtual void Process_vkCmdBuildAccelerationStructuresIndirectKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    infoCount,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
@@ -2945,18 +3434,21 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint32_t*>*                  ppMaxPrimitiveCounts) override;
 
     virtual void Process_vkCopyAccelerationStructureToMemoryKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            deferredOperation,
         StructPointerDecoder<Decoded_VkCopyAccelerationStructureToMemoryInfoKHR>* pInfo) override;
 
     virtual void Process_vkCopyMemoryToAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            deferredOperation,
         StructPointerDecoder<Decoded_VkCopyMemoryToAccelerationStructureInfoKHR>* pInfo) override;
 
     virtual void Process_vkWriteAccelerationStructuresPropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    accelerationStructureCount,
@@ -2967,23 +3459,28 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         size_t                                      stride) override;
 
     virtual void Process_vkCmdCopyAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo) override;
 
     virtual void Process_vkCmdCopyAccelerationStructureToMemoryKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyAccelerationStructureToMemoryInfoKHR>* pInfo) override;
 
     virtual void Process_vkCmdCopyMemoryToAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyMemoryToAccelerationStructureInfoKHR>* pInfo) override;
 
     virtual void Process_vkGetAccelerationStructureDeviceAddressKHR(
+        const ApiCallInfo&                          call_info,
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAccelerationStructureDeviceAddressInfoKHR>* pInfo) override;
 
     virtual void Process_vkCmdWriteAccelerationStructuresPropertiesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    accelerationStructureCount,
         HandlePointerDecoder<VkAccelerationStructureKHR>* pAccelerationStructures,
@@ -2992,11 +3489,13 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    firstQuery) override;
 
     virtual void Process_vkGetDeviceAccelerationStructureCompatibilityKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAccelerationStructureVersionInfoKHR>* pVersionInfo,
         PointerDecoder<VkAccelerationStructureCompatibilityKHR>* pCompatibility) override;
 
     virtual void Process_vkGetAccelerationStructureBuildSizesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         VkAccelerationStructureBuildTypeKHR         buildType,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pBuildInfo,
@@ -3004,6 +3503,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildSizesInfoKHR>* pSizeInfo) override;
 
     virtual void Process_vkCmdTraceRaysKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pRaygenShaderBindingTable,
         StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pMissShaderBindingTable,
@@ -3014,6 +3514,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         uint32_t                                    depth) override;
 
     virtual void Process_vkCreateRayTracingPipelinesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            deferredOperation,
@@ -3024,6 +3525,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         HandlePointerDecoder<VkPipeline>*           pPipelines) override;
 
     virtual void Process_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
@@ -3033,6 +3535,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkCmdTraceRaysIndirectKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pRaygenShaderBindingTable,
         StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pMissShaderBindingTable,
@@ -3041,6 +3544,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkDeviceAddress                             indirectDeviceAddress) override;
 
     virtual void Process_vkGetRayTracingShaderGroupStackSizeKHR(
+        const ApiCallInfo&                          call_info,
         VkDeviceSize                                returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
@@ -3048,6 +3552,7 @@ class VulkanAsciiConsumer : public VulkanAsciiConsumerBase
         VkShaderGroupShaderKHR                      groupShader) override;
 
     virtual void Process_vkCmdSetRayTracingPipelineStackSizeKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    pipelineStackSize) override;
 };

--- a/framework/generated/generated_vulkan_consumer.h
+++ b/framework/generated/generated_vulkan_consumer.h
@@ -45,31 +45,37 @@ class VulkanConsumer : public VulkanConsumerBase
     virtual ~VulkanConsumer() override { }
 
     virtual void Process_vkCreateInstance(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         StructPointerDecoder<Decoded_VkInstanceCreateInfo>* pCreateInfo,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkInstance>*           pInstance) {}
 
     virtual void Process_vkDestroyInstance(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkEnumeratePhysicalDevices(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         PointerDecoder<uint32_t>*                   pPhysicalDeviceCount,
         HandlePointerDecoder<VkPhysicalDevice>*     pPhysicalDevices) {}
 
     virtual void Process_vkGetPhysicalDeviceFeatures(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures>* pFeatures) {}
 
     virtual void Process_vkGetPhysicalDeviceFormatProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
         StructPointerDecoder<Decoded_VkFormatProperties>* pFormatProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
@@ -80,19 +86,23 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkImageFormatProperties>* pImageFormatProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceProperties>* pProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
         StructPointerDecoder<Decoded_VkQueueFamilyProperties>* pQueueFamilyProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceMemoryProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties>* pMemoryProperties) {}
 
     virtual void Process_vkCreateDevice(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkDeviceCreateInfo>* pCreateInfo,
@@ -100,16 +110,19 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkDevice>*             pDevice) {}
 
     virtual void Process_vkDestroyDevice(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetDeviceQueue(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         uint32_t                                    queueFamilyIndex,
         uint32_t                                    queueIndex,
         HandlePointerDecoder<VkQueue>*              pQueue) {}
 
     virtual void Process_vkQueueSubmit(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    submitCount,
@@ -117,14 +130,17 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            fence) {}
 
     virtual void Process_vkQueueWaitIdle(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue) {}
 
     virtual void Process_vkDeviceWaitIdle(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device) {}
 
     virtual void Process_vkAllocateMemory(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryAllocateInfo>* pAllocateInfo,
@@ -132,11 +148,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkDeviceMemory>*       pMemory) {}
 
     virtual void Process_vkFreeMemory(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            memory,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkMapMemory(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            memory,
@@ -146,27 +164,32 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint64_t, void*>*            ppData) {}
 
     virtual void Process_vkUnmapMemory(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            memory) {}
 
     virtual void Process_vkFlushMappedMemoryRanges(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    memoryRangeCount,
         StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges) {}
 
     virtual void Process_vkInvalidateMappedMemoryRanges(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    memoryRangeCount,
         StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges) {}
 
     virtual void Process_vkGetDeviceMemoryCommitment(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            memory,
         PointerDecoder<VkDeviceSize>*               pCommittedMemoryInBytes) {}
 
     virtual void Process_vkBindBufferMemory(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            buffer,
@@ -174,6 +197,7 @@ class VulkanConsumer : public VulkanConsumerBase
         VkDeviceSize                                memoryOffset) {}
 
     virtual void Process_vkBindImageMemory(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            image,
@@ -181,22 +205,26 @@ class VulkanConsumer : public VulkanConsumerBase
         VkDeviceSize                                memoryOffset) {}
 
     virtual void Process_vkGetBufferMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            buffer,
         StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements) {}
 
     virtual void Process_vkGetImageMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            image,
         StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements) {}
 
     virtual void Process_vkGetImageSparseMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            image,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements>* pSparseMemoryRequirements) {}
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
         VkImageType                                 type,
@@ -207,6 +235,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkSparseImageFormatProperties>* pProperties) {}
 
     virtual void Process_vkQueueBindSparse(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    bindInfoCount,
@@ -214,6 +243,7 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            fence) {}
 
     virtual void Process_vkCreateFence(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkFenceCreateInfo>* pCreateInfo,
@@ -221,22 +251,26 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkFence>*              pFence) {}
 
     virtual void Process_vkDestroyFence(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            fence,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkResetFences(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    fenceCount,
         HandlePointerDecoder<VkFence>*              pFences) {}
 
     virtual void Process_vkGetFenceStatus(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            fence) {}
 
     virtual void Process_vkWaitForFences(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    fenceCount,
@@ -245,6 +279,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint64_t                                    timeout) {}
 
     virtual void Process_vkCreateSemaphore(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreCreateInfo>* pCreateInfo,
@@ -252,11 +287,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSemaphore>*          pSemaphore) {}
 
     virtual void Process_vkDestroySemaphore(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            semaphore,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateEvent(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkEventCreateInfo>* pCreateInfo,
@@ -264,26 +301,31 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkEvent>*              pEvent) {}
 
     virtual void Process_vkDestroyEvent(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            event,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetEventStatus(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            event) {}
 
     virtual void Process_vkSetEvent(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            event) {}
 
     virtual void Process_vkResetEvent(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            event) {}
 
     virtual void Process_vkCreateQueryPool(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkQueryPoolCreateInfo>* pCreateInfo,
@@ -291,11 +333,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkQueryPool>*          pQueryPool) {}
 
     virtual void Process_vkDestroyQueryPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            queryPool,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetQueryPoolResults(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            queryPool,
@@ -307,6 +351,7 @@ class VulkanConsumer : public VulkanConsumerBase
         VkQueryResultFlags                          flags) {}
 
     virtual void Process_vkCreateBuffer(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferCreateInfo>* pCreateInfo,
@@ -314,11 +359,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkBuffer>*             pBuffer) {}
 
     virtual void Process_vkDestroyBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            buffer,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateBufferView(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferViewCreateInfo>* pCreateInfo,
@@ -326,11 +373,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkBufferView>*         pView) {}
 
     virtual void Process_vkDestroyBufferView(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            bufferView,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateImage(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageCreateInfo>* pCreateInfo,
@@ -338,17 +387,20 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkImage>*              pImage) {}
 
     virtual void Process_vkDestroyImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            image,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetImageSubresourceLayout(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            image,
         StructPointerDecoder<Decoded_VkImageSubresource>* pSubresource,
         StructPointerDecoder<Decoded_VkSubresourceLayout>* pLayout) {}
 
     virtual void Process_vkCreateImageView(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageViewCreateInfo>* pCreateInfo,
@@ -356,11 +408,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkImageView>*          pView) {}
 
     virtual void Process_vkDestroyImageView(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            imageView,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateShaderModule(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>* pCreateInfo,
@@ -368,11 +422,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkShaderModule>*       pShaderModule) {}
 
     virtual void Process_vkDestroyShaderModule(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            shaderModule,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreatePipelineCache(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>* pCreateInfo,
@@ -380,11 +436,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkPipelineCache>*      pPipelineCache) {}
 
     virtual void Process_vkDestroyPipelineCache(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetPipelineCacheData(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
@@ -392,6 +450,7 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint8_t>*                    pData) {}
 
     virtual void Process_vkMergePipelineCaches(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            dstCache,
@@ -399,6 +458,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkPipelineCache>*      pSrcCaches) {}
 
     virtual void Process_vkCreateGraphicsPipelines(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
@@ -408,6 +468,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkPipeline>*           pPipelines) {}
 
     virtual void Process_vkCreateComputePipelines(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
@@ -417,11 +478,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkPipeline>*           pPipelines) {}
 
     virtual void Process_vkDestroyPipeline(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            pipeline,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreatePipelineLayout(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPipelineLayoutCreateInfo>* pCreateInfo,
@@ -429,11 +492,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkPipelineLayout>*     pPipelineLayout) {}
 
     virtual void Process_vkDestroyPipelineLayout(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            pipelineLayout,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateSampler(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSamplerCreateInfo>* pCreateInfo,
@@ -441,11 +506,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSampler>*            pSampler) {}
 
     virtual void Process_vkDestroySampler(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            sampler,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateDescriptorSetLayout(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
@@ -453,11 +520,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkDescriptorSetLayout>* pSetLayout) {}
 
     virtual void Process_vkDestroyDescriptorSetLayout(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            descriptorSetLayout,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateDescriptorPool(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>* pCreateInfo,
@@ -465,23 +534,27 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkDescriptorPool>*     pDescriptorPool) {}
 
     virtual void Process_vkDestroyDescriptorPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkResetDescriptorPool(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
         VkDescriptorPoolResetFlags                  flags) {}
 
     virtual void Process_vkAllocateDescriptorSets(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
         HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) {}
 
     virtual void Process_vkFreeDescriptorSets(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
@@ -489,6 +562,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) {}
 
     virtual void Process_vkUpdateDescriptorSets(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         uint32_t                                    descriptorWriteCount,
         StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites,
@@ -496,6 +570,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkCopyDescriptorSet>* pDescriptorCopies) {}
 
     virtual void Process_vkCreateFramebuffer(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* pCreateInfo,
@@ -503,11 +578,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkFramebuffer>*        pFramebuffer) {}
 
     virtual void Process_vkDestroyFramebuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            framebuffer,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateRenderPass(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkRenderPassCreateInfo>* pCreateInfo,
@@ -515,16 +592,19 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkRenderPass>*         pRenderPass) {}
 
     virtual void Process_vkDestroyRenderPass(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            renderPass,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetRenderAreaGranularity(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            renderPass,
         StructPointerDecoder<Decoded_VkExtent2D>*   pGranularity) {}
 
     virtual void Process_vkCreateCommandPool(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>* pCreateInfo,
@@ -532,94 +612,112 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkCommandPool>*        pCommandPool) {}
 
     virtual void Process_vkDestroyCommandPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            commandPool,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkResetCommandPool(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            commandPool,
         VkCommandPoolResetFlags                     flags) {}
 
     virtual void Process_vkAllocateCommandBuffers(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
         HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) {}
 
     virtual void Process_vkFreeCommandBuffers(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            commandPool,
         uint32_t                                    commandBufferCount,
         HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) {}
 
     virtual void Process_vkBeginCommandBuffer(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo) {}
 
     virtual void Process_vkEndCommandBuffer(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer) {}
 
     virtual void Process_vkResetCommandBuffer(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
         VkCommandBufferResetFlags                   flags) {}
 
     virtual void Process_vkCmdBindPipeline(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineBindPoint                         pipelineBindPoint,
         format::HandleId                            pipeline) {}
 
     virtual void Process_vkCmdSetViewport(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
         StructPointerDecoder<Decoded_VkViewport>*   pViewports) {}
 
     virtual void Process_vkCmdSetScissor(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstScissor,
         uint32_t                                    scissorCount,
         StructPointerDecoder<Decoded_VkRect2D>*     pScissors) {}
 
     virtual void Process_vkCmdSetLineWidth(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         float                                       lineWidth) {}
 
     virtual void Process_vkCmdSetDepthBias(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         float                                       depthBiasConstantFactor,
         float                                       depthBiasClamp,
         float                                       depthBiasSlopeFactor) {}
 
     virtual void Process_vkCmdSetBlendConstants(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         PointerDecoder<float>*                      blendConstants) {}
 
     virtual void Process_vkCmdSetDepthBounds(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         float                                       minDepthBounds,
         float                                       maxDepthBounds) {}
 
     virtual void Process_vkCmdSetStencilCompareMask(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
         uint32_t                                    compareMask) {}
 
     virtual void Process_vkCmdSetStencilWriteMask(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
         uint32_t                                    writeMask) {}
 
     virtual void Process_vkCmdSetStencilReference(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
         uint32_t                                    reference) {}
 
     virtual void Process_vkCmdBindDescriptorSets(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineBindPoint                         pipelineBindPoint,
         format::HandleId                            layout,
@@ -630,12 +728,14 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint32_t>*                   pDynamicOffsets) {}
 
     virtual void Process_vkCmdBindIndexBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
         VkIndexType                                 indexType) {}
 
     virtual void Process_vkCmdBindVertexBuffers(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
@@ -643,6 +743,7 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<VkDeviceSize>*               pOffsets) {}
 
     virtual void Process_vkCmdDraw(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    vertexCount,
         uint32_t                                    instanceCount,
@@ -650,6 +751,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    firstInstance) {}
 
     virtual void Process_vkCmdDrawIndexed(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    indexCount,
         uint32_t                                    instanceCount,
@@ -658,6 +760,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    firstInstance) {}
 
     virtual void Process_vkCmdDrawIndirect(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -665,6 +768,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    stride) {}
 
     virtual void Process_vkCmdDrawIndexedIndirect(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -672,17 +776,20 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    stride) {}
 
     virtual void Process_vkCmdDispatch(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    groupCountX,
         uint32_t                                    groupCountY,
         uint32_t                                    groupCountZ) {}
 
     virtual void Process_vkCmdDispatchIndirect(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset) {}
 
     virtual void Process_vkCmdCopyBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcBuffer,
         format::HandleId                            dstBuffer,
@@ -690,6 +797,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkBufferCopy>* pRegions) {}
 
     virtual void Process_vkCmdCopyImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcImage,
         VkImageLayout                               srcImageLayout,
@@ -699,6 +807,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkImageCopy>*  pRegions) {}
 
     virtual void Process_vkCmdBlitImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcImage,
         VkImageLayout                               srcImageLayout,
@@ -709,6 +818,7 @@ class VulkanConsumer : public VulkanConsumerBase
         VkFilter                                    filter) {}
 
     virtual void Process_vkCmdCopyBufferToImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcBuffer,
         format::HandleId                            dstImage,
@@ -717,6 +827,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions) {}
 
     virtual void Process_vkCmdCopyImageToBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcImage,
         VkImageLayout                               srcImageLayout,
@@ -725,6 +836,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions) {}
 
     virtual void Process_vkCmdUpdateBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            dstBuffer,
         VkDeviceSize                                dstOffset,
@@ -732,6 +844,7 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint8_t>*                    pData) {}
 
     virtual void Process_vkCmdFillBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            dstBuffer,
         VkDeviceSize                                dstOffset,
@@ -739,6 +852,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    data) {}
 
     virtual void Process_vkCmdClearColorImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            image,
         VkImageLayout                               imageLayout,
@@ -747,6 +861,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges) {}
 
     virtual void Process_vkCmdClearDepthStencilImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            image,
         VkImageLayout                               imageLayout,
@@ -755,6 +870,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges) {}
 
     virtual void Process_vkCmdClearAttachments(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    attachmentCount,
         StructPointerDecoder<Decoded_VkClearAttachment>* pAttachments,
@@ -762,6 +878,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkClearRect>*  pRects) {}
 
     virtual void Process_vkCmdResolveImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcImage,
         VkImageLayout                               srcImageLayout,
@@ -771,16 +888,19 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkImageResolve>* pRegions) {}
 
     virtual void Process_vkCmdSetEvent(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         VkPipelineStageFlags                        stageMask) {}
 
     virtual void Process_vkCmdResetEvent(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         VkPipelineStageFlags                        stageMask) {}
 
     virtual void Process_vkCmdWaitEvents(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    eventCount,
         HandlePointerDecoder<VkEvent>*              pEvents,
@@ -794,6 +914,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers) {}
 
     virtual void Process_vkCmdPipelineBarrier(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlags                        srcStageMask,
         VkPipelineStageFlags                        dstStageMask,
@@ -806,29 +927,34 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers) {}
 
     virtual void Process_vkCmdBeginQuery(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    query,
         VkQueryControlFlags                         flags) {}
 
     virtual void Process_vkCmdEndQuery(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    query) {}
 
     virtual void Process_vkCmdResetQueryPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery,
         uint32_t                                    queryCount) {}
 
     virtual void Process_vkCmdWriteTimestamp(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlagBits                     pipelineStage,
         format::HandleId                            queryPool,
         uint32_t                                    query) {}
 
     virtual void Process_vkCmdCopyQueryPoolResults(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery,
@@ -839,6 +965,7 @@ class VulkanConsumer : public VulkanConsumerBase
         VkQueryResultFlags                          flags) {}
 
     virtual void Process_vkCmdPushConstants(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            layout,
         VkShaderStageFlags                          stageFlags,
@@ -847,35 +974,42 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint8_t>*                    pValues) {}
 
     virtual void Process_vkCmdBeginRenderPass(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
         VkSubpassContents                           contents) {}
 
     virtual void Process_vkCmdNextSubpass(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkSubpassContents                           contents) {}
 
     virtual void Process_vkCmdEndRenderPass(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) {}
 
     virtual void Process_vkCmdExecuteCommands(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    commandBufferCount,
         HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) {}
 
     virtual void Process_vkBindBufferMemory2(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
         StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos) {}
 
     virtual void Process_vkBindImageMemory2(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
         StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos) {}
 
     virtual void Process_vkGetDeviceGroupPeerMemoryFeatures(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         uint32_t                                    heapIndex,
         uint32_t                                    localDeviceIndex,
@@ -883,10 +1017,12 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<VkPeerMemoryFeatureFlags>*   pPeerMemoryFeatures) {}
 
     virtual void Process_vkCmdSetDeviceMask(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    deviceMask) {}
 
     virtual void Process_vkCmdDispatchBase(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    baseGroupX,
         uint32_t                                    baseGroupY,
@@ -896,72 +1032,86 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    groupCountZ) {}
 
     virtual void Process_vkEnumeratePhysicalDeviceGroups(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         PointerDecoder<uint32_t>*                   pPhysicalDeviceGroupCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties) {}
 
     virtual void Process_vkGetImageMemoryRequirements2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkGetBufferMemoryRequirements2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkGetImageSparseMemoryRequirements2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) {}
 
     virtual void Process_vkGetPhysicalDeviceFeatures2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures) {}
 
     virtual void Process_vkGetPhysicalDeviceProperties2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceFormatProperties2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
         StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties2(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
         StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
         StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceMemoryProperties2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties) {}
 
     virtual void Process_vkTrimCommandPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            commandPool,
         VkCommandPoolTrimFlags                      flags) {}
 
     virtual void Process_vkGetDeviceQueue2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceQueueInfo2>* pQueueInfo,
         HandlePointerDecoder<VkQueue>*              pQueue) {}
 
     virtual void Process_vkCreateSamplerYcbcrConversion(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
@@ -969,11 +1119,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion) {}
 
     virtual void Process_vkDestroySamplerYcbcrConversion(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            ycbcrConversion,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateDescriptorUpdateTemplate(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
@@ -981,31 +1133,37 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate) {}
 
     virtual void Process_vkDestroyDescriptorUpdateTemplate(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            descriptorUpdateTemplate,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalBufferProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
         StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalFenceProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
         StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalSemaphoreProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
         StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties) {}
 
     virtual void Process_vkGetDescriptorSetLayoutSupport(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport) {}
 
     virtual void Process_vkCmdDrawIndirectCount(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -1015,6 +1173,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    stride) {}
 
     virtual void Process_vkCmdDrawIndexedIndirectCount(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -1024,6 +1183,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    stride) {}
 
     virtual void Process_vkCreateRenderPass2(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkRenderPassCreateInfo2>* pCreateInfo,
@@ -1031,64 +1191,76 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkRenderPass>*         pRenderPass) {}
 
     virtual void Process_vkCmdBeginRenderPass2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
         StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo) {}
 
     virtual void Process_vkCmdNextSubpass2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo,
         StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo) {}
 
     virtual void Process_vkCmdEndRenderPass2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo) {}
 
     virtual void Process_vkResetQueryPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery,
         uint32_t                                    queryCount) {}
 
     virtual void Process_vkGetSemaphoreCounterValue(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            semaphore,
         PointerDecoder<uint64_t>*                   pValue) {}
 
     virtual void Process_vkWaitSemaphores(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreWaitInfo>* pWaitInfo,
         uint64_t                                    timeout) {}
 
     virtual void Process_vkSignalSemaphore(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreSignalInfo>* pSignalInfo) {}
 
     virtual void Process_vkGetBufferDeviceAddress(
+        const ApiCallInfo&                          call_info,
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) {}
 
     virtual void Process_vkGetBufferOpaqueCaptureAddress(
+        const ApiCallInfo&                          call_info,
         uint64_t                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) {}
 
     virtual void Process_vkGetDeviceMemoryOpaqueCaptureAddress(
+        const ApiCallInfo&                          call_info,
         uint64_t                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo>* pInfo) {}
 
     virtual void Process_vkGetPhysicalDeviceToolProperties(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pToolCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceToolProperties>* pToolProperties) {}
 
     virtual void Process_vkCreatePrivateDataSlot(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPrivateDataSlotCreateInfo>* pCreateInfo,
@@ -1096,11 +1268,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkPrivateDataSlot>*    pPrivateDataSlot) {}
 
     virtual void Process_vkDestroyPrivateDataSlot(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            privateDataSlot,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkSetPrivateData(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkObjectType                                objectType,
@@ -1109,6 +1283,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint64_t                                    data) {}
 
     virtual void Process_vkGetPrivateData(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         VkObjectType                                objectType,
         uint64_t                                    objectHandle,
@@ -1116,32 +1291,38 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint64_t>*                   pData) {}
 
     virtual void Process_vkCmdSetEvent2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo) {}
 
     virtual void Process_vkCmdResetEvent2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         VkPipelineStageFlags2                       stageMask) {}
 
     virtual void Process_vkCmdWaitEvents2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    eventCount,
         HandlePointerDecoder<VkEvent>*              pEvents,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfos) {}
 
     virtual void Process_vkCmdPipelineBarrier2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo) {}
 
     virtual void Process_vkCmdWriteTimestamp2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlags2                       stage,
         format::HandleId                            queryPool,
         uint32_t                                    query) {}
 
     virtual void Process_vkQueueSubmit2(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    submitCount,
@@ -1149,59 +1330,73 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            fence) {}
 
     virtual void Process_vkCmdCopyBuffer2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyBufferInfo2>* pCopyBufferInfo) {}
 
     virtual void Process_vkCmdCopyImage2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyImageInfo2>* pCopyImageInfo) {}
 
     virtual void Process_vkCmdCopyBufferToImage2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2>* pCopyBufferToImageInfo) {}
 
     virtual void Process_vkCmdCopyImageToBuffer2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2>* pCopyImageToBufferInfo) {}
 
     virtual void Process_vkCmdBlitImage2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkBlitImageInfo2>* pBlitImageInfo) {}
 
     virtual void Process_vkCmdResolveImage2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkResolveImageInfo2>* pResolveImageInfo) {}
 
     virtual void Process_vkCmdBeginRendering(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo) {}
 
     virtual void Process_vkCmdEndRendering(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) {}
 
     virtual void Process_vkCmdSetCullMode(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkCullModeFlags                             cullMode) {}
 
     virtual void Process_vkCmdSetFrontFace(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkFrontFace                                 frontFace) {}
 
     virtual void Process_vkCmdSetPrimitiveTopology(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPrimitiveTopology                         primitiveTopology) {}
 
     virtual void Process_vkCmdSetViewportWithCount(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    viewportCount,
         StructPointerDecoder<Decoded_VkViewport>*   pViewports) {}
 
     virtual void Process_vkCmdSetScissorWithCount(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    scissorCount,
         StructPointerDecoder<Decoded_VkRect2D>*     pScissors) {}
 
     virtual void Process_vkCmdBindVertexBuffers2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
@@ -1211,26 +1406,32 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<VkDeviceSize>*               pStrides) {}
 
     virtual void Process_vkCmdSetDepthTestEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthTestEnable) {}
 
     virtual void Process_vkCmdSetDepthWriteEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthWriteEnable) {}
 
     virtual void Process_vkCmdSetDepthCompareOp(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkCompareOp                                 depthCompareOp) {}
 
     virtual void Process_vkCmdSetDepthBoundsTestEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthBoundsTestEnable) {}
 
     virtual void Process_vkCmdSetStencilTestEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    stencilTestEnable) {}
 
     virtual void Process_vkCmdSetStencilOp(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
         VkStencilOp                                 failOp,
@@ -1239,39 +1440,47 @@ class VulkanConsumer : public VulkanConsumerBase
         VkCompareOp                                 compareOp) {}
 
     virtual void Process_vkCmdSetRasterizerDiscardEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    rasterizerDiscardEnable) {}
 
     virtual void Process_vkCmdSetDepthBiasEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthBiasEnable) {}
 
     virtual void Process_vkCmdSetPrimitiveRestartEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    primitiveRestartEnable) {}
 
     virtual void Process_vkGetDeviceBufferMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceBufferMemoryRequirements>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkGetDeviceImageMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkGetDeviceImageSparseMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) {}
 
     virtual void Process_vkDestroySurfaceKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         format::HandleId                            surface,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfaceSupportKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
@@ -1279,12 +1488,14 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<VkBool32>*                   pSupported) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
         StructPointerDecoder<Decoded_VkSurfaceCapabilitiesKHR>* pSurfaceCapabilities) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
@@ -1292,6 +1503,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkSurfaceFormatKHR>* pSurfaceFormats) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
@@ -1299,6 +1511,7 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<VkPresentModeKHR>*           pPresentModes) {}
 
     virtual void Process_vkCreateSwapchainKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfo,
@@ -1306,11 +1519,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSwapchainKHR>*       pSwapchain) {}
 
     virtual void Process_vkDestroySwapchainKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            swapchain,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetSwapchainImagesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
@@ -1318,6 +1533,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkImage>*              pSwapchainImages) {}
 
     virtual void Process_vkAcquireNextImageKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
@@ -1327,22 +1543,26 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint32_t>*                   pImageIndex) {}
 
     virtual void Process_vkQueuePresentKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo) {}
 
     virtual void Process_vkGetDeviceGroupPresentCapabilitiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceGroupPresentCapabilitiesKHR>* pDeviceGroupPresentCapabilities) {}
 
     virtual void Process_vkGetDeviceGroupSurfacePresentModesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            surface,
         PointerDecoder<VkDeviceGroupPresentModeFlagsKHR>* pModes) {}
 
     virtual void Process_vkGetPhysicalDevicePresentRectanglesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
@@ -1350,24 +1570,28 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkRect2D>*     pRects) {}
 
     virtual void Process_vkAcquireNextImage2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>* pAcquireInfo,
         PointerDecoder<uint32_t>*                   pImageIndex) {}
 
     virtual void Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkDisplayPropertiesKHR>* pProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkDisplayPlanePropertiesKHR>* pProperties) {}
 
     virtual void Process_vkGetDisplayPlaneSupportedDisplaysKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    planeIndex,
@@ -1375,6 +1599,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkDisplayKHR>*         pDisplays) {}
 
     virtual void Process_vkGetDisplayModePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display,
@@ -1382,6 +1607,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkDisplayModePropertiesKHR>* pProperties) {}
 
     virtual void Process_vkCreateDisplayModeKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display,
@@ -1390,6 +1616,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkDisplayModeKHR>*     pMode) {}
 
     virtual void Process_vkGetDisplayPlaneCapabilitiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            mode,
@@ -1397,6 +1624,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkDisplayPlaneCapabilitiesKHR>* pCapabilities) {}
 
     virtual void Process_vkCreateDisplayPlaneSurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkDisplaySurfaceCreateInfoKHR>* pCreateInfo,
@@ -1404,6 +1632,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCreateSharedSwapchainsKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    swapchainCount,
@@ -1412,6 +1641,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains) {}
 
     virtual void Process_vkCreateXlibSurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>* pCreateInfo,
@@ -1419,6 +1649,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
@@ -1426,6 +1657,7 @@ class VulkanConsumer : public VulkanConsumerBase
         size_t                                      visualID) {}
 
     virtual void Process_vkCreateXcbSurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>* pCreateInfo,
@@ -1433,6 +1665,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
@@ -1440,6 +1673,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    visual_id) {}
 
     virtual void Process_vkCreateWaylandSurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>* pCreateInfo,
@@ -1447,12 +1681,14 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceWaylandPresentationSupportKHR(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
         uint64_t                                    display) {}
 
     virtual void Process_vkCreateAndroidSurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>* pCreateInfo,
@@ -1460,6 +1696,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCreateWin32SurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>* pCreateInfo,
@@ -1467,52 +1704,63 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceWin32PresentationSupportKHR(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex) {}
 
     virtual void Process_vkCmdBeginRenderingKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo) {}
 
     virtual void Process_vkCmdEndRenderingKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) {}
 
     virtual void Process_vkGetPhysicalDeviceFeatures2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures) {}
 
     virtual void Process_vkGetPhysicalDeviceProperties2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceFormatProperties2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
         StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
         StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
         StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceMemoryProperties2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties) {}
 
     virtual void Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         uint32_t                                    heapIndex,
         uint32_t                                    localDeviceIndex,
@@ -1520,10 +1768,12 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<VkPeerMemoryFeatureFlags>*   pPeerMemoryFeatures) {}
 
     virtual void Process_vkCmdSetDeviceMaskKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    deviceMask) {}
 
     virtual void Process_vkCmdDispatchBaseKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    baseGroupX,
         uint32_t                                    baseGroupY,
@@ -1533,28 +1783,33 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    groupCountZ) {}
 
     virtual void Process_vkTrimCommandPoolKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            commandPool,
         VkCommandPoolTrimFlags                      flags) {}
 
     virtual void Process_vkEnumeratePhysicalDeviceGroupsKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         PointerDecoder<uint32_t>*                   pPhysicalDeviceGroupCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
         StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties) {}
 
     virtual void Process_vkGetMemoryWin32HandleKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) {}
 
     virtual void Process_vkGetMemoryWin32HandlePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -1562,12 +1817,14 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkMemoryWin32HandlePropertiesKHR>* pMemoryWin32HandleProperties) {}
 
     virtual void Process_vkGetMemoryFdKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) {}
 
     virtual void Process_vkGetMemoryFdPropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -1575,33 +1832,39 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkMemoryFdPropertiesKHR>* pMemoryFdProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
         StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties) {}
 
     virtual void Process_vkImportSemaphoreWin32HandleKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>* pImportSemaphoreWin32HandleInfo) {}
 
     virtual void Process_vkGetSemaphoreWin32HandleKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) {}
 
     virtual void Process_vkImportSemaphoreFdKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>* pImportSemaphoreFdInfo) {}
 
     virtual void Process_vkGetSemaphoreFdKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) {}
 
     virtual void Process_vkCmdPushDescriptorSetKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineBindPoint                         pipelineBindPoint,
         format::HandleId                            layout,
@@ -1610,6 +1873,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites) {}
 
     virtual void Process_vkCreateDescriptorUpdateTemplateKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
@@ -1617,11 +1881,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate) {}
 
     virtual void Process_vkDestroyDescriptorUpdateTemplateKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            descriptorUpdateTemplate,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCreateRenderPass2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkRenderPassCreateInfo2>* pCreateInfo,
@@ -1629,52 +1895,62 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkRenderPass>*         pRenderPass) {}
 
     virtual void Process_vkCmdBeginRenderPass2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
         StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo) {}
 
     virtual void Process_vkCmdNextSubpass2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo,
         StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo) {}
 
     virtual void Process_vkCmdEndRenderPass2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo) {}
 
     virtual void Process_vkGetSwapchainStatusKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
         StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties) {}
 
     virtual void Process_vkImportFenceWin32HandleKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImportFenceWin32HandleInfoKHR>* pImportFenceWin32HandleInfo) {}
 
     virtual void Process_vkGetFenceWin32HandleKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkFenceGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) {}
 
     virtual void Process_vkImportFenceFdKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImportFenceFdInfoKHR>* pImportFenceFdInfo) {}
 
     virtual void Process_vkGetFenceFdKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkFenceGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) {}
 
     virtual void Process_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
@@ -1683,25 +1959,30 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkPerformanceCounterDescriptionKHR>* pCounterDescriptions) {}
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkQueryPoolPerformanceCreateInfoKHR>* pPerformanceQueryCreateInfo,
         PointerDecoder<uint32_t>*                   pNumPasses) {}
 
     virtual void Process_vkAcquireProfilingLockKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAcquireProfilingLockInfoKHR>* pInfo) {}
 
     virtual void Process_vkReleaseProfilingLockKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         StructPointerDecoder<Decoded_VkSurfaceCapabilities2KHR>* pSurfaceCapabilities) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
@@ -1709,18 +1990,21 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkSurfaceFormat2KHR>* pSurfaceFormats) {}
 
     virtual void Process_vkGetPhysicalDeviceDisplayProperties2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkDisplayProperties2KHR>* pProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkDisplayPlaneProperties2KHR>* pProperties) {}
 
     virtual void Process_vkGetDisplayModeProperties2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display,
@@ -1728,28 +2012,33 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkDisplayModeProperties2KHR>* pProperties) {}
 
     virtual void Process_vkGetDisplayPlaneCapabilities2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkDisplayPlaneInfo2KHR>* pDisplayPlaneInfo,
         StructPointerDecoder<Decoded_VkDisplayPlaneCapabilities2KHR>* pCapabilities) {}
 
     virtual void Process_vkGetImageMemoryRequirements2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkGetBufferMemoryRequirements2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkGetImageSparseMemoryRequirements2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) {}
 
     virtual void Process_vkCreateSamplerYcbcrConversionKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
@@ -1757,28 +2046,33 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion) {}
 
     virtual void Process_vkDestroySamplerYcbcrConversionKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            ycbcrConversion,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkBindBufferMemory2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
         StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos) {}
 
     virtual void Process_vkBindImageMemory2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
         StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos) {}
 
     virtual void Process_vkGetDescriptorSetLayoutSupportKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport) {}
 
     virtual void Process_vkCmdDrawIndirectCountKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -1788,6 +2082,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    stride) {}
 
     virtual void Process_vkCmdDrawIndexedIndirectCountKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -1797,34 +2092,40 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    stride) {}
 
     virtual void Process_vkGetSemaphoreCounterValueKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            semaphore,
         PointerDecoder<uint64_t>*                   pValue) {}
 
     virtual void Process_vkWaitSemaphoresKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreWaitInfo>* pWaitInfo,
         uint64_t                                    timeout) {}
 
     virtual void Process_vkSignalSemaphoreKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreSignalInfo>* pSignalInfo) {}
 
     virtual void Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pFragmentShadingRateCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceFragmentShadingRateKHR>* pFragmentShadingRates) {}
 
     virtual void Process_vkCmdSetFragmentShadingRateKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkExtent2D>*   pFragmentSize,
         PointerDecoder<VkFragmentShadingRateCombinerOpKHR>* combinerOps) {}
 
     virtual void Process_vkWaitForPresentKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
@@ -1832,47 +2133,56 @@ class VulkanConsumer : public VulkanConsumerBase
         uint64_t                                    timeout) {}
 
     virtual void Process_vkGetBufferDeviceAddressKHR(
+        const ApiCallInfo&                          call_info,
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) {}
 
     virtual void Process_vkGetBufferOpaqueCaptureAddressKHR(
+        const ApiCallInfo&                          call_info,
         uint64_t                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) {}
 
     virtual void Process_vkGetDeviceMemoryOpaqueCaptureAddressKHR(
+        const ApiCallInfo&                          call_info,
         uint64_t                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo>* pInfo) {}
 
     virtual void Process_vkCreateDeferredOperationKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDeferredOperationKHR>* pDeferredOperation) {}
 
     virtual void Process_vkDestroyDeferredOperationKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            operation,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetDeferredOperationMaxConcurrencyKHR(
+        const ApiCallInfo&                          call_info,
         uint32_t                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            operation) {}
 
     virtual void Process_vkGetDeferredOperationResultKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            operation) {}
 
     virtual void Process_vkDeferredOperationJoinKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            operation) {}
 
     virtual void Process_vkGetPipelineExecutablePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPipelineInfoKHR>* pPipelineInfo,
@@ -1880,6 +2190,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkPipelineExecutablePropertiesKHR>* pProperties) {}
 
     virtual void Process_vkGetPipelineExecutableStatisticsKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
@@ -1887,6 +2198,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkPipelineExecutableStatisticKHR>* pStatistics) {}
 
     virtual void Process_vkGetPipelineExecutableInternalRepresentationsKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
@@ -1894,32 +2206,38 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkPipelineExecutableInternalRepresentationKHR>* pInternalRepresentations) {}
 
     virtual void Process_vkCmdSetEvent2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo) {}
 
     virtual void Process_vkCmdResetEvent2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         VkPipelineStageFlags2                       stageMask) {}
 
     virtual void Process_vkCmdWaitEvents2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    eventCount,
         HandlePointerDecoder<VkEvent>*              pEvents,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfos) {}
 
     virtual void Process_vkCmdPipelineBarrier2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo) {}
 
     virtual void Process_vkCmdWriteTimestamp2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlags2                       stage,
         format::HandleId                            queryPool,
         uint32_t                                    query) {}
 
     virtual void Process_vkQueueSubmit2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    submitCount,
@@ -1927,6 +2245,7 @@ class VulkanConsumer : public VulkanConsumerBase
         format::HandleId                            fence) {}
 
     virtual void Process_vkCmdWriteBufferMarker2AMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlags2                       stage,
         format::HandleId                            dstBuffer,
@@ -1934,51 +2253,62 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    marker) {}
 
     virtual void Process_vkGetQueueCheckpointData2NV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            queue,
         PointerDecoder<uint32_t>*                   pCheckpointDataCount,
         StructPointerDecoder<Decoded_VkCheckpointData2NV>* pCheckpointData) {}
 
     virtual void Process_vkCmdCopyBuffer2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyBufferInfo2>* pCopyBufferInfo) {}
 
     virtual void Process_vkCmdCopyImage2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyImageInfo2>* pCopyImageInfo) {}
 
     virtual void Process_vkCmdCopyBufferToImage2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2>* pCopyBufferToImageInfo) {}
 
     virtual void Process_vkCmdCopyImageToBuffer2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2>* pCopyImageToBufferInfo) {}
 
     virtual void Process_vkCmdBlitImage2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkBlitImageInfo2>* pBlitImageInfo) {}
 
     virtual void Process_vkCmdResolveImage2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkResolveImageInfo2>* pResolveImageInfo) {}
 
     virtual void Process_vkGetDeviceBufferMemoryRequirementsKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceBufferMemoryRequirements>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkGetDeviceImageMemoryRequirementsKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkGetDeviceImageSparseMemoryRequirementsKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) {}
 
     virtual void Process_vkCreateDebugReportCallbackEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>* pCreateInfo,
@@ -1986,11 +2316,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkDebugReportCallbackEXT>* pCallback) {}
 
     virtual void Process_vkDestroyDebugReportCallbackEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         format::HandleId                            callback,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkDebugReportMessageEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         VkDebugReportFlagsEXT                       flags,
         VkDebugReportObjectTypeEXT                  objectType,
@@ -2001,27 +2333,33 @@ class VulkanConsumer : public VulkanConsumerBase
         StringDecoder*                              pMessage) {}
 
     virtual void Process_vkDebugMarkerSetObjectTagEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDebugMarkerObjectTagInfoEXT>* pTagInfo) {}
 
     virtual void Process_vkDebugMarkerSetObjectNameEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDebugMarkerObjectNameInfoEXT>* pNameInfo) {}
 
     virtual void Process_vkCmdDebugMarkerBeginEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo) {}
 
     virtual void Process_vkCmdDebugMarkerEndEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) {}
 
     virtual void Process_vkCmdDebugMarkerInsertEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo) {}
 
     virtual void Process_vkCmdBindTransformFeedbackBuffersEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
@@ -2030,6 +2368,7 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<VkDeviceSize>*               pSizes) {}
 
     virtual void Process_vkCmdBeginTransformFeedbackEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstCounterBuffer,
         uint32_t                                    counterBufferCount,
@@ -2037,6 +2376,7 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets) {}
 
     virtual void Process_vkCmdEndTransformFeedbackEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstCounterBuffer,
         uint32_t                                    counterBufferCount,
@@ -2044,6 +2384,7 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets) {}
 
     virtual void Process_vkCmdBeginQueryIndexedEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    query,
@@ -2051,12 +2392,14 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    index) {}
 
     virtual void Process_vkCmdEndQueryIndexedEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    query,
         uint32_t                                    index) {}
 
     virtual void Process_vkCmdDrawIndirectByteCountEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    instanceCount,
         uint32_t                                    firstInstance,
@@ -2066,17 +2409,20 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    vertexStride) {}
 
     virtual void Process_vkGetImageViewHandleNVX(
+        const ApiCallInfo&                          call_info,
         uint32_t                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>* pInfo) {}
 
     virtual void Process_vkGetImageViewAddressNVX(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            imageView,
         StructPointerDecoder<Decoded_VkImageViewAddressPropertiesNVX>* pProperties) {}
 
     virtual void Process_vkCmdDrawIndirectCountAMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -2086,6 +2432,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    stride) {}
 
     virtual void Process_vkCmdDrawIndexedIndirectCountAMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -2095,6 +2442,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    stride) {}
 
     virtual void Process_vkGetShaderInfoAMD(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
@@ -2104,6 +2452,7 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint8_t>*                    pInfo) {}
 
     virtual void Process_vkCreateStreamDescriptorSurfaceGGP(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkStreamDescriptorSurfaceCreateInfoGGP>* pCreateInfo,
@@ -2111,6 +2460,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
@@ -2122,6 +2472,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkExternalImageFormatPropertiesNV>* pExternalImageFormatProperties) {}
 
     virtual void Process_vkGetMemoryWin32HandleNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            memory,
@@ -2129,6 +2480,7 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint64_t, void*>*            pHandle) {}
 
     virtual void Process_vkCreateViSurfaceNN(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkViSurfaceCreateInfoNN>* pCreateInfo,
@@ -2136,30 +2488,36 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCmdBeginConditionalRenderingEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>* pConditionalRenderingBegin) {}
 
     virtual void Process_vkCmdEndConditionalRenderingEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) {}
 
     virtual void Process_vkCmdSetViewportWScalingNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
         StructPointerDecoder<Decoded_VkViewportWScalingNV>* pViewportWScalings) {}
 
     virtual void Process_vkReleaseDisplayEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display) {}
 
     virtual void Process_vkAcquireXlibDisplayEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint64_t                                    dpy,
         format::HandleId                            display) {}
 
     virtual void Process_vkGetRandROutputDisplayEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint64_t                                    dpy,
@@ -2167,18 +2525,21 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkDisplayKHR>*         pDisplay) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
         StructPointerDecoder<Decoded_VkSurfaceCapabilities2EXT>* pSurfaceCapabilities) {}
 
     virtual void Process_vkDisplayPowerControlEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            display,
         StructPointerDecoder<Decoded_VkDisplayPowerInfoEXT>* pDisplayPowerInfo) {}
 
     virtual void Process_vkRegisterDeviceEventEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceEventInfoEXT>* pDeviceEventInfo,
@@ -2186,6 +2547,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkFence>*              pFence) {}
 
     virtual void Process_vkRegisterDisplayEventEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            display,
@@ -2194,6 +2556,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkFence>*              pFence) {}
 
     virtual void Process_vkGetSwapchainCounterEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
@@ -2201,12 +2564,14 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint64_t>*                   pCounterValue) {}
 
     virtual void Process_vkGetRefreshCycleDurationGOOGLE(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
         StructPointerDecoder<Decoded_VkRefreshCycleDurationGOOGLE>* pDisplayTimingProperties) {}
 
     virtual void Process_vkGetPastPresentationTimingGOOGLE(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
@@ -2214,18 +2579,21 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkPastPresentationTimingGOOGLE>* pPresentationTimings) {}
 
     virtual void Process_vkCmdSetDiscardRectangleEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstDiscardRectangle,
         uint32_t                                    discardRectangleCount,
         StructPointerDecoder<Decoded_VkRect2D>*     pDiscardRectangles) {}
 
     virtual void Process_vkSetHdrMetadataEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         uint32_t                                    swapchainCount,
         HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains,
         StructPointerDecoder<Decoded_VkHdrMetadataEXT>* pMetadata) {}
 
     virtual void Process_vkCreateIOSSurfaceMVK(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkIOSSurfaceCreateInfoMVK>* pCreateInfo,
@@ -2233,6 +2601,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCreateMacOSSurfaceMVK(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkMacOSSurfaceCreateInfoMVK>* pCreateInfo,
@@ -2240,38 +2609,47 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkSetDebugUtilsObjectNameEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* pNameInfo) {}
 
     virtual void Process_vkSetDebugUtilsObjectTagEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>* pTagInfo) {}
 
     virtual void Process_vkQueueBeginDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            queue,
         StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) {}
 
     virtual void Process_vkQueueEndDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            queue) {}
 
     virtual void Process_vkQueueInsertDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            queue,
         StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) {}
 
     virtual void Process_vkCmdBeginDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) {}
 
     virtual void Process_vkCmdEndDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) {}
 
     virtual void Process_vkCmdInsertDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) {}
 
     virtual void Process_vkCreateDebugUtilsMessengerEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>* pCreateInfo,
@@ -2279,44 +2657,52 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkDebugUtilsMessengerEXT>* pMessenger) {}
 
     virtual void Process_vkDestroyDebugUtilsMessengerEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         format::HandleId                            messenger,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkSubmitDebugUtilsMessageEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         VkDebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,
         VkDebugUtilsMessageTypeFlagsEXT             messageTypes,
         StructPointerDecoder<Decoded_VkDebugUtilsMessengerCallbackDataEXT>* pCallbackData) {}
 
     virtual void Process_vkGetAndroidHardwareBufferPropertiesANDROID(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint64_t                                    buffer,
         StructPointerDecoder<Decoded_VkAndroidHardwareBufferPropertiesANDROID>* pProperties) {}
 
     virtual void Process_vkGetMemoryAndroidHardwareBufferANDROID(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID>* pInfo,
         PointerDecoder<uint64_t, void*>*            pBuffer) {}
 
     virtual void Process_vkCmdSetSampleLocationsEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkSampleLocationsInfoEXT>* pSampleLocationsInfo) {}
 
     virtual void Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         VkSampleCountFlagBits                       samples,
         StructPointerDecoder<Decoded_VkMultisamplePropertiesEXT>* pMultisampleProperties) {}
 
     virtual void Process_vkGetImageDrmFormatModifierPropertiesEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            image,
         StructPointerDecoder<Decoded_VkImageDrmFormatModifierPropertiesEXT>* pProperties) {}
 
     virtual void Process_vkCreateValidationCacheEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkValidationCacheCreateInfoEXT>* pCreateInfo,
@@ -2324,11 +2710,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkValidationCacheEXT>* pValidationCache) {}
 
     virtual void Process_vkDestroyValidationCacheEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            validationCache,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkMergeValidationCachesEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            dstCache,
@@ -2336,6 +2724,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkValidationCacheEXT>* pSrcCaches) {}
 
     virtual void Process_vkGetValidationCacheDataEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            validationCache,
@@ -2343,23 +2732,27 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint8_t>*                    pData) {}
 
     virtual void Process_vkCmdBindShadingRateImageNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            imageView,
         VkImageLayout                               imageLayout) {}
 
     virtual void Process_vkCmdSetViewportShadingRatePaletteNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
         StructPointerDecoder<Decoded_VkShadingRatePaletteNV>* pShadingRatePalettes) {}
 
     virtual void Process_vkCmdSetCoarseSampleOrderNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkCoarseSampleOrderTypeNV                   sampleOrderType,
         uint32_t                                    customSampleOrderCount,
         StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>* pCustomSampleOrders) {}
 
     virtual void Process_vkCreateAccelerationStructureNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoNV>* pCreateInfo,
@@ -2367,22 +2760,26 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructure) {}
 
     virtual void Process_vkDestroyAccelerationStructureNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            accelerationStructure,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkGetAccelerationStructureMemoryRequirementsNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAccelerationStructureMemoryRequirementsInfoNV>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2KHR>* pMemoryRequirements) {}
 
     virtual void Process_vkBindAccelerationStructureMemoryNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
         StructPointerDecoder<Decoded_VkBindAccelerationStructureMemoryInfoNV>* pBindInfos) {}
 
     virtual void Process_vkCmdBuildAccelerationStructureNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>* pInfo,
         format::HandleId                            instanceData,
@@ -2394,12 +2791,14 @@ class VulkanConsumer : public VulkanConsumerBase
         VkDeviceSize                                scratchOffset) {}
 
     virtual void Process_vkCmdCopyAccelerationStructureNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            dst,
         format::HandleId                            src,
         VkCopyAccelerationStructureModeKHR          mode) {}
 
     virtual void Process_vkCmdTraceRaysNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            raygenShaderBindingTableBuffer,
         VkDeviceSize                                raygenShaderBindingOffset,
@@ -2417,6 +2816,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    depth) {}
 
     virtual void Process_vkCreateRayTracingPipelinesNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
@@ -2426,6 +2826,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkPipeline>*           pPipelines) {}
 
     virtual void Process_vkGetRayTracingShaderGroupHandlesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
@@ -2435,6 +2836,7 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint8_t>*                    pData) {}
 
     virtual void Process_vkGetRayTracingShaderGroupHandlesNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
@@ -2444,6 +2846,7 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint8_t>*                    pData) {}
 
     virtual void Process_vkGetAccelerationStructureHandleNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            accelerationStructure,
@@ -2451,6 +2854,7 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint8_t>*                    pData) {}
 
     virtual void Process_vkCmdWriteAccelerationStructuresPropertiesNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    accelerationStructureCount,
         HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructures,
@@ -2459,12 +2863,14 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    firstQuery) {}
 
     virtual void Process_vkCompileDeferredNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
         uint32_t                                    shader) {}
 
     virtual void Process_vkGetMemoryHostPointerPropertiesEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -2472,6 +2878,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkMemoryHostPointerPropertiesEXT>* pMemoryHostPointerProperties) {}
 
     virtual void Process_vkCmdWriteBufferMarkerAMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlagBits                     pipelineStage,
         format::HandleId                            dstBuffer,
@@ -2479,12 +2886,14 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    marker) {}
 
     virtual void Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pTimeDomainCount,
         PointerDecoder<VkTimeDomainEXT>*            pTimeDomains) {}
 
     virtual void Process_vkGetCalibratedTimestampsEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    timestampCount,
@@ -2493,11 +2902,13 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint64_t>*                   pMaxDeviation) {}
 
     virtual void Process_vkCmdDrawMeshTasksNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    taskCount,
         uint32_t                                    firstTask) {}
 
     virtual void Process_vkCmdDrawMeshTasksIndirectNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -2505,6 +2916,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    stride) {}
 
     virtual void Process_vkCmdDrawMeshTasksIndirectCountNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -2514,71 +2926,85 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    stride) {}
 
     virtual void Process_vkCmdSetExclusiveScissorNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstExclusiveScissor,
         uint32_t                                    exclusiveScissorCount,
         StructPointerDecoder<Decoded_VkRect2D>*     pExclusiveScissors) {}
 
     virtual void Process_vkCmdSetCheckpointNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint64_t                                    pCheckpointMarker) {}
 
     virtual void Process_vkGetQueueCheckpointDataNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            queue,
         PointerDecoder<uint32_t>*                   pCheckpointDataCount,
         StructPointerDecoder<Decoded_VkCheckpointDataNV>* pCheckpointData) {}
 
     virtual void Process_vkInitializePerformanceApiINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkInitializePerformanceApiInfoINTEL>* pInitializeInfo) {}
 
     virtual void Process_vkUninitializePerformanceApiINTEL(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device) {}
 
     virtual void Process_vkCmdSetPerformanceMarkerINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkPerformanceMarkerInfoINTEL>* pMarkerInfo) {}
 
     virtual void Process_vkCmdSetPerformanceStreamMarkerINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkPerformanceStreamMarkerInfoINTEL>* pMarkerInfo) {}
 
     virtual void Process_vkCmdSetPerformanceOverrideINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkPerformanceOverrideInfoINTEL>* pOverrideInfo) {}
 
     virtual void Process_vkAcquirePerformanceConfigurationINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPerformanceConfigurationAcquireInfoINTEL>* pAcquireInfo,
         HandlePointerDecoder<VkPerformanceConfigurationINTEL>* pConfiguration) {}
 
     virtual void Process_vkReleasePerformanceConfigurationINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            configuration) {}
 
     virtual void Process_vkQueueSetPerformanceConfigurationINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         format::HandleId                            configuration) {}
 
     virtual void Process_vkGetPerformanceParameterINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkPerformanceParameterTypeINTEL             parameter,
         StructPointerDecoder<Decoded_VkPerformanceValueINTEL>* pValue) {}
 
     virtual void Process_vkSetLocalDimmingAMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            swapChain,
         VkBool32                                    localDimmingEnable) {}
 
     virtual void Process_vkCreateImagePipeSurfaceFUCHSIA(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA>* pCreateInfo,
@@ -2586,6 +3012,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCreateMetalSurfaceEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>* pCreateInfo,
@@ -2593,29 +3020,34 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetBufferDeviceAddressEXT(
+        const ApiCallInfo&                          call_info,
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) {}
 
     virtual void Process_vkGetPhysicalDeviceToolPropertiesEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pToolCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceToolProperties>* pToolProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkCooperativeMatrixPropertiesNV>* pProperties) {}
 
     virtual void Process_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pCombinationCount,
         StructPointerDecoder<Decoded_VkFramebufferMixedSamplesCombinationNV>* pCombinations) {}
 
     virtual void Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
@@ -2623,22 +3055,26 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<VkPresentModeKHR>*           pPresentModes) {}
 
     virtual void Process_vkAcquireFullScreenExclusiveModeEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain) {}
 
     virtual void Process_vkReleaseFullScreenExclusiveModeEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain) {}
 
     virtual void Process_vkGetDeviceGroupSurfacePresentModes2EXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         PointerDecoder<VkDeviceGroupPresentModeFlagsKHR>* pModes) {}
 
     virtual void Process_vkCreateHeadlessSurfaceEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkHeadlessSurfaceCreateInfoEXT>* pCreateInfo,
@@ -2646,39 +3082,47 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkCmdSetLineStippleEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    lineStippleFactor,
         uint16_t                                    lineStipplePattern) {}
 
     virtual void Process_vkResetQueryPoolEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery,
         uint32_t                                    queryCount) {}
 
     virtual void Process_vkCmdSetCullModeEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkCullModeFlags                             cullMode) {}
 
     virtual void Process_vkCmdSetFrontFaceEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkFrontFace                                 frontFace) {}
 
     virtual void Process_vkCmdSetPrimitiveTopologyEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPrimitiveTopology                         primitiveTopology) {}
 
     virtual void Process_vkCmdSetViewportWithCountEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    viewportCount,
         StructPointerDecoder<Decoded_VkViewport>*   pViewports) {}
 
     virtual void Process_vkCmdSetScissorWithCountEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    scissorCount,
         StructPointerDecoder<Decoded_VkRect2D>*     pScissors) {}
 
     virtual void Process_vkCmdBindVertexBuffers2EXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
@@ -2688,26 +3132,32 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<VkDeviceSize>*               pStrides) {}
 
     virtual void Process_vkCmdSetDepthTestEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthTestEnable) {}
 
     virtual void Process_vkCmdSetDepthWriteEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthWriteEnable) {}
 
     virtual void Process_vkCmdSetDepthCompareOpEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkCompareOp                                 depthCompareOp) {}
 
     virtual void Process_vkCmdSetDepthBoundsTestEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthBoundsTestEnable) {}
 
     virtual void Process_vkCmdSetStencilTestEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    stencilTestEnable) {}
 
     virtual void Process_vkCmdSetStencilOpEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
         VkStencilOp                                 failOp,
@@ -2716,26 +3166,31 @@ class VulkanConsumer : public VulkanConsumerBase
         VkCompareOp                                 compareOp) {}
 
     virtual void Process_vkGetGeneratedCommandsMemoryRequirementsNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkGeneratedCommandsMemoryRequirementsInfoNV>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) {}
 
     virtual void Process_vkCmdPreprocessGeneratedCommandsNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo) {}
 
     virtual void Process_vkCmdExecuteGeneratedCommandsNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    isPreprocessed,
         StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo) {}
 
     virtual void Process_vkCmdBindPipelineShaderGroupNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineBindPoint                         pipelineBindPoint,
         format::HandleId                            pipeline,
         uint32_t                                    groupIndex) {}
 
     virtual void Process_vkCreateIndirectCommandsLayoutNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkIndirectCommandsLayoutCreateInfoNV>* pCreateInfo,
@@ -2743,17 +3198,20 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkIndirectCommandsLayoutNV>* pIndirectCommandsLayout) {}
 
     virtual void Process_vkDestroyIndirectCommandsLayoutNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            indirectCommandsLayout,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkAcquireDrmDisplayEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         int32_t                                     drmFd,
         format::HandleId                            display) {}
 
     virtual void Process_vkGetDrmDisplayEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         int32_t                                     drmFd,
@@ -2761,6 +3219,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkDisplayKHR>*         display) {}
 
     virtual void Process_vkCreatePrivateDataSlotEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPrivateDataSlotCreateInfo>* pCreateInfo,
@@ -2768,11 +3227,13 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkPrivateDataSlot>*    pPrivateDataSlot) {}
 
     virtual void Process_vkDestroyPrivateDataSlotEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            privateDataSlot,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkSetPrivateDataEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkObjectType                                objectType,
@@ -2781,6 +3242,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint64_t                                    data) {}
 
     virtual void Process_vkGetPrivateDataEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         VkObjectType                                objectType,
         uint64_t                                    objectHandle,
@@ -2788,22 +3250,26 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint64_t>*                   pData) {}
 
     virtual void Process_vkCmdSetFragmentShadingRateEnumNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkFragmentShadingRateNV                     shadingRate,
         PointerDecoder<VkFragmentShadingRateCombinerOpKHR>* combinerOps) {}
 
     virtual void Process_vkAcquireWinrtDisplayNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display) {}
 
     virtual void Process_vkGetWinrtDisplayNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    deviceRelativeId,
         HandlePointerDecoder<VkDisplayKHR>*         pDisplay) {}
 
     virtual void Process_vkCreateDirectFBSurfaceEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkDirectFBSurfaceCreateInfoEXT>* pCreateInfo,
@@ -2811,12 +3277,14 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceDirectFBPresentationSupportEXT(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
         uint64_t                                    dfb) {}
 
     virtual void Process_vkCmdSetVertexInputEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    vertexBindingDescriptionCount,
         StructPointerDecoder<Decoded_VkVertexInputBindingDescription2EXT>* pVertexBindingDescriptions,
@@ -2824,12 +3292,14 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkVertexInputAttributeDescription2EXT>* pVertexAttributeDescriptions) {}
 
     virtual void Process_vkGetMemoryZirconHandleFUCHSIA(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryGetZirconHandleInfoFUCHSIA>* pGetZirconHandleInfo,
         PointerDecoder<uint32_t>*                   pZirconHandle) {}
 
     virtual void Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -2837,48 +3307,58 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkMemoryZirconHandlePropertiesFUCHSIA>* pMemoryZirconHandleProperties) {}
 
     virtual void Process_vkImportSemaphoreZirconHandleFUCHSIA(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImportSemaphoreZirconHandleInfoFUCHSIA>* pImportSemaphoreZirconHandleInfo) {}
 
     virtual void Process_vkGetSemaphoreZirconHandleFUCHSIA(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreGetZirconHandleInfoFUCHSIA>* pGetZirconHandleInfo,
         PointerDecoder<uint32_t>*                   pZirconHandle) {}
 
     virtual void Process_vkCmdBindInvocationMaskHUAWEI(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            imageView,
         VkImageLayout                               imageLayout) {}
 
     virtual void Process_vkGetMemoryRemoteAddressNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryGetRemoteAddressInfoNV>* pMemoryGetRemoteAddressInfo,
         PointerDecoder<uint64_t, void*>*            pAddress) {}
 
     virtual void Process_vkCmdSetPatchControlPointsEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    patchControlPoints) {}
 
     virtual void Process_vkCmdSetRasterizerDiscardEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    rasterizerDiscardEnable) {}
 
     virtual void Process_vkCmdSetDepthBiasEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthBiasEnable) {}
 
     virtual void Process_vkCmdSetLogicOpEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkLogicOp                                   logicOp) {}
 
     virtual void Process_vkCmdSetPrimitiveRestartEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    primitiveRestartEnable) {}
 
     virtual void Process_vkCreateScreenSurfaceQNX(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkScreenSurfaceCreateInfoQNX>* pCreateInfo,
@@ -2886,17 +3366,20 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) {}
 
     virtual void Process_vkGetPhysicalDeviceScreenPresentationSupportQNX(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
         uint64_t                                    window) {}
 
     virtual void Process_vkCmdSetColorWriteEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    attachmentCount,
         PointerDecoder<VkBool32>*                   pColorWriteEnables) {}
 
     virtual void Process_vkCmdDrawMultiEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    drawCount,
         StructPointerDecoder<Decoded_VkMultiDrawInfoEXT>* pVertexInfo,
@@ -2905,6 +3388,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    stride) {}
 
     virtual void Process_vkCmdDrawMultiIndexedEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    drawCount,
         StructPointerDecoder<Decoded_VkMultiDrawIndexedInfoEXT>* pIndexInfo,
@@ -2914,11 +3398,13 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<int32_t>*                    pVertexOffset) {}
 
     virtual void Process_vkSetDeviceMemoryPriorityEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            memory,
         float                                       priority) {}
 
     virtual void Process_vkCreateAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoKHR>* pCreateInfo,
@@ -2926,17 +3412,20 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkAccelerationStructureKHR>* pAccelerationStructure) {}
 
     virtual void Process_vkDestroyAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            accelerationStructure,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) {}
 
     virtual void Process_vkCmdBuildAccelerationStructuresKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    infoCount,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>* ppBuildRangeInfos) {}
 
     virtual void Process_vkCmdBuildAccelerationStructuresIndirectKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    infoCount,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
@@ -2945,18 +3434,21 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint32_t*>*                  ppMaxPrimitiveCounts) {}
 
     virtual void Process_vkCopyAccelerationStructureToMemoryKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            deferredOperation,
         StructPointerDecoder<Decoded_VkCopyAccelerationStructureToMemoryInfoKHR>* pInfo) {}
 
     virtual void Process_vkCopyMemoryToAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            deferredOperation,
         StructPointerDecoder<Decoded_VkCopyMemoryToAccelerationStructureInfoKHR>* pInfo) {}
 
     virtual void Process_vkWriteAccelerationStructuresPropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    accelerationStructureCount,
@@ -2967,23 +3459,28 @@ class VulkanConsumer : public VulkanConsumerBase
         size_t                                      stride) {}
 
     virtual void Process_vkCmdCopyAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo) {}
 
     virtual void Process_vkCmdCopyAccelerationStructureToMemoryKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyAccelerationStructureToMemoryInfoKHR>* pInfo) {}
 
     virtual void Process_vkCmdCopyMemoryToAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyMemoryToAccelerationStructureInfoKHR>* pInfo) {}
 
     virtual void Process_vkGetAccelerationStructureDeviceAddressKHR(
+        const ApiCallInfo&                          call_info,
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAccelerationStructureDeviceAddressInfoKHR>* pInfo) {}
 
     virtual void Process_vkCmdWriteAccelerationStructuresPropertiesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    accelerationStructureCount,
         HandlePointerDecoder<VkAccelerationStructureKHR>* pAccelerationStructures,
@@ -2992,11 +3489,13 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    firstQuery) {}
 
     virtual void Process_vkGetDeviceAccelerationStructureCompatibilityKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAccelerationStructureVersionInfoKHR>* pVersionInfo,
         PointerDecoder<VkAccelerationStructureCompatibilityKHR>* pCompatibility) {}
 
     virtual void Process_vkGetAccelerationStructureBuildSizesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         VkAccelerationStructureBuildTypeKHR         buildType,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pBuildInfo,
@@ -3004,6 +3503,7 @@ class VulkanConsumer : public VulkanConsumerBase
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildSizesInfoKHR>* pSizeInfo) {}
 
     virtual void Process_vkCmdTraceRaysKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pRaygenShaderBindingTable,
         StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pMissShaderBindingTable,
@@ -3014,6 +3514,7 @@ class VulkanConsumer : public VulkanConsumerBase
         uint32_t                                    depth) {}
 
     virtual void Process_vkCreateRayTracingPipelinesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            deferredOperation,
@@ -3024,6 +3525,7 @@ class VulkanConsumer : public VulkanConsumerBase
         HandlePointerDecoder<VkPipeline>*           pPipelines) {}
 
     virtual void Process_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
@@ -3033,6 +3535,7 @@ class VulkanConsumer : public VulkanConsumerBase
         PointerDecoder<uint8_t>*                    pData) {}
 
     virtual void Process_vkCmdTraceRaysIndirectKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pRaygenShaderBindingTable,
         StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pMissShaderBindingTable,
@@ -3041,6 +3544,7 @@ class VulkanConsumer : public VulkanConsumerBase
         VkDeviceAddress                             indirectDeviceAddress) {}
 
     virtual void Process_vkGetRayTracingShaderGroupStackSizeKHR(
+        const ApiCallInfo&                          call_info,
         VkDeviceSize                                returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
@@ -3048,6 +3552,7 @@ class VulkanConsumer : public VulkanConsumerBase
         VkShaderGroupShaderKHR                      groupShader) {}
 
     virtual void Process_vkCmdSetRayTracingPipelineStackSizeKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    pipelineStackSize) {}
 };

--- a/framework/generated/generated_vulkan_decoder.cpp
+++ b/framework/generated/generated_vulkan_decoder.cpp
@@ -44,7 +44,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
-size_t VulkanDecoder::Decode_vkCreateInstance(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateInstance(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -60,13 +60,13 @@ size_t VulkanDecoder::Decode_vkCreateInstance(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateInstance(return_value, &pCreateInfo, &pAllocator, &pInstance);
+        consumer->Process_vkCreateInstance(call_info, return_value, &pCreateInfo, &pAllocator, &pInstance);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyInstance(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyInstance(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -78,13 +78,13 @@ size_t VulkanDecoder::Decode_vkDestroyInstance(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyInstance(instance, &pAllocator);
+        consumer->Process_vkDestroyInstance(call_info, instance, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkEnumeratePhysicalDevices(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkEnumeratePhysicalDevices(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -100,13 +100,13 @@ size_t VulkanDecoder::Decode_vkEnumeratePhysicalDevices(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkEnumeratePhysicalDevices(return_value, instance, &pPhysicalDeviceCount, &pPhysicalDevices);
+        consumer->Process_vkEnumeratePhysicalDevices(call_info, return_value, instance, &pPhysicalDeviceCount, &pPhysicalDevices);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFeatures(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFeatures(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -118,13 +118,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFeatures(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceFeatures(physicalDevice, &pFeatures);
+        consumer->Process_vkGetPhysicalDeviceFeatures(call_info, physicalDevice, &pFeatures);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFormatProperties(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFormatProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -138,13 +138,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFormatProperties(const uint8_t* 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceFormatProperties(physicalDevice, format, &pFormatProperties);
+        consumer->Process_vkGetPhysicalDeviceFormatProperties(call_info, physicalDevice, format, &pFormatProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceImageFormatProperties(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceImageFormatProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -168,13 +168,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceImageFormatProperties(const uint
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceImageFormatProperties(return_value, physicalDevice, format, type, tiling, usage, flags, &pImageFormatProperties);
+        consumer->Process_vkGetPhysicalDeviceImageFormatProperties(call_info, return_value, physicalDevice, format, type, tiling, usage, flags, &pImageFormatProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceProperties(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -186,13 +186,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceProperties(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceProperties(physicalDevice, &pProperties);
+        consumer->Process_vkGetPhysicalDeviceProperties(call_info, physicalDevice, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceQueueFamilyProperties(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceQueueFamilyProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -206,13 +206,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceQueueFamilyProperties(const uint
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceQueueFamilyProperties(physicalDevice, &pQueueFamilyPropertyCount, &pQueueFamilyProperties);
+        consumer->Process_vkGetPhysicalDeviceQueueFamilyProperties(call_info, physicalDevice, &pQueueFamilyPropertyCount, &pQueueFamilyProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceMemoryProperties(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceMemoryProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -224,13 +224,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceMemoryProperties(const uint8_t* 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceMemoryProperties(physicalDevice, &pMemoryProperties);
+        consumer->Process_vkGetPhysicalDeviceMemoryProperties(call_info, physicalDevice, &pMemoryProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateDevice(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateDevice(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -248,13 +248,13 @@ size_t VulkanDecoder::Decode_vkCreateDevice(const uint8_t* parameter_buffer, siz
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDevice(return_value, physicalDevice, &pCreateInfo, &pAllocator, &pDevice);
+        consumer->Process_vkCreateDevice(call_info, return_value, physicalDevice, &pCreateInfo, &pAllocator, &pDevice);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyDevice(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyDevice(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -266,13 +266,13 @@ size_t VulkanDecoder::Decode_vkDestroyDevice(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyDevice(device, &pAllocator);
+        consumer->Process_vkDestroyDevice(call_info, device, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceQueue(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceQueue(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -288,13 +288,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceQueue(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceQueue(device, queueFamilyIndex, queueIndex, &pQueue);
+        consumer->Process_vkGetDeviceQueue(call_info, device, queueFamilyIndex, queueIndex, &pQueue);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkQueueSubmit(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkQueueSubmit(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -312,13 +312,13 @@ size_t VulkanDecoder::Decode_vkQueueSubmit(const uint8_t* parameter_buffer, size
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkQueueSubmit(return_value, queue, submitCount, &pSubmits, fence);
+        consumer->Process_vkQueueSubmit(call_info, return_value, queue, submitCount, &pSubmits, fence);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkQueueWaitIdle(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkQueueWaitIdle(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -330,13 +330,13 @@ size_t VulkanDecoder::Decode_vkQueueWaitIdle(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkQueueWaitIdle(return_value, queue);
+        consumer->Process_vkQueueWaitIdle(call_info, return_value, queue);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDeviceWaitIdle(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDeviceWaitIdle(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -348,13 +348,13 @@ size_t VulkanDecoder::Decode_vkDeviceWaitIdle(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDeviceWaitIdle(return_value, device);
+        consumer->Process_vkDeviceWaitIdle(call_info, return_value, device);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkAllocateMemory(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkAllocateMemory(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -372,13 +372,13 @@ size_t VulkanDecoder::Decode_vkAllocateMemory(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkAllocateMemory(return_value, device, &pAllocateInfo, &pAllocator, &pMemory);
+        consumer->Process_vkAllocateMemory(call_info, return_value, device, &pAllocateInfo, &pAllocator, &pMemory);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkFreeMemory(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkFreeMemory(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -392,13 +392,13 @@ size_t VulkanDecoder::Decode_vkFreeMemory(const uint8_t* parameter_buffer, size_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkFreeMemory(device, memory, &pAllocator);
+        consumer->Process_vkFreeMemory(call_info, device, memory, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkMapMemory(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkMapMemory(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -420,13 +420,13 @@ size_t VulkanDecoder::Decode_vkMapMemory(const uint8_t* parameter_buffer, size_t
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkMapMemory(return_value, device, memory, offset, size, flags, &ppData);
+        consumer->Process_vkMapMemory(call_info, return_value, device, memory, offset, size, flags, &ppData);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkUnmapMemory(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkUnmapMemory(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -438,13 +438,13 @@ size_t VulkanDecoder::Decode_vkUnmapMemory(const uint8_t* parameter_buffer, size
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkUnmapMemory(device, memory);
+        consumer->Process_vkUnmapMemory(call_info, device, memory);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkFlushMappedMemoryRanges(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkFlushMappedMemoryRanges(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -460,13 +460,13 @@ size_t VulkanDecoder::Decode_vkFlushMappedMemoryRanges(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkFlushMappedMemoryRanges(return_value, device, memoryRangeCount, &pMemoryRanges);
+        consumer->Process_vkFlushMappedMemoryRanges(call_info, return_value, device, memoryRangeCount, &pMemoryRanges);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkInvalidateMappedMemoryRanges(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkInvalidateMappedMemoryRanges(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -482,13 +482,13 @@ size_t VulkanDecoder::Decode_vkInvalidateMappedMemoryRanges(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkInvalidateMappedMemoryRanges(return_value, device, memoryRangeCount, &pMemoryRanges);
+        consumer->Process_vkInvalidateMappedMemoryRanges(call_info, return_value, device, memoryRangeCount, &pMemoryRanges);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceMemoryCommitment(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceMemoryCommitment(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -502,13 +502,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceMemoryCommitment(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceMemoryCommitment(device, memory, &pCommittedMemoryInBytes);
+        consumer->Process_vkGetDeviceMemoryCommitment(call_info, device, memory, &pCommittedMemoryInBytes);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkBindBufferMemory(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkBindBufferMemory(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -526,13 +526,13 @@ size_t VulkanDecoder::Decode_vkBindBufferMemory(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkBindBufferMemory(return_value, device, buffer, memory, memoryOffset);
+        consumer->Process_vkBindBufferMemory(call_info, return_value, device, buffer, memory, memoryOffset);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkBindImageMemory(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkBindImageMemory(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -550,13 +550,13 @@ size_t VulkanDecoder::Decode_vkBindImageMemory(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkBindImageMemory(return_value, device, image, memory, memoryOffset);
+        consumer->Process_vkBindImageMemory(call_info, return_value, device, image, memory, memoryOffset);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetBufferMemoryRequirements(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetBufferMemoryRequirements(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -570,13 +570,13 @@ size_t VulkanDecoder::Decode_vkGetBufferMemoryRequirements(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetBufferMemoryRequirements(device, buffer, &pMemoryRequirements);
+        consumer->Process_vkGetBufferMemoryRequirements(call_info, device, buffer, &pMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetImageMemoryRequirements(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetImageMemoryRequirements(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -590,13 +590,13 @@ size_t VulkanDecoder::Decode_vkGetImageMemoryRequirements(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetImageMemoryRequirements(device, image, &pMemoryRequirements);
+        consumer->Process_vkGetImageMemoryRequirements(call_info, device, image, &pMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetImageSparseMemoryRequirements(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetImageSparseMemoryRequirements(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -612,13 +612,13 @@ size_t VulkanDecoder::Decode_vkGetImageSparseMemoryRequirements(const uint8_t* p
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetImageSparseMemoryRequirements(device, image, &pSparseMemoryRequirementCount, &pSparseMemoryRequirements);
+        consumer->Process_vkGetImageSparseMemoryRequirements(call_info, device, image, &pSparseMemoryRequirementCount, &pSparseMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSparseImageFormatProperties(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSparseImageFormatProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -642,13 +642,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSparseImageFormatProperties(cons
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSparseImageFormatProperties(physicalDevice, format, type, samples, usage, tiling, &pPropertyCount, &pProperties);
+        consumer->Process_vkGetPhysicalDeviceSparseImageFormatProperties(call_info, physicalDevice, format, type, samples, usage, tiling, &pPropertyCount, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkQueueBindSparse(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkQueueBindSparse(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -666,13 +666,13 @@ size_t VulkanDecoder::Decode_vkQueueBindSparse(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkQueueBindSparse(return_value, queue, bindInfoCount, &pBindInfo, fence);
+        consumer->Process_vkQueueBindSparse(call_info, return_value, queue, bindInfoCount, &pBindInfo, fence);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateFence(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateFence(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -690,13 +690,13 @@ size_t VulkanDecoder::Decode_vkCreateFence(const uint8_t* parameter_buffer, size
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateFence(return_value, device, &pCreateInfo, &pAllocator, &pFence);
+        consumer->Process_vkCreateFence(call_info, return_value, device, &pCreateInfo, &pAllocator, &pFence);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyFence(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyFence(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -710,13 +710,13 @@ size_t VulkanDecoder::Decode_vkDestroyFence(const uint8_t* parameter_buffer, siz
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyFence(device, fence, &pAllocator);
+        consumer->Process_vkDestroyFence(call_info, device, fence, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkResetFences(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkResetFences(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -732,13 +732,13 @@ size_t VulkanDecoder::Decode_vkResetFences(const uint8_t* parameter_buffer, size
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkResetFences(return_value, device, fenceCount, &pFences);
+        consumer->Process_vkResetFences(call_info, return_value, device, fenceCount, &pFences);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetFenceStatus(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetFenceStatus(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -752,13 +752,13 @@ size_t VulkanDecoder::Decode_vkGetFenceStatus(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetFenceStatus(return_value, device, fence);
+        consumer->Process_vkGetFenceStatus(call_info, return_value, device, fence);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkWaitForFences(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkWaitForFences(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -778,13 +778,13 @@ size_t VulkanDecoder::Decode_vkWaitForFences(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkWaitForFences(return_value, device, fenceCount, &pFences, waitAll, timeout);
+        consumer->Process_vkWaitForFences(call_info, return_value, device, fenceCount, &pFences, waitAll, timeout);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateSemaphore(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateSemaphore(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -802,13 +802,13 @@ size_t VulkanDecoder::Decode_vkCreateSemaphore(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateSemaphore(return_value, device, &pCreateInfo, &pAllocator, &pSemaphore);
+        consumer->Process_vkCreateSemaphore(call_info, return_value, device, &pCreateInfo, &pAllocator, &pSemaphore);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroySemaphore(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroySemaphore(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -822,13 +822,13 @@ size_t VulkanDecoder::Decode_vkDestroySemaphore(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroySemaphore(device, semaphore, &pAllocator);
+        consumer->Process_vkDestroySemaphore(call_info, device, semaphore, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateEvent(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateEvent(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -846,13 +846,13 @@ size_t VulkanDecoder::Decode_vkCreateEvent(const uint8_t* parameter_buffer, size
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateEvent(return_value, device, &pCreateInfo, &pAllocator, &pEvent);
+        consumer->Process_vkCreateEvent(call_info, return_value, device, &pCreateInfo, &pAllocator, &pEvent);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyEvent(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyEvent(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -866,13 +866,13 @@ size_t VulkanDecoder::Decode_vkDestroyEvent(const uint8_t* parameter_buffer, siz
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyEvent(device, event, &pAllocator);
+        consumer->Process_vkDestroyEvent(call_info, device, event, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetEventStatus(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetEventStatus(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -886,13 +886,13 @@ size_t VulkanDecoder::Decode_vkGetEventStatus(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetEventStatus(return_value, device, event);
+        consumer->Process_vkGetEventStatus(call_info, return_value, device, event);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkSetEvent(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkSetEvent(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -906,13 +906,13 @@ size_t VulkanDecoder::Decode_vkSetEvent(const uint8_t* parameter_buffer, size_t 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkSetEvent(return_value, device, event);
+        consumer->Process_vkSetEvent(call_info, return_value, device, event);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkResetEvent(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkResetEvent(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -926,13 +926,13 @@ size_t VulkanDecoder::Decode_vkResetEvent(const uint8_t* parameter_buffer, size_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkResetEvent(return_value, device, event);
+        consumer->Process_vkResetEvent(call_info, return_value, device, event);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateQueryPool(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateQueryPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -950,13 +950,13 @@ size_t VulkanDecoder::Decode_vkCreateQueryPool(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateQueryPool(return_value, device, &pCreateInfo, &pAllocator, &pQueryPool);
+        consumer->Process_vkCreateQueryPool(call_info, return_value, device, &pCreateInfo, &pAllocator, &pQueryPool);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyQueryPool(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyQueryPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -970,13 +970,13 @@ size_t VulkanDecoder::Decode_vkDestroyQueryPool(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyQueryPool(device, queryPool, &pAllocator);
+        consumer->Process_vkDestroyQueryPool(call_info, device, queryPool, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetQueryPoolResults(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetQueryPoolResults(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1002,13 +1002,13 @@ size_t VulkanDecoder::Decode_vkGetQueryPoolResults(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetQueryPoolResults(return_value, device, queryPool, firstQuery, queryCount, dataSize, &pData, stride, flags);
+        consumer->Process_vkGetQueryPoolResults(call_info, return_value, device, queryPool, firstQuery, queryCount, dataSize, &pData, stride, flags);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateBuffer(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1026,13 +1026,13 @@ size_t VulkanDecoder::Decode_vkCreateBuffer(const uint8_t* parameter_buffer, siz
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateBuffer(return_value, device, &pCreateInfo, &pAllocator, &pBuffer);
+        consumer->Process_vkCreateBuffer(call_info, return_value, device, &pCreateInfo, &pAllocator, &pBuffer);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyBuffer(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1046,13 +1046,13 @@ size_t VulkanDecoder::Decode_vkDestroyBuffer(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyBuffer(device, buffer, &pAllocator);
+        consumer->Process_vkDestroyBuffer(call_info, device, buffer, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateBufferView(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateBufferView(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1070,13 +1070,13 @@ size_t VulkanDecoder::Decode_vkCreateBufferView(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateBufferView(return_value, device, &pCreateInfo, &pAllocator, &pView);
+        consumer->Process_vkCreateBufferView(call_info, return_value, device, &pCreateInfo, &pAllocator, &pView);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyBufferView(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyBufferView(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1090,13 +1090,13 @@ size_t VulkanDecoder::Decode_vkDestroyBufferView(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyBufferView(device, bufferView, &pAllocator);
+        consumer->Process_vkDestroyBufferView(call_info, device, bufferView, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateImage(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateImage(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1114,13 +1114,13 @@ size_t VulkanDecoder::Decode_vkCreateImage(const uint8_t* parameter_buffer, size
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateImage(return_value, device, &pCreateInfo, &pAllocator, &pImage);
+        consumer->Process_vkCreateImage(call_info, return_value, device, &pCreateInfo, &pAllocator, &pImage);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyImage(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyImage(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1134,13 +1134,13 @@ size_t VulkanDecoder::Decode_vkDestroyImage(const uint8_t* parameter_buffer, siz
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyImage(device, image, &pAllocator);
+        consumer->Process_vkDestroyImage(call_info, device, image, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetImageSubresourceLayout(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetImageSubresourceLayout(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1156,13 +1156,13 @@ size_t VulkanDecoder::Decode_vkGetImageSubresourceLayout(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetImageSubresourceLayout(device, image, &pSubresource, &pLayout);
+        consumer->Process_vkGetImageSubresourceLayout(call_info, device, image, &pSubresource, &pLayout);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateImageView(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateImageView(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1180,13 +1180,13 @@ size_t VulkanDecoder::Decode_vkCreateImageView(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateImageView(return_value, device, &pCreateInfo, &pAllocator, &pView);
+        consumer->Process_vkCreateImageView(call_info, return_value, device, &pCreateInfo, &pAllocator, &pView);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyImageView(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyImageView(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1200,13 +1200,13 @@ size_t VulkanDecoder::Decode_vkDestroyImageView(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyImageView(device, imageView, &pAllocator);
+        consumer->Process_vkDestroyImageView(call_info, device, imageView, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateShaderModule(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateShaderModule(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1224,13 +1224,13 @@ size_t VulkanDecoder::Decode_vkCreateShaderModule(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateShaderModule(return_value, device, &pCreateInfo, &pAllocator, &pShaderModule);
+        consumer->Process_vkCreateShaderModule(call_info, return_value, device, &pCreateInfo, &pAllocator, &pShaderModule);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyShaderModule(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyShaderModule(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1244,13 +1244,13 @@ size_t VulkanDecoder::Decode_vkDestroyShaderModule(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyShaderModule(device, shaderModule, &pAllocator);
+        consumer->Process_vkDestroyShaderModule(call_info, device, shaderModule, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreatePipelineCache(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreatePipelineCache(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1268,13 +1268,13 @@ size_t VulkanDecoder::Decode_vkCreatePipelineCache(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreatePipelineCache(return_value, device, &pCreateInfo, &pAllocator, &pPipelineCache);
+        consumer->Process_vkCreatePipelineCache(call_info, return_value, device, &pCreateInfo, &pAllocator, &pPipelineCache);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyPipelineCache(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyPipelineCache(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1288,13 +1288,13 @@ size_t VulkanDecoder::Decode_vkDestroyPipelineCache(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyPipelineCache(device, pipelineCache, &pAllocator);
+        consumer->Process_vkDestroyPipelineCache(call_info, device, pipelineCache, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPipelineCacheData(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPipelineCacheData(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1312,13 +1312,13 @@ size_t VulkanDecoder::Decode_vkGetPipelineCacheData(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPipelineCacheData(return_value, device, pipelineCache, &pDataSize, &pData);
+        consumer->Process_vkGetPipelineCacheData(call_info, return_value, device, pipelineCache, &pDataSize, &pData);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkMergePipelineCaches(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkMergePipelineCaches(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1336,13 +1336,13 @@ size_t VulkanDecoder::Decode_vkMergePipelineCaches(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkMergePipelineCaches(return_value, device, dstCache, srcCacheCount, &pSrcCaches);
+        consumer->Process_vkMergePipelineCaches(call_info, return_value, device, dstCache, srcCacheCount, &pSrcCaches);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateGraphicsPipelines(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateGraphicsPipelines(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1364,13 +1364,13 @@ size_t VulkanDecoder::Decode_vkCreateGraphicsPipelines(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateGraphicsPipelines(return_value, device, pipelineCache, createInfoCount, &pCreateInfos, &pAllocator, &pPipelines);
+        consumer->Process_vkCreateGraphicsPipelines(call_info, return_value, device, pipelineCache, createInfoCount, &pCreateInfos, &pAllocator, &pPipelines);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateComputePipelines(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateComputePipelines(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1392,13 +1392,13 @@ size_t VulkanDecoder::Decode_vkCreateComputePipelines(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateComputePipelines(return_value, device, pipelineCache, createInfoCount, &pCreateInfos, &pAllocator, &pPipelines);
+        consumer->Process_vkCreateComputePipelines(call_info, return_value, device, pipelineCache, createInfoCount, &pCreateInfos, &pAllocator, &pPipelines);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyPipeline(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyPipeline(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1412,13 +1412,13 @@ size_t VulkanDecoder::Decode_vkDestroyPipeline(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyPipeline(device, pipeline, &pAllocator);
+        consumer->Process_vkDestroyPipeline(call_info, device, pipeline, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreatePipelineLayout(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreatePipelineLayout(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1436,13 +1436,13 @@ size_t VulkanDecoder::Decode_vkCreatePipelineLayout(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreatePipelineLayout(return_value, device, &pCreateInfo, &pAllocator, &pPipelineLayout);
+        consumer->Process_vkCreatePipelineLayout(call_info, return_value, device, &pCreateInfo, &pAllocator, &pPipelineLayout);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyPipelineLayout(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyPipelineLayout(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1456,13 +1456,13 @@ size_t VulkanDecoder::Decode_vkDestroyPipelineLayout(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyPipelineLayout(device, pipelineLayout, &pAllocator);
+        consumer->Process_vkDestroyPipelineLayout(call_info, device, pipelineLayout, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateSampler(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateSampler(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1480,13 +1480,13 @@ size_t VulkanDecoder::Decode_vkCreateSampler(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateSampler(return_value, device, &pCreateInfo, &pAllocator, &pSampler);
+        consumer->Process_vkCreateSampler(call_info, return_value, device, &pCreateInfo, &pAllocator, &pSampler);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroySampler(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroySampler(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1500,13 +1500,13 @@ size_t VulkanDecoder::Decode_vkDestroySampler(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroySampler(device, sampler, &pAllocator);
+        consumer->Process_vkDestroySampler(call_info, device, sampler, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateDescriptorSetLayout(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateDescriptorSetLayout(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1524,13 +1524,13 @@ size_t VulkanDecoder::Decode_vkCreateDescriptorSetLayout(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDescriptorSetLayout(return_value, device, &pCreateInfo, &pAllocator, &pSetLayout);
+        consumer->Process_vkCreateDescriptorSetLayout(call_info, return_value, device, &pCreateInfo, &pAllocator, &pSetLayout);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyDescriptorSetLayout(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyDescriptorSetLayout(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1544,13 +1544,13 @@ size_t VulkanDecoder::Decode_vkDestroyDescriptorSetLayout(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyDescriptorSetLayout(device, descriptorSetLayout, &pAllocator);
+        consumer->Process_vkDestroyDescriptorSetLayout(call_info, device, descriptorSetLayout, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateDescriptorPool(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateDescriptorPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1568,13 +1568,13 @@ size_t VulkanDecoder::Decode_vkCreateDescriptorPool(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDescriptorPool(return_value, device, &pCreateInfo, &pAllocator, &pDescriptorPool);
+        consumer->Process_vkCreateDescriptorPool(call_info, return_value, device, &pCreateInfo, &pAllocator, &pDescriptorPool);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyDescriptorPool(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyDescriptorPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1588,13 +1588,13 @@ size_t VulkanDecoder::Decode_vkDestroyDescriptorPool(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyDescriptorPool(device, descriptorPool, &pAllocator);
+        consumer->Process_vkDestroyDescriptorPool(call_info, device, descriptorPool, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkResetDescriptorPool(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkResetDescriptorPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1610,13 +1610,13 @@ size_t VulkanDecoder::Decode_vkResetDescriptorPool(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkResetDescriptorPool(return_value, device, descriptorPool, flags);
+        consumer->Process_vkResetDescriptorPool(call_info, return_value, device, descriptorPool, flags);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkAllocateDescriptorSets(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkAllocateDescriptorSets(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1632,13 +1632,13 @@ size_t VulkanDecoder::Decode_vkAllocateDescriptorSets(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkAllocateDescriptorSets(return_value, device, &pAllocateInfo, &pDescriptorSets);
+        consumer->Process_vkAllocateDescriptorSets(call_info, return_value, device, &pAllocateInfo, &pDescriptorSets);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkFreeDescriptorSets(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkFreeDescriptorSets(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1656,13 +1656,13 @@ size_t VulkanDecoder::Decode_vkFreeDescriptorSets(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkFreeDescriptorSets(return_value, device, descriptorPool, descriptorSetCount, &pDescriptorSets);
+        consumer->Process_vkFreeDescriptorSets(call_info, return_value, device, descriptorPool, descriptorSetCount, &pDescriptorSets);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkUpdateDescriptorSets(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkUpdateDescriptorSets(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1680,13 +1680,13 @@ size_t VulkanDecoder::Decode_vkUpdateDescriptorSets(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkUpdateDescriptorSets(device, descriptorWriteCount, &pDescriptorWrites, descriptorCopyCount, &pDescriptorCopies);
+        consumer->Process_vkUpdateDescriptorSets(call_info, device, descriptorWriteCount, &pDescriptorWrites, descriptorCopyCount, &pDescriptorCopies);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateFramebuffer(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateFramebuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1704,13 +1704,13 @@ size_t VulkanDecoder::Decode_vkCreateFramebuffer(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateFramebuffer(return_value, device, &pCreateInfo, &pAllocator, &pFramebuffer);
+        consumer->Process_vkCreateFramebuffer(call_info, return_value, device, &pCreateInfo, &pAllocator, &pFramebuffer);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyFramebuffer(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyFramebuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1724,13 +1724,13 @@ size_t VulkanDecoder::Decode_vkDestroyFramebuffer(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyFramebuffer(device, framebuffer, &pAllocator);
+        consumer->Process_vkDestroyFramebuffer(call_info, device, framebuffer, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateRenderPass(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateRenderPass(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1748,13 +1748,13 @@ size_t VulkanDecoder::Decode_vkCreateRenderPass(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateRenderPass(return_value, device, &pCreateInfo, &pAllocator, &pRenderPass);
+        consumer->Process_vkCreateRenderPass(call_info, return_value, device, &pCreateInfo, &pAllocator, &pRenderPass);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyRenderPass(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyRenderPass(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1768,13 +1768,13 @@ size_t VulkanDecoder::Decode_vkDestroyRenderPass(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyRenderPass(device, renderPass, &pAllocator);
+        consumer->Process_vkDestroyRenderPass(call_info, device, renderPass, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetRenderAreaGranularity(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetRenderAreaGranularity(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1788,13 +1788,13 @@ size_t VulkanDecoder::Decode_vkGetRenderAreaGranularity(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetRenderAreaGranularity(device, renderPass, &pGranularity);
+        consumer->Process_vkGetRenderAreaGranularity(call_info, device, renderPass, &pGranularity);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateCommandPool(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateCommandPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1812,13 +1812,13 @@ size_t VulkanDecoder::Decode_vkCreateCommandPool(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateCommandPool(return_value, device, &pCreateInfo, &pAllocator, &pCommandPool);
+        consumer->Process_vkCreateCommandPool(call_info, return_value, device, &pCreateInfo, &pAllocator, &pCommandPool);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyCommandPool(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyCommandPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1832,13 +1832,13 @@ size_t VulkanDecoder::Decode_vkDestroyCommandPool(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyCommandPool(device, commandPool, &pAllocator);
+        consumer->Process_vkDestroyCommandPool(call_info, device, commandPool, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkResetCommandPool(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkResetCommandPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1854,13 +1854,13 @@ size_t VulkanDecoder::Decode_vkResetCommandPool(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkResetCommandPool(return_value, device, commandPool, flags);
+        consumer->Process_vkResetCommandPool(call_info, return_value, device, commandPool, flags);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkAllocateCommandBuffers(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkAllocateCommandBuffers(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1876,13 +1876,13 @@ size_t VulkanDecoder::Decode_vkAllocateCommandBuffers(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkAllocateCommandBuffers(return_value, device, &pAllocateInfo, &pCommandBuffers);
+        consumer->Process_vkAllocateCommandBuffers(call_info, return_value, device, &pAllocateInfo, &pCommandBuffers);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkFreeCommandBuffers(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkFreeCommandBuffers(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1898,13 +1898,13 @@ size_t VulkanDecoder::Decode_vkFreeCommandBuffers(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkFreeCommandBuffers(device, commandPool, commandBufferCount, &pCommandBuffers);
+        consumer->Process_vkFreeCommandBuffers(call_info, device, commandPool, commandBufferCount, &pCommandBuffers);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkBeginCommandBuffer(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkBeginCommandBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1918,13 +1918,13 @@ size_t VulkanDecoder::Decode_vkBeginCommandBuffer(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkBeginCommandBuffer(return_value, commandBuffer, &pBeginInfo);
+        consumer->Process_vkBeginCommandBuffer(call_info, return_value, commandBuffer, &pBeginInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkEndCommandBuffer(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkEndCommandBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1936,13 +1936,13 @@ size_t VulkanDecoder::Decode_vkEndCommandBuffer(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkEndCommandBuffer(return_value, commandBuffer);
+        consumer->Process_vkEndCommandBuffer(call_info, return_value, commandBuffer);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkResetCommandBuffer(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkResetCommandBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1956,13 +1956,13 @@ size_t VulkanDecoder::Decode_vkResetCommandBuffer(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkResetCommandBuffer(return_value, commandBuffer, flags);
+        consumer->Process_vkResetCommandBuffer(call_info, return_value, commandBuffer, flags);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBindPipeline(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBindPipeline(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1976,13 +1976,13 @@ size_t VulkanDecoder::Decode_vkCmdBindPipeline(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline);
+        consumer->Process_vkCmdBindPipeline(call_info, commandBuffer, pipelineBindPoint, pipeline);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetViewport(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetViewport(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -1998,13 +1998,13 @@ size_t VulkanDecoder::Decode_vkCmdSetViewport(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetViewport(commandBuffer, firstViewport, viewportCount, &pViewports);
+        consumer->Process_vkCmdSetViewport(call_info, commandBuffer, firstViewport, viewportCount, &pViewports);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetScissor(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetScissor(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2020,13 +2020,13 @@ size_t VulkanDecoder::Decode_vkCmdSetScissor(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetScissor(commandBuffer, firstScissor, scissorCount, &pScissors);
+        consumer->Process_vkCmdSetScissor(call_info, commandBuffer, firstScissor, scissorCount, &pScissors);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetLineWidth(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetLineWidth(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2038,13 +2038,13 @@ size_t VulkanDecoder::Decode_vkCmdSetLineWidth(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetLineWidth(commandBuffer, lineWidth);
+        consumer->Process_vkCmdSetLineWidth(call_info, commandBuffer, lineWidth);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetDepthBias(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetDepthBias(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2060,13 +2060,13 @@ size_t VulkanDecoder::Decode_vkCmdSetDepthBias(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetDepthBias(commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
+        consumer->Process_vkCmdSetDepthBias(call_info, commandBuffer, depthBiasConstantFactor, depthBiasClamp, depthBiasSlopeFactor);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetBlendConstants(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetBlendConstants(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2078,13 +2078,13 @@ size_t VulkanDecoder::Decode_vkCmdSetBlendConstants(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetBlendConstants(commandBuffer, &blendConstants);
+        consumer->Process_vkCmdSetBlendConstants(call_info, commandBuffer, &blendConstants);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetDepthBounds(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetDepthBounds(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2098,13 +2098,13 @@ size_t VulkanDecoder::Decode_vkCmdSetDepthBounds(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetDepthBounds(commandBuffer, minDepthBounds, maxDepthBounds);
+        consumer->Process_vkCmdSetDepthBounds(call_info, commandBuffer, minDepthBounds, maxDepthBounds);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetStencilCompareMask(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetStencilCompareMask(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2118,13 +2118,13 @@ size_t VulkanDecoder::Decode_vkCmdSetStencilCompareMask(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetStencilCompareMask(commandBuffer, faceMask, compareMask);
+        consumer->Process_vkCmdSetStencilCompareMask(call_info, commandBuffer, faceMask, compareMask);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetStencilWriteMask(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetStencilWriteMask(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2138,13 +2138,13 @@ size_t VulkanDecoder::Decode_vkCmdSetStencilWriteMask(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetStencilWriteMask(commandBuffer, faceMask, writeMask);
+        consumer->Process_vkCmdSetStencilWriteMask(call_info, commandBuffer, faceMask, writeMask);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetStencilReference(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetStencilReference(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2158,13 +2158,13 @@ size_t VulkanDecoder::Decode_vkCmdSetStencilReference(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetStencilReference(commandBuffer, faceMask, reference);
+        consumer->Process_vkCmdSetStencilReference(call_info, commandBuffer, faceMask, reference);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBindDescriptorSets(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBindDescriptorSets(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2188,13 +2188,13 @@ size_t VulkanDecoder::Decode_vkCmdBindDescriptorSets(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, &pDescriptorSets, dynamicOffsetCount, &pDynamicOffsets);
+        consumer->Process_vkCmdBindDescriptorSets(call_info, commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount, &pDescriptorSets, dynamicOffsetCount, &pDynamicOffsets);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBindIndexBuffer(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBindIndexBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2210,13 +2210,13 @@ size_t VulkanDecoder::Decode_vkCmdBindIndexBuffer(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBindIndexBuffer(commandBuffer, buffer, offset, indexType);
+        consumer->Process_vkCmdBindIndexBuffer(call_info, commandBuffer, buffer, offset, indexType);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBindVertexBuffers(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBindVertexBuffers(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2234,13 +2234,13 @@ size_t VulkanDecoder::Decode_vkCmdBindVertexBuffers(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBindVertexBuffers(commandBuffer, firstBinding, bindingCount, &pBuffers, &pOffsets);
+        consumer->Process_vkCmdBindVertexBuffers(call_info, commandBuffer, firstBinding, bindingCount, &pBuffers, &pOffsets);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDraw(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDraw(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2258,13 +2258,13 @@ size_t VulkanDecoder::Decode_vkCmdDraw(const uint8_t* parameter_buffer, size_t b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
+        consumer->Process_vkCmdDraw(call_info, commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDrawIndexed(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDrawIndexed(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2284,13 +2284,13 @@ size_t VulkanDecoder::Decode_vkCmdDrawIndexed(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
+        consumer->Process_vkCmdDrawIndexed(call_info, commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDrawIndirect(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDrawIndirect(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2308,13 +2308,13 @@ size_t VulkanDecoder::Decode_vkCmdDrawIndirect(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride);
+        consumer->Process_vkCmdDrawIndirect(call_info, commandBuffer, buffer, offset, drawCount, stride);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDrawIndexedIndirect(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDrawIndexedIndirect(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2332,13 +2332,13 @@ size_t VulkanDecoder::Decode_vkCmdDrawIndexedIndirect(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride);
+        consumer->Process_vkCmdDrawIndexedIndirect(call_info, commandBuffer, buffer, offset, drawCount, stride);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDispatch(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDispatch(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2354,13 +2354,13 @@ size_t VulkanDecoder::Decode_vkCmdDispatch(const uint8_t* parameter_buffer, size
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ);
+        consumer->Process_vkCmdDispatch(call_info, commandBuffer, groupCountX, groupCountY, groupCountZ);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDispatchIndirect(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDispatchIndirect(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2374,13 +2374,13 @@ size_t VulkanDecoder::Decode_vkCmdDispatchIndirect(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDispatchIndirect(commandBuffer, buffer, offset);
+        consumer->Process_vkCmdDispatchIndirect(call_info, commandBuffer, buffer, offset);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyBuffer(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2398,13 +2398,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyBuffer(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, &pRegions);
+        consumer->Process_vkCmdCopyBuffer(call_info, commandBuffer, srcBuffer, dstBuffer, regionCount, &pRegions);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyImage(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyImage(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2426,13 +2426,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyImage(const uint8_t* parameter_buffer, siz
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, &pRegions);
+        consumer->Process_vkCmdCopyImage(call_info, commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, &pRegions);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBlitImage(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBlitImage(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2456,13 +2456,13 @@ size_t VulkanDecoder::Decode_vkCmdBlitImage(const uint8_t* parameter_buffer, siz
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, &pRegions, filter);
+        consumer->Process_vkCmdBlitImage(call_info, commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, &pRegions, filter);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyBufferToImage(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyBufferToImage(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2482,13 +2482,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyBufferToImage(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, &pRegions);
+        consumer->Process_vkCmdCopyBufferToImage(call_info, commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, &pRegions);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyImageToBuffer(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyImageToBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2508,13 +2508,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyImageToBuffer(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, &pRegions);
+        consumer->Process_vkCmdCopyImageToBuffer(call_info, commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, &pRegions);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdUpdateBuffer(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdUpdateBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2532,13 +2532,13 @@ size_t VulkanDecoder::Decode_vkCmdUpdateBuffer(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, &pData);
+        consumer->Process_vkCmdUpdateBuffer(call_info, commandBuffer, dstBuffer, dstOffset, dataSize, &pData);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdFillBuffer(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdFillBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2556,13 +2556,13 @@ size_t VulkanDecoder::Decode_vkCmdFillBuffer(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data);
+        consumer->Process_vkCmdFillBuffer(call_info, commandBuffer, dstBuffer, dstOffset, size, data);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdClearColorImage(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdClearColorImage(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2582,13 +2582,13 @@ size_t VulkanDecoder::Decode_vkCmdClearColorImage(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdClearColorImage(commandBuffer, image, imageLayout, &pColor, rangeCount, &pRanges);
+        consumer->Process_vkCmdClearColorImage(call_info, commandBuffer, image, imageLayout, &pColor, rangeCount, &pRanges);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdClearDepthStencilImage(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdClearDepthStencilImage(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2608,13 +2608,13 @@ size_t VulkanDecoder::Decode_vkCmdClearDepthStencilImage(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, &pDepthStencil, rangeCount, &pRanges);
+        consumer->Process_vkCmdClearDepthStencilImage(call_info, commandBuffer, image, imageLayout, &pDepthStencil, rangeCount, &pRanges);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdClearAttachments(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdClearAttachments(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2632,13 +2632,13 @@ size_t VulkanDecoder::Decode_vkCmdClearAttachments(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdClearAttachments(commandBuffer, attachmentCount, &pAttachments, rectCount, &pRects);
+        consumer->Process_vkCmdClearAttachments(call_info, commandBuffer, attachmentCount, &pAttachments, rectCount, &pRects);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdResolveImage(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdResolveImage(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2660,13 +2660,13 @@ size_t VulkanDecoder::Decode_vkCmdResolveImage(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, &pRegions);
+        consumer->Process_vkCmdResolveImage(call_info, commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, &pRegions);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetEvent(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetEvent(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2680,13 +2680,13 @@ size_t VulkanDecoder::Decode_vkCmdSetEvent(const uint8_t* parameter_buffer, size
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetEvent(commandBuffer, event, stageMask);
+        consumer->Process_vkCmdSetEvent(call_info, commandBuffer, event, stageMask);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdResetEvent(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdResetEvent(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2700,13 +2700,13 @@ size_t VulkanDecoder::Decode_vkCmdResetEvent(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdResetEvent(commandBuffer, event, stageMask);
+        consumer->Process_vkCmdResetEvent(call_info, commandBuffer, event, stageMask);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdWaitEvents(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdWaitEvents(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2736,13 +2736,13 @@ size_t VulkanDecoder::Decode_vkCmdWaitEvents(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdWaitEvents(commandBuffer, eventCount, &pEvents, srcStageMask, dstStageMask, memoryBarrierCount, &pMemoryBarriers, bufferMemoryBarrierCount, &pBufferMemoryBarriers, imageMemoryBarrierCount, &pImageMemoryBarriers);
+        consumer->Process_vkCmdWaitEvents(call_info, commandBuffer, eventCount, &pEvents, srcStageMask, dstStageMask, memoryBarrierCount, &pMemoryBarriers, bufferMemoryBarrierCount, &pBufferMemoryBarriers, imageMemoryBarrierCount, &pImageMemoryBarriers);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdPipelineBarrier(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdPipelineBarrier(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2770,13 +2770,13 @@ size_t VulkanDecoder::Decode_vkCmdPipelineBarrier(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, &pMemoryBarriers, bufferMemoryBarrierCount, &pBufferMemoryBarriers, imageMemoryBarrierCount, &pImageMemoryBarriers);
+        consumer->Process_vkCmdPipelineBarrier(call_info, commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, &pMemoryBarriers, bufferMemoryBarrierCount, &pBufferMemoryBarriers, imageMemoryBarrierCount, &pImageMemoryBarriers);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBeginQuery(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBeginQuery(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2792,13 +2792,13 @@ size_t VulkanDecoder::Decode_vkCmdBeginQuery(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBeginQuery(commandBuffer, queryPool, query, flags);
+        consumer->Process_vkCmdBeginQuery(call_info, commandBuffer, queryPool, query, flags);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdEndQuery(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdEndQuery(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2812,13 +2812,13 @@ size_t VulkanDecoder::Decode_vkCmdEndQuery(const uint8_t* parameter_buffer, size
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdEndQuery(commandBuffer, queryPool, query);
+        consumer->Process_vkCmdEndQuery(call_info, commandBuffer, queryPool, query);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdResetQueryPool(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdResetQueryPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2834,13 +2834,13 @@ size_t VulkanDecoder::Decode_vkCmdResetQueryPool(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount);
+        consumer->Process_vkCmdResetQueryPool(call_info, commandBuffer, queryPool, firstQuery, queryCount);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdWriteTimestamp(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdWriteTimestamp(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2856,13 +2856,13 @@ size_t VulkanDecoder::Decode_vkCmdWriteTimestamp(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query);
+        consumer->Process_vkCmdWriteTimestamp(call_info, commandBuffer, pipelineStage, queryPool, query);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyQueryPoolResults(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyQueryPoolResults(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2886,13 +2886,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyQueryPoolResults(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyQueryPoolResults(commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags);
+        consumer->Process_vkCmdCopyQueryPoolResults(call_info, commandBuffer, queryPool, firstQuery, queryCount, dstBuffer, dstOffset, stride, flags);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdPushConstants(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdPushConstants(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2912,13 +2912,13 @@ size_t VulkanDecoder::Decode_vkCmdPushConstants(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, &pValues);
+        consumer->Process_vkCmdPushConstants(call_info, commandBuffer, layout, stageFlags, offset, size, &pValues);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBeginRenderPass(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBeginRenderPass(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2932,13 +2932,13 @@ size_t VulkanDecoder::Decode_vkCmdBeginRenderPass(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBeginRenderPass(commandBuffer, &pRenderPassBegin, contents);
+        consumer->Process_vkCmdBeginRenderPass(call_info, commandBuffer, &pRenderPassBegin, contents);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdNextSubpass(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdNextSubpass(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2950,13 +2950,13 @@ size_t VulkanDecoder::Decode_vkCmdNextSubpass(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdNextSubpass(commandBuffer, contents);
+        consumer->Process_vkCmdNextSubpass(call_info, commandBuffer, contents);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdEndRenderPass(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdEndRenderPass(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2966,13 +2966,13 @@ size_t VulkanDecoder::Decode_vkCmdEndRenderPass(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdEndRenderPass(commandBuffer);
+        consumer->Process_vkCmdEndRenderPass(call_info, commandBuffer);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdExecuteCommands(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdExecuteCommands(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -2986,13 +2986,13 @@ size_t VulkanDecoder::Decode_vkCmdExecuteCommands(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdExecuteCommands(commandBuffer, commandBufferCount, &pCommandBuffers);
+        consumer->Process_vkCmdExecuteCommands(call_info, commandBuffer, commandBufferCount, &pCommandBuffers);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkBindBufferMemory2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkBindBufferMemory2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3008,13 +3008,13 @@ size_t VulkanDecoder::Decode_vkBindBufferMemory2(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkBindBufferMemory2(return_value, device, bindInfoCount, &pBindInfos);
+        consumer->Process_vkBindBufferMemory2(call_info, return_value, device, bindInfoCount, &pBindInfos);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkBindImageMemory2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkBindImageMemory2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3030,13 +3030,13 @@ size_t VulkanDecoder::Decode_vkBindImageMemory2(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkBindImageMemory2(return_value, device, bindInfoCount, &pBindInfos);
+        consumer->Process_vkBindImageMemory2(call_info, return_value, device, bindInfoCount, &pBindInfos);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceGroupPeerMemoryFeatures(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceGroupPeerMemoryFeatures(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3054,13 +3054,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceGroupPeerMemoryFeatures(const uint8_t* p
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceGroupPeerMemoryFeatures(device, heapIndex, localDeviceIndex, remoteDeviceIndex, &pPeerMemoryFeatures);
+        consumer->Process_vkGetDeviceGroupPeerMemoryFeatures(call_info, device, heapIndex, localDeviceIndex, remoteDeviceIndex, &pPeerMemoryFeatures);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetDeviceMask(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetDeviceMask(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3072,13 +3072,13 @@ size_t VulkanDecoder::Decode_vkCmdSetDeviceMask(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetDeviceMask(commandBuffer, deviceMask);
+        consumer->Process_vkCmdSetDeviceMask(call_info, commandBuffer, deviceMask);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDispatchBase(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDispatchBase(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3100,13 +3100,13 @@ size_t VulkanDecoder::Decode_vkCmdDispatchBase(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
+        consumer->Process_vkCmdDispatchBase(call_info, commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkEnumeratePhysicalDeviceGroups(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkEnumeratePhysicalDeviceGroups(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3122,13 +3122,13 @@ size_t VulkanDecoder::Decode_vkEnumeratePhysicalDeviceGroups(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkEnumeratePhysicalDeviceGroups(return_value, instance, &pPhysicalDeviceGroupCount, &pPhysicalDeviceGroupProperties);
+        consumer->Process_vkEnumeratePhysicalDeviceGroups(call_info, return_value, instance, &pPhysicalDeviceGroupCount, &pPhysicalDeviceGroupProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetImageMemoryRequirements2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetImageMemoryRequirements2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3142,13 +3142,13 @@ size_t VulkanDecoder::Decode_vkGetImageMemoryRequirements2(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetImageMemoryRequirements2(device, &pInfo, &pMemoryRequirements);
+        consumer->Process_vkGetImageMemoryRequirements2(call_info, device, &pInfo, &pMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetBufferMemoryRequirements2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetBufferMemoryRequirements2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3162,13 +3162,13 @@ size_t VulkanDecoder::Decode_vkGetBufferMemoryRequirements2(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetBufferMemoryRequirements2(device, &pInfo, &pMemoryRequirements);
+        consumer->Process_vkGetBufferMemoryRequirements2(call_info, device, &pInfo, &pMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetImageSparseMemoryRequirements2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetImageSparseMemoryRequirements2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3184,13 +3184,13 @@ size_t VulkanDecoder::Decode_vkGetImageSparseMemoryRequirements2(const uint8_t* 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetImageSparseMemoryRequirements2(device, &pInfo, &pSparseMemoryRequirementCount, &pSparseMemoryRequirements);
+        consumer->Process_vkGetImageSparseMemoryRequirements2(call_info, device, &pInfo, &pSparseMemoryRequirementCount, &pSparseMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFeatures2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFeatures2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3202,13 +3202,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFeatures2(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceFeatures2(physicalDevice, &pFeatures);
+        consumer->Process_vkGetPhysicalDeviceFeatures2(call_info, physicalDevice, &pFeatures);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceProperties2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceProperties2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3220,13 +3220,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceProperties2(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceProperties2(physicalDevice, &pProperties);
+        consumer->Process_vkGetPhysicalDeviceProperties2(call_info, physicalDevice, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFormatProperties2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFormatProperties2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3240,13 +3240,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFormatProperties2(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceFormatProperties2(physicalDevice, format, &pFormatProperties);
+        consumer->Process_vkGetPhysicalDeviceFormatProperties2(call_info, physicalDevice, format, &pFormatProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceImageFormatProperties2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceImageFormatProperties2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3262,13 +3262,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceImageFormatProperties2(const uin
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceImageFormatProperties2(return_value, physicalDevice, &pImageFormatInfo, &pImageFormatProperties);
+        consumer->Process_vkGetPhysicalDeviceImageFormatProperties2(call_info, return_value, physicalDevice, &pImageFormatInfo, &pImageFormatProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceQueueFamilyProperties2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceQueueFamilyProperties2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3282,13 +3282,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceQueueFamilyProperties2(const uin
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, &pQueueFamilyPropertyCount, &pQueueFamilyProperties);
+        consumer->Process_vkGetPhysicalDeviceQueueFamilyProperties2(call_info, physicalDevice, &pQueueFamilyPropertyCount, &pQueueFamilyProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceMemoryProperties2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceMemoryProperties2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3300,13 +3300,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceMemoryProperties2(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceMemoryProperties2(physicalDevice, &pMemoryProperties);
+        consumer->Process_vkGetPhysicalDeviceMemoryProperties2(call_info, physicalDevice, &pMemoryProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSparseImageFormatProperties2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSparseImageFormatProperties2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3322,13 +3322,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSparseImageFormatProperties2(con
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, &pFormatInfo, &pPropertyCount, &pProperties);
+        consumer->Process_vkGetPhysicalDeviceSparseImageFormatProperties2(call_info, physicalDevice, &pFormatInfo, &pPropertyCount, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkTrimCommandPool(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkTrimCommandPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3342,13 +3342,13 @@ size_t VulkanDecoder::Decode_vkTrimCommandPool(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkTrimCommandPool(device, commandPool, flags);
+        consumer->Process_vkTrimCommandPool(call_info, device, commandPool, flags);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceQueue2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceQueue2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3362,13 +3362,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceQueue2(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceQueue2(device, &pQueueInfo, &pQueue);
+        consumer->Process_vkGetDeviceQueue2(call_info, device, &pQueueInfo, &pQueue);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateSamplerYcbcrConversion(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateSamplerYcbcrConversion(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3386,13 +3386,13 @@ size_t VulkanDecoder::Decode_vkCreateSamplerYcbcrConversion(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateSamplerYcbcrConversion(return_value, device, &pCreateInfo, &pAllocator, &pYcbcrConversion);
+        consumer->Process_vkCreateSamplerYcbcrConversion(call_info, return_value, device, &pCreateInfo, &pAllocator, &pYcbcrConversion);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroySamplerYcbcrConversion(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroySamplerYcbcrConversion(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3406,13 +3406,13 @@ size_t VulkanDecoder::Decode_vkDestroySamplerYcbcrConversion(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroySamplerYcbcrConversion(device, ycbcrConversion, &pAllocator);
+        consumer->Process_vkDestroySamplerYcbcrConversion(call_info, device, ycbcrConversion, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateDescriptorUpdateTemplate(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateDescriptorUpdateTemplate(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3430,13 +3430,13 @@ size_t VulkanDecoder::Decode_vkCreateDescriptorUpdateTemplate(const uint8_t* par
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDescriptorUpdateTemplate(return_value, device, &pCreateInfo, &pAllocator, &pDescriptorUpdateTemplate);
+        consumer->Process_vkCreateDescriptorUpdateTemplate(call_info, return_value, device, &pCreateInfo, &pAllocator, &pDescriptorUpdateTemplate);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyDescriptorUpdateTemplate(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyDescriptorUpdateTemplate(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3450,13 +3450,13 @@ size_t VulkanDecoder::Decode_vkDestroyDescriptorUpdateTemplate(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyDescriptorUpdateTemplate(device, descriptorUpdateTemplate, &pAllocator);
+        consumer->Process_vkDestroyDescriptorUpdateTemplate(call_info, device, descriptorUpdateTemplate, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalBufferProperties(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalBufferProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3470,13 +3470,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalBufferProperties(const u
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceExternalBufferProperties(physicalDevice, &pExternalBufferInfo, &pExternalBufferProperties);
+        consumer->Process_vkGetPhysicalDeviceExternalBufferProperties(call_info, physicalDevice, &pExternalBufferInfo, &pExternalBufferProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalFenceProperties(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalFenceProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3490,13 +3490,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalFenceProperties(const ui
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceExternalFenceProperties(physicalDevice, &pExternalFenceInfo, &pExternalFenceProperties);
+        consumer->Process_vkGetPhysicalDeviceExternalFenceProperties(call_info, physicalDevice, &pExternalFenceInfo, &pExternalFenceProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalSemaphoreProperties(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalSemaphoreProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3510,13 +3510,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalSemaphoreProperties(cons
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceExternalSemaphoreProperties(physicalDevice, &pExternalSemaphoreInfo, &pExternalSemaphoreProperties);
+        consumer->Process_vkGetPhysicalDeviceExternalSemaphoreProperties(call_info, physicalDevice, &pExternalSemaphoreInfo, &pExternalSemaphoreProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDescriptorSetLayoutSupport(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDescriptorSetLayoutSupport(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3530,13 +3530,13 @@ size_t VulkanDecoder::Decode_vkGetDescriptorSetLayoutSupport(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDescriptorSetLayoutSupport(device, &pCreateInfo, &pSupport);
+        consumer->Process_vkGetDescriptorSetLayoutSupport(call_info, device, &pCreateInfo, &pSupport);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDrawIndirectCount(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDrawIndirectCount(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3558,13 +3558,13 @@ size_t VulkanDecoder::Decode_vkCmdDrawIndirectCount(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+        consumer->Process_vkCmdDrawIndirectCount(call_info, commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDrawIndexedIndirectCount(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDrawIndexedIndirectCount(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3586,13 +3586,13 @@ size_t VulkanDecoder::Decode_vkCmdDrawIndexedIndirectCount(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+        consumer->Process_vkCmdDrawIndexedIndirectCount(call_info, commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateRenderPass2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateRenderPass2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3610,13 +3610,13 @@ size_t VulkanDecoder::Decode_vkCreateRenderPass2(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateRenderPass2(return_value, device, &pCreateInfo, &pAllocator, &pRenderPass);
+        consumer->Process_vkCreateRenderPass2(call_info, return_value, device, &pCreateInfo, &pAllocator, &pRenderPass);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBeginRenderPass2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBeginRenderPass2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3630,13 +3630,13 @@ size_t VulkanDecoder::Decode_vkCmdBeginRenderPass2(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBeginRenderPass2(commandBuffer, &pRenderPassBegin, &pSubpassBeginInfo);
+        consumer->Process_vkCmdBeginRenderPass2(call_info, commandBuffer, &pRenderPassBegin, &pSubpassBeginInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdNextSubpass2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdNextSubpass2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3650,13 +3650,13 @@ size_t VulkanDecoder::Decode_vkCmdNextSubpass2(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdNextSubpass2(commandBuffer, &pSubpassBeginInfo, &pSubpassEndInfo);
+        consumer->Process_vkCmdNextSubpass2(call_info, commandBuffer, &pSubpassBeginInfo, &pSubpassEndInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdEndRenderPass2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdEndRenderPass2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3668,13 +3668,13 @@ size_t VulkanDecoder::Decode_vkCmdEndRenderPass2(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdEndRenderPass2(commandBuffer, &pSubpassEndInfo);
+        consumer->Process_vkCmdEndRenderPass2(call_info, commandBuffer, &pSubpassEndInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkResetQueryPool(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkResetQueryPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3690,13 +3690,13 @@ size_t VulkanDecoder::Decode_vkResetQueryPool(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkResetQueryPool(device, queryPool, firstQuery, queryCount);
+        consumer->Process_vkResetQueryPool(call_info, device, queryPool, firstQuery, queryCount);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetSemaphoreCounterValue(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetSemaphoreCounterValue(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3712,13 +3712,13 @@ size_t VulkanDecoder::Decode_vkGetSemaphoreCounterValue(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetSemaphoreCounterValue(return_value, device, semaphore, &pValue);
+        consumer->Process_vkGetSemaphoreCounterValue(call_info, return_value, device, semaphore, &pValue);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkWaitSemaphores(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkWaitSemaphores(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3734,13 +3734,13 @@ size_t VulkanDecoder::Decode_vkWaitSemaphores(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkWaitSemaphores(return_value, device, &pWaitInfo, timeout);
+        consumer->Process_vkWaitSemaphores(call_info, return_value, device, &pWaitInfo, timeout);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkSignalSemaphore(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkSignalSemaphore(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3754,13 +3754,13 @@ size_t VulkanDecoder::Decode_vkSignalSemaphore(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkSignalSemaphore(return_value, device, &pSignalInfo);
+        consumer->Process_vkSignalSemaphore(call_info, return_value, device, &pSignalInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetBufferDeviceAddress(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetBufferDeviceAddress(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3774,13 +3774,13 @@ size_t VulkanDecoder::Decode_vkGetBufferDeviceAddress(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetBufferDeviceAddress(return_value, device, &pInfo);
+        consumer->Process_vkGetBufferDeviceAddress(call_info, return_value, device, &pInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetBufferOpaqueCaptureAddress(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetBufferOpaqueCaptureAddress(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3794,13 +3794,13 @@ size_t VulkanDecoder::Decode_vkGetBufferOpaqueCaptureAddress(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetBufferOpaqueCaptureAddress(return_value, device, &pInfo);
+        consumer->Process_vkGetBufferOpaqueCaptureAddress(call_info, return_value, device, &pInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceMemoryOpaqueCaptureAddress(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceMemoryOpaqueCaptureAddress(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3814,13 +3814,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceMemoryOpaqueCaptureAddress(const uint8_t
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceMemoryOpaqueCaptureAddress(return_value, device, &pInfo);
+        consumer->Process_vkGetDeviceMemoryOpaqueCaptureAddress(call_info, return_value, device, &pInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceToolProperties(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceToolProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3836,13 +3836,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceToolProperties(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceToolProperties(return_value, physicalDevice, &pToolCount, &pToolProperties);
+        consumer->Process_vkGetPhysicalDeviceToolProperties(call_info, return_value, physicalDevice, &pToolCount, &pToolProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreatePrivateDataSlot(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreatePrivateDataSlot(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3860,13 +3860,13 @@ size_t VulkanDecoder::Decode_vkCreatePrivateDataSlot(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreatePrivateDataSlot(return_value, device, &pCreateInfo, &pAllocator, &pPrivateDataSlot);
+        consumer->Process_vkCreatePrivateDataSlot(call_info, return_value, device, &pCreateInfo, &pAllocator, &pPrivateDataSlot);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyPrivateDataSlot(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyPrivateDataSlot(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3880,13 +3880,13 @@ size_t VulkanDecoder::Decode_vkDestroyPrivateDataSlot(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyPrivateDataSlot(device, privateDataSlot, &pAllocator);
+        consumer->Process_vkDestroyPrivateDataSlot(call_info, device, privateDataSlot, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkSetPrivateData(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkSetPrivateData(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3906,13 +3906,13 @@ size_t VulkanDecoder::Decode_vkSetPrivateData(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkSetPrivateData(return_value, device, objectType, objectHandle, privateDataSlot, data);
+        consumer->Process_vkSetPrivateData(call_info, return_value, device, objectType, objectHandle, privateDataSlot, data);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPrivateData(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPrivateData(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3930,13 +3930,13 @@ size_t VulkanDecoder::Decode_vkGetPrivateData(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPrivateData(device, objectType, objectHandle, privateDataSlot, &pData);
+        consumer->Process_vkGetPrivateData(call_info, device, objectType, objectHandle, privateDataSlot, &pData);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetEvent2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetEvent2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3950,13 +3950,13 @@ size_t VulkanDecoder::Decode_vkCmdSetEvent2(const uint8_t* parameter_buffer, siz
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetEvent2(commandBuffer, event, &pDependencyInfo);
+        consumer->Process_vkCmdSetEvent2(call_info, commandBuffer, event, &pDependencyInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdResetEvent2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdResetEvent2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3970,13 +3970,13 @@ size_t VulkanDecoder::Decode_vkCmdResetEvent2(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdResetEvent2(commandBuffer, event, stageMask);
+        consumer->Process_vkCmdResetEvent2(call_info, commandBuffer, event, stageMask);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdWaitEvents2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdWaitEvents2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -3992,13 +3992,13 @@ size_t VulkanDecoder::Decode_vkCmdWaitEvents2(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdWaitEvents2(commandBuffer, eventCount, &pEvents, &pDependencyInfos);
+        consumer->Process_vkCmdWaitEvents2(call_info, commandBuffer, eventCount, &pEvents, &pDependencyInfos);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdPipelineBarrier2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdPipelineBarrier2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4010,13 +4010,13 @@ size_t VulkanDecoder::Decode_vkCmdPipelineBarrier2(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdPipelineBarrier2(commandBuffer, &pDependencyInfo);
+        consumer->Process_vkCmdPipelineBarrier2(call_info, commandBuffer, &pDependencyInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdWriteTimestamp2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdWriteTimestamp2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4032,13 +4032,13 @@ size_t VulkanDecoder::Decode_vkCmdWriteTimestamp2(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdWriteTimestamp2(commandBuffer, stage, queryPool, query);
+        consumer->Process_vkCmdWriteTimestamp2(call_info, commandBuffer, stage, queryPool, query);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkQueueSubmit2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkQueueSubmit2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4056,13 +4056,13 @@ size_t VulkanDecoder::Decode_vkQueueSubmit2(const uint8_t* parameter_buffer, siz
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkQueueSubmit2(return_value, queue, submitCount, &pSubmits, fence);
+        consumer->Process_vkQueueSubmit2(call_info, return_value, queue, submitCount, &pSubmits, fence);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyBuffer2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyBuffer2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4074,13 +4074,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyBuffer2(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyBuffer2(commandBuffer, &pCopyBufferInfo);
+        consumer->Process_vkCmdCopyBuffer2(call_info, commandBuffer, &pCopyBufferInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyImage2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyImage2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4092,13 +4092,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyImage2(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyImage2(commandBuffer, &pCopyImageInfo);
+        consumer->Process_vkCmdCopyImage2(call_info, commandBuffer, &pCopyImageInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyBufferToImage2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyBufferToImage2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4110,13 +4110,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyBufferToImage2(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyBufferToImage2(commandBuffer, &pCopyBufferToImageInfo);
+        consumer->Process_vkCmdCopyBufferToImage2(call_info, commandBuffer, &pCopyBufferToImageInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyImageToBuffer2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyImageToBuffer2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4128,13 +4128,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyImageToBuffer2(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyImageToBuffer2(commandBuffer, &pCopyImageToBufferInfo);
+        consumer->Process_vkCmdCopyImageToBuffer2(call_info, commandBuffer, &pCopyImageToBufferInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBlitImage2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBlitImage2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4146,13 +4146,13 @@ size_t VulkanDecoder::Decode_vkCmdBlitImage2(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBlitImage2(commandBuffer, &pBlitImageInfo);
+        consumer->Process_vkCmdBlitImage2(call_info, commandBuffer, &pBlitImageInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdResolveImage2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdResolveImage2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4164,13 +4164,13 @@ size_t VulkanDecoder::Decode_vkCmdResolveImage2(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdResolveImage2(commandBuffer, &pResolveImageInfo);
+        consumer->Process_vkCmdResolveImage2(call_info, commandBuffer, &pResolveImageInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBeginRendering(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBeginRendering(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4182,13 +4182,13 @@ size_t VulkanDecoder::Decode_vkCmdBeginRendering(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBeginRendering(commandBuffer, &pRenderingInfo);
+        consumer->Process_vkCmdBeginRendering(call_info, commandBuffer, &pRenderingInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdEndRendering(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdEndRendering(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4198,13 +4198,13 @@ size_t VulkanDecoder::Decode_vkCmdEndRendering(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdEndRendering(commandBuffer);
+        consumer->Process_vkCmdEndRendering(call_info, commandBuffer);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetCullMode(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetCullMode(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4216,13 +4216,13 @@ size_t VulkanDecoder::Decode_vkCmdSetCullMode(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetCullMode(commandBuffer, cullMode);
+        consumer->Process_vkCmdSetCullMode(call_info, commandBuffer, cullMode);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetFrontFace(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetFrontFace(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4234,13 +4234,13 @@ size_t VulkanDecoder::Decode_vkCmdSetFrontFace(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetFrontFace(commandBuffer, frontFace);
+        consumer->Process_vkCmdSetFrontFace(call_info, commandBuffer, frontFace);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetPrimitiveTopology(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetPrimitiveTopology(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4252,13 +4252,13 @@ size_t VulkanDecoder::Decode_vkCmdSetPrimitiveTopology(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetPrimitiveTopology(commandBuffer, primitiveTopology);
+        consumer->Process_vkCmdSetPrimitiveTopology(call_info, commandBuffer, primitiveTopology);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetViewportWithCount(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetViewportWithCount(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4272,13 +4272,13 @@ size_t VulkanDecoder::Decode_vkCmdSetViewportWithCount(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetViewportWithCount(commandBuffer, viewportCount, &pViewports);
+        consumer->Process_vkCmdSetViewportWithCount(call_info, commandBuffer, viewportCount, &pViewports);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetScissorWithCount(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetScissorWithCount(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4292,13 +4292,13 @@ size_t VulkanDecoder::Decode_vkCmdSetScissorWithCount(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetScissorWithCount(commandBuffer, scissorCount, &pScissors);
+        consumer->Process_vkCmdSetScissorWithCount(call_info, commandBuffer, scissorCount, &pScissors);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBindVertexBuffers2(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBindVertexBuffers2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4320,13 +4320,13 @@ size_t VulkanDecoder::Decode_vkCmdBindVertexBuffers2(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBindVertexBuffers2(commandBuffer, firstBinding, bindingCount, &pBuffers, &pOffsets, &pSizes, &pStrides);
+        consumer->Process_vkCmdBindVertexBuffers2(call_info, commandBuffer, firstBinding, bindingCount, &pBuffers, &pOffsets, &pSizes, &pStrides);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetDepthTestEnable(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetDepthTestEnable(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4338,13 +4338,13 @@ size_t VulkanDecoder::Decode_vkCmdSetDepthTestEnable(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetDepthTestEnable(commandBuffer, depthTestEnable);
+        consumer->Process_vkCmdSetDepthTestEnable(call_info, commandBuffer, depthTestEnable);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetDepthWriteEnable(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetDepthWriteEnable(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4356,13 +4356,13 @@ size_t VulkanDecoder::Decode_vkCmdSetDepthWriteEnable(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetDepthWriteEnable(commandBuffer, depthWriteEnable);
+        consumer->Process_vkCmdSetDepthWriteEnable(call_info, commandBuffer, depthWriteEnable);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetDepthCompareOp(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetDepthCompareOp(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4374,13 +4374,13 @@ size_t VulkanDecoder::Decode_vkCmdSetDepthCompareOp(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetDepthCompareOp(commandBuffer, depthCompareOp);
+        consumer->Process_vkCmdSetDepthCompareOp(call_info, commandBuffer, depthCompareOp);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetDepthBoundsTestEnable(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetDepthBoundsTestEnable(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4392,13 +4392,13 @@ size_t VulkanDecoder::Decode_vkCmdSetDepthBoundsTestEnable(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetDepthBoundsTestEnable(commandBuffer, depthBoundsTestEnable);
+        consumer->Process_vkCmdSetDepthBoundsTestEnable(call_info, commandBuffer, depthBoundsTestEnable);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetStencilTestEnable(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetStencilTestEnable(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4410,13 +4410,13 @@ size_t VulkanDecoder::Decode_vkCmdSetStencilTestEnable(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetStencilTestEnable(commandBuffer, stencilTestEnable);
+        consumer->Process_vkCmdSetStencilTestEnable(call_info, commandBuffer, stencilTestEnable);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetStencilOp(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetStencilOp(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4436,13 +4436,13 @@ size_t VulkanDecoder::Decode_vkCmdSetStencilOp(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetStencilOp(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
+        consumer->Process_vkCmdSetStencilOp(call_info, commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetRasterizerDiscardEnable(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetRasterizerDiscardEnable(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4454,13 +4454,13 @@ size_t VulkanDecoder::Decode_vkCmdSetRasterizerDiscardEnable(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetRasterizerDiscardEnable(commandBuffer, rasterizerDiscardEnable);
+        consumer->Process_vkCmdSetRasterizerDiscardEnable(call_info, commandBuffer, rasterizerDiscardEnable);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetDepthBiasEnable(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetDepthBiasEnable(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4472,13 +4472,13 @@ size_t VulkanDecoder::Decode_vkCmdSetDepthBiasEnable(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetDepthBiasEnable(commandBuffer, depthBiasEnable);
+        consumer->Process_vkCmdSetDepthBiasEnable(call_info, commandBuffer, depthBiasEnable);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetPrimitiveRestartEnable(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetPrimitiveRestartEnable(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4490,13 +4490,13 @@ size_t VulkanDecoder::Decode_vkCmdSetPrimitiveRestartEnable(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetPrimitiveRestartEnable(commandBuffer, primitiveRestartEnable);
+        consumer->Process_vkCmdSetPrimitiveRestartEnable(call_info, commandBuffer, primitiveRestartEnable);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceBufferMemoryRequirements(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceBufferMemoryRequirements(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4510,13 +4510,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceBufferMemoryRequirements(const uint8_t* 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceBufferMemoryRequirements(device, &pInfo, &pMemoryRequirements);
+        consumer->Process_vkGetDeviceBufferMemoryRequirements(call_info, device, &pInfo, &pMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceImageMemoryRequirements(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceImageMemoryRequirements(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4530,13 +4530,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceImageMemoryRequirements(const uint8_t* p
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceImageMemoryRequirements(device, &pInfo, &pMemoryRequirements);
+        consumer->Process_vkGetDeviceImageMemoryRequirements(call_info, device, &pInfo, &pMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceImageSparseMemoryRequirements(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceImageSparseMemoryRequirements(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4552,13 +4552,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceImageSparseMemoryRequirements(const uint
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceImageSparseMemoryRequirements(device, &pInfo, &pSparseMemoryRequirementCount, &pSparseMemoryRequirements);
+        consumer->Process_vkGetDeviceImageSparseMemoryRequirements(call_info, device, &pInfo, &pSparseMemoryRequirementCount, &pSparseMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroySurfaceKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroySurfaceKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4572,13 +4572,13 @@ size_t VulkanDecoder::Decode_vkDestroySurfaceKHR(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroySurfaceKHR(instance, surface, &pAllocator);
+        consumer->Process_vkDestroySurfaceKHR(call_info, instance, surface, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceSupportKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceSupportKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4596,13 +4596,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceSupportKHR(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSurfaceSupportKHR(return_value, physicalDevice, queueFamilyIndex, surface, &pSupported);
+        consumer->Process_vkGetPhysicalDeviceSurfaceSupportKHR(call_info, return_value, physicalDevice, queueFamilyIndex, surface, &pSupported);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4618,13 +4618,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(const uin
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(return_value, physicalDevice, surface, &pSurfaceCapabilities);
+        consumer->Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(call_info, return_value, physicalDevice, surface, &pSurfaceCapabilities);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceFormatsKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceFormatsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4642,13 +4642,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceFormatsKHR(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSurfaceFormatsKHR(return_value, physicalDevice, surface, &pSurfaceFormatCount, &pSurfaceFormats);
+        consumer->Process_vkGetPhysicalDeviceSurfaceFormatsKHR(call_info, return_value, physicalDevice, surface, &pSurfaceFormatCount, &pSurfaceFormats);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfacePresentModesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfacePresentModesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4666,13 +4666,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfacePresentModesKHR(const uin
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSurfacePresentModesKHR(return_value, physicalDevice, surface, &pPresentModeCount, &pPresentModes);
+        consumer->Process_vkGetPhysicalDeviceSurfacePresentModesKHR(call_info, return_value, physicalDevice, surface, &pPresentModeCount, &pPresentModes);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateSwapchainKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateSwapchainKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4690,13 +4690,13 @@ size_t VulkanDecoder::Decode_vkCreateSwapchainKHR(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateSwapchainKHR(return_value, device, &pCreateInfo, &pAllocator, &pSwapchain);
+        consumer->Process_vkCreateSwapchainKHR(call_info, return_value, device, &pCreateInfo, &pAllocator, &pSwapchain);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroySwapchainKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroySwapchainKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4710,13 +4710,13 @@ size_t VulkanDecoder::Decode_vkDestroySwapchainKHR(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroySwapchainKHR(device, swapchain, &pAllocator);
+        consumer->Process_vkDestroySwapchainKHR(call_info, device, swapchain, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetSwapchainImagesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetSwapchainImagesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4734,13 +4734,13 @@ size_t VulkanDecoder::Decode_vkGetSwapchainImagesKHR(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetSwapchainImagesKHR(return_value, device, swapchain, &pSwapchainImageCount, &pSwapchainImages);
+        consumer->Process_vkGetSwapchainImagesKHR(call_info, return_value, device, swapchain, &pSwapchainImageCount, &pSwapchainImages);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkAcquireNextImageKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkAcquireNextImageKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4762,13 +4762,13 @@ size_t VulkanDecoder::Decode_vkAcquireNextImageKHR(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkAcquireNextImageKHR(return_value, device, swapchain, timeout, semaphore, fence, &pImageIndex);
+        consumer->Process_vkAcquireNextImageKHR(call_info, return_value, device, swapchain, timeout, semaphore, fence, &pImageIndex);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkQueuePresentKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkQueuePresentKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4782,13 +4782,13 @@ size_t VulkanDecoder::Decode_vkQueuePresentKHR(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkQueuePresentKHR(return_value, queue, &pPresentInfo);
+        consumer->Process_vkQueuePresentKHR(call_info, return_value, queue, &pPresentInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceGroupPresentCapabilitiesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceGroupPresentCapabilitiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4802,13 +4802,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceGroupPresentCapabilitiesKHR(const uint8_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceGroupPresentCapabilitiesKHR(return_value, device, &pDeviceGroupPresentCapabilities);
+        consumer->Process_vkGetDeviceGroupPresentCapabilitiesKHR(call_info, return_value, device, &pDeviceGroupPresentCapabilities);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceGroupSurfacePresentModesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceGroupSurfacePresentModesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4824,13 +4824,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceGroupSurfacePresentModesKHR(const uint8_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceGroupSurfacePresentModesKHR(return_value, device, surface, &pModes);
+        consumer->Process_vkGetDeviceGroupSurfacePresentModesKHR(call_info, return_value, device, surface, &pModes);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDevicePresentRectanglesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDevicePresentRectanglesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4848,13 +4848,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDevicePresentRectanglesKHR(const uint8
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDevicePresentRectanglesKHR(return_value, physicalDevice, surface, &pRectCount, &pRects);
+        consumer->Process_vkGetPhysicalDevicePresentRectanglesKHR(call_info, return_value, physicalDevice, surface, &pRectCount, &pRects);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkAcquireNextImage2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkAcquireNextImage2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4870,13 +4870,13 @@ size_t VulkanDecoder::Decode_vkAcquireNextImage2KHR(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkAcquireNextImage2KHR(return_value, device, &pAcquireInfo, &pImageIndex);
+        consumer->Process_vkAcquireNextImage2KHR(call_info, return_value, device, &pAcquireInfo, &pImageIndex);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceDisplayPropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceDisplayPropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4892,13 +4892,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceDisplayPropertiesKHR(const uint8
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceDisplayPropertiesKHR(return_value, physicalDevice, &pPropertyCount, &pProperties);
+        consumer->Process_vkGetPhysicalDeviceDisplayPropertiesKHR(call_info, return_value, physicalDevice, &pPropertyCount, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4914,13 +4914,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(const 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(return_value, physicalDevice, &pPropertyCount, &pProperties);
+        consumer->Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(call_info, return_value, physicalDevice, &pPropertyCount, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDisplayPlaneSupportedDisplaysKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDisplayPlaneSupportedDisplaysKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4938,13 +4938,13 @@ size_t VulkanDecoder::Decode_vkGetDisplayPlaneSupportedDisplaysKHR(const uint8_t
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDisplayPlaneSupportedDisplaysKHR(return_value, physicalDevice, planeIndex, &pDisplayCount, &pDisplays);
+        consumer->Process_vkGetDisplayPlaneSupportedDisplaysKHR(call_info, return_value, physicalDevice, planeIndex, &pDisplayCount, &pDisplays);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDisplayModePropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDisplayModePropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4962,13 +4962,13 @@ size_t VulkanDecoder::Decode_vkGetDisplayModePropertiesKHR(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDisplayModePropertiesKHR(return_value, physicalDevice, display, &pPropertyCount, &pProperties);
+        consumer->Process_vkGetDisplayModePropertiesKHR(call_info, return_value, physicalDevice, display, &pPropertyCount, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateDisplayModeKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateDisplayModeKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -4988,13 +4988,13 @@ size_t VulkanDecoder::Decode_vkCreateDisplayModeKHR(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDisplayModeKHR(return_value, physicalDevice, display, &pCreateInfo, &pAllocator, &pMode);
+        consumer->Process_vkCreateDisplayModeKHR(call_info, return_value, physicalDevice, display, &pCreateInfo, &pAllocator, &pMode);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDisplayPlaneCapabilitiesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDisplayPlaneCapabilitiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5012,13 +5012,13 @@ size_t VulkanDecoder::Decode_vkGetDisplayPlaneCapabilitiesKHR(const uint8_t* par
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDisplayPlaneCapabilitiesKHR(return_value, physicalDevice, mode, planeIndex, &pCapabilities);
+        consumer->Process_vkGetDisplayPlaneCapabilitiesKHR(call_info, return_value, physicalDevice, mode, planeIndex, &pCapabilities);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateDisplayPlaneSurfaceKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateDisplayPlaneSurfaceKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5036,13 +5036,13 @@ size_t VulkanDecoder::Decode_vkCreateDisplayPlaneSurfaceKHR(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDisplayPlaneSurfaceKHR(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
+        consumer->Process_vkCreateDisplayPlaneSurfaceKHR(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateSharedSwapchainsKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateSharedSwapchainsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5062,13 +5062,13 @@ size_t VulkanDecoder::Decode_vkCreateSharedSwapchainsKHR(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateSharedSwapchainsKHR(return_value, device, swapchainCount, &pCreateInfos, &pAllocator, &pSwapchains);
+        consumer->Process_vkCreateSharedSwapchainsKHR(call_info, return_value, device, swapchainCount, &pCreateInfos, &pAllocator, &pSwapchains);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateXlibSurfaceKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateXlibSurfaceKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5086,13 +5086,13 @@ size_t VulkanDecoder::Decode_vkCreateXlibSurfaceKHR(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateXlibSurfaceKHR(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
+        consumer->Process_vkCreateXlibSurfaceKHR(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceXlibPresentationSupportKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceXlibPresentationSupportKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5110,13 +5110,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceXlibPresentationSupportKHR(const
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(return_value, physicalDevice, queueFamilyIndex, dpy, visualID);
+        consumer->Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(call_info, return_value, physicalDevice, queueFamilyIndex, dpy, visualID);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateXcbSurfaceKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateXcbSurfaceKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5134,13 +5134,13 @@ size_t VulkanDecoder::Decode_vkCreateXcbSurfaceKHR(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateXcbSurfaceKHR(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
+        consumer->Process_vkCreateXcbSurfaceKHR(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceXcbPresentationSupportKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceXcbPresentationSupportKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5158,13 +5158,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceXcbPresentationSupportKHR(const 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(return_value, physicalDevice, queueFamilyIndex, connection, visual_id);
+        consumer->Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(call_info, return_value, physicalDevice, queueFamilyIndex, connection, visual_id);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateWaylandSurfaceKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateWaylandSurfaceKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5182,13 +5182,13 @@ size_t VulkanDecoder::Decode_vkCreateWaylandSurfaceKHR(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateWaylandSurfaceKHR(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
+        consumer->Process_vkCreateWaylandSurfaceKHR(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceWaylandPresentationSupportKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceWaylandPresentationSupportKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5204,13 +5204,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceWaylandPresentationSupportKHR(co
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceWaylandPresentationSupportKHR(return_value, physicalDevice, queueFamilyIndex, display);
+        consumer->Process_vkGetPhysicalDeviceWaylandPresentationSupportKHR(call_info, return_value, physicalDevice, queueFamilyIndex, display);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateAndroidSurfaceKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateAndroidSurfaceKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5228,13 +5228,13 @@ size_t VulkanDecoder::Decode_vkCreateAndroidSurfaceKHR(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateAndroidSurfaceKHR(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
+        consumer->Process_vkCreateAndroidSurfaceKHR(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateWin32SurfaceKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateWin32SurfaceKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5252,13 +5252,13 @@ size_t VulkanDecoder::Decode_vkCreateWin32SurfaceKHR(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateWin32SurfaceKHR(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
+        consumer->Process_vkCreateWin32SurfaceKHR(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceWin32PresentationSupportKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceWin32PresentationSupportKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5272,13 +5272,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceWin32PresentationSupportKHR(cons
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceWin32PresentationSupportKHR(return_value, physicalDevice, queueFamilyIndex);
+        consumer->Process_vkGetPhysicalDeviceWin32PresentationSupportKHR(call_info, return_value, physicalDevice, queueFamilyIndex);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBeginRenderingKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBeginRenderingKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5290,13 +5290,13 @@ size_t VulkanDecoder::Decode_vkCmdBeginRenderingKHR(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBeginRenderingKHR(commandBuffer, &pRenderingInfo);
+        consumer->Process_vkCmdBeginRenderingKHR(call_info, commandBuffer, &pRenderingInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdEndRenderingKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdEndRenderingKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5306,13 +5306,13 @@ size_t VulkanDecoder::Decode_vkCmdEndRenderingKHR(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdEndRenderingKHR(commandBuffer);
+        consumer->Process_vkCmdEndRenderingKHR(call_info, commandBuffer);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFeatures2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFeatures2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5324,13 +5324,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFeatures2KHR(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceFeatures2KHR(physicalDevice, &pFeatures);
+        consumer->Process_vkGetPhysicalDeviceFeatures2KHR(call_info, physicalDevice, &pFeatures);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5342,13 +5342,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceProperties2KHR(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceProperties2KHR(physicalDevice, &pProperties);
+        consumer->Process_vkGetPhysicalDeviceProperties2KHR(call_info, physicalDevice, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFormatProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFormatProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5362,13 +5362,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFormatProperties2KHR(const uint8
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, &pFormatProperties);
+        consumer->Process_vkGetPhysicalDeviceFormatProperties2KHR(call_info, physicalDevice, format, &pFormatProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceImageFormatProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceImageFormatProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5384,13 +5384,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceImageFormatProperties2KHR(const 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceImageFormatProperties2KHR(return_value, physicalDevice, &pImageFormatInfo, &pImageFormatProperties);
+        consumer->Process_vkGetPhysicalDeviceImageFormatProperties2KHR(call_info, return_value, physicalDevice, &pImageFormatInfo, &pImageFormatProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceQueueFamilyProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceQueueFamilyProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5404,13 +5404,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceQueueFamilyProperties2KHR(const 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, &pQueueFamilyPropertyCount, &pQueueFamilyProperties);
+        consumer->Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(call_info, physicalDevice, &pQueueFamilyPropertyCount, &pQueueFamilyProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceMemoryProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceMemoryProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5422,13 +5422,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceMemoryProperties2KHR(const uint8
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, &pMemoryProperties);
+        consumer->Process_vkGetPhysicalDeviceMemoryProperties2KHR(call_info, physicalDevice, &pMemoryProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5444,13 +5444,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, &pFormatInfo, &pPropertyCount, &pProperties);
+        consumer->Process_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(call_info, physicalDevice, &pFormatInfo, &pPropertyCount, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceGroupPeerMemoryFeaturesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceGroupPeerMemoryFeaturesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5468,13 +5468,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceGroupPeerMemoryFeaturesKHR(const uint8_t
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(device, heapIndex, localDeviceIndex, remoteDeviceIndex, &pPeerMemoryFeatures);
+        consumer->Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(call_info, device, heapIndex, localDeviceIndex, remoteDeviceIndex, &pPeerMemoryFeatures);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetDeviceMaskKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetDeviceMaskKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5486,13 +5486,13 @@ size_t VulkanDecoder::Decode_vkCmdSetDeviceMaskKHR(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetDeviceMaskKHR(commandBuffer, deviceMask);
+        consumer->Process_vkCmdSetDeviceMaskKHR(call_info, commandBuffer, deviceMask);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDispatchBaseKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDispatchBaseKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5514,13 +5514,13 @@ size_t VulkanDecoder::Decode_vkCmdDispatchBaseKHR(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
+        consumer->Process_vkCmdDispatchBaseKHR(call_info, commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkTrimCommandPoolKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkTrimCommandPoolKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5534,13 +5534,13 @@ size_t VulkanDecoder::Decode_vkTrimCommandPoolKHR(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkTrimCommandPoolKHR(device, commandPool, flags);
+        consumer->Process_vkTrimCommandPoolKHR(call_info, device, commandPool, flags);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkEnumeratePhysicalDeviceGroupsKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkEnumeratePhysicalDeviceGroupsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5556,13 +5556,13 @@ size_t VulkanDecoder::Decode_vkEnumeratePhysicalDeviceGroupsKHR(const uint8_t* p
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkEnumeratePhysicalDeviceGroupsKHR(return_value, instance, &pPhysicalDeviceGroupCount, &pPhysicalDeviceGroupProperties);
+        consumer->Process_vkEnumeratePhysicalDeviceGroupsKHR(call_info, return_value, instance, &pPhysicalDeviceGroupCount, &pPhysicalDeviceGroupProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalBufferPropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalBufferPropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5576,13 +5576,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalBufferPropertiesKHR(cons
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR(physicalDevice, &pExternalBufferInfo, &pExternalBufferProperties);
+        consumer->Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR(call_info, physicalDevice, &pExternalBufferInfo, &pExternalBufferProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetMemoryWin32HandleKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetMemoryWin32HandleKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5598,13 +5598,13 @@ size_t VulkanDecoder::Decode_vkGetMemoryWin32HandleKHR(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetMemoryWin32HandleKHR(return_value, device, &pGetWin32HandleInfo, &pHandle);
+        consumer->Process_vkGetMemoryWin32HandleKHR(call_info, return_value, device, &pGetWin32HandleInfo, &pHandle);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetMemoryWin32HandlePropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetMemoryWin32HandlePropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5622,13 +5622,13 @@ size_t VulkanDecoder::Decode_vkGetMemoryWin32HandlePropertiesKHR(const uint8_t* 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetMemoryWin32HandlePropertiesKHR(return_value, device, handleType, handle, &pMemoryWin32HandleProperties);
+        consumer->Process_vkGetMemoryWin32HandlePropertiesKHR(call_info, return_value, device, handleType, handle, &pMemoryWin32HandleProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetMemoryFdKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetMemoryFdKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5644,13 +5644,13 @@ size_t VulkanDecoder::Decode_vkGetMemoryFdKHR(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetMemoryFdKHR(return_value, device, &pGetFdInfo, &pFd);
+        consumer->Process_vkGetMemoryFdKHR(call_info, return_value, device, &pGetFdInfo, &pFd);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetMemoryFdPropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetMemoryFdPropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5668,13 +5668,13 @@ size_t VulkanDecoder::Decode_vkGetMemoryFdPropertiesKHR(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetMemoryFdPropertiesKHR(return_value, device, handleType, fd, &pMemoryFdProperties);
+        consumer->Process_vkGetMemoryFdPropertiesKHR(call_info, return_value, device, handleType, fd, &pMemoryFdProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5688,13 +5688,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(c
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(physicalDevice, &pExternalSemaphoreInfo, &pExternalSemaphoreProperties);
+        consumer->Process_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(call_info, physicalDevice, &pExternalSemaphoreInfo, &pExternalSemaphoreProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkImportSemaphoreWin32HandleKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkImportSemaphoreWin32HandleKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5708,13 +5708,13 @@ size_t VulkanDecoder::Decode_vkImportSemaphoreWin32HandleKHR(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkImportSemaphoreWin32HandleKHR(return_value, device, &pImportSemaphoreWin32HandleInfo);
+        consumer->Process_vkImportSemaphoreWin32HandleKHR(call_info, return_value, device, &pImportSemaphoreWin32HandleInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetSemaphoreWin32HandleKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetSemaphoreWin32HandleKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5730,13 +5730,13 @@ size_t VulkanDecoder::Decode_vkGetSemaphoreWin32HandleKHR(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetSemaphoreWin32HandleKHR(return_value, device, &pGetWin32HandleInfo, &pHandle);
+        consumer->Process_vkGetSemaphoreWin32HandleKHR(call_info, return_value, device, &pGetWin32HandleInfo, &pHandle);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkImportSemaphoreFdKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkImportSemaphoreFdKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5750,13 +5750,13 @@ size_t VulkanDecoder::Decode_vkImportSemaphoreFdKHR(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkImportSemaphoreFdKHR(return_value, device, &pImportSemaphoreFdInfo);
+        consumer->Process_vkImportSemaphoreFdKHR(call_info, return_value, device, &pImportSemaphoreFdInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetSemaphoreFdKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetSemaphoreFdKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5772,13 +5772,13 @@ size_t VulkanDecoder::Decode_vkGetSemaphoreFdKHR(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetSemaphoreFdKHR(return_value, device, &pGetFdInfo, &pFd);
+        consumer->Process_vkGetSemaphoreFdKHR(call_info, return_value, device, &pGetFdInfo, &pFd);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdPushDescriptorSetKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdPushDescriptorSetKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5798,13 +5798,13 @@ size_t VulkanDecoder::Decode_vkCmdPushDescriptorSetKHR(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdPushDescriptorSetKHR(commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, &pDescriptorWrites);
+        consumer->Process_vkCmdPushDescriptorSetKHR(call_info, commandBuffer, pipelineBindPoint, layout, set, descriptorWriteCount, &pDescriptorWrites);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateDescriptorUpdateTemplateKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateDescriptorUpdateTemplateKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5822,13 +5822,13 @@ size_t VulkanDecoder::Decode_vkCreateDescriptorUpdateTemplateKHR(const uint8_t* 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDescriptorUpdateTemplateKHR(return_value, device, &pCreateInfo, &pAllocator, &pDescriptorUpdateTemplate);
+        consumer->Process_vkCreateDescriptorUpdateTemplateKHR(call_info, return_value, device, &pCreateInfo, &pAllocator, &pDescriptorUpdateTemplate);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyDescriptorUpdateTemplateKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyDescriptorUpdateTemplateKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5842,13 +5842,13 @@ size_t VulkanDecoder::Decode_vkDestroyDescriptorUpdateTemplateKHR(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyDescriptorUpdateTemplateKHR(device, descriptorUpdateTemplate, &pAllocator);
+        consumer->Process_vkDestroyDescriptorUpdateTemplateKHR(call_info, device, descriptorUpdateTemplate, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateRenderPass2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateRenderPass2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5866,13 +5866,13 @@ size_t VulkanDecoder::Decode_vkCreateRenderPass2KHR(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateRenderPass2KHR(return_value, device, &pCreateInfo, &pAllocator, &pRenderPass);
+        consumer->Process_vkCreateRenderPass2KHR(call_info, return_value, device, &pCreateInfo, &pAllocator, &pRenderPass);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBeginRenderPass2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBeginRenderPass2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5886,13 +5886,13 @@ size_t VulkanDecoder::Decode_vkCmdBeginRenderPass2KHR(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBeginRenderPass2KHR(commandBuffer, &pRenderPassBegin, &pSubpassBeginInfo);
+        consumer->Process_vkCmdBeginRenderPass2KHR(call_info, commandBuffer, &pRenderPassBegin, &pSubpassBeginInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdNextSubpass2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdNextSubpass2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5906,13 +5906,13 @@ size_t VulkanDecoder::Decode_vkCmdNextSubpass2KHR(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdNextSubpass2KHR(commandBuffer, &pSubpassBeginInfo, &pSubpassEndInfo);
+        consumer->Process_vkCmdNextSubpass2KHR(call_info, commandBuffer, &pSubpassBeginInfo, &pSubpassEndInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdEndRenderPass2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdEndRenderPass2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5924,13 +5924,13 @@ size_t VulkanDecoder::Decode_vkCmdEndRenderPass2KHR(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdEndRenderPass2KHR(commandBuffer, &pSubpassEndInfo);
+        consumer->Process_vkCmdEndRenderPass2KHR(call_info, commandBuffer, &pSubpassEndInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetSwapchainStatusKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetSwapchainStatusKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5944,13 +5944,13 @@ size_t VulkanDecoder::Decode_vkGetSwapchainStatusKHR(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetSwapchainStatusKHR(return_value, device, swapchain);
+        consumer->Process_vkGetSwapchainStatusKHR(call_info, return_value, device, swapchain);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalFencePropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalFencePropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5964,13 +5964,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalFencePropertiesKHR(const
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(physicalDevice, &pExternalFenceInfo, &pExternalFenceProperties);
+        consumer->Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(call_info, physicalDevice, &pExternalFenceInfo, &pExternalFenceProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkImportFenceWin32HandleKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkImportFenceWin32HandleKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -5984,13 +5984,13 @@ size_t VulkanDecoder::Decode_vkImportFenceWin32HandleKHR(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkImportFenceWin32HandleKHR(return_value, device, &pImportFenceWin32HandleInfo);
+        consumer->Process_vkImportFenceWin32HandleKHR(call_info, return_value, device, &pImportFenceWin32HandleInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetFenceWin32HandleKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetFenceWin32HandleKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6006,13 +6006,13 @@ size_t VulkanDecoder::Decode_vkGetFenceWin32HandleKHR(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetFenceWin32HandleKHR(return_value, device, &pGetWin32HandleInfo, &pHandle);
+        consumer->Process_vkGetFenceWin32HandleKHR(call_info, return_value, device, &pGetWin32HandleInfo, &pHandle);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkImportFenceFdKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkImportFenceFdKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6026,13 +6026,13 @@ size_t VulkanDecoder::Decode_vkImportFenceFdKHR(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkImportFenceFdKHR(return_value, device, &pImportFenceFdInfo);
+        consumer->Process_vkImportFenceFdKHR(call_info, return_value, device, &pImportFenceFdInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetFenceFdKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetFenceFdKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6048,13 +6048,13 @@ size_t VulkanDecoder::Decode_vkGetFenceFdKHR(const uint8_t* parameter_buffer, si
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetFenceFdKHR(return_value, device, &pGetFdInfo, &pFd);
+        consumer->Process_vkGetFenceFdKHR(call_info, return_value, device, &pGetFdInfo, &pFd);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6074,13 +6074,13 @@ size_t VulkanDecoder::Decode_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQuer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(return_value, physicalDevice, queueFamilyIndex, &pCounterCount, &pCounters, &pCounterDescriptions);
+        consumer->Process_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(call_info, return_value, physicalDevice, queueFamilyIndex, &pCounterCount, &pCounters, &pCounterDescriptions);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6094,13 +6094,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPasse
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physicalDevice, &pPerformanceQueryCreateInfo, &pNumPasses);
+        consumer->Process_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(call_info, physicalDevice, &pPerformanceQueryCreateInfo, &pNumPasses);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkAcquireProfilingLockKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkAcquireProfilingLockKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6114,13 +6114,13 @@ size_t VulkanDecoder::Decode_vkAcquireProfilingLockKHR(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkAcquireProfilingLockKHR(return_value, device, &pInfo);
+        consumer->Process_vkAcquireProfilingLockKHR(call_info, return_value, device, &pInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkReleaseProfilingLockKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkReleaseProfilingLockKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6130,13 +6130,13 @@ size_t VulkanDecoder::Decode_vkReleaseProfilingLockKHR(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkReleaseProfilingLockKHR(device);
+        consumer->Process_vkReleaseProfilingLockKHR(call_info, device);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceCapabilities2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceCapabilities2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6152,13 +6152,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceCapabilities2KHR(const ui
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(return_value, physicalDevice, &pSurfaceInfo, &pSurfaceCapabilities);
+        consumer->Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(call_info, return_value, physicalDevice, &pSurfaceInfo, &pSurfaceCapabilities);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceFormats2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceFormats2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6176,13 +6176,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceFormats2KHR(const uint8_t
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSurfaceFormats2KHR(return_value, physicalDevice, &pSurfaceInfo, &pSurfaceFormatCount, &pSurfaceFormats);
+        consumer->Process_vkGetPhysicalDeviceSurfaceFormats2KHR(call_info, return_value, physicalDevice, &pSurfaceInfo, &pSurfaceFormatCount, &pSurfaceFormats);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceDisplayProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceDisplayProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6198,13 +6198,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceDisplayProperties2KHR(const uint
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceDisplayProperties2KHR(return_value, physicalDevice, &pPropertyCount, &pProperties);
+        consumer->Process_vkGetPhysicalDeviceDisplayProperties2KHR(call_info, return_value, physicalDevice, &pPropertyCount, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6220,13 +6220,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(const
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(return_value, physicalDevice, &pPropertyCount, &pProperties);
+        consumer->Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(call_info, return_value, physicalDevice, &pPropertyCount, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDisplayModeProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDisplayModeProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6244,13 +6244,13 @@ size_t VulkanDecoder::Decode_vkGetDisplayModeProperties2KHR(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDisplayModeProperties2KHR(return_value, physicalDevice, display, &pPropertyCount, &pProperties);
+        consumer->Process_vkGetDisplayModeProperties2KHR(call_info, return_value, physicalDevice, display, &pPropertyCount, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDisplayPlaneCapabilities2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDisplayPlaneCapabilities2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6266,13 +6266,13 @@ size_t VulkanDecoder::Decode_vkGetDisplayPlaneCapabilities2KHR(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDisplayPlaneCapabilities2KHR(return_value, physicalDevice, &pDisplayPlaneInfo, &pCapabilities);
+        consumer->Process_vkGetDisplayPlaneCapabilities2KHR(call_info, return_value, physicalDevice, &pDisplayPlaneInfo, &pCapabilities);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetImageMemoryRequirements2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetImageMemoryRequirements2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6286,13 +6286,13 @@ size_t VulkanDecoder::Decode_vkGetImageMemoryRequirements2KHR(const uint8_t* par
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetImageMemoryRequirements2KHR(device, &pInfo, &pMemoryRequirements);
+        consumer->Process_vkGetImageMemoryRequirements2KHR(call_info, device, &pInfo, &pMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetBufferMemoryRequirements2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetBufferMemoryRequirements2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6306,13 +6306,13 @@ size_t VulkanDecoder::Decode_vkGetBufferMemoryRequirements2KHR(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetBufferMemoryRequirements2KHR(device, &pInfo, &pMemoryRequirements);
+        consumer->Process_vkGetBufferMemoryRequirements2KHR(call_info, device, &pInfo, &pMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetImageSparseMemoryRequirements2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetImageSparseMemoryRequirements2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6328,13 +6328,13 @@ size_t VulkanDecoder::Decode_vkGetImageSparseMemoryRequirements2KHR(const uint8_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetImageSparseMemoryRequirements2KHR(device, &pInfo, &pSparseMemoryRequirementCount, &pSparseMemoryRequirements);
+        consumer->Process_vkGetImageSparseMemoryRequirements2KHR(call_info, device, &pInfo, &pSparseMemoryRequirementCount, &pSparseMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateSamplerYcbcrConversionKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateSamplerYcbcrConversionKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6352,13 +6352,13 @@ size_t VulkanDecoder::Decode_vkCreateSamplerYcbcrConversionKHR(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateSamplerYcbcrConversionKHR(return_value, device, &pCreateInfo, &pAllocator, &pYcbcrConversion);
+        consumer->Process_vkCreateSamplerYcbcrConversionKHR(call_info, return_value, device, &pCreateInfo, &pAllocator, &pYcbcrConversion);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroySamplerYcbcrConversionKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroySamplerYcbcrConversionKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6372,13 +6372,13 @@ size_t VulkanDecoder::Decode_vkDestroySamplerYcbcrConversionKHR(const uint8_t* p
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroySamplerYcbcrConversionKHR(device, ycbcrConversion, &pAllocator);
+        consumer->Process_vkDestroySamplerYcbcrConversionKHR(call_info, device, ycbcrConversion, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkBindBufferMemory2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkBindBufferMemory2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6394,13 +6394,13 @@ size_t VulkanDecoder::Decode_vkBindBufferMemory2KHR(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkBindBufferMemory2KHR(return_value, device, bindInfoCount, &pBindInfos);
+        consumer->Process_vkBindBufferMemory2KHR(call_info, return_value, device, bindInfoCount, &pBindInfos);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkBindImageMemory2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkBindImageMemory2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6416,13 +6416,13 @@ size_t VulkanDecoder::Decode_vkBindImageMemory2KHR(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkBindImageMemory2KHR(return_value, device, bindInfoCount, &pBindInfos);
+        consumer->Process_vkBindImageMemory2KHR(call_info, return_value, device, bindInfoCount, &pBindInfos);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDescriptorSetLayoutSupportKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDescriptorSetLayoutSupportKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6436,13 +6436,13 @@ size_t VulkanDecoder::Decode_vkGetDescriptorSetLayoutSupportKHR(const uint8_t* p
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDescriptorSetLayoutSupportKHR(device, &pCreateInfo, &pSupport);
+        consumer->Process_vkGetDescriptorSetLayoutSupportKHR(call_info, device, &pCreateInfo, &pSupport);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDrawIndirectCountKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDrawIndirectCountKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6464,13 +6464,13 @@ size_t VulkanDecoder::Decode_vkCmdDrawIndirectCountKHR(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+        consumer->Process_vkCmdDrawIndirectCountKHR(call_info, commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDrawIndexedIndirectCountKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDrawIndexedIndirectCountKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6492,13 +6492,13 @@ size_t VulkanDecoder::Decode_vkCmdDrawIndexedIndirectCountKHR(const uint8_t* par
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+        consumer->Process_vkCmdDrawIndexedIndirectCountKHR(call_info, commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetSemaphoreCounterValueKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetSemaphoreCounterValueKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6514,13 +6514,13 @@ size_t VulkanDecoder::Decode_vkGetSemaphoreCounterValueKHR(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetSemaphoreCounterValueKHR(return_value, device, semaphore, &pValue);
+        consumer->Process_vkGetSemaphoreCounterValueKHR(call_info, return_value, device, semaphore, &pValue);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkWaitSemaphoresKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkWaitSemaphoresKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6536,13 +6536,13 @@ size_t VulkanDecoder::Decode_vkWaitSemaphoresKHR(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkWaitSemaphoresKHR(return_value, device, &pWaitInfo, timeout);
+        consumer->Process_vkWaitSemaphoresKHR(call_info, return_value, device, &pWaitInfo, timeout);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkSignalSemaphoreKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkSignalSemaphoreKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6556,13 +6556,13 @@ size_t VulkanDecoder::Decode_vkSignalSemaphoreKHR(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkSignalSemaphoreKHR(return_value, device, &pSignalInfo);
+        consumer->Process_vkSignalSemaphoreKHR(call_info, return_value, device, &pSignalInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFragmentShadingRatesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFragmentShadingRatesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6578,13 +6578,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceFragmentShadingRatesKHR(const ui
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(return_value, physicalDevice, &pFragmentShadingRateCount, &pFragmentShadingRates);
+        consumer->Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(call_info, return_value, physicalDevice, &pFragmentShadingRateCount, &pFragmentShadingRates);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetFragmentShadingRateKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetFragmentShadingRateKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6598,13 +6598,13 @@ size_t VulkanDecoder::Decode_vkCmdSetFragmentShadingRateKHR(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetFragmentShadingRateKHR(commandBuffer, &pFragmentSize, &combinerOps);
+        consumer->Process_vkCmdSetFragmentShadingRateKHR(call_info, commandBuffer, &pFragmentSize, &combinerOps);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkWaitForPresentKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkWaitForPresentKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6622,13 +6622,13 @@ size_t VulkanDecoder::Decode_vkWaitForPresentKHR(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkWaitForPresentKHR(return_value, device, swapchain, presentId, timeout);
+        consumer->Process_vkWaitForPresentKHR(call_info, return_value, device, swapchain, presentId, timeout);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetBufferDeviceAddressKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetBufferDeviceAddressKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6642,13 +6642,13 @@ size_t VulkanDecoder::Decode_vkGetBufferDeviceAddressKHR(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetBufferDeviceAddressKHR(return_value, device, &pInfo);
+        consumer->Process_vkGetBufferDeviceAddressKHR(call_info, return_value, device, &pInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetBufferOpaqueCaptureAddressKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetBufferOpaqueCaptureAddressKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6662,13 +6662,13 @@ size_t VulkanDecoder::Decode_vkGetBufferOpaqueCaptureAddressKHR(const uint8_t* p
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetBufferOpaqueCaptureAddressKHR(return_value, device, &pInfo);
+        consumer->Process_vkGetBufferOpaqueCaptureAddressKHR(call_info, return_value, device, &pInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceMemoryOpaqueCaptureAddressKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceMemoryOpaqueCaptureAddressKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6682,13 +6682,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceMemoryOpaqueCaptureAddressKHR(const uint
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceMemoryOpaqueCaptureAddressKHR(return_value, device, &pInfo);
+        consumer->Process_vkGetDeviceMemoryOpaqueCaptureAddressKHR(call_info, return_value, device, &pInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateDeferredOperationKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateDeferredOperationKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6704,13 +6704,13 @@ size_t VulkanDecoder::Decode_vkCreateDeferredOperationKHR(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDeferredOperationKHR(return_value, device, &pAllocator, &pDeferredOperation);
+        consumer->Process_vkCreateDeferredOperationKHR(call_info, return_value, device, &pAllocator, &pDeferredOperation);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyDeferredOperationKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyDeferredOperationKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6724,13 +6724,13 @@ size_t VulkanDecoder::Decode_vkDestroyDeferredOperationKHR(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyDeferredOperationKHR(device, operation, &pAllocator);
+        consumer->Process_vkDestroyDeferredOperationKHR(call_info, device, operation, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeferredOperationMaxConcurrencyKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeferredOperationMaxConcurrencyKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6744,13 +6744,13 @@ size_t VulkanDecoder::Decode_vkGetDeferredOperationMaxConcurrencyKHR(const uint8
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeferredOperationMaxConcurrencyKHR(return_value, device, operation);
+        consumer->Process_vkGetDeferredOperationMaxConcurrencyKHR(call_info, return_value, device, operation);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeferredOperationResultKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeferredOperationResultKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6764,13 +6764,13 @@ size_t VulkanDecoder::Decode_vkGetDeferredOperationResultKHR(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeferredOperationResultKHR(return_value, device, operation);
+        consumer->Process_vkGetDeferredOperationResultKHR(call_info, return_value, device, operation);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDeferredOperationJoinKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDeferredOperationJoinKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6784,13 +6784,13 @@ size_t VulkanDecoder::Decode_vkDeferredOperationJoinKHR(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDeferredOperationJoinKHR(return_value, device, operation);
+        consumer->Process_vkDeferredOperationJoinKHR(call_info, return_value, device, operation);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPipelineExecutablePropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPipelineExecutablePropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6808,13 +6808,13 @@ size_t VulkanDecoder::Decode_vkGetPipelineExecutablePropertiesKHR(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPipelineExecutablePropertiesKHR(return_value, device, &pPipelineInfo, &pExecutableCount, &pProperties);
+        consumer->Process_vkGetPipelineExecutablePropertiesKHR(call_info, return_value, device, &pPipelineInfo, &pExecutableCount, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPipelineExecutableStatisticsKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPipelineExecutableStatisticsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6832,13 +6832,13 @@ size_t VulkanDecoder::Decode_vkGetPipelineExecutableStatisticsKHR(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPipelineExecutableStatisticsKHR(return_value, device, &pExecutableInfo, &pStatisticCount, &pStatistics);
+        consumer->Process_vkGetPipelineExecutableStatisticsKHR(call_info, return_value, device, &pExecutableInfo, &pStatisticCount, &pStatistics);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPipelineExecutableInternalRepresentationsKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPipelineExecutableInternalRepresentationsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6856,13 +6856,13 @@ size_t VulkanDecoder::Decode_vkGetPipelineExecutableInternalRepresentationsKHR(c
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPipelineExecutableInternalRepresentationsKHR(return_value, device, &pExecutableInfo, &pInternalRepresentationCount, &pInternalRepresentations);
+        consumer->Process_vkGetPipelineExecutableInternalRepresentationsKHR(call_info, return_value, device, &pExecutableInfo, &pInternalRepresentationCount, &pInternalRepresentations);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetEvent2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetEvent2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6876,13 +6876,13 @@ size_t VulkanDecoder::Decode_vkCmdSetEvent2KHR(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetEvent2KHR(commandBuffer, event, &pDependencyInfo);
+        consumer->Process_vkCmdSetEvent2KHR(call_info, commandBuffer, event, &pDependencyInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdResetEvent2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdResetEvent2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6896,13 +6896,13 @@ size_t VulkanDecoder::Decode_vkCmdResetEvent2KHR(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdResetEvent2KHR(commandBuffer, event, stageMask);
+        consumer->Process_vkCmdResetEvent2KHR(call_info, commandBuffer, event, stageMask);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdWaitEvents2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdWaitEvents2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6918,13 +6918,13 @@ size_t VulkanDecoder::Decode_vkCmdWaitEvents2KHR(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdWaitEvents2KHR(commandBuffer, eventCount, &pEvents, &pDependencyInfos);
+        consumer->Process_vkCmdWaitEvents2KHR(call_info, commandBuffer, eventCount, &pEvents, &pDependencyInfos);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdPipelineBarrier2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdPipelineBarrier2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6936,13 +6936,13 @@ size_t VulkanDecoder::Decode_vkCmdPipelineBarrier2KHR(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdPipelineBarrier2KHR(commandBuffer, &pDependencyInfo);
+        consumer->Process_vkCmdPipelineBarrier2KHR(call_info, commandBuffer, &pDependencyInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdWriteTimestamp2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdWriteTimestamp2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6958,13 +6958,13 @@ size_t VulkanDecoder::Decode_vkCmdWriteTimestamp2KHR(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query);
+        consumer->Process_vkCmdWriteTimestamp2KHR(call_info, commandBuffer, stage, queryPool, query);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkQueueSubmit2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkQueueSubmit2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -6982,13 +6982,13 @@ size_t VulkanDecoder::Decode_vkQueueSubmit2KHR(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkQueueSubmit2KHR(return_value, queue, submitCount, &pSubmits, fence);
+        consumer->Process_vkQueueSubmit2KHR(call_info, return_value, queue, submitCount, &pSubmits, fence);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdWriteBufferMarker2AMD(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdWriteBufferMarker2AMD(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7006,13 +7006,13 @@ size_t VulkanDecoder::Decode_vkCmdWriteBufferMarker2AMD(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker);
+        consumer->Process_vkCmdWriteBufferMarker2AMD(call_info, commandBuffer, stage, dstBuffer, dstOffset, marker);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetQueueCheckpointData2NV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetQueueCheckpointData2NV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7026,13 +7026,13 @@ size_t VulkanDecoder::Decode_vkGetQueueCheckpointData2NV(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetQueueCheckpointData2NV(queue, &pCheckpointDataCount, &pCheckpointData);
+        consumer->Process_vkGetQueueCheckpointData2NV(call_info, queue, &pCheckpointDataCount, &pCheckpointData);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyBuffer2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyBuffer2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7044,13 +7044,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyBuffer2KHR(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyBuffer2KHR(commandBuffer, &pCopyBufferInfo);
+        consumer->Process_vkCmdCopyBuffer2KHR(call_info, commandBuffer, &pCopyBufferInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyImage2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyImage2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7062,13 +7062,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyImage2KHR(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyImage2KHR(commandBuffer, &pCopyImageInfo);
+        consumer->Process_vkCmdCopyImage2KHR(call_info, commandBuffer, &pCopyImageInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyBufferToImage2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyBufferToImage2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7080,13 +7080,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyBufferToImage2KHR(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyBufferToImage2KHR(commandBuffer, &pCopyBufferToImageInfo);
+        consumer->Process_vkCmdCopyBufferToImage2KHR(call_info, commandBuffer, &pCopyBufferToImageInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyImageToBuffer2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyImageToBuffer2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7098,13 +7098,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyImageToBuffer2KHR(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyImageToBuffer2KHR(commandBuffer, &pCopyImageToBufferInfo);
+        consumer->Process_vkCmdCopyImageToBuffer2KHR(call_info, commandBuffer, &pCopyImageToBufferInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBlitImage2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBlitImage2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7116,13 +7116,13 @@ size_t VulkanDecoder::Decode_vkCmdBlitImage2KHR(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBlitImage2KHR(commandBuffer, &pBlitImageInfo);
+        consumer->Process_vkCmdBlitImage2KHR(call_info, commandBuffer, &pBlitImageInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdResolveImage2KHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdResolveImage2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7134,13 +7134,13 @@ size_t VulkanDecoder::Decode_vkCmdResolveImage2KHR(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdResolveImage2KHR(commandBuffer, &pResolveImageInfo);
+        consumer->Process_vkCmdResolveImage2KHR(call_info, commandBuffer, &pResolveImageInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceBufferMemoryRequirementsKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceBufferMemoryRequirementsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7154,13 +7154,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceBufferMemoryRequirementsKHR(const uint8_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceBufferMemoryRequirementsKHR(device, &pInfo, &pMemoryRequirements);
+        consumer->Process_vkGetDeviceBufferMemoryRequirementsKHR(call_info, device, &pInfo, &pMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceImageMemoryRequirementsKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceImageMemoryRequirementsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7174,13 +7174,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceImageMemoryRequirementsKHR(const uint8_t
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceImageMemoryRequirementsKHR(device, &pInfo, &pMemoryRequirements);
+        consumer->Process_vkGetDeviceImageMemoryRequirementsKHR(call_info, device, &pInfo, &pMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceImageSparseMemoryRequirementsKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceImageSparseMemoryRequirementsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7196,13 +7196,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceImageSparseMemoryRequirementsKHR(const u
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceImageSparseMemoryRequirementsKHR(device, &pInfo, &pSparseMemoryRequirementCount, &pSparseMemoryRequirements);
+        consumer->Process_vkGetDeviceImageSparseMemoryRequirementsKHR(call_info, device, &pInfo, &pSparseMemoryRequirementCount, &pSparseMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateDebugReportCallbackEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateDebugReportCallbackEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7220,13 +7220,13 @@ size_t VulkanDecoder::Decode_vkCreateDebugReportCallbackEXT(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDebugReportCallbackEXT(return_value, instance, &pCreateInfo, &pAllocator, &pCallback);
+        consumer->Process_vkCreateDebugReportCallbackEXT(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pCallback);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyDebugReportCallbackEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyDebugReportCallbackEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7240,13 +7240,13 @@ size_t VulkanDecoder::Decode_vkDestroyDebugReportCallbackEXT(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyDebugReportCallbackEXT(instance, callback, &pAllocator);
+        consumer->Process_vkDestroyDebugReportCallbackEXT(call_info, instance, callback, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDebugReportMessageEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDebugReportMessageEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7270,13 +7270,13 @@ size_t VulkanDecoder::Decode_vkDebugReportMessageEXT(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDebugReportMessageEXT(instance, flags, objectType, object, location, messageCode, &pLayerPrefix, &pMessage);
+        consumer->Process_vkDebugReportMessageEXT(call_info, instance, flags, objectType, object, location, messageCode, &pLayerPrefix, &pMessage);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDebugMarkerSetObjectTagEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDebugMarkerSetObjectTagEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7290,13 +7290,13 @@ size_t VulkanDecoder::Decode_vkDebugMarkerSetObjectTagEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDebugMarkerSetObjectTagEXT(return_value, device, &pTagInfo);
+        consumer->Process_vkDebugMarkerSetObjectTagEXT(call_info, return_value, device, &pTagInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDebugMarkerSetObjectNameEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDebugMarkerSetObjectNameEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7310,13 +7310,13 @@ size_t VulkanDecoder::Decode_vkDebugMarkerSetObjectNameEXT(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDebugMarkerSetObjectNameEXT(return_value, device, &pNameInfo);
+        consumer->Process_vkDebugMarkerSetObjectNameEXT(call_info, return_value, device, &pNameInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDebugMarkerBeginEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDebugMarkerBeginEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7328,13 +7328,13 @@ size_t VulkanDecoder::Decode_vkCmdDebugMarkerBeginEXT(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDebugMarkerBeginEXT(commandBuffer, &pMarkerInfo);
+        consumer->Process_vkCmdDebugMarkerBeginEXT(call_info, commandBuffer, &pMarkerInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDebugMarkerEndEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDebugMarkerEndEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7344,13 +7344,13 @@ size_t VulkanDecoder::Decode_vkCmdDebugMarkerEndEXT(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDebugMarkerEndEXT(commandBuffer);
+        consumer->Process_vkCmdDebugMarkerEndEXT(call_info, commandBuffer);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDebugMarkerInsertEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDebugMarkerInsertEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7362,13 +7362,13 @@ size_t VulkanDecoder::Decode_vkCmdDebugMarkerInsertEXT(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDebugMarkerInsertEXT(commandBuffer, &pMarkerInfo);
+        consumer->Process_vkCmdDebugMarkerInsertEXT(call_info, commandBuffer, &pMarkerInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBindTransformFeedbackBuffersEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBindTransformFeedbackBuffersEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7388,13 +7388,13 @@ size_t VulkanDecoder::Decode_vkCmdBindTransformFeedbackBuffersEXT(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBindTransformFeedbackBuffersEXT(commandBuffer, firstBinding, bindingCount, &pBuffers, &pOffsets, &pSizes);
+        consumer->Process_vkCmdBindTransformFeedbackBuffersEXT(call_info, commandBuffer, firstBinding, bindingCount, &pBuffers, &pOffsets, &pSizes);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBeginTransformFeedbackEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBeginTransformFeedbackEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7412,13 +7412,13 @@ size_t VulkanDecoder::Decode_vkCmdBeginTransformFeedbackEXT(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBeginTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, &pCounterBuffers, &pCounterBufferOffsets);
+        consumer->Process_vkCmdBeginTransformFeedbackEXT(call_info, commandBuffer, firstCounterBuffer, counterBufferCount, &pCounterBuffers, &pCounterBufferOffsets);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdEndTransformFeedbackEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdEndTransformFeedbackEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7436,13 +7436,13 @@ size_t VulkanDecoder::Decode_vkCmdEndTransformFeedbackEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdEndTransformFeedbackEXT(commandBuffer, firstCounterBuffer, counterBufferCount, &pCounterBuffers, &pCounterBufferOffsets);
+        consumer->Process_vkCmdEndTransformFeedbackEXT(call_info, commandBuffer, firstCounterBuffer, counterBufferCount, &pCounterBuffers, &pCounterBufferOffsets);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBeginQueryIndexedEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBeginQueryIndexedEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7460,13 +7460,13 @@ size_t VulkanDecoder::Decode_vkCmdBeginQueryIndexedEXT(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index);
+        consumer->Process_vkCmdBeginQueryIndexedEXT(call_info, commandBuffer, queryPool, query, flags, index);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdEndQueryIndexedEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdEndQueryIndexedEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7482,13 +7482,13 @@ size_t VulkanDecoder::Decode_vkCmdEndQueryIndexedEXT(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index);
+        consumer->Process_vkCmdEndQueryIndexedEXT(call_info, commandBuffer, queryPool, query, index);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDrawIndirectByteCountEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDrawIndirectByteCountEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7510,13 +7510,13 @@ size_t VulkanDecoder::Decode_vkCmdDrawIndirectByteCountEXT(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride);
+        consumer->Process_vkCmdDrawIndirectByteCountEXT(call_info, commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetImageViewHandleNVX(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetImageViewHandleNVX(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7530,13 +7530,13 @@ size_t VulkanDecoder::Decode_vkGetImageViewHandleNVX(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetImageViewHandleNVX(return_value, device, &pInfo);
+        consumer->Process_vkGetImageViewHandleNVX(call_info, return_value, device, &pInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetImageViewAddressNVX(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetImageViewAddressNVX(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7552,13 +7552,13 @@ size_t VulkanDecoder::Decode_vkGetImageViewAddressNVX(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetImageViewAddressNVX(return_value, device, imageView, &pProperties);
+        consumer->Process_vkGetImageViewAddressNVX(call_info, return_value, device, imageView, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDrawIndirectCountAMD(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDrawIndirectCountAMD(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7580,13 +7580,13 @@ size_t VulkanDecoder::Decode_vkCmdDrawIndirectCountAMD(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDrawIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+        consumer->Process_vkCmdDrawIndirectCountAMD(call_info, commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDrawIndexedIndirectCountAMD(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDrawIndexedIndirectCountAMD(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7608,13 +7608,13 @@ size_t VulkanDecoder::Decode_vkCmdDrawIndexedIndirectCountAMD(const uint8_t* par
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDrawIndexedIndirectCountAMD(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+        consumer->Process_vkCmdDrawIndexedIndirectCountAMD(call_info, commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetShaderInfoAMD(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetShaderInfoAMD(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7636,13 +7636,13 @@ size_t VulkanDecoder::Decode_vkGetShaderInfoAMD(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetShaderInfoAMD(return_value, device, pipeline, shaderStage, infoType, &pInfoSize, &pInfo);
+        consumer->Process_vkGetShaderInfoAMD(call_info, return_value, device, pipeline, shaderStage, infoType, &pInfoSize, &pInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateStreamDescriptorSurfaceGGP(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateStreamDescriptorSurfaceGGP(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7660,13 +7660,13 @@ size_t VulkanDecoder::Decode_vkCreateStreamDescriptorSurfaceGGP(const uint8_t* p
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateStreamDescriptorSurfaceGGP(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
+        consumer->Process_vkCreateStreamDescriptorSurfaceGGP(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7692,13 +7692,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(return_value, physicalDevice, format, type, tiling, usage, flags, externalHandleType, &pExternalImageFormatProperties);
+        consumer->Process_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(call_info, return_value, physicalDevice, format, type, tiling, usage, flags, externalHandleType, &pExternalImageFormatProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetMemoryWin32HandleNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetMemoryWin32HandleNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7716,13 +7716,13 @@ size_t VulkanDecoder::Decode_vkGetMemoryWin32HandleNV(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetMemoryWin32HandleNV(return_value, device, memory, handleType, &pHandle);
+        consumer->Process_vkGetMemoryWin32HandleNV(call_info, return_value, device, memory, handleType, &pHandle);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateViSurfaceNN(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateViSurfaceNN(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7740,13 +7740,13 @@ size_t VulkanDecoder::Decode_vkCreateViSurfaceNN(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateViSurfaceNN(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
+        consumer->Process_vkCreateViSurfaceNN(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBeginConditionalRenderingEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBeginConditionalRenderingEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7758,13 +7758,13 @@ size_t VulkanDecoder::Decode_vkCmdBeginConditionalRenderingEXT(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBeginConditionalRenderingEXT(commandBuffer, &pConditionalRenderingBegin);
+        consumer->Process_vkCmdBeginConditionalRenderingEXT(call_info, commandBuffer, &pConditionalRenderingBegin);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdEndConditionalRenderingEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdEndConditionalRenderingEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7774,13 +7774,13 @@ size_t VulkanDecoder::Decode_vkCmdEndConditionalRenderingEXT(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdEndConditionalRenderingEXT(commandBuffer);
+        consumer->Process_vkCmdEndConditionalRenderingEXT(call_info, commandBuffer);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetViewportWScalingNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetViewportWScalingNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7796,13 +7796,13 @@ size_t VulkanDecoder::Decode_vkCmdSetViewportWScalingNV(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetViewportWScalingNV(commandBuffer, firstViewport, viewportCount, &pViewportWScalings);
+        consumer->Process_vkCmdSetViewportWScalingNV(call_info, commandBuffer, firstViewport, viewportCount, &pViewportWScalings);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkReleaseDisplayEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkReleaseDisplayEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7816,13 +7816,13 @@ size_t VulkanDecoder::Decode_vkReleaseDisplayEXT(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkReleaseDisplayEXT(return_value, physicalDevice, display);
+        consumer->Process_vkReleaseDisplayEXT(call_info, return_value, physicalDevice, display);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkAcquireXlibDisplayEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkAcquireXlibDisplayEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7838,13 +7838,13 @@ size_t VulkanDecoder::Decode_vkAcquireXlibDisplayEXT(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkAcquireXlibDisplayEXT(return_value, physicalDevice, dpy, display);
+        consumer->Process_vkAcquireXlibDisplayEXT(call_info, return_value, physicalDevice, dpy, display);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetRandROutputDisplayEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetRandROutputDisplayEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7862,13 +7862,13 @@ size_t VulkanDecoder::Decode_vkGetRandROutputDisplayEXT(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetRandROutputDisplayEXT(return_value, physicalDevice, dpy, rrOutput, &pDisplay);
+        consumer->Process_vkGetRandROutputDisplayEXT(call_info, return_value, physicalDevice, dpy, rrOutput, &pDisplay);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceCapabilities2EXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceCapabilities2EXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7884,13 +7884,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfaceCapabilities2EXT(const ui
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(return_value, physicalDevice, surface, &pSurfaceCapabilities);
+        consumer->Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(call_info, return_value, physicalDevice, surface, &pSurfaceCapabilities);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDisplayPowerControlEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDisplayPowerControlEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7906,13 +7906,13 @@ size_t VulkanDecoder::Decode_vkDisplayPowerControlEXT(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDisplayPowerControlEXT(return_value, device, display, &pDisplayPowerInfo);
+        consumer->Process_vkDisplayPowerControlEXT(call_info, return_value, device, display, &pDisplayPowerInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkRegisterDeviceEventEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkRegisterDeviceEventEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7930,13 +7930,13 @@ size_t VulkanDecoder::Decode_vkRegisterDeviceEventEXT(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkRegisterDeviceEventEXT(return_value, device, &pDeviceEventInfo, &pAllocator, &pFence);
+        consumer->Process_vkRegisterDeviceEventEXT(call_info, return_value, device, &pDeviceEventInfo, &pAllocator, &pFence);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkRegisterDisplayEventEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkRegisterDisplayEventEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7956,13 +7956,13 @@ size_t VulkanDecoder::Decode_vkRegisterDisplayEventEXT(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkRegisterDisplayEventEXT(return_value, device, display, &pDisplayEventInfo, &pAllocator, &pFence);
+        consumer->Process_vkRegisterDisplayEventEXT(call_info, return_value, device, display, &pDisplayEventInfo, &pAllocator, &pFence);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetSwapchainCounterEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetSwapchainCounterEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -7980,13 +7980,13 @@ size_t VulkanDecoder::Decode_vkGetSwapchainCounterEXT(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetSwapchainCounterEXT(return_value, device, swapchain, counter, &pCounterValue);
+        consumer->Process_vkGetSwapchainCounterEXT(call_info, return_value, device, swapchain, counter, &pCounterValue);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetRefreshCycleDurationGOOGLE(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetRefreshCycleDurationGOOGLE(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8002,13 +8002,13 @@ size_t VulkanDecoder::Decode_vkGetRefreshCycleDurationGOOGLE(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetRefreshCycleDurationGOOGLE(return_value, device, swapchain, &pDisplayTimingProperties);
+        consumer->Process_vkGetRefreshCycleDurationGOOGLE(call_info, return_value, device, swapchain, &pDisplayTimingProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPastPresentationTimingGOOGLE(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPastPresentationTimingGOOGLE(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8026,13 +8026,13 @@ size_t VulkanDecoder::Decode_vkGetPastPresentationTimingGOOGLE(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPastPresentationTimingGOOGLE(return_value, device, swapchain, &pPresentationTimingCount, &pPresentationTimings);
+        consumer->Process_vkGetPastPresentationTimingGOOGLE(call_info, return_value, device, swapchain, &pPresentationTimingCount, &pPresentationTimings);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetDiscardRectangleEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetDiscardRectangleEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8048,13 +8048,13 @@ size_t VulkanDecoder::Decode_vkCmdSetDiscardRectangleEXT(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, &pDiscardRectangles);
+        consumer->Process_vkCmdSetDiscardRectangleEXT(call_info, commandBuffer, firstDiscardRectangle, discardRectangleCount, &pDiscardRectangles);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkSetHdrMetadataEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkSetHdrMetadataEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8070,13 +8070,13 @@ size_t VulkanDecoder::Decode_vkSetHdrMetadataEXT(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkSetHdrMetadataEXT(device, swapchainCount, &pSwapchains, &pMetadata);
+        consumer->Process_vkSetHdrMetadataEXT(call_info, device, swapchainCount, &pSwapchains, &pMetadata);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateIOSSurfaceMVK(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateIOSSurfaceMVK(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8094,13 +8094,13 @@ size_t VulkanDecoder::Decode_vkCreateIOSSurfaceMVK(const uint8_t* parameter_buff
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateIOSSurfaceMVK(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
+        consumer->Process_vkCreateIOSSurfaceMVK(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateMacOSSurfaceMVK(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateMacOSSurfaceMVK(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8118,13 +8118,13 @@ size_t VulkanDecoder::Decode_vkCreateMacOSSurfaceMVK(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateMacOSSurfaceMVK(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
+        consumer->Process_vkCreateMacOSSurfaceMVK(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkSetDebugUtilsObjectNameEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkSetDebugUtilsObjectNameEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8138,13 +8138,13 @@ size_t VulkanDecoder::Decode_vkSetDebugUtilsObjectNameEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkSetDebugUtilsObjectNameEXT(return_value, device, &pNameInfo);
+        consumer->Process_vkSetDebugUtilsObjectNameEXT(call_info, return_value, device, &pNameInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkSetDebugUtilsObjectTagEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkSetDebugUtilsObjectTagEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8158,13 +8158,13 @@ size_t VulkanDecoder::Decode_vkSetDebugUtilsObjectTagEXT(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkSetDebugUtilsObjectTagEXT(return_value, device, &pTagInfo);
+        consumer->Process_vkSetDebugUtilsObjectTagEXT(call_info, return_value, device, &pTagInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkQueueBeginDebugUtilsLabelEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkQueueBeginDebugUtilsLabelEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8176,13 +8176,13 @@ size_t VulkanDecoder::Decode_vkQueueBeginDebugUtilsLabelEXT(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkQueueBeginDebugUtilsLabelEXT(queue, &pLabelInfo);
+        consumer->Process_vkQueueBeginDebugUtilsLabelEXT(call_info, queue, &pLabelInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkQueueEndDebugUtilsLabelEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkQueueEndDebugUtilsLabelEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8192,13 +8192,13 @@ size_t VulkanDecoder::Decode_vkQueueEndDebugUtilsLabelEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkQueueEndDebugUtilsLabelEXT(queue);
+        consumer->Process_vkQueueEndDebugUtilsLabelEXT(call_info, queue);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkQueueInsertDebugUtilsLabelEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkQueueInsertDebugUtilsLabelEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8210,13 +8210,13 @@ size_t VulkanDecoder::Decode_vkQueueInsertDebugUtilsLabelEXT(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkQueueInsertDebugUtilsLabelEXT(queue, &pLabelInfo);
+        consumer->Process_vkQueueInsertDebugUtilsLabelEXT(call_info, queue, &pLabelInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBeginDebugUtilsLabelEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBeginDebugUtilsLabelEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8228,13 +8228,13 @@ size_t VulkanDecoder::Decode_vkCmdBeginDebugUtilsLabelEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBeginDebugUtilsLabelEXT(commandBuffer, &pLabelInfo);
+        consumer->Process_vkCmdBeginDebugUtilsLabelEXT(call_info, commandBuffer, &pLabelInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdEndDebugUtilsLabelEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdEndDebugUtilsLabelEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8244,13 +8244,13 @@ size_t VulkanDecoder::Decode_vkCmdEndDebugUtilsLabelEXT(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+        consumer->Process_vkCmdEndDebugUtilsLabelEXT(call_info, commandBuffer);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdInsertDebugUtilsLabelEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdInsertDebugUtilsLabelEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8262,13 +8262,13 @@ size_t VulkanDecoder::Decode_vkCmdInsertDebugUtilsLabelEXT(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdInsertDebugUtilsLabelEXT(commandBuffer, &pLabelInfo);
+        consumer->Process_vkCmdInsertDebugUtilsLabelEXT(call_info, commandBuffer, &pLabelInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateDebugUtilsMessengerEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateDebugUtilsMessengerEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8286,13 +8286,13 @@ size_t VulkanDecoder::Decode_vkCreateDebugUtilsMessengerEXT(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDebugUtilsMessengerEXT(return_value, instance, &pCreateInfo, &pAllocator, &pMessenger);
+        consumer->Process_vkCreateDebugUtilsMessengerEXT(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pMessenger);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyDebugUtilsMessengerEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyDebugUtilsMessengerEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8306,13 +8306,13 @@ size_t VulkanDecoder::Decode_vkDestroyDebugUtilsMessengerEXT(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyDebugUtilsMessengerEXT(instance, messenger, &pAllocator);
+        consumer->Process_vkDestroyDebugUtilsMessengerEXT(call_info, instance, messenger, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkSubmitDebugUtilsMessageEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkSubmitDebugUtilsMessageEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8328,13 +8328,13 @@ size_t VulkanDecoder::Decode_vkSubmitDebugUtilsMessageEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, &pCallbackData);
+        consumer->Process_vkSubmitDebugUtilsMessageEXT(call_info, instance, messageSeverity, messageTypes, &pCallbackData);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetAndroidHardwareBufferPropertiesANDROID(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetAndroidHardwareBufferPropertiesANDROID(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8350,13 +8350,13 @@ size_t VulkanDecoder::Decode_vkGetAndroidHardwareBufferPropertiesANDROID(const u
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetAndroidHardwareBufferPropertiesANDROID(return_value, device, buffer, &pProperties);
+        consumer->Process_vkGetAndroidHardwareBufferPropertiesANDROID(call_info, return_value, device, buffer, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetMemoryAndroidHardwareBufferANDROID(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetMemoryAndroidHardwareBufferANDROID(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8372,13 +8372,13 @@ size_t VulkanDecoder::Decode_vkGetMemoryAndroidHardwareBufferANDROID(const uint8
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetMemoryAndroidHardwareBufferANDROID(return_value, device, &pInfo, &pBuffer);
+        consumer->Process_vkGetMemoryAndroidHardwareBufferANDROID(call_info, return_value, device, &pInfo, &pBuffer);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetSampleLocationsEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetSampleLocationsEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8390,13 +8390,13 @@ size_t VulkanDecoder::Decode_vkCmdSetSampleLocationsEXT(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetSampleLocationsEXT(commandBuffer, &pSampleLocationsInfo);
+        consumer->Process_vkCmdSetSampleLocationsEXT(call_info, commandBuffer, &pSampleLocationsInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceMultisamplePropertiesEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceMultisamplePropertiesEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8410,13 +8410,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceMultisamplePropertiesEXT(const u
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(physicalDevice, samples, &pMultisampleProperties);
+        consumer->Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(call_info, physicalDevice, samples, &pMultisampleProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetImageDrmFormatModifierPropertiesEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetImageDrmFormatModifierPropertiesEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8432,13 +8432,13 @@ size_t VulkanDecoder::Decode_vkGetImageDrmFormatModifierPropertiesEXT(const uint
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetImageDrmFormatModifierPropertiesEXT(return_value, device, image, &pProperties);
+        consumer->Process_vkGetImageDrmFormatModifierPropertiesEXT(call_info, return_value, device, image, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateValidationCacheEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateValidationCacheEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8456,13 +8456,13 @@ size_t VulkanDecoder::Decode_vkCreateValidationCacheEXT(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateValidationCacheEXT(return_value, device, &pCreateInfo, &pAllocator, &pValidationCache);
+        consumer->Process_vkCreateValidationCacheEXT(call_info, return_value, device, &pCreateInfo, &pAllocator, &pValidationCache);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyValidationCacheEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyValidationCacheEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8476,13 +8476,13 @@ size_t VulkanDecoder::Decode_vkDestroyValidationCacheEXT(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyValidationCacheEXT(device, validationCache, &pAllocator);
+        consumer->Process_vkDestroyValidationCacheEXT(call_info, device, validationCache, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkMergeValidationCachesEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkMergeValidationCachesEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8500,13 +8500,13 @@ size_t VulkanDecoder::Decode_vkMergeValidationCachesEXT(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkMergeValidationCachesEXT(return_value, device, dstCache, srcCacheCount, &pSrcCaches);
+        consumer->Process_vkMergeValidationCachesEXT(call_info, return_value, device, dstCache, srcCacheCount, &pSrcCaches);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetValidationCacheDataEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetValidationCacheDataEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8524,13 +8524,13 @@ size_t VulkanDecoder::Decode_vkGetValidationCacheDataEXT(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetValidationCacheDataEXT(return_value, device, validationCache, &pDataSize, &pData);
+        consumer->Process_vkGetValidationCacheDataEXT(call_info, return_value, device, validationCache, &pDataSize, &pData);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBindShadingRateImageNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBindShadingRateImageNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8544,13 +8544,13 @@ size_t VulkanDecoder::Decode_vkCmdBindShadingRateImageNV(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout);
+        consumer->Process_vkCmdBindShadingRateImageNV(call_info, commandBuffer, imageView, imageLayout);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetViewportShadingRatePaletteNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetViewportShadingRatePaletteNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8566,13 +8566,13 @@ size_t VulkanDecoder::Decode_vkCmdSetViewportShadingRatePaletteNV(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetViewportShadingRatePaletteNV(commandBuffer, firstViewport, viewportCount, &pShadingRatePalettes);
+        consumer->Process_vkCmdSetViewportShadingRatePaletteNV(call_info, commandBuffer, firstViewport, viewportCount, &pShadingRatePalettes);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetCoarseSampleOrderNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetCoarseSampleOrderNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8588,13 +8588,13 @@ size_t VulkanDecoder::Decode_vkCmdSetCoarseSampleOrderNV(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetCoarseSampleOrderNV(commandBuffer, sampleOrderType, customSampleOrderCount, &pCustomSampleOrders);
+        consumer->Process_vkCmdSetCoarseSampleOrderNV(call_info, commandBuffer, sampleOrderType, customSampleOrderCount, &pCustomSampleOrders);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateAccelerationStructureNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateAccelerationStructureNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8612,13 +8612,13 @@ size_t VulkanDecoder::Decode_vkCreateAccelerationStructureNV(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateAccelerationStructureNV(return_value, device, &pCreateInfo, &pAllocator, &pAccelerationStructure);
+        consumer->Process_vkCreateAccelerationStructureNV(call_info, return_value, device, &pCreateInfo, &pAllocator, &pAccelerationStructure);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyAccelerationStructureNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyAccelerationStructureNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8632,13 +8632,13 @@ size_t VulkanDecoder::Decode_vkDestroyAccelerationStructureNV(const uint8_t* par
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyAccelerationStructureNV(device, accelerationStructure, &pAllocator);
+        consumer->Process_vkDestroyAccelerationStructureNV(call_info, device, accelerationStructure, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetAccelerationStructureMemoryRequirementsNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetAccelerationStructureMemoryRequirementsNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8652,13 +8652,13 @@ size_t VulkanDecoder::Decode_vkGetAccelerationStructureMemoryRequirementsNV(cons
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetAccelerationStructureMemoryRequirementsNV(device, &pInfo, &pMemoryRequirements);
+        consumer->Process_vkGetAccelerationStructureMemoryRequirementsNV(call_info, device, &pInfo, &pMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkBindAccelerationStructureMemoryNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkBindAccelerationStructureMemoryNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8674,13 +8674,13 @@ size_t VulkanDecoder::Decode_vkBindAccelerationStructureMemoryNV(const uint8_t* 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkBindAccelerationStructureMemoryNV(return_value, device, bindInfoCount, &pBindInfos);
+        consumer->Process_vkBindAccelerationStructureMemoryNV(call_info, return_value, device, bindInfoCount, &pBindInfos);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBuildAccelerationStructureNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBuildAccelerationStructureNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8706,13 +8706,13 @@ size_t VulkanDecoder::Decode_vkCmdBuildAccelerationStructureNV(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBuildAccelerationStructureNV(commandBuffer, &pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset);
+        consumer->Process_vkCmdBuildAccelerationStructureNV(call_info, commandBuffer, &pInfo, instanceData, instanceOffset, update, dst, src, scratch, scratchOffset);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyAccelerationStructureNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyAccelerationStructureNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8728,13 +8728,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyAccelerationStructureNV(const uint8_t* par
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyAccelerationStructureNV(commandBuffer, dst, src, mode);
+        consumer->Process_vkCmdCopyAccelerationStructureNV(call_info, commandBuffer, dst, src, mode);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdTraceRaysNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdTraceRaysNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8772,13 +8772,13 @@ size_t VulkanDecoder::Decode_vkCmdTraceRaysNV(const uint8_t* parameter_buffer, s
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth);
+        consumer->Process_vkCmdTraceRaysNV(call_info, commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset, missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride, hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride, callableShaderBindingTableBuffer, callableShaderBindingOffset, callableShaderBindingStride, width, height, depth);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateRayTracingPipelinesNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateRayTracingPipelinesNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8800,13 +8800,13 @@ size_t VulkanDecoder::Decode_vkCreateRayTracingPipelinesNV(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateRayTracingPipelinesNV(return_value, device, pipelineCache, createInfoCount, &pCreateInfos, &pAllocator, &pPipelines);
+        consumer->Process_vkCreateRayTracingPipelinesNV(call_info, return_value, device, pipelineCache, createInfoCount, &pCreateInfos, &pAllocator, &pPipelines);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetRayTracingShaderGroupHandlesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetRayTracingShaderGroupHandlesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8828,13 +8828,13 @@ size_t VulkanDecoder::Decode_vkGetRayTracingShaderGroupHandlesKHR(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetRayTracingShaderGroupHandlesKHR(return_value, device, pipeline, firstGroup, groupCount, dataSize, &pData);
+        consumer->Process_vkGetRayTracingShaderGroupHandlesKHR(call_info, return_value, device, pipeline, firstGroup, groupCount, dataSize, &pData);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetRayTracingShaderGroupHandlesNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetRayTracingShaderGroupHandlesNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8856,13 +8856,13 @@ size_t VulkanDecoder::Decode_vkGetRayTracingShaderGroupHandlesNV(const uint8_t* 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetRayTracingShaderGroupHandlesNV(return_value, device, pipeline, firstGroup, groupCount, dataSize, &pData);
+        consumer->Process_vkGetRayTracingShaderGroupHandlesNV(call_info, return_value, device, pipeline, firstGroup, groupCount, dataSize, &pData);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetAccelerationStructureHandleNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetAccelerationStructureHandleNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8880,13 +8880,13 @@ size_t VulkanDecoder::Decode_vkGetAccelerationStructureHandleNV(const uint8_t* p
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetAccelerationStructureHandleNV(return_value, device, accelerationStructure, dataSize, &pData);
+        consumer->Process_vkGetAccelerationStructureHandleNV(call_info, return_value, device, accelerationStructure, dataSize, &pData);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdWriteAccelerationStructuresPropertiesNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdWriteAccelerationStructuresPropertiesNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8906,13 +8906,13 @@ size_t VulkanDecoder::Decode_vkCmdWriteAccelerationStructuresPropertiesNV(const 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdWriteAccelerationStructuresPropertiesNV(commandBuffer, accelerationStructureCount, &pAccelerationStructures, queryType, queryPool, firstQuery);
+        consumer->Process_vkCmdWriteAccelerationStructuresPropertiesNV(call_info, commandBuffer, accelerationStructureCount, &pAccelerationStructures, queryType, queryPool, firstQuery);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCompileDeferredNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCompileDeferredNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8928,13 +8928,13 @@ size_t VulkanDecoder::Decode_vkCompileDeferredNV(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCompileDeferredNV(return_value, device, pipeline, shader);
+        consumer->Process_vkCompileDeferredNV(call_info, return_value, device, pipeline, shader);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetMemoryHostPointerPropertiesEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetMemoryHostPointerPropertiesEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8952,13 +8952,13 @@ size_t VulkanDecoder::Decode_vkGetMemoryHostPointerPropertiesEXT(const uint8_t* 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetMemoryHostPointerPropertiesEXT(return_value, device, handleType, pHostPointer, &pMemoryHostPointerProperties);
+        consumer->Process_vkGetMemoryHostPointerPropertiesEXT(call_info, return_value, device, handleType, pHostPointer, &pMemoryHostPointerProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdWriteBufferMarkerAMD(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdWriteBufferMarkerAMD(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8976,13 +8976,13 @@ size_t VulkanDecoder::Decode_vkCmdWriteBufferMarkerAMD(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
+        consumer->Process_vkCmdWriteBufferMarkerAMD(call_info, commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -8998,13 +8998,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(cons
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(return_value, physicalDevice, &pTimeDomainCount, &pTimeDomains);
+        consumer->Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(call_info, return_value, physicalDevice, &pTimeDomainCount, &pTimeDomains);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetCalibratedTimestampsEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetCalibratedTimestampsEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9024,13 +9024,13 @@ size_t VulkanDecoder::Decode_vkGetCalibratedTimestampsEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetCalibratedTimestampsEXT(return_value, device, timestampCount, &pTimestampInfos, &pTimestamps, &pMaxDeviation);
+        consumer->Process_vkGetCalibratedTimestampsEXT(call_info, return_value, device, timestampCount, &pTimestampInfos, &pTimestamps, &pMaxDeviation);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDrawMeshTasksNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDrawMeshTasksNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9044,13 +9044,13 @@ size_t VulkanDecoder::Decode_vkCmdDrawMeshTasksNV(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask);
+        consumer->Process_vkCmdDrawMeshTasksNV(call_info, commandBuffer, taskCount, firstTask);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDrawMeshTasksIndirectNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDrawMeshTasksIndirectNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9068,13 +9068,13 @@ size_t VulkanDecoder::Decode_vkCmdDrawMeshTasksIndirectNV(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride);
+        consumer->Process_vkCmdDrawMeshTasksIndirectNV(call_info, commandBuffer, buffer, offset, drawCount, stride);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDrawMeshTasksIndirectCountNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDrawMeshTasksIndirectCountNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9096,13 +9096,13 @@ size_t VulkanDecoder::Decode_vkCmdDrawMeshTasksIndirectCountNV(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+        consumer->Process_vkCmdDrawMeshTasksIndirectCountNV(call_info, commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetExclusiveScissorNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetExclusiveScissorNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9118,13 +9118,13 @@ size_t VulkanDecoder::Decode_vkCmdSetExclusiveScissorNV(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetExclusiveScissorNV(commandBuffer, firstExclusiveScissor, exclusiveScissorCount, &pExclusiveScissors);
+        consumer->Process_vkCmdSetExclusiveScissorNV(call_info, commandBuffer, firstExclusiveScissor, exclusiveScissorCount, &pExclusiveScissors);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetCheckpointNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetCheckpointNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9136,13 +9136,13 @@ size_t VulkanDecoder::Decode_vkCmdSetCheckpointNV(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetCheckpointNV(commandBuffer, pCheckpointMarker);
+        consumer->Process_vkCmdSetCheckpointNV(call_info, commandBuffer, pCheckpointMarker);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetQueueCheckpointDataNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetQueueCheckpointDataNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9156,13 +9156,13 @@ size_t VulkanDecoder::Decode_vkGetQueueCheckpointDataNV(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetQueueCheckpointDataNV(queue, &pCheckpointDataCount, &pCheckpointData);
+        consumer->Process_vkGetQueueCheckpointDataNV(call_info, queue, &pCheckpointDataCount, &pCheckpointData);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkInitializePerformanceApiINTEL(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkInitializePerformanceApiINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9176,13 +9176,13 @@ size_t VulkanDecoder::Decode_vkInitializePerformanceApiINTEL(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkInitializePerformanceApiINTEL(return_value, device, &pInitializeInfo);
+        consumer->Process_vkInitializePerformanceApiINTEL(call_info, return_value, device, &pInitializeInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkUninitializePerformanceApiINTEL(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkUninitializePerformanceApiINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9192,13 +9192,13 @@ size_t VulkanDecoder::Decode_vkUninitializePerformanceApiINTEL(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkUninitializePerformanceApiINTEL(device);
+        consumer->Process_vkUninitializePerformanceApiINTEL(call_info, device);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetPerformanceMarkerINTEL(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetPerformanceMarkerINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9212,13 +9212,13 @@ size_t VulkanDecoder::Decode_vkCmdSetPerformanceMarkerINTEL(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetPerformanceMarkerINTEL(return_value, commandBuffer, &pMarkerInfo);
+        consumer->Process_vkCmdSetPerformanceMarkerINTEL(call_info, return_value, commandBuffer, &pMarkerInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetPerformanceStreamMarkerINTEL(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetPerformanceStreamMarkerINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9232,13 +9232,13 @@ size_t VulkanDecoder::Decode_vkCmdSetPerformanceStreamMarkerINTEL(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetPerformanceStreamMarkerINTEL(return_value, commandBuffer, &pMarkerInfo);
+        consumer->Process_vkCmdSetPerformanceStreamMarkerINTEL(call_info, return_value, commandBuffer, &pMarkerInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetPerformanceOverrideINTEL(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetPerformanceOverrideINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9252,13 +9252,13 @@ size_t VulkanDecoder::Decode_vkCmdSetPerformanceOverrideINTEL(const uint8_t* par
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetPerformanceOverrideINTEL(return_value, commandBuffer, &pOverrideInfo);
+        consumer->Process_vkCmdSetPerformanceOverrideINTEL(call_info, return_value, commandBuffer, &pOverrideInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkAcquirePerformanceConfigurationINTEL(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkAcquirePerformanceConfigurationINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9274,13 +9274,13 @@ size_t VulkanDecoder::Decode_vkAcquirePerformanceConfigurationINTEL(const uint8_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkAcquirePerformanceConfigurationINTEL(return_value, device, &pAcquireInfo, &pConfiguration);
+        consumer->Process_vkAcquirePerformanceConfigurationINTEL(call_info, return_value, device, &pAcquireInfo, &pConfiguration);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkReleasePerformanceConfigurationINTEL(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkReleasePerformanceConfigurationINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9294,13 +9294,13 @@ size_t VulkanDecoder::Decode_vkReleasePerformanceConfigurationINTEL(const uint8_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkReleasePerformanceConfigurationINTEL(return_value, device, configuration);
+        consumer->Process_vkReleasePerformanceConfigurationINTEL(call_info, return_value, device, configuration);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkQueueSetPerformanceConfigurationINTEL(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkQueueSetPerformanceConfigurationINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9314,13 +9314,13 @@ size_t VulkanDecoder::Decode_vkQueueSetPerformanceConfigurationINTEL(const uint8
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkQueueSetPerformanceConfigurationINTEL(return_value, queue, configuration);
+        consumer->Process_vkQueueSetPerformanceConfigurationINTEL(call_info, return_value, queue, configuration);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPerformanceParameterINTEL(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPerformanceParameterINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9336,13 +9336,13 @@ size_t VulkanDecoder::Decode_vkGetPerformanceParameterINTEL(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPerformanceParameterINTEL(return_value, device, parameter, &pValue);
+        consumer->Process_vkGetPerformanceParameterINTEL(call_info, return_value, device, parameter, &pValue);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkSetLocalDimmingAMD(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkSetLocalDimmingAMD(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9356,13 +9356,13 @@ size_t VulkanDecoder::Decode_vkSetLocalDimmingAMD(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkSetLocalDimmingAMD(device, swapChain, localDimmingEnable);
+        consumer->Process_vkSetLocalDimmingAMD(call_info, device, swapChain, localDimmingEnable);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateImagePipeSurfaceFUCHSIA(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateImagePipeSurfaceFUCHSIA(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9380,13 +9380,13 @@ size_t VulkanDecoder::Decode_vkCreateImagePipeSurfaceFUCHSIA(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateImagePipeSurfaceFUCHSIA(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
+        consumer->Process_vkCreateImagePipeSurfaceFUCHSIA(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateMetalSurfaceEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateMetalSurfaceEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9404,13 +9404,13 @@ size_t VulkanDecoder::Decode_vkCreateMetalSurfaceEXT(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateMetalSurfaceEXT(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
+        consumer->Process_vkCreateMetalSurfaceEXT(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetBufferDeviceAddressEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetBufferDeviceAddressEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9424,13 +9424,13 @@ size_t VulkanDecoder::Decode_vkGetBufferDeviceAddressEXT(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetBufferDeviceAddressEXT(return_value, device, &pInfo);
+        consumer->Process_vkGetBufferDeviceAddressEXT(call_info, return_value, device, &pInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceToolPropertiesEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceToolPropertiesEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9446,13 +9446,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceToolPropertiesEXT(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceToolPropertiesEXT(return_value, physicalDevice, &pToolCount, &pToolProperties);
+        consumer->Process_vkGetPhysicalDeviceToolPropertiesEXT(call_info, return_value, physicalDevice, &pToolCount, &pToolProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9468,13 +9468,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(co
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(return_value, physicalDevice, &pPropertyCount, &pProperties);
+        consumer->Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(call_info, return_value, physicalDevice, &pPropertyCount, &pProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9490,13 +9490,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSupportedFramebufferMixedSamples
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(return_value, physicalDevice, &pCombinationCount, &pCombinations);
+        consumer->Process_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(call_info, return_value, physicalDevice, &pCombinationCount, &pCombinations);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfacePresentModes2EXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfacePresentModes2EXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9514,13 +9514,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceSurfacePresentModes2EXT(const ui
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(return_value, physicalDevice, &pSurfaceInfo, &pPresentModeCount, &pPresentModes);
+        consumer->Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(call_info, return_value, physicalDevice, &pSurfaceInfo, &pPresentModeCount, &pPresentModes);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkAcquireFullScreenExclusiveModeEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkAcquireFullScreenExclusiveModeEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9534,13 +9534,13 @@ size_t VulkanDecoder::Decode_vkAcquireFullScreenExclusiveModeEXT(const uint8_t* 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkAcquireFullScreenExclusiveModeEXT(return_value, device, swapchain);
+        consumer->Process_vkAcquireFullScreenExclusiveModeEXT(call_info, return_value, device, swapchain);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkReleaseFullScreenExclusiveModeEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkReleaseFullScreenExclusiveModeEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9554,13 +9554,13 @@ size_t VulkanDecoder::Decode_vkReleaseFullScreenExclusiveModeEXT(const uint8_t* 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkReleaseFullScreenExclusiveModeEXT(return_value, device, swapchain);
+        consumer->Process_vkReleaseFullScreenExclusiveModeEXT(call_info, return_value, device, swapchain);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceGroupSurfacePresentModes2EXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceGroupSurfacePresentModes2EXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9576,13 +9576,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceGroupSurfacePresentModes2EXT(const uint8
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceGroupSurfacePresentModes2EXT(return_value, device, &pSurfaceInfo, &pModes);
+        consumer->Process_vkGetDeviceGroupSurfacePresentModes2EXT(call_info, return_value, device, &pSurfaceInfo, &pModes);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateHeadlessSurfaceEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateHeadlessSurfaceEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9600,13 +9600,13 @@ size_t VulkanDecoder::Decode_vkCreateHeadlessSurfaceEXT(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateHeadlessSurfaceEXT(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
+        consumer->Process_vkCreateHeadlessSurfaceEXT(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetLineStippleEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetLineStippleEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9620,13 +9620,13 @@ size_t VulkanDecoder::Decode_vkCmdSetLineStippleEXT(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetLineStippleEXT(commandBuffer, lineStippleFactor, lineStipplePattern);
+        consumer->Process_vkCmdSetLineStippleEXT(call_info, commandBuffer, lineStippleFactor, lineStipplePattern);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkResetQueryPoolEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkResetQueryPoolEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9642,13 +9642,13 @@ size_t VulkanDecoder::Decode_vkResetQueryPoolEXT(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkResetQueryPoolEXT(device, queryPool, firstQuery, queryCount);
+        consumer->Process_vkResetQueryPoolEXT(call_info, device, queryPool, firstQuery, queryCount);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetCullModeEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetCullModeEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9660,13 +9660,13 @@ size_t VulkanDecoder::Decode_vkCmdSetCullModeEXT(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetCullModeEXT(commandBuffer, cullMode);
+        consumer->Process_vkCmdSetCullModeEXT(call_info, commandBuffer, cullMode);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetFrontFaceEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetFrontFaceEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9678,13 +9678,13 @@ size_t VulkanDecoder::Decode_vkCmdSetFrontFaceEXT(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetFrontFaceEXT(commandBuffer, frontFace);
+        consumer->Process_vkCmdSetFrontFaceEXT(call_info, commandBuffer, frontFace);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetPrimitiveTopologyEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetPrimitiveTopologyEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9696,13 +9696,13 @@ size_t VulkanDecoder::Decode_vkCmdSetPrimitiveTopologyEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetPrimitiveTopologyEXT(commandBuffer, primitiveTopology);
+        consumer->Process_vkCmdSetPrimitiveTopologyEXT(call_info, commandBuffer, primitiveTopology);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetViewportWithCountEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetViewportWithCountEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9716,13 +9716,13 @@ size_t VulkanDecoder::Decode_vkCmdSetViewportWithCountEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetViewportWithCountEXT(commandBuffer, viewportCount, &pViewports);
+        consumer->Process_vkCmdSetViewportWithCountEXT(call_info, commandBuffer, viewportCount, &pViewports);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetScissorWithCountEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetScissorWithCountEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9736,13 +9736,13 @@ size_t VulkanDecoder::Decode_vkCmdSetScissorWithCountEXT(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetScissorWithCountEXT(commandBuffer, scissorCount, &pScissors);
+        consumer->Process_vkCmdSetScissorWithCountEXT(call_info, commandBuffer, scissorCount, &pScissors);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBindVertexBuffers2EXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBindVertexBuffers2EXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9764,13 +9764,13 @@ size_t VulkanDecoder::Decode_vkCmdBindVertexBuffers2EXT(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBindVertexBuffers2EXT(commandBuffer, firstBinding, bindingCount, &pBuffers, &pOffsets, &pSizes, &pStrides);
+        consumer->Process_vkCmdBindVertexBuffers2EXT(call_info, commandBuffer, firstBinding, bindingCount, &pBuffers, &pOffsets, &pSizes, &pStrides);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetDepthTestEnableEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetDepthTestEnableEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9782,13 +9782,13 @@ size_t VulkanDecoder::Decode_vkCmdSetDepthTestEnableEXT(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetDepthTestEnableEXT(commandBuffer, depthTestEnable);
+        consumer->Process_vkCmdSetDepthTestEnableEXT(call_info, commandBuffer, depthTestEnable);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetDepthWriteEnableEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetDepthWriteEnableEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9800,13 +9800,13 @@ size_t VulkanDecoder::Decode_vkCmdSetDepthWriteEnableEXT(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetDepthWriteEnableEXT(commandBuffer, depthWriteEnable);
+        consumer->Process_vkCmdSetDepthWriteEnableEXT(call_info, commandBuffer, depthWriteEnable);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetDepthCompareOpEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetDepthCompareOpEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9818,13 +9818,13 @@ size_t VulkanDecoder::Decode_vkCmdSetDepthCompareOpEXT(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetDepthCompareOpEXT(commandBuffer, depthCompareOp);
+        consumer->Process_vkCmdSetDepthCompareOpEXT(call_info, commandBuffer, depthCompareOp);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetDepthBoundsTestEnableEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetDepthBoundsTestEnableEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9836,13 +9836,13 @@ size_t VulkanDecoder::Decode_vkCmdSetDepthBoundsTestEnableEXT(const uint8_t* par
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetDepthBoundsTestEnableEXT(commandBuffer, depthBoundsTestEnable);
+        consumer->Process_vkCmdSetDepthBoundsTestEnableEXT(call_info, commandBuffer, depthBoundsTestEnable);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetStencilTestEnableEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetStencilTestEnableEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9854,13 +9854,13 @@ size_t VulkanDecoder::Decode_vkCmdSetStencilTestEnableEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetStencilTestEnableEXT(commandBuffer, stencilTestEnable);
+        consumer->Process_vkCmdSetStencilTestEnableEXT(call_info, commandBuffer, stencilTestEnable);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetStencilOpEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetStencilOpEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9880,13 +9880,13 @@ size_t VulkanDecoder::Decode_vkCmdSetStencilOpEXT(const uint8_t* parameter_buffe
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetStencilOpEXT(commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
+        consumer->Process_vkCmdSetStencilOpEXT(call_info, commandBuffer, faceMask, failOp, passOp, depthFailOp, compareOp);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetGeneratedCommandsMemoryRequirementsNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetGeneratedCommandsMemoryRequirementsNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9900,13 +9900,13 @@ size_t VulkanDecoder::Decode_vkGetGeneratedCommandsMemoryRequirementsNV(const ui
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetGeneratedCommandsMemoryRequirementsNV(device, &pInfo, &pMemoryRequirements);
+        consumer->Process_vkGetGeneratedCommandsMemoryRequirementsNV(call_info, device, &pInfo, &pMemoryRequirements);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdPreprocessGeneratedCommandsNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdPreprocessGeneratedCommandsNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9918,13 +9918,13 @@ size_t VulkanDecoder::Decode_vkCmdPreprocessGeneratedCommandsNV(const uint8_t* p
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdPreprocessGeneratedCommandsNV(commandBuffer, &pGeneratedCommandsInfo);
+        consumer->Process_vkCmdPreprocessGeneratedCommandsNV(call_info, commandBuffer, &pGeneratedCommandsInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdExecuteGeneratedCommandsNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdExecuteGeneratedCommandsNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9938,13 +9938,13 @@ size_t VulkanDecoder::Decode_vkCmdExecuteGeneratedCommandsNV(const uint8_t* para
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdExecuteGeneratedCommandsNV(commandBuffer, isPreprocessed, &pGeneratedCommandsInfo);
+        consumer->Process_vkCmdExecuteGeneratedCommandsNV(call_info, commandBuffer, isPreprocessed, &pGeneratedCommandsInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBindPipelineShaderGroupNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBindPipelineShaderGroupNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9960,13 +9960,13 @@ size_t VulkanDecoder::Decode_vkCmdBindPipelineShaderGroupNV(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex);
+        consumer->Process_vkCmdBindPipelineShaderGroupNV(call_info, commandBuffer, pipelineBindPoint, pipeline, groupIndex);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateIndirectCommandsLayoutNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateIndirectCommandsLayoutNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -9984,13 +9984,13 @@ size_t VulkanDecoder::Decode_vkCreateIndirectCommandsLayoutNV(const uint8_t* par
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateIndirectCommandsLayoutNV(return_value, device, &pCreateInfo, &pAllocator, &pIndirectCommandsLayout);
+        consumer->Process_vkCreateIndirectCommandsLayoutNV(call_info, return_value, device, &pCreateInfo, &pAllocator, &pIndirectCommandsLayout);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyIndirectCommandsLayoutNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyIndirectCommandsLayoutNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10004,13 +10004,13 @@ size_t VulkanDecoder::Decode_vkDestroyIndirectCommandsLayoutNV(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyIndirectCommandsLayoutNV(device, indirectCommandsLayout, &pAllocator);
+        consumer->Process_vkDestroyIndirectCommandsLayoutNV(call_info, device, indirectCommandsLayout, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkAcquireDrmDisplayEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkAcquireDrmDisplayEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10026,13 +10026,13 @@ size_t VulkanDecoder::Decode_vkAcquireDrmDisplayEXT(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkAcquireDrmDisplayEXT(return_value, physicalDevice, drmFd, display);
+        consumer->Process_vkAcquireDrmDisplayEXT(call_info, return_value, physicalDevice, drmFd, display);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDrmDisplayEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDrmDisplayEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10050,13 +10050,13 @@ size_t VulkanDecoder::Decode_vkGetDrmDisplayEXT(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDrmDisplayEXT(return_value, physicalDevice, drmFd, connectorId, &display);
+        consumer->Process_vkGetDrmDisplayEXT(call_info, return_value, physicalDevice, drmFd, connectorId, &display);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreatePrivateDataSlotEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreatePrivateDataSlotEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10074,13 +10074,13 @@ size_t VulkanDecoder::Decode_vkCreatePrivateDataSlotEXT(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreatePrivateDataSlotEXT(return_value, device, &pCreateInfo, &pAllocator, &pPrivateDataSlot);
+        consumer->Process_vkCreatePrivateDataSlotEXT(call_info, return_value, device, &pCreateInfo, &pAllocator, &pPrivateDataSlot);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyPrivateDataSlotEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyPrivateDataSlotEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10094,13 +10094,13 @@ size_t VulkanDecoder::Decode_vkDestroyPrivateDataSlotEXT(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyPrivateDataSlotEXT(device, privateDataSlot, &pAllocator);
+        consumer->Process_vkDestroyPrivateDataSlotEXT(call_info, device, privateDataSlot, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkSetPrivateDataEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkSetPrivateDataEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10120,13 +10120,13 @@ size_t VulkanDecoder::Decode_vkSetPrivateDataEXT(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkSetPrivateDataEXT(return_value, device, objectType, objectHandle, privateDataSlot, data);
+        consumer->Process_vkSetPrivateDataEXT(call_info, return_value, device, objectType, objectHandle, privateDataSlot, data);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPrivateDataEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPrivateDataEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10144,13 +10144,13 @@ size_t VulkanDecoder::Decode_vkGetPrivateDataEXT(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPrivateDataEXT(device, objectType, objectHandle, privateDataSlot, &pData);
+        consumer->Process_vkGetPrivateDataEXT(call_info, device, objectType, objectHandle, privateDataSlot, &pData);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetFragmentShadingRateEnumNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetFragmentShadingRateEnumNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10164,13 +10164,13 @@ size_t VulkanDecoder::Decode_vkCmdSetFragmentShadingRateEnumNV(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetFragmentShadingRateEnumNV(commandBuffer, shadingRate, &combinerOps);
+        consumer->Process_vkCmdSetFragmentShadingRateEnumNV(call_info, commandBuffer, shadingRate, &combinerOps);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkAcquireWinrtDisplayNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkAcquireWinrtDisplayNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10184,13 +10184,13 @@ size_t VulkanDecoder::Decode_vkAcquireWinrtDisplayNV(const uint8_t* parameter_bu
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkAcquireWinrtDisplayNV(return_value, physicalDevice, display);
+        consumer->Process_vkAcquireWinrtDisplayNV(call_info, return_value, physicalDevice, display);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetWinrtDisplayNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetWinrtDisplayNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10206,13 +10206,13 @@ size_t VulkanDecoder::Decode_vkGetWinrtDisplayNV(const uint8_t* parameter_buffer
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetWinrtDisplayNV(return_value, physicalDevice, deviceRelativeId, &pDisplay);
+        consumer->Process_vkGetWinrtDisplayNV(call_info, return_value, physicalDevice, deviceRelativeId, &pDisplay);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateDirectFBSurfaceEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateDirectFBSurfaceEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10230,13 +10230,13 @@ size_t VulkanDecoder::Decode_vkCreateDirectFBSurfaceEXT(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateDirectFBSurfaceEXT(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
+        consumer->Process_vkCreateDirectFBSurfaceEXT(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceDirectFBPresentationSupportEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceDirectFBPresentationSupportEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10252,13 +10252,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceDirectFBPresentationSupportEXT(c
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceDirectFBPresentationSupportEXT(return_value, physicalDevice, queueFamilyIndex, dfb);
+        consumer->Process_vkGetPhysicalDeviceDirectFBPresentationSupportEXT(call_info, return_value, physicalDevice, queueFamilyIndex, dfb);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetVertexInputEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetVertexInputEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10276,13 +10276,13 @@ size_t VulkanDecoder::Decode_vkCmdSetVertexInputEXT(const uint8_t* parameter_buf
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetVertexInputEXT(commandBuffer, vertexBindingDescriptionCount, &pVertexBindingDescriptions, vertexAttributeDescriptionCount, &pVertexAttributeDescriptions);
+        consumer->Process_vkCmdSetVertexInputEXT(call_info, commandBuffer, vertexBindingDescriptionCount, &pVertexBindingDescriptions, vertexAttributeDescriptionCount, &pVertexAttributeDescriptions);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetMemoryZirconHandleFUCHSIA(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetMemoryZirconHandleFUCHSIA(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10298,13 +10298,13 @@ size_t VulkanDecoder::Decode_vkGetMemoryZirconHandleFUCHSIA(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetMemoryZirconHandleFUCHSIA(return_value, device, &pGetZirconHandleInfo, &pZirconHandle);
+        consumer->Process_vkGetMemoryZirconHandleFUCHSIA(call_info, return_value, device, &pGetZirconHandleInfo, &pZirconHandle);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetMemoryZirconHandlePropertiesFUCHSIA(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetMemoryZirconHandlePropertiesFUCHSIA(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10322,13 +10322,13 @@ size_t VulkanDecoder::Decode_vkGetMemoryZirconHandlePropertiesFUCHSIA(const uint
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(return_value, device, handleType, zirconHandle, &pMemoryZirconHandleProperties);
+        consumer->Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(call_info, return_value, device, handleType, zirconHandle, &pMemoryZirconHandleProperties);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkImportSemaphoreZirconHandleFUCHSIA(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkImportSemaphoreZirconHandleFUCHSIA(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10342,13 +10342,13 @@ size_t VulkanDecoder::Decode_vkImportSemaphoreZirconHandleFUCHSIA(const uint8_t*
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkImportSemaphoreZirconHandleFUCHSIA(return_value, device, &pImportSemaphoreZirconHandleInfo);
+        consumer->Process_vkImportSemaphoreZirconHandleFUCHSIA(call_info, return_value, device, &pImportSemaphoreZirconHandleInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetSemaphoreZirconHandleFUCHSIA(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetSemaphoreZirconHandleFUCHSIA(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10364,13 +10364,13 @@ size_t VulkanDecoder::Decode_vkGetSemaphoreZirconHandleFUCHSIA(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetSemaphoreZirconHandleFUCHSIA(return_value, device, &pGetZirconHandleInfo, &pZirconHandle);
+        consumer->Process_vkGetSemaphoreZirconHandleFUCHSIA(call_info, return_value, device, &pGetZirconHandleInfo, &pZirconHandle);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBindInvocationMaskHUAWEI(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBindInvocationMaskHUAWEI(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10384,13 +10384,13 @@ size_t VulkanDecoder::Decode_vkCmdBindInvocationMaskHUAWEI(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBindInvocationMaskHUAWEI(commandBuffer, imageView, imageLayout);
+        consumer->Process_vkCmdBindInvocationMaskHUAWEI(call_info, commandBuffer, imageView, imageLayout);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetMemoryRemoteAddressNV(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetMemoryRemoteAddressNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10406,13 +10406,13 @@ size_t VulkanDecoder::Decode_vkGetMemoryRemoteAddressNV(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetMemoryRemoteAddressNV(return_value, device, &pMemoryGetRemoteAddressInfo, &pAddress);
+        consumer->Process_vkGetMemoryRemoteAddressNV(call_info, return_value, device, &pMemoryGetRemoteAddressInfo, &pAddress);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetPatchControlPointsEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetPatchControlPointsEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10424,13 +10424,13 @@ size_t VulkanDecoder::Decode_vkCmdSetPatchControlPointsEXT(const uint8_t* parame
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetPatchControlPointsEXT(commandBuffer, patchControlPoints);
+        consumer->Process_vkCmdSetPatchControlPointsEXT(call_info, commandBuffer, patchControlPoints);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetRasterizerDiscardEnableEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetRasterizerDiscardEnableEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10442,13 +10442,13 @@ size_t VulkanDecoder::Decode_vkCmdSetRasterizerDiscardEnableEXT(const uint8_t* p
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetRasterizerDiscardEnableEXT(commandBuffer, rasterizerDiscardEnable);
+        consumer->Process_vkCmdSetRasterizerDiscardEnableEXT(call_info, commandBuffer, rasterizerDiscardEnable);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetDepthBiasEnableEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetDepthBiasEnableEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10460,13 +10460,13 @@ size_t VulkanDecoder::Decode_vkCmdSetDepthBiasEnableEXT(const uint8_t* parameter
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetDepthBiasEnableEXT(commandBuffer, depthBiasEnable);
+        consumer->Process_vkCmdSetDepthBiasEnableEXT(call_info, commandBuffer, depthBiasEnable);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetLogicOpEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetLogicOpEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10478,13 +10478,13 @@ size_t VulkanDecoder::Decode_vkCmdSetLogicOpEXT(const uint8_t* parameter_buffer,
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetLogicOpEXT(commandBuffer, logicOp);
+        consumer->Process_vkCmdSetLogicOpEXT(call_info, commandBuffer, logicOp);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetPrimitiveRestartEnableEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetPrimitiveRestartEnableEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10496,13 +10496,13 @@ size_t VulkanDecoder::Decode_vkCmdSetPrimitiveRestartEnableEXT(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetPrimitiveRestartEnableEXT(commandBuffer, primitiveRestartEnable);
+        consumer->Process_vkCmdSetPrimitiveRestartEnableEXT(call_info, commandBuffer, primitiveRestartEnable);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateScreenSurfaceQNX(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateScreenSurfaceQNX(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10520,13 +10520,13 @@ size_t VulkanDecoder::Decode_vkCreateScreenSurfaceQNX(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateScreenSurfaceQNX(return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
+        consumer->Process_vkCreateScreenSurfaceQNX(call_info, return_value, instance, &pCreateInfo, &pAllocator, &pSurface);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetPhysicalDeviceScreenPresentationSupportQNX(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetPhysicalDeviceScreenPresentationSupportQNX(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10542,13 +10542,13 @@ size_t VulkanDecoder::Decode_vkGetPhysicalDeviceScreenPresentationSupportQNX(con
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetPhysicalDeviceScreenPresentationSupportQNX(return_value, physicalDevice, queueFamilyIndex, window);
+        consumer->Process_vkGetPhysicalDeviceScreenPresentationSupportQNX(call_info, return_value, physicalDevice, queueFamilyIndex, window);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetColorWriteEnableEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetColorWriteEnableEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10562,13 +10562,13 @@ size_t VulkanDecoder::Decode_vkCmdSetColorWriteEnableEXT(const uint8_t* paramete
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetColorWriteEnableEXT(commandBuffer, attachmentCount, &pColorWriteEnables);
+        consumer->Process_vkCmdSetColorWriteEnableEXT(call_info, commandBuffer, attachmentCount, &pColorWriteEnables);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDrawMultiEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDrawMultiEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10588,13 +10588,13 @@ size_t VulkanDecoder::Decode_vkCmdDrawMultiEXT(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDrawMultiEXT(commandBuffer, drawCount, &pVertexInfo, instanceCount, firstInstance, stride);
+        consumer->Process_vkCmdDrawMultiEXT(call_info, commandBuffer, drawCount, &pVertexInfo, instanceCount, firstInstance, stride);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdDrawMultiIndexedEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdDrawMultiIndexedEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10616,13 +10616,13 @@ size_t VulkanDecoder::Decode_vkCmdDrawMultiIndexedEXT(const uint8_t* parameter_b
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdDrawMultiIndexedEXT(commandBuffer, drawCount, &pIndexInfo, instanceCount, firstInstance, stride, &pVertexOffset);
+        consumer->Process_vkCmdDrawMultiIndexedEXT(call_info, commandBuffer, drawCount, &pIndexInfo, instanceCount, firstInstance, stride, &pVertexOffset);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkSetDeviceMemoryPriorityEXT(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkSetDeviceMemoryPriorityEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10636,13 +10636,13 @@ size_t VulkanDecoder::Decode_vkSetDeviceMemoryPriorityEXT(const uint8_t* paramet
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkSetDeviceMemoryPriorityEXT(device, memory, priority);
+        consumer->Process_vkSetDeviceMemoryPriorityEXT(call_info, device, memory, priority);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateAccelerationStructureKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateAccelerationStructureKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10660,13 +10660,13 @@ size_t VulkanDecoder::Decode_vkCreateAccelerationStructureKHR(const uint8_t* par
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateAccelerationStructureKHR(return_value, device, &pCreateInfo, &pAllocator, &pAccelerationStructure);
+        consumer->Process_vkCreateAccelerationStructureKHR(call_info, return_value, device, &pCreateInfo, &pAllocator, &pAccelerationStructure);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDestroyAccelerationStructureKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkDestroyAccelerationStructureKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10680,13 +10680,13 @@ size_t VulkanDecoder::Decode_vkDestroyAccelerationStructureKHR(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkDestroyAccelerationStructureKHR(device, accelerationStructure, &pAllocator);
+        consumer->Process_vkDestroyAccelerationStructureKHR(call_info, device, accelerationStructure, &pAllocator);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBuildAccelerationStructuresKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBuildAccelerationStructuresKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10702,13 +10702,13 @@ size_t VulkanDecoder::Decode_vkCmdBuildAccelerationStructuresKHR(const uint8_t* 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, &pInfos, &ppBuildRangeInfos);
+        consumer->Process_vkCmdBuildAccelerationStructuresKHR(call_info, commandBuffer, infoCount, &pInfos, &ppBuildRangeInfos);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdBuildAccelerationStructuresIndirectKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdBuildAccelerationStructuresIndirectKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10728,13 +10728,13 @@ size_t VulkanDecoder::Decode_vkCmdBuildAccelerationStructuresIndirectKHR(const u
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdBuildAccelerationStructuresIndirectKHR(commandBuffer, infoCount, &pInfos, &pIndirectDeviceAddresses, &pIndirectStrides, &ppMaxPrimitiveCounts);
+        consumer->Process_vkCmdBuildAccelerationStructuresIndirectKHR(call_info, commandBuffer, infoCount, &pInfos, &pIndirectDeviceAddresses, &pIndirectStrides, &ppMaxPrimitiveCounts);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCopyAccelerationStructureToMemoryKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCopyAccelerationStructureToMemoryKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10750,13 +10750,13 @@ size_t VulkanDecoder::Decode_vkCopyAccelerationStructureToMemoryKHR(const uint8_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCopyAccelerationStructureToMemoryKHR(return_value, device, deferredOperation, &pInfo);
+        consumer->Process_vkCopyAccelerationStructureToMemoryKHR(call_info, return_value, device, deferredOperation, &pInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCopyMemoryToAccelerationStructureKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCopyMemoryToAccelerationStructureKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10772,13 +10772,13 @@ size_t VulkanDecoder::Decode_vkCopyMemoryToAccelerationStructureKHR(const uint8_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCopyMemoryToAccelerationStructureKHR(return_value, device, deferredOperation, &pInfo);
+        consumer->Process_vkCopyMemoryToAccelerationStructureKHR(call_info, return_value, device, deferredOperation, &pInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkWriteAccelerationStructuresPropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkWriteAccelerationStructuresPropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10802,13 +10802,13 @@ size_t VulkanDecoder::Decode_vkWriteAccelerationStructuresPropertiesKHR(const ui
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkWriteAccelerationStructuresPropertiesKHR(return_value, device, accelerationStructureCount, &pAccelerationStructures, queryType, dataSize, &pData, stride);
+        consumer->Process_vkWriteAccelerationStructuresPropertiesKHR(call_info, return_value, device, accelerationStructureCount, &pAccelerationStructures, queryType, dataSize, &pData, stride);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyAccelerationStructureKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyAccelerationStructureKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10820,13 +10820,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyAccelerationStructureKHR(const uint8_t* pa
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyAccelerationStructureKHR(commandBuffer, &pInfo);
+        consumer->Process_vkCmdCopyAccelerationStructureKHR(call_info, commandBuffer, &pInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyAccelerationStructureToMemoryKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyAccelerationStructureToMemoryKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10838,13 +10838,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyAccelerationStructureToMemoryKHR(const uin
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, &pInfo);
+        consumer->Process_vkCmdCopyAccelerationStructureToMemoryKHR(call_info, commandBuffer, &pInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdCopyMemoryToAccelerationStructureKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdCopyMemoryToAccelerationStructureKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10856,13 +10856,13 @@ size_t VulkanDecoder::Decode_vkCmdCopyMemoryToAccelerationStructureKHR(const uin
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, &pInfo);
+        consumer->Process_vkCmdCopyMemoryToAccelerationStructureKHR(call_info, commandBuffer, &pInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetAccelerationStructureDeviceAddressKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetAccelerationStructureDeviceAddressKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10876,13 +10876,13 @@ size_t VulkanDecoder::Decode_vkGetAccelerationStructureDeviceAddressKHR(const ui
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetAccelerationStructureDeviceAddressKHR(return_value, device, &pInfo);
+        consumer->Process_vkGetAccelerationStructureDeviceAddressKHR(call_info, return_value, device, &pInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdWriteAccelerationStructuresPropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdWriteAccelerationStructuresPropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10902,13 +10902,13 @@ size_t VulkanDecoder::Decode_vkCmdWriteAccelerationStructuresPropertiesKHR(const
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdWriteAccelerationStructuresPropertiesKHR(commandBuffer, accelerationStructureCount, &pAccelerationStructures, queryType, queryPool, firstQuery);
+        consumer->Process_vkCmdWriteAccelerationStructuresPropertiesKHR(call_info, commandBuffer, accelerationStructureCount, &pAccelerationStructures, queryType, queryPool, firstQuery);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetDeviceAccelerationStructureCompatibilityKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetDeviceAccelerationStructureCompatibilityKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10922,13 +10922,13 @@ size_t VulkanDecoder::Decode_vkGetDeviceAccelerationStructureCompatibilityKHR(co
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetDeviceAccelerationStructureCompatibilityKHR(device, &pVersionInfo, &pCompatibility);
+        consumer->Process_vkGetDeviceAccelerationStructureCompatibilityKHR(call_info, device, &pVersionInfo, &pCompatibility);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetAccelerationStructureBuildSizesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetAccelerationStructureBuildSizesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10946,13 +10946,13 @@ size_t VulkanDecoder::Decode_vkGetAccelerationStructureBuildSizesKHR(const uint8
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetAccelerationStructureBuildSizesKHR(device, buildType, &pBuildInfo, &pMaxPrimitiveCounts, &pSizeInfo);
+        consumer->Process_vkGetAccelerationStructureBuildSizesKHR(call_info, device, buildType, &pBuildInfo, &pMaxPrimitiveCounts, &pSizeInfo);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdTraceRaysKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdTraceRaysKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -10976,13 +10976,13 @@ size_t VulkanDecoder::Decode_vkCmdTraceRaysKHR(const uint8_t* parameter_buffer, 
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdTraceRaysKHR(commandBuffer, &pRaygenShaderBindingTable, &pMissShaderBindingTable, &pHitShaderBindingTable, &pCallableShaderBindingTable, width, height, depth);
+        consumer->Process_vkCmdTraceRaysKHR(call_info, commandBuffer, &pRaygenShaderBindingTable, &pMissShaderBindingTable, &pHitShaderBindingTable, &pCallableShaderBindingTable, width, height, depth);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateRayTracingPipelinesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCreateRayTracingPipelinesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -11006,13 +11006,13 @@ size_t VulkanDecoder::Decode_vkCreateRayTracingPipelinesKHR(const uint8_t* param
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCreateRayTracingPipelinesKHR(return_value, device, deferredOperation, pipelineCache, createInfoCount, &pCreateInfos, &pAllocator, &pPipelines);
+        consumer->Process_vkCreateRayTracingPipelinesKHR(call_info, return_value, device, deferredOperation, pipelineCache, createInfoCount, &pCreateInfos, &pAllocator, &pPipelines);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -11034,13 +11034,13 @@ size_t VulkanDecoder::Decode_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(c
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(return_value, device, pipeline, firstGroup, groupCount, dataSize, &pData);
+        consumer->Process_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(call_info, return_value, device, pipeline, firstGroup, groupCount, dataSize, &pData);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdTraceRaysIndirectKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdTraceRaysIndirectKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -11060,13 +11060,13 @@ size_t VulkanDecoder::Decode_vkCmdTraceRaysIndirectKHR(const uint8_t* parameter_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdTraceRaysIndirectKHR(commandBuffer, &pRaygenShaderBindingTable, &pMissShaderBindingTable, &pHitShaderBindingTable, &pCallableShaderBindingTable, indirectDeviceAddress);
+        consumer->Process_vkCmdTraceRaysIndirectKHR(call_info, commandBuffer, &pRaygenShaderBindingTable, &pMissShaderBindingTable, &pHitShaderBindingTable, &pCallableShaderBindingTable, indirectDeviceAddress);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkGetRayTracingShaderGroupStackSizeKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkGetRayTracingShaderGroupStackSizeKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -11084,13 +11084,13 @@ size_t VulkanDecoder::Decode_vkGetRayTracingShaderGroupStackSizeKHR(const uint8_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkGetRayTracingShaderGroupStackSizeKHR(return_value, device, pipeline, group, groupShader);
+        consumer->Process_vkGetRayTracingShaderGroupStackSizeKHR(call_info, return_value, device, pipeline, group, groupShader);
     }
 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCmdSetRayTracingPipelineStackSizeKHR(const uint8_t* parameter_buffer, size_t buffer_size)
+size_t VulkanDecoder::Decode_vkCmdSetRayTracingPipelineStackSizeKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
 
@@ -11102,7 +11102,7 @@ size_t VulkanDecoder::Decode_vkCmdSetRayTracingPipelineStackSizeKHR(const uint8_
 
     for (auto consumer : GetConsumers())
     {
-        consumer->Process_vkCmdSetRayTracingPipelineStackSizeKHR(commandBuffer, pipelineStackSize);
+        consumer->Process_vkCmdSetRayTracingPipelineStackSizeKHR(call_info, commandBuffer, pipelineStackSize);
     }
 
     return bytes_read;
@@ -11119,1519 +11119,1519 @@ void VulkanDecoder::DecodeFunctionCall(format::ApiCallId             call_id,
         VulkanDecoderBase::DecodeFunctionCall(call_id, call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateInstance:
-        Decode_vkCreateInstance(parameter_buffer, buffer_size);
+        Decode_vkCreateInstance(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyInstance:
-        Decode_vkDestroyInstance(parameter_buffer, buffer_size);
+        Decode_vkDestroyInstance(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkEnumeratePhysicalDevices:
-        Decode_vkEnumeratePhysicalDevices(parameter_buffer, buffer_size);
+        Decode_vkEnumeratePhysicalDevices(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceFeatures:
-        Decode_vkGetPhysicalDeviceFeatures(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceFeatures(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceFormatProperties:
-        Decode_vkGetPhysicalDeviceFormatProperties(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceFormatProperties(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceImageFormatProperties:
-        Decode_vkGetPhysicalDeviceImageFormatProperties(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceImageFormatProperties(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceProperties:
-        Decode_vkGetPhysicalDeviceProperties(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceProperties(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties:
-        Decode_vkGetPhysicalDeviceQueueFamilyProperties(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceQueueFamilyProperties(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties:
-        Decode_vkGetPhysicalDeviceMemoryProperties(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceMemoryProperties(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateDevice:
-        Decode_vkCreateDevice(parameter_buffer, buffer_size);
+        Decode_vkCreateDevice(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyDevice:
-        Decode_vkDestroyDevice(parameter_buffer, buffer_size);
+        Decode_vkDestroyDevice(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceQueue:
-        Decode_vkGetDeviceQueue(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceQueue(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkQueueSubmit:
-        Decode_vkQueueSubmit(parameter_buffer, buffer_size);
+        Decode_vkQueueSubmit(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkQueueWaitIdle:
-        Decode_vkQueueWaitIdle(parameter_buffer, buffer_size);
+        Decode_vkQueueWaitIdle(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDeviceWaitIdle:
-        Decode_vkDeviceWaitIdle(parameter_buffer, buffer_size);
+        Decode_vkDeviceWaitIdle(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkAllocateMemory:
-        Decode_vkAllocateMemory(parameter_buffer, buffer_size);
+        Decode_vkAllocateMemory(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkFreeMemory:
-        Decode_vkFreeMemory(parameter_buffer, buffer_size);
+        Decode_vkFreeMemory(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkMapMemory:
-        Decode_vkMapMemory(parameter_buffer, buffer_size);
+        Decode_vkMapMemory(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkUnmapMemory:
-        Decode_vkUnmapMemory(parameter_buffer, buffer_size);
+        Decode_vkUnmapMemory(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkFlushMappedMemoryRanges:
-        Decode_vkFlushMappedMemoryRanges(parameter_buffer, buffer_size);
+        Decode_vkFlushMappedMemoryRanges(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkInvalidateMappedMemoryRanges:
-        Decode_vkInvalidateMappedMemoryRanges(parameter_buffer, buffer_size);
+        Decode_vkInvalidateMappedMemoryRanges(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceMemoryCommitment:
-        Decode_vkGetDeviceMemoryCommitment(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceMemoryCommitment(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkBindBufferMemory:
-        Decode_vkBindBufferMemory(parameter_buffer, buffer_size);
+        Decode_vkBindBufferMemory(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkBindImageMemory:
-        Decode_vkBindImageMemory(parameter_buffer, buffer_size);
+        Decode_vkBindImageMemory(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetBufferMemoryRequirements:
-        Decode_vkGetBufferMemoryRequirements(parameter_buffer, buffer_size);
+        Decode_vkGetBufferMemoryRequirements(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetImageMemoryRequirements:
-        Decode_vkGetImageMemoryRequirements(parameter_buffer, buffer_size);
+        Decode_vkGetImageMemoryRequirements(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetImageSparseMemoryRequirements:
-        Decode_vkGetImageSparseMemoryRequirements(parameter_buffer, buffer_size);
+        Decode_vkGetImageSparseMemoryRequirements(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceSparseImageFormatProperties:
-        Decode_vkGetPhysicalDeviceSparseImageFormatProperties(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceSparseImageFormatProperties(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkQueueBindSparse:
-        Decode_vkQueueBindSparse(parameter_buffer, buffer_size);
+        Decode_vkQueueBindSparse(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateFence:
-        Decode_vkCreateFence(parameter_buffer, buffer_size);
+        Decode_vkCreateFence(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyFence:
-        Decode_vkDestroyFence(parameter_buffer, buffer_size);
+        Decode_vkDestroyFence(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkResetFences:
-        Decode_vkResetFences(parameter_buffer, buffer_size);
+        Decode_vkResetFences(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetFenceStatus:
-        Decode_vkGetFenceStatus(parameter_buffer, buffer_size);
+        Decode_vkGetFenceStatus(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkWaitForFences:
-        Decode_vkWaitForFences(parameter_buffer, buffer_size);
+        Decode_vkWaitForFences(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateSemaphore:
-        Decode_vkCreateSemaphore(parameter_buffer, buffer_size);
+        Decode_vkCreateSemaphore(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroySemaphore:
-        Decode_vkDestroySemaphore(parameter_buffer, buffer_size);
+        Decode_vkDestroySemaphore(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateEvent:
-        Decode_vkCreateEvent(parameter_buffer, buffer_size);
+        Decode_vkCreateEvent(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyEvent:
-        Decode_vkDestroyEvent(parameter_buffer, buffer_size);
+        Decode_vkDestroyEvent(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetEventStatus:
-        Decode_vkGetEventStatus(parameter_buffer, buffer_size);
+        Decode_vkGetEventStatus(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkSetEvent:
-        Decode_vkSetEvent(parameter_buffer, buffer_size);
+        Decode_vkSetEvent(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkResetEvent:
-        Decode_vkResetEvent(parameter_buffer, buffer_size);
+        Decode_vkResetEvent(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateQueryPool:
-        Decode_vkCreateQueryPool(parameter_buffer, buffer_size);
+        Decode_vkCreateQueryPool(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyQueryPool:
-        Decode_vkDestroyQueryPool(parameter_buffer, buffer_size);
+        Decode_vkDestroyQueryPool(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetQueryPoolResults:
-        Decode_vkGetQueryPoolResults(parameter_buffer, buffer_size);
+        Decode_vkGetQueryPoolResults(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateBuffer:
-        Decode_vkCreateBuffer(parameter_buffer, buffer_size);
+        Decode_vkCreateBuffer(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyBuffer:
-        Decode_vkDestroyBuffer(parameter_buffer, buffer_size);
+        Decode_vkDestroyBuffer(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateBufferView:
-        Decode_vkCreateBufferView(parameter_buffer, buffer_size);
+        Decode_vkCreateBufferView(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyBufferView:
-        Decode_vkDestroyBufferView(parameter_buffer, buffer_size);
+        Decode_vkDestroyBufferView(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateImage:
-        Decode_vkCreateImage(parameter_buffer, buffer_size);
+        Decode_vkCreateImage(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyImage:
-        Decode_vkDestroyImage(parameter_buffer, buffer_size);
+        Decode_vkDestroyImage(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetImageSubresourceLayout:
-        Decode_vkGetImageSubresourceLayout(parameter_buffer, buffer_size);
+        Decode_vkGetImageSubresourceLayout(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateImageView:
-        Decode_vkCreateImageView(parameter_buffer, buffer_size);
+        Decode_vkCreateImageView(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyImageView:
-        Decode_vkDestroyImageView(parameter_buffer, buffer_size);
+        Decode_vkDestroyImageView(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateShaderModule:
-        Decode_vkCreateShaderModule(parameter_buffer, buffer_size);
+        Decode_vkCreateShaderModule(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyShaderModule:
-        Decode_vkDestroyShaderModule(parameter_buffer, buffer_size);
+        Decode_vkDestroyShaderModule(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreatePipelineCache:
-        Decode_vkCreatePipelineCache(parameter_buffer, buffer_size);
+        Decode_vkCreatePipelineCache(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyPipelineCache:
-        Decode_vkDestroyPipelineCache(parameter_buffer, buffer_size);
+        Decode_vkDestroyPipelineCache(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPipelineCacheData:
-        Decode_vkGetPipelineCacheData(parameter_buffer, buffer_size);
+        Decode_vkGetPipelineCacheData(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkMergePipelineCaches:
-        Decode_vkMergePipelineCaches(parameter_buffer, buffer_size);
+        Decode_vkMergePipelineCaches(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateGraphicsPipelines:
-        Decode_vkCreateGraphicsPipelines(parameter_buffer, buffer_size);
+        Decode_vkCreateGraphicsPipelines(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateComputePipelines:
-        Decode_vkCreateComputePipelines(parameter_buffer, buffer_size);
+        Decode_vkCreateComputePipelines(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyPipeline:
-        Decode_vkDestroyPipeline(parameter_buffer, buffer_size);
+        Decode_vkDestroyPipeline(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreatePipelineLayout:
-        Decode_vkCreatePipelineLayout(parameter_buffer, buffer_size);
+        Decode_vkCreatePipelineLayout(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyPipelineLayout:
-        Decode_vkDestroyPipelineLayout(parameter_buffer, buffer_size);
+        Decode_vkDestroyPipelineLayout(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateSampler:
-        Decode_vkCreateSampler(parameter_buffer, buffer_size);
+        Decode_vkCreateSampler(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroySampler:
-        Decode_vkDestroySampler(parameter_buffer, buffer_size);
+        Decode_vkDestroySampler(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateDescriptorSetLayout:
-        Decode_vkCreateDescriptorSetLayout(parameter_buffer, buffer_size);
+        Decode_vkCreateDescriptorSetLayout(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyDescriptorSetLayout:
-        Decode_vkDestroyDescriptorSetLayout(parameter_buffer, buffer_size);
+        Decode_vkDestroyDescriptorSetLayout(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateDescriptorPool:
-        Decode_vkCreateDescriptorPool(parameter_buffer, buffer_size);
+        Decode_vkCreateDescriptorPool(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyDescriptorPool:
-        Decode_vkDestroyDescriptorPool(parameter_buffer, buffer_size);
+        Decode_vkDestroyDescriptorPool(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkResetDescriptorPool:
-        Decode_vkResetDescriptorPool(parameter_buffer, buffer_size);
+        Decode_vkResetDescriptorPool(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkAllocateDescriptorSets:
-        Decode_vkAllocateDescriptorSets(parameter_buffer, buffer_size);
+        Decode_vkAllocateDescriptorSets(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkFreeDescriptorSets:
-        Decode_vkFreeDescriptorSets(parameter_buffer, buffer_size);
+        Decode_vkFreeDescriptorSets(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkUpdateDescriptorSets:
-        Decode_vkUpdateDescriptorSets(parameter_buffer, buffer_size);
+        Decode_vkUpdateDescriptorSets(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateFramebuffer:
-        Decode_vkCreateFramebuffer(parameter_buffer, buffer_size);
+        Decode_vkCreateFramebuffer(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyFramebuffer:
-        Decode_vkDestroyFramebuffer(parameter_buffer, buffer_size);
+        Decode_vkDestroyFramebuffer(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateRenderPass:
-        Decode_vkCreateRenderPass(parameter_buffer, buffer_size);
+        Decode_vkCreateRenderPass(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyRenderPass:
-        Decode_vkDestroyRenderPass(parameter_buffer, buffer_size);
+        Decode_vkDestroyRenderPass(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetRenderAreaGranularity:
-        Decode_vkGetRenderAreaGranularity(parameter_buffer, buffer_size);
+        Decode_vkGetRenderAreaGranularity(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateCommandPool:
-        Decode_vkCreateCommandPool(parameter_buffer, buffer_size);
+        Decode_vkCreateCommandPool(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyCommandPool:
-        Decode_vkDestroyCommandPool(parameter_buffer, buffer_size);
+        Decode_vkDestroyCommandPool(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkResetCommandPool:
-        Decode_vkResetCommandPool(parameter_buffer, buffer_size);
+        Decode_vkResetCommandPool(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkAllocateCommandBuffers:
-        Decode_vkAllocateCommandBuffers(parameter_buffer, buffer_size);
+        Decode_vkAllocateCommandBuffers(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkFreeCommandBuffers:
-        Decode_vkFreeCommandBuffers(parameter_buffer, buffer_size);
+        Decode_vkFreeCommandBuffers(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkBeginCommandBuffer:
-        Decode_vkBeginCommandBuffer(parameter_buffer, buffer_size);
+        Decode_vkBeginCommandBuffer(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkEndCommandBuffer:
-        Decode_vkEndCommandBuffer(parameter_buffer, buffer_size);
+        Decode_vkEndCommandBuffer(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkResetCommandBuffer:
-        Decode_vkResetCommandBuffer(parameter_buffer, buffer_size);
+        Decode_vkResetCommandBuffer(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBindPipeline:
-        Decode_vkCmdBindPipeline(parameter_buffer, buffer_size);
+        Decode_vkCmdBindPipeline(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetViewport:
-        Decode_vkCmdSetViewport(parameter_buffer, buffer_size);
+        Decode_vkCmdSetViewport(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetScissor:
-        Decode_vkCmdSetScissor(parameter_buffer, buffer_size);
+        Decode_vkCmdSetScissor(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetLineWidth:
-        Decode_vkCmdSetLineWidth(parameter_buffer, buffer_size);
+        Decode_vkCmdSetLineWidth(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetDepthBias:
-        Decode_vkCmdSetDepthBias(parameter_buffer, buffer_size);
+        Decode_vkCmdSetDepthBias(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetBlendConstants:
-        Decode_vkCmdSetBlendConstants(parameter_buffer, buffer_size);
+        Decode_vkCmdSetBlendConstants(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetDepthBounds:
-        Decode_vkCmdSetDepthBounds(parameter_buffer, buffer_size);
+        Decode_vkCmdSetDepthBounds(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetStencilCompareMask:
-        Decode_vkCmdSetStencilCompareMask(parameter_buffer, buffer_size);
+        Decode_vkCmdSetStencilCompareMask(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetStencilWriteMask:
-        Decode_vkCmdSetStencilWriteMask(parameter_buffer, buffer_size);
+        Decode_vkCmdSetStencilWriteMask(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetStencilReference:
-        Decode_vkCmdSetStencilReference(parameter_buffer, buffer_size);
+        Decode_vkCmdSetStencilReference(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBindDescriptorSets:
-        Decode_vkCmdBindDescriptorSets(parameter_buffer, buffer_size);
+        Decode_vkCmdBindDescriptorSets(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBindIndexBuffer:
-        Decode_vkCmdBindIndexBuffer(parameter_buffer, buffer_size);
+        Decode_vkCmdBindIndexBuffer(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBindVertexBuffers:
-        Decode_vkCmdBindVertexBuffers(parameter_buffer, buffer_size);
+        Decode_vkCmdBindVertexBuffers(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDraw:
-        Decode_vkCmdDraw(parameter_buffer, buffer_size);
+        Decode_vkCmdDraw(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDrawIndexed:
-        Decode_vkCmdDrawIndexed(parameter_buffer, buffer_size);
+        Decode_vkCmdDrawIndexed(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDrawIndirect:
-        Decode_vkCmdDrawIndirect(parameter_buffer, buffer_size);
+        Decode_vkCmdDrawIndirect(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirect:
-        Decode_vkCmdDrawIndexedIndirect(parameter_buffer, buffer_size);
+        Decode_vkCmdDrawIndexedIndirect(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDispatch:
-        Decode_vkCmdDispatch(parameter_buffer, buffer_size);
+        Decode_vkCmdDispatch(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDispatchIndirect:
-        Decode_vkCmdDispatchIndirect(parameter_buffer, buffer_size);
+        Decode_vkCmdDispatchIndirect(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyBuffer:
-        Decode_vkCmdCopyBuffer(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyBuffer(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyImage:
-        Decode_vkCmdCopyImage(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyImage(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBlitImage:
-        Decode_vkCmdBlitImage(parameter_buffer, buffer_size);
+        Decode_vkCmdBlitImage(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyBufferToImage:
-        Decode_vkCmdCopyBufferToImage(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyBufferToImage(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyImageToBuffer:
-        Decode_vkCmdCopyImageToBuffer(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyImageToBuffer(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdUpdateBuffer:
-        Decode_vkCmdUpdateBuffer(parameter_buffer, buffer_size);
+        Decode_vkCmdUpdateBuffer(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdFillBuffer:
-        Decode_vkCmdFillBuffer(parameter_buffer, buffer_size);
+        Decode_vkCmdFillBuffer(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdClearColorImage:
-        Decode_vkCmdClearColorImage(parameter_buffer, buffer_size);
+        Decode_vkCmdClearColorImage(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdClearDepthStencilImage:
-        Decode_vkCmdClearDepthStencilImage(parameter_buffer, buffer_size);
+        Decode_vkCmdClearDepthStencilImage(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdClearAttachments:
-        Decode_vkCmdClearAttachments(parameter_buffer, buffer_size);
+        Decode_vkCmdClearAttachments(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdResolveImage:
-        Decode_vkCmdResolveImage(parameter_buffer, buffer_size);
+        Decode_vkCmdResolveImage(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetEvent:
-        Decode_vkCmdSetEvent(parameter_buffer, buffer_size);
+        Decode_vkCmdSetEvent(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdResetEvent:
-        Decode_vkCmdResetEvent(parameter_buffer, buffer_size);
+        Decode_vkCmdResetEvent(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdWaitEvents:
-        Decode_vkCmdWaitEvents(parameter_buffer, buffer_size);
+        Decode_vkCmdWaitEvents(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdPipelineBarrier:
-        Decode_vkCmdPipelineBarrier(parameter_buffer, buffer_size);
+        Decode_vkCmdPipelineBarrier(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBeginQuery:
-        Decode_vkCmdBeginQuery(parameter_buffer, buffer_size);
+        Decode_vkCmdBeginQuery(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdEndQuery:
-        Decode_vkCmdEndQuery(parameter_buffer, buffer_size);
+        Decode_vkCmdEndQuery(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdResetQueryPool:
-        Decode_vkCmdResetQueryPool(parameter_buffer, buffer_size);
+        Decode_vkCmdResetQueryPool(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdWriteTimestamp:
-        Decode_vkCmdWriteTimestamp(parameter_buffer, buffer_size);
+        Decode_vkCmdWriteTimestamp(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyQueryPoolResults:
-        Decode_vkCmdCopyQueryPoolResults(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyQueryPoolResults(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdPushConstants:
-        Decode_vkCmdPushConstants(parameter_buffer, buffer_size);
+        Decode_vkCmdPushConstants(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBeginRenderPass:
-        Decode_vkCmdBeginRenderPass(parameter_buffer, buffer_size);
+        Decode_vkCmdBeginRenderPass(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdNextSubpass:
-        Decode_vkCmdNextSubpass(parameter_buffer, buffer_size);
+        Decode_vkCmdNextSubpass(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdEndRenderPass:
-        Decode_vkCmdEndRenderPass(parameter_buffer, buffer_size);
+        Decode_vkCmdEndRenderPass(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdExecuteCommands:
-        Decode_vkCmdExecuteCommands(parameter_buffer, buffer_size);
+        Decode_vkCmdExecuteCommands(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkBindBufferMemory2:
-        Decode_vkBindBufferMemory2(parameter_buffer, buffer_size);
+        Decode_vkBindBufferMemory2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkBindImageMemory2:
-        Decode_vkBindImageMemory2(parameter_buffer, buffer_size);
+        Decode_vkBindImageMemory2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceGroupPeerMemoryFeatures:
-        Decode_vkGetDeviceGroupPeerMemoryFeatures(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceGroupPeerMemoryFeatures(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetDeviceMask:
-        Decode_vkCmdSetDeviceMask(parameter_buffer, buffer_size);
+        Decode_vkCmdSetDeviceMask(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDispatchBase:
-        Decode_vkCmdDispatchBase(parameter_buffer, buffer_size);
+        Decode_vkCmdDispatchBase(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkEnumeratePhysicalDeviceGroups:
-        Decode_vkEnumeratePhysicalDeviceGroups(parameter_buffer, buffer_size);
+        Decode_vkEnumeratePhysicalDeviceGroups(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetImageMemoryRequirements2:
-        Decode_vkGetImageMemoryRequirements2(parameter_buffer, buffer_size);
+        Decode_vkGetImageMemoryRequirements2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetBufferMemoryRequirements2:
-        Decode_vkGetBufferMemoryRequirements2(parameter_buffer, buffer_size);
+        Decode_vkGetBufferMemoryRequirements2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetImageSparseMemoryRequirements2:
-        Decode_vkGetImageSparseMemoryRequirements2(parameter_buffer, buffer_size);
+        Decode_vkGetImageSparseMemoryRequirements2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceFeatures2:
-        Decode_vkGetPhysicalDeviceFeatures2(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceFeatures2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceProperties2:
-        Decode_vkGetPhysicalDeviceProperties2(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceProperties2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceFormatProperties2:
-        Decode_vkGetPhysicalDeviceFormatProperties2(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceFormatProperties2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceImageFormatProperties2:
-        Decode_vkGetPhysicalDeviceImageFormatProperties2(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceImageFormatProperties2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties2:
-        Decode_vkGetPhysicalDeviceQueueFamilyProperties2(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceQueueFamilyProperties2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties2:
-        Decode_vkGetPhysicalDeviceMemoryProperties2(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceMemoryProperties2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceSparseImageFormatProperties2:
-        Decode_vkGetPhysicalDeviceSparseImageFormatProperties2(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceSparseImageFormatProperties2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkTrimCommandPool:
-        Decode_vkTrimCommandPool(parameter_buffer, buffer_size);
+        Decode_vkTrimCommandPool(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceQueue2:
-        Decode_vkGetDeviceQueue2(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceQueue2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversion:
-        Decode_vkCreateSamplerYcbcrConversion(parameter_buffer, buffer_size);
+        Decode_vkCreateSamplerYcbcrConversion(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversion:
-        Decode_vkDestroySamplerYcbcrConversion(parameter_buffer, buffer_size);
+        Decode_vkDestroySamplerYcbcrConversion(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplate:
-        Decode_vkCreateDescriptorUpdateTemplate(parameter_buffer, buffer_size);
+        Decode_vkCreateDescriptorUpdateTemplate(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplate:
-        Decode_vkDestroyDescriptorUpdateTemplate(parameter_buffer, buffer_size);
+        Decode_vkDestroyDescriptorUpdateTemplate(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalBufferProperties:
-        Decode_vkGetPhysicalDeviceExternalBufferProperties(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceExternalBufferProperties(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalFenceProperties:
-        Decode_vkGetPhysicalDeviceExternalFenceProperties(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceExternalFenceProperties(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalSemaphoreProperties:
-        Decode_vkGetPhysicalDeviceExternalSemaphoreProperties(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceExternalSemaphoreProperties(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDescriptorSetLayoutSupport:
-        Decode_vkGetDescriptorSetLayoutSupport(parameter_buffer, buffer_size);
+        Decode_vkGetDescriptorSetLayoutSupport(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDrawIndirectCount:
-        Decode_vkCmdDrawIndirectCount(parameter_buffer, buffer_size);
+        Decode_vkCmdDrawIndirectCount(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCount:
-        Decode_vkCmdDrawIndexedIndirectCount(parameter_buffer, buffer_size);
+        Decode_vkCmdDrawIndexedIndirectCount(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateRenderPass2:
-        Decode_vkCreateRenderPass2(parameter_buffer, buffer_size);
+        Decode_vkCreateRenderPass2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBeginRenderPass2:
-        Decode_vkCmdBeginRenderPass2(parameter_buffer, buffer_size);
+        Decode_vkCmdBeginRenderPass2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdNextSubpass2:
-        Decode_vkCmdNextSubpass2(parameter_buffer, buffer_size);
+        Decode_vkCmdNextSubpass2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdEndRenderPass2:
-        Decode_vkCmdEndRenderPass2(parameter_buffer, buffer_size);
+        Decode_vkCmdEndRenderPass2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkResetQueryPool:
-        Decode_vkResetQueryPool(parameter_buffer, buffer_size);
+        Decode_vkResetQueryPool(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetSemaphoreCounterValue:
-        Decode_vkGetSemaphoreCounterValue(parameter_buffer, buffer_size);
+        Decode_vkGetSemaphoreCounterValue(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkWaitSemaphores:
-        Decode_vkWaitSemaphores(parameter_buffer, buffer_size);
+        Decode_vkWaitSemaphores(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkSignalSemaphore:
-        Decode_vkSignalSemaphore(parameter_buffer, buffer_size);
+        Decode_vkSignalSemaphore(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetBufferDeviceAddress:
-        Decode_vkGetBufferDeviceAddress(parameter_buffer, buffer_size);
+        Decode_vkGetBufferDeviceAddress(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetBufferOpaqueCaptureAddress:
-        Decode_vkGetBufferOpaqueCaptureAddress(parameter_buffer, buffer_size);
+        Decode_vkGetBufferOpaqueCaptureAddress(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceMemoryOpaqueCaptureAddress:
-        Decode_vkGetDeviceMemoryOpaqueCaptureAddress(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceMemoryOpaqueCaptureAddress(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceToolProperties:
-        Decode_vkGetPhysicalDeviceToolProperties(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceToolProperties(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreatePrivateDataSlot:
-        Decode_vkCreatePrivateDataSlot(parameter_buffer, buffer_size);
+        Decode_vkCreatePrivateDataSlot(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyPrivateDataSlot:
-        Decode_vkDestroyPrivateDataSlot(parameter_buffer, buffer_size);
+        Decode_vkDestroyPrivateDataSlot(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkSetPrivateData:
-        Decode_vkSetPrivateData(parameter_buffer, buffer_size);
+        Decode_vkSetPrivateData(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPrivateData:
-        Decode_vkGetPrivateData(parameter_buffer, buffer_size);
+        Decode_vkGetPrivateData(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetEvent2:
-        Decode_vkCmdSetEvent2(parameter_buffer, buffer_size);
+        Decode_vkCmdSetEvent2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdResetEvent2:
-        Decode_vkCmdResetEvent2(parameter_buffer, buffer_size);
+        Decode_vkCmdResetEvent2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdWaitEvents2:
-        Decode_vkCmdWaitEvents2(parameter_buffer, buffer_size);
+        Decode_vkCmdWaitEvents2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdPipelineBarrier2:
-        Decode_vkCmdPipelineBarrier2(parameter_buffer, buffer_size);
+        Decode_vkCmdPipelineBarrier2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdWriteTimestamp2:
-        Decode_vkCmdWriteTimestamp2(parameter_buffer, buffer_size);
+        Decode_vkCmdWriteTimestamp2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkQueueSubmit2:
-        Decode_vkQueueSubmit2(parameter_buffer, buffer_size);
+        Decode_vkQueueSubmit2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyBuffer2:
-        Decode_vkCmdCopyBuffer2(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyBuffer2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyImage2:
-        Decode_vkCmdCopyImage2(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyImage2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyBufferToImage2:
-        Decode_vkCmdCopyBufferToImage2(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyBufferToImage2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyImageToBuffer2:
-        Decode_vkCmdCopyImageToBuffer2(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyImageToBuffer2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBlitImage2:
-        Decode_vkCmdBlitImage2(parameter_buffer, buffer_size);
+        Decode_vkCmdBlitImage2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdResolveImage2:
-        Decode_vkCmdResolveImage2(parameter_buffer, buffer_size);
+        Decode_vkCmdResolveImage2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBeginRendering:
-        Decode_vkCmdBeginRendering(parameter_buffer, buffer_size);
+        Decode_vkCmdBeginRendering(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdEndRendering:
-        Decode_vkCmdEndRendering(parameter_buffer, buffer_size);
+        Decode_vkCmdEndRendering(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetCullMode:
-        Decode_vkCmdSetCullMode(parameter_buffer, buffer_size);
+        Decode_vkCmdSetCullMode(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetFrontFace:
-        Decode_vkCmdSetFrontFace(parameter_buffer, buffer_size);
+        Decode_vkCmdSetFrontFace(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetPrimitiveTopology:
-        Decode_vkCmdSetPrimitiveTopology(parameter_buffer, buffer_size);
+        Decode_vkCmdSetPrimitiveTopology(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetViewportWithCount:
-        Decode_vkCmdSetViewportWithCount(parameter_buffer, buffer_size);
+        Decode_vkCmdSetViewportWithCount(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetScissorWithCount:
-        Decode_vkCmdSetScissorWithCount(parameter_buffer, buffer_size);
+        Decode_vkCmdSetScissorWithCount(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBindVertexBuffers2:
-        Decode_vkCmdBindVertexBuffers2(parameter_buffer, buffer_size);
+        Decode_vkCmdBindVertexBuffers2(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetDepthTestEnable:
-        Decode_vkCmdSetDepthTestEnable(parameter_buffer, buffer_size);
+        Decode_vkCmdSetDepthTestEnable(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetDepthWriteEnable:
-        Decode_vkCmdSetDepthWriteEnable(parameter_buffer, buffer_size);
+        Decode_vkCmdSetDepthWriteEnable(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetDepthCompareOp:
-        Decode_vkCmdSetDepthCompareOp(parameter_buffer, buffer_size);
+        Decode_vkCmdSetDepthCompareOp(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetDepthBoundsTestEnable:
-        Decode_vkCmdSetDepthBoundsTestEnable(parameter_buffer, buffer_size);
+        Decode_vkCmdSetDepthBoundsTestEnable(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetStencilTestEnable:
-        Decode_vkCmdSetStencilTestEnable(parameter_buffer, buffer_size);
+        Decode_vkCmdSetStencilTestEnable(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetStencilOp:
-        Decode_vkCmdSetStencilOp(parameter_buffer, buffer_size);
+        Decode_vkCmdSetStencilOp(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetRasterizerDiscardEnable:
-        Decode_vkCmdSetRasterizerDiscardEnable(parameter_buffer, buffer_size);
+        Decode_vkCmdSetRasterizerDiscardEnable(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetDepthBiasEnable:
-        Decode_vkCmdSetDepthBiasEnable(parameter_buffer, buffer_size);
+        Decode_vkCmdSetDepthBiasEnable(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetPrimitiveRestartEnable:
-        Decode_vkCmdSetPrimitiveRestartEnable(parameter_buffer, buffer_size);
+        Decode_vkCmdSetPrimitiveRestartEnable(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceBufferMemoryRequirements:
-        Decode_vkGetDeviceBufferMemoryRequirements(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceBufferMemoryRequirements(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceImageMemoryRequirements:
-        Decode_vkGetDeviceImageMemoryRequirements(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceImageMemoryRequirements(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceImageSparseMemoryRequirements:
-        Decode_vkGetDeviceImageSparseMemoryRequirements(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceImageSparseMemoryRequirements(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroySurfaceKHR:
-        Decode_vkDestroySurfaceKHR(parameter_buffer, buffer_size);
+        Decode_vkDestroySurfaceKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceSupportKHR:
-        Decode_vkGetPhysicalDeviceSurfaceSupportKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceSurfaceSupportKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceCapabilitiesKHR:
-        Decode_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceFormatsKHR:
-        Decode_vkGetPhysicalDeviceSurfaceFormatsKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceSurfaceFormatsKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfacePresentModesKHR:
-        Decode_vkGetPhysicalDeviceSurfacePresentModesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceSurfacePresentModesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateSwapchainKHR:
-        Decode_vkCreateSwapchainKHR(parameter_buffer, buffer_size);
+        Decode_vkCreateSwapchainKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroySwapchainKHR:
-        Decode_vkDestroySwapchainKHR(parameter_buffer, buffer_size);
+        Decode_vkDestroySwapchainKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetSwapchainImagesKHR:
-        Decode_vkGetSwapchainImagesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetSwapchainImagesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkAcquireNextImageKHR:
-        Decode_vkAcquireNextImageKHR(parameter_buffer, buffer_size);
+        Decode_vkAcquireNextImageKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkQueuePresentKHR:
-        Decode_vkQueuePresentKHR(parameter_buffer, buffer_size);
+        Decode_vkQueuePresentKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceGroupPresentCapabilitiesKHR:
-        Decode_vkGetDeviceGroupPresentCapabilitiesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceGroupPresentCapabilitiesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceGroupSurfacePresentModesKHR:
-        Decode_vkGetDeviceGroupSurfacePresentModesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceGroupSurfacePresentModesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDevicePresentRectanglesKHR:
-        Decode_vkGetPhysicalDevicePresentRectanglesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDevicePresentRectanglesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkAcquireNextImage2KHR:
-        Decode_vkAcquireNextImage2KHR(parameter_buffer, buffer_size);
+        Decode_vkAcquireNextImage2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPropertiesKHR:
-        Decode_vkGetPhysicalDeviceDisplayPropertiesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceDisplayPropertiesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPlanePropertiesKHR:
-        Decode_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDisplayPlaneSupportedDisplaysKHR:
-        Decode_vkGetDisplayPlaneSupportedDisplaysKHR(parameter_buffer, buffer_size);
+        Decode_vkGetDisplayPlaneSupportedDisplaysKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDisplayModePropertiesKHR:
-        Decode_vkGetDisplayModePropertiesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetDisplayModePropertiesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateDisplayModeKHR:
-        Decode_vkCreateDisplayModeKHR(parameter_buffer, buffer_size);
+        Decode_vkCreateDisplayModeKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDisplayPlaneCapabilitiesKHR:
-        Decode_vkGetDisplayPlaneCapabilitiesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetDisplayPlaneCapabilitiesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateDisplayPlaneSurfaceKHR:
-        Decode_vkCreateDisplayPlaneSurfaceKHR(parameter_buffer, buffer_size);
+        Decode_vkCreateDisplayPlaneSurfaceKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateSharedSwapchainsKHR:
-        Decode_vkCreateSharedSwapchainsKHR(parameter_buffer, buffer_size);
+        Decode_vkCreateSharedSwapchainsKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateXlibSurfaceKHR:
-        Decode_vkCreateXlibSurfaceKHR(parameter_buffer, buffer_size);
+        Decode_vkCreateXlibSurfaceKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceXlibPresentationSupportKHR:
-        Decode_vkGetPhysicalDeviceXlibPresentationSupportKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceXlibPresentationSupportKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateXcbSurfaceKHR:
-        Decode_vkCreateXcbSurfaceKHR(parameter_buffer, buffer_size);
+        Decode_vkCreateXcbSurfaceKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceXcbPresentationSupportKHR:
-        Decode_vkGetPhysicalDeviceXcbPresentationSupportKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceXcbPresentationSupportKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateWaylandSurfaceKHR:
-        Decode_vkCreateWaylandSurfaceKHR(parameter_buffer, buffer_size);
+        Decode_vkCreateWaylandSurfaceKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceWaylandPresentationSupportKHR:
-        Decode_vkGetPhysicalDeviceWaylandPresentationSupportKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceWaylandPresentationSupportKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateAndroidSurfaceKHR:
-        Decode_vkCreateAndroidSurfaceKHR(parameter_buffer, buffer_size);
+        Decode_vkCreateAndroidSurfaceKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateWin32SurfaceKHR:
-        Decode_vkCreateWin32SurfaceKHR(parameter_buffer, buffer_size);
+        Decode_vkCreateWin32SurfaceKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceWin32PresentationSupportKHR:
-        Decode_vkGetPhysicalDeviceWin32PresentationSupportKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceWin32PresentationSupportKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBeginRenderingKHR:
-        Decode_vkCmdBeginRenderingKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdBeginRenderingKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdEndRenderingKHR:
-        Decode_vkCmdEndRenderingKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdEndRenderingKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceFeatures2KHR:
-        Decode_vkGetPhysicalDeviceFeatures2KHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceFeatures2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceProperties2KHR:
-        Decode_vkGetPhysicalDeviceProperties2KHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceProperties2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceFormatProperties2KHR:
-        Decode_vkGetPhysicalDeviceFormatProperties2KHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceFormatProperties2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceImageFormatProperties2KHR:
-        Decode_vkGetPhysicalDeviceImageFormatProperties2KHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceImageFormatProperties2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties2KHR:
-        Decode_vkGetPhysicalDeviceQueueFamilyProperties2KHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceQueueFamilyProperties2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceMemoryProperties2KHR:
-        Decode_vkGetPhysicalDeviceMemoryProperties2KHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceMemoryProperties2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceSparseImageFormatProperties2KHR:
-        Decode_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceGroupPeerMemoryFeaturesKHR:
-        Decode_vkGetDeviceGroupPeerMemoryFeaturesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceGroupPeerMemoryFeaturesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetDeviceMaskKHR:
-        Decode_vkCmdSetDeviceMaskKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdSetDeviceMaskKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDispatchBaseKHR:
-        Decode_vkCmdDispatchBaseKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdDispatchBaseKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkTrimCommandPoolKHR:
-        Decode_vkTrimCommandPoolKHR(parameter_buffer, buffer_size);
+        Decode_vkTrimCommandPoolKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkEnumeratePhysicalDeviceGroupsKHR:
-        Decode_vkEnumeratePhysicalDeviceGroupsKHR(parameter_buffer, buffer_size);
+        Decode_vkEnumeratePhysicalDeviceGroupsKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalBufferPropertiesKHR:
-        Decode_vkGetPhysicalDeviceExternalBufferPropertiesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceExternalBufferPropertiesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetMemoryWin32HandleKHR:
-        Decode_vkGetMemoryWin32HandleKHR(parameter_buffer, buffer_size);
+        Decode_vkGetMemoryWin32HandleKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetMemoryWin32HandlePropertiesKHR:
-        Decode_vkGetMemoryWin32HandlePropertiesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetMemoryWin32HandlePropertiesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetMemoryFdKHR:
-        Decode_vkGetMemoryFdKHR(parameter_buffer, buffer_size);
+        Decode_vkGetMemoryFdKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetMemoryFdPropertiesKHR:
-        Decode_vkGetMemoryFdPropertiesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetMemoryFdPropertiesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR:
-        Decode_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkImportSemaphoreWin32HandleKHR:
-        Decode_vkImportSemaphoreWin32HandleKHR(parameter_buffer, buffer_size);
+        Decode_vkImportSemaphoreWin32HandleKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetSemaphoreWin32HandleKHR:
-        Decode_vkGetSemaphoreWin32HandleKHR(parameter_buffer, buffer_size);
+        Decode_vkGetSemaphoreWin32HandleKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkImportSemaphoreFdKHR:
-        Decode_vkImportSemaphoreFdKHR(parameter_buffer, buffer_size);
+        Decode_vkImportSemaphoreFdKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetSemaphoreFdKHR:
-        Decode_vkGetSemaphoreFdKHR(parameter_buffer, buffer_size);
+        Decode_vkGetSemaphoreFdKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdPushDescriptorSetKHR:
-        Decode_vkCmdPushDescriptorSetKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdPushDescriptorSetKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateDescriptorUpdateTemplateKHR:
-        Decode_vkCreateDescriptorUpdateTemplateKHR(parameter_buffer, buffer_size);
+        Decode_vkCreateDescriptorUpdateTemplateKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyDescriptorUpdateTemplateKHR:
-        Decode_vkDestroyDescriptorUpdateTemplateKHR(parameter_buffer, buffer_size);
+        Decode_vkDestroyDescriptorUpdateTemplateKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateRenderPass2KHR:
-        Decode_vkCreateRenderPass2KHR(parameter_buffer, buffer_size);
+        Decode_vkCreateRenderPass2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBeginRenderPass2KHR:
-        Decode_vkCmdBeginRenderPass2KHR(parameter_buffer, buffer_size);
+        Decode_vkCmdBeginRenderPass2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdNextSubpass2KHR:
-        Decode_vkCmdNextSubpass2KHR(parameter_buffer, buffer_size);
+        Decode_vkCmdNextSubpass2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdEndRenderPass2KHR:
-        Decode_vkCmdEndRenderPass2KHR(parameter_buffer, buffer_size);
+        Decode_vkCmdEndRenderPass2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetSwapchainStatusKHR:
-        Decode_vkGetSwapchainStatusKHR(parameter_buffer, buffer_size);
+        Decode_vkGetSwapchainStatusKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalFencePropertiesKHR:
-        Decode_vkGetPhysicalDeviceExternalFencePropertiesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceExternalFencePropertiesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkImportFenceWin32HandleKHR:
-        Decode_vkImportFenceWin32HandleKHR(parameter_buffer, buffer_size);
+        Decode_vkImportFenceWin32HandleKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetFenceWin32HandleKHR:
-        Decode_vkGetFenceWin32HandleKHR(parameter_buffer, buffer_size);
+        Decode_vkGetFenceWin32HandleKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkImportFenceFdKHR:
-        Decode_vkImportFenceFdKHR(parameter_buffer, buffer_size);
+        Decode_vkImportFenceFdKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetFenceFdKHR:
-        Decode_vkGetFenceFdKHR(parameter_buffer, buffer_size);
+        Decode_vkGetFenceFdKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR:
-        Decode_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(parameter_buffer, buffer_size);
+        Decode_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR:
-        Decode_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkAcquireProfilingLockKHR:
-        Decode_vkAcquireProfilingLockKHR(parameter_buffer, buffer_size);
+        Decode_vkAcquireProfilingLockKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkReleaseProfilingLockKHR:
-        Decode_vkReleaseProfilingLockKHR(parameter_buffer, buffer_size);
+        Decode_vkReleaseProfilingLockKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceCapabilities2KHR:
-        Decode_vkGetPhysicalDeviceSurfaceCapabilities2KHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceSurfaceCapabilities2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceFormats2KHR:
-        Decode_vkGetPhysicalDeviceSurfaceFormats2KHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceSurfaceFormats2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayProperties2KHR:
-        Decode_vkGetPhysicalDeviceDisplayProperties2KHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceDisplayProperties2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPlaneProperties2KHR:
-        Decode_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDisplayModeProperties2KHR:
-        Decode_vkGetDisplayModeProperties2KHR(parameter_buffer, buffer_size);
+        Decode_vkGetDisplayModeProperties2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDisplayPlaneCapabilities2KHR:
-        Decode_vkGetDisplayPlaneCapabilities2KHR(parameter_buffer, buffer_size);
+        Decode_vkGetDisplayPlaneCapabilities2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetImageMemoryRequirements2KHR:
-        Decode_vkGetImageMemoryRequirements2KHR(parameter_buffer, buffer_size);
+        Decode_vkGetImageMemoryRequirements2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetBufferMemoryRequirements2KHR:
-        Decode_vkGetBufferMemoryRequirements2KHR(parameter_buffer, buffer_size);
+        Decode_vkGetBufferMemoryRequirements2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetImageSparseMemoryRequirements2KHR:
-        Decode_vkGetImageSparseMemoryRequirements2KHR(parameter_buffer, buffer_size);
+        Decode_vkGetImageSparseMemoryRequirements2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateSamplerYcbcrConversionKHR:
-        Decode_vkCreateSamplerYcbcrConversionKHR(parameter_buffer, buffer_size);
+        Decode_vkCreateSamplerYcbcrConversionKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroySamplerYcbcrConversionKHR:
-        Decode_vkDestroySamplerYcbcrConversionKHR(parameter_buffer, buffer_size);
+        Decode_vkDestroySamplerYcbcrConversionKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkBindBufferMemory2KHR:
-        Decode_vkBindBufferMemory2KHR(parameter_buffer, buffer_size);
+        Decode_vkBindBufferMemory2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkBindImageMemory2KHR:
-        Decode_vkBindImageMemory2KHR(parameter_buffer, buffer_size);
+        Decode_vkBindImageMemory2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDescriptorSetLayoutSupportKHR:
-        Decode_vkGetDescriptorSetLayoutSupportKHR(parameter_buffer, buffer_size);
+        Decode_vkGetDescriptorSetLayoutSupportKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDrawIndirectCountKHR:
-        Decode_vkCmdDrawIndirectCountKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdDrawIndirectCountKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCountKHR:
-        Decode_vkCmdDrawIndexedIndirectCountKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdDrawIndexedIndirectCountKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetSemaphoreCounterValueKHR:
-        Decode_vkGetSemaphoreCounterValueKHR(parameter_buffer, buffer_size);
+        Decode_vkGetSemaphoreCounterValueKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkWaitSemaphoresKHR:
-        Decode_vkWaitSemaphoresKHR(parameter_buffer, buffer_size);
+        Decode_vkWaitSemaphoresKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkSignalSemaphoreKHR:
-        Decode_vkSignalSemaphoreKHR(parameter_buffer, buffer_size);
+        Decode_vkSignalSemaphoreKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceFragmentShadingRatesKHR:
-        Decode_vkGetPhysicalDeviceFragmentShadingRatesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceFragmentShadingRatesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetFragmentShadingRateKHR:
-        Decode_vkCmdSetFragmentShadingRateKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdSetFragmentShadingRateKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkWaitForPresentKHR:
-        Decode_vkWaitForPresentKHR(parameter_buffer, buffer_size);
+        Decode_vkWaitForPresentKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetBufferDeviceAddressKHR:
-        Decode_vkGetBufferDeviceAddressKHR(parameter_buffer, buffer_size);
+        Decode_vkGetBufferDeviceAddressKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetBufferOpaqueCaptureAddressKHR:
-        Decode_vkGetBufferOpaqueCaptureAddressKHR(parameter_buffer, buffer_size);
+        Decode_vkGetBufferOpaqueCaptureAddressKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceMemoryOpaqueCaptureAddressKHR:
-        Decode_vkGetDeviceMemoryOpaqueCaptureAddressKHR(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceMemoryOpaqueCaptureAddressKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateDeferredOperationKHR:
-        Decode_vkCreateDeferredOperationKHR(parameter_buffer, buffer_size);
+        Decode_vkCreateDeferredOperationKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyDeferredOperationKHR:
-        Decode_vkDestroyDeferredOperationKHR(parameter_buffer, buffer_size);
+        Decode_vkDestroyDeferredOperationKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeferredOperationMaxConcurrencyKHR:
-        Decode_vkGetDeferredOperationMaxConcurrencyKHR(parameter_buffer, buffer_size);
+        Decode_vkGetDeferredOperationMaxConcurrencyKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeferredOperationResultKHR:
-        Decode_vkGetDeferredOperationResultKHR(parameter_buffer, buffer_size);
+        Decode_vkGetDeferredOperationResultKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDeferredOperationJoinKHR:
-        Decode_vkDeferredOperationJoinKHR(parameter_buffer, buffer_size);
+        Decode_vkDeferredOperationJoinKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPipelineExecutablePropertiesKHR:
-        Decode_vkGetPipelineExecutablePropertiesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPipelineExecutablePropertiesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPipelineExecutableStatisticsKHR:
-        Decode_vkGetPipelineExecutableStatisticsKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPipelineExecutableStatisticsKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPipelineExecutableInternalRepresentationsKHR:
-        Decode_vkGetPipelineExecutableInternalRepresentationsKHR(parameter_buffer, buffer_size);
+        Decode_vkGetPipelineExecutableInternalRepresentationsKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetEvent2KHR:
-        Decode_vkCmdSetEvent2KHR(parameter_buffer, buffer_size);
+        Decode_vkCmdSetEvent2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdResetEvent2KHR:
-        Decode_vkCmdResetEvent2KHR(parameter_buffer, buffer_size);
+        Decode_vkCmdResetEvent2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdWaitEvents2KHR:
-        Decode_vkCmdWaitEvents2KHR(parameter_buffer, buffer_size);
+        Decode_vkCmdWaitEvents2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdPipelineBarrier2KHR:
-        Decode_vkCmdPipelineBarrier2KHR(parameter_buffer, buffer_size);
+        Decode_vkCmdPipelineBarrier2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdWriteTimestamp2KHR:
-        Decode_vkCmdWriteTimestamp2KHR(parameter_buffer, buffer_size);
+        Decode_vkCmdWriteTimestamp2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkQueueSubmit2KHR:
-        Decode_vkQueueSubmit2KHR(parameter_buffer, buffer_size);
+        Decode_vkQueueSubmit2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdWriteBufferMarker2AMD:
-        Decode_vkCmdWriteBufferMarker2AMD(parameter_buffer, buffer_size);
+        Decode_vkCmdWriteBufferMarker2AMD(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetQueueCheckpointData2NV:
-        Decode_vkGetQueueCheckpointData2NV(parameter_buffer, buffer_size);
+        Decode_vkGetQueueCheckpointData2NV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyBuffer2KHR:
-        Decode_vkCmdCopyBuffer2KHR(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyBuffer2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyImage2KHR:
-        Decode_vkCmdCopyImage2KHR(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyImage2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyBufferToImage2KHR:
-        Decode_vkCmdCopyBufferToImage2KHR(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyBufferToImage2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyImageToBuffer2KHR:
-        Decode_vkCmdCopyImageToBuffer2KHR(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyImageToBuffer2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBlitImage2KHR:
-        Decode_vkCmdBlitImage2KHR(parameter_buffer, buffer_size);
+        Decode_vkCmdBlitImage2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdResolveImage2KHR:
-        Decode_vkCmdResolveImage2KHR(parameter_buffer, buffer_size);
+        Decode_vkCmdResolveImage2KHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceBufferMemoryRequirementsKHR:
-        Decode_vkGetDeviceBufferMemoryRequirementsKHR(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceBufferMemoryRequirementsKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceImageMemoryRequirementsKHR:
-        Decode_vkGetDeviceImageMemoryRequirementsKHR(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceImageMemoryRequirementsKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceImageSparseMemoryRequirementsKHR:
-        Decode_vkGetDeviceImageSparseMemoryRequirementsKHR(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceImageSparseMemoryRequirementsKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateDebugReportCallbackEXT:
-        Decode_vkCreateDebugReportCallbackEXT(parameter_buffer, buffer_size);
+        Decode_vkCreateDebugReportCallbackEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyDebugReportCallbackEXT:
-        Decode_vkDestroyDebugReportCallbackEXT(parameter_buffer, buffer_size);
+        Decode_vkDestroyDebugReportCallbackEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDebugReportMessageEXT:
-        Decode_vkDebugReportMessageEXT(parameter_buffer, buffer_size);
+        Decode_vkDebugReportMessageEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDebugMarkerSetObjectTagEXT:
-        Decode_vkDebugMarkerSetObjectTagEXT(parameter_buffer, buffer_size);
+        Decode_vkDebugMarkerSetObjectTagEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDebugMarkerSetObjectNameEXT:
-        Decode_vkDebugMarkerSetObjectNameEXT(parameter_buffer, buffer_size);
+        Decode_vkDebugMarkerSetObjectNameEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDebugMarkerBeginEXT:
-        Decode_vkCmdDebugMarkerBeginEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdDebugMarkerBeginEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDebugMarkerEndEXT:
-        Decode_vkCmdDebugMarkerEndEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdDebugMarkerEndEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDebugMarkerInsertEXT:
-        Decode_vkCmdDebugMarkerInsertEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdDebugMarkerInsertEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBindTransformFeedbackBuffersEXT:
-        Decode_vkCmdBindTransformFeedbackBuffersEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdBindTransformFeedbackBuffersEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBeginTransformFeedbackEXT:
-        Decode_vkCmdBeginTransformFeedbackEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdBeginTransformFeedbackEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdEndTransformFeedbackEXT:
-        Decode_vkCmdEndTransformFeedbackEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdEndTransformFeedbackEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBeginQueryIndexedEXT:
-        Decode_vkCmdBeginQueryIndexedEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdBeginQueryIndexedEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdEndQueryIndexedEXT:
-        Decode_vkCmdEndQueryIndexedEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdEndQueryIndexedEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDrawIndirectByteCountEXT:
-        Decode_vkCmdDrawIndirectByteCountEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdDrawIndirectByteCountEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetImageViewHandleNVX:
-        Decode_vkGetImageViewHandleNVX(parameter_buffer, buffer_size);
+        Decode_vkGetImageViewHandleNVX(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetImageViewAddressNVX:
-        Decode_vkGetImageViewAddressNVX(parameter_buffer, buffer_size);
+        Decode_vkGetImageViewAddressNVX(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDrawIndirectCountAMD:
-        Decode_vkCmdDrawIndirectCountAMD(parameter_buffer, buffer_size);
+        Decode_vkCmdDrawIndirectCountAMD(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDrawIndexedIndirectCountAMD:
-        Decode_vkCmdDrawIndexedIndirectCountAMD(parameter_buffer, buffer_size);
+        Decode_vkCmdDrawIndexedIndirectCountAMD(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetShaderInfoAMD:
-        Decode_vkGetShaderInfoAMD(parameter_buffer, buffer_size);
+        Decode_vkGetShaderInfoAMD(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateStreamDescriptorSurfaceGGP:
-        Decode_vkCreateStreamDescriptorSurfaceGGP(parameter_buffer, buffer_size);
+        Decode_vkCreateStreamDescriptorSurfaceGGP(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceExternalImageFormatPropertiesNV:
-        Decode_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetMemoryWin32HandleNV:
-        Decode_vkGetMemoryWin32HandleNV(parameter_buffer, buffer_size);
+        Decode_vkGetMemoryWin32HandleNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateViSurfaceNN:
-        Decode_vkCreateViSurfaceNN(parameter_buffer, buffer_size);
+        Decode_vkCreateViSurfaceNN(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBeginConditionalRenderingEXT:
-        Decode_vkCmdBeginConditionalRenderingEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdBeginConditionalRenderingEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdEndConditionalRenderingEXT:
-        Decode_vkCmdEndConditionalRenderingEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdEndConditionalRenderingEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetViewportWScalingNV:
-        Decode_vkCmdSetViewportWScalingNV(parameter_buffer, buffer_size);
+        Decode_vkCmdSetViewportWScalingNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkReleaseDisplayEXT:
-        Decode_vkReleaseDisplayEXT(parameter_buffer, buffer_size);
+        Decode_vkReleaseDisplayEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkAcquireXlibDisplayEXT:
-        Decode_vkAcquireXlibDisplayEXT(parameter_buffer, buffer_size);
+        Decode_vkAcquireXlibDisplayEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetRandROutputDisplayEXT:
-        Decode_vkGetRandROutputDisplayEXT(parameter_buffer, buffer_size);
+        Decode_vkGetRandROutputDisplayEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfaceCapabilities2EXT:
-        Decode_vkGetPhysicalDeviceSurfaceCapabilities2EXT(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceSurfaceCapabilities2EXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDisplayPowerControlEXT:
-        Decode_vkDisplayPowerControlEXT(parameter_buffer, buffer_size);
+        Decode_vkDisplayPowerControlEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkRegisterDeviceEventEXT:
-        Decode_vkRegisterDeviceEventEXT(parameter_buffer, buffer_size);
+        Decode_vkRegisterDeviceEventEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkRegisterDisplayEventEXT:
-        Decode_vkRegisterDisplayEventEXT(parameter_buffer, buffer_size);
+        Decode_vkRegisterDisplayEventEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetSwapchainCounterEXT:
-        Decode_vkGetSwapchainCounterEXT(parameter_buffer, buffer_size);
+        Decode_vkGetSwapchainCounterEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetRefreshCycleDurationGOOGLE:
-        Decode_vkGetRefreshCycleDurationGOOGLE(parameter_buffer, buffer_size);
+        Decode_vkGetRefreshCycleDurationGOOGLE(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPastPresentationTimingGOOGLE:
-        Decode_vkGetPastPresentationTimingGOOGLE(parameter_buffer, buffer_size);
+        Decode_vkGetPastPresentationTimingGOOGLE(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetDiscardRectangleEXT:
-        Decode_vkCmdSetDiscardRectangleEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetDiscardRectangleEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkSetHdrMetadataEXT:
-        Decode_vkSetHdrMetadataEXT(parameter_buffer, buffer_size);
+        Decode_vkSetHdrMetadataEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateIOSSurfaceMVK:
-        Decode_vkCreateIOSSurfaceMVK(parameter_buffer, buffer_size);
+        Decode_vkCreateIOSSurfaceMVK(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateMacOSSurfaceMVK:
-        Decode_vkCreateMacOSSurfaceMVK(parameter_buffer, buffer_size);
+        Decode_vkCreateMacOSSurfaceMVK(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkSetDebugUtilsObjectNameEXT:
-        Decode_vkSetDebugUtilsObjectNameEXT(parameter_buffer, buffer_size);
+        Decode_vkSetDebugUtilsObjectNameEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkSetDebugUtilsObjectTagEXT:
-        Decode_vkSetDebugUtilsObjectTagEXT(parameter_buffer, buffer_size);
+        Decode_vkSetDebugUtilsObjectTagEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkQueueBeginDebugUtilsLabelEXT:
-        Decode_vkQueueBeginDebugUtilsLabelEXT(parameter_buffer, buffer_size);
+        Decode_vkQueueBeginDebugUtilsLabelEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkQueueEndDebugUtilsLabelEXT:
-        Decode_vkQueueEndDebugUtilsLabelEXT(parameter_buffer, buffer_size);
+        Decode_vkQueueEndDebugUtilsLabelEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkQueueInsertDebugUtilsLabelEXT:
-        Decode_vkQueueInsertDebugUtilsLabelEXT(parameter_buffer, buffer_size);
+        Decode_vkQueueInsertDebugUtilsLabelEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBeginDebugUtilsLabelEXT:
-        Decode_vkCmdBeginDebugUtilsLabelEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdBeginDebugUtilsLabelEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdEndDebugUtilsLabelEXT:
-        Decode_vkCmdEndDebugUtilsLabelEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdEndDebugUtilsLabelEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdInsertDebugUtilsLabelEXT:
-        Decode_vkCmdInsertDebugUtilsLabelEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdInsertDebugUtilsLabelEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateDebugUtilsMessengerEXT:
-        Decode_vkCreateDebugUtilsMessengerEXT(parameter_buffer, buffer_size);
+        Decode_vkCreateDebugUtilsMessengerEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyDebugUtilsMessengerEXT:
-        Decode_vkDestroyDebugUtilsMessengerEXT(parameter_buffer, buffer_size);
+        Decode_vkDestroyDebugUtilsMessengerEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkSubmitDebugUtilsMessageEXT:
-        Decode_vkSubmitDebugUtilsMessageEXT(parameter_buffer, buffer_size);
+        Decode_vkSubmitDebugUtilsMessageEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetAndroidHardwareBufferPropertiesANDROID:
-        Decode_vkGetAndroidHardwareBufferPropertiesANDROID(parameter_buffer, buffer_size);
+        Decode_vkGetAndroidHardwareBufferPropertiesANDROID(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetMemoryAndroidHardwareBufferANDROID:
-        Decode_vkGetMemoryAndroidHardwareBufferANDROID(parameter_buffer, buffer_size);
+        Decode_vkGetMemoryAndroidHardwareBufferANDROID(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetSampleLocationsEXT:
-        Decode_vkCmdSetSampleLocationsEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetSampleLocationsEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceMultisamplePropertiesEXT:
-        Decode_vkGetPhysicalDeviceMultisamplePropertiesEXT(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceMultisamplePropertiesEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetImageDrmFormatModifierPropertiesEXT:
-        Decode_vkGetImageDrmFormatModifierPropertiesEXT(parameter_buffer, buffer_size);
+        Decode_vkGetImageDrmFormatModifierPropertiesEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateValidationCacheEXT:
-        Decode_vkCreateValidationCacheEXT(parameter_buffer, buffer_size);
+        Decode_vkCreateValidationCacheEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyValidationCacheEXT:
-        Decode_vkDestroyValidationCacheEXT(parameter_buffer, buffer_size);
+        Decode_vkDestroyValidationCacheEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkMergeValidationCachesEXT:
-        Decode_vkMergeValidationCachesEXT(parameter_buffer, buffer_size);
+        Decode_vkMergeValidationCachesEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetValidationCacheDataEXT:
-        Decode_vkGetValidationCacheDataEXT(parameter_buffer, buffer_size);
+        Decode_vkGetValidationCacheDataEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBindShadingRateImageNV:
-        Decode_vkCmdBindShadingRateImageNV(parameter_buffer, buffer_size);
+        Decode_vkCmdBindShadingRateImageNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetViewportShadingRatePaletteNV:
-        Decode_vkCmdSetViewportShadingRatePaletteNV(parameter_buffer, buffer_size);
+        Decode_vkCmdSetViewportShadingRatePaletteNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetCoarseSampleOrderNV:
-        Decode_vkCmdSetCoarseSampleOrderNV(parameter_buffer, buffer_size);
+        Decode_vkCmdSetCoarseSampleOrderNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateAccelerationStructureNV:
-        Decode_vkCreateAccelerationStructureNV(parameter_buffer, buffer_size);
+        Decode_vkCreateAccelerationStructureNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyAccelerationStructureNV:
-        Decode_vkDestroyAccelerationStructureNV(parameter_buffer, buffer_size);
+        Decode_vkDestroyAccelerationStructureNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetAccelerationStructureMemoryRequirementsNV:
-        Decode_vkGetAccelerationStructureMemoryRequirementsNV(parameter_buffer, buffer_size);
+        Decode_vkGetAccelerationStructureMemoryRequirementsNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkBindAccelerationStructureMemoryNV:
-        Decode_vkBindAccelerationStructureMemoryNV(parameter_buffer, buffer_size);
+        Decode_vkBindAccelerationStructureMemoryNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructureNV:
-        Decode_vkCmdBuildAccelerationStructureNV(parameter_buffer, buffer_size);
+        Decode_vkCmdBuildAccelerationStructureNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyAccelerationStructureNV:
-        Decode_vkCmdCopyAccelerationStructureNV(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyAccelerationStructureNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdTraceRaysNV:
-        Decode_vkCmdTraceRaysNV(parameter_buffer, buffer_size);
+        Decode_vkCmdTraceRaysNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesNV:
-        Decode_vkCreateRayTracingPipelinesNV(parameter_buffer, buffer_size);
+        Decode_vkCreateRayTracingPipelinesNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetRayTracingShaderGroupHandlesKHR:
-        Decode_vkGetRayTracingShaderGroupHandlesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetRayTracingShaderGroupHandlesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetRayTracingShaderGroupHandlesNV:
-        Decode_vkGetRayTracingShaderGroupHandlesNV(parameter_buffer, buffer_size);
+        Decode_vkGetRayTracingShaderGroupHandlesNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetAccelerationStructureHandleNV:
-        Decode_vkGetAccelerationStructureHandleNV(parameter_buffer, buffer_size);
+        Decode_vkGetAccelerationStructureHandleNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdWriteAccelerationStructuresPropertiesNV:
-        Decode_vkCmdWriteAccelerationStructuresPropertiesNV(parameter_buffer, buffer_size);
+        Decode_vkCmdWriteAccelerationStructuresPropertiesNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCompileDeferredNV:
-        Decode_vkCompileDeferredNV(parameter_buffer, buffer_size);
+        Decode_vkCompileDeferredNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetMemoryHostPointerPropertiesEXT:
-        Decode_vkGetMemoryHostPointerPropertiesEXT(parameter_buffer, buffer_size);
+        Decode_vkGetMemoryHostPointerPropertiesEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdWriteBufferMarkerAMD:
-        Decode_vkCmdWriteBufferMarkerAMD(parameter_buffer, buffer_size);
+        Decode_vkCmdWriteBufferMarkerAMD(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT:
-        Decode_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetCalibratedTimestampsEXT:
-        Decode_vkGetCalibratedTimestampsEXT(parameter_buffer, buffer_size);
+        Decode_vkGetCalibratedTimestampsEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDrawMeshTasksNV:
-        Decode_vkCmdDrawMeshTasksNV(parameter_buffer, buffer_size);
+        Decode_vkCmdDrawMeshTasksNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectNV:
-        Decode_vkCmdDrawMeshTasksIndirectNV(parameter_buffer, buffer_size);
+        Decode_vkCmdDrawMeshTasksIndirectNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDrawMeshTasksIndirectCountNV:
-        Decode_vkCmdDrawMeshTasksIndirectCountNV(parameter_buffer, buffer_size);
+        Decode_vkCmdDrawMeshTasksIndirectCountNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetExclusiveScissorNV:
-        Decode_vkCmdSetExclusiveScissorNV(parameter_buffer, buffer_size);
+        Decode_vkCmdSetExclusiveScissorNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetCheckpointNV:
-        Decode_vkCmdSetCheckpointNV(parameter_buffer, buffer_size);
+        Decode_vkCmdSetCheckpointNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetQueueCheckpointDataNV:
-        Decode_vkGetQueueCheckpointDataNV(parameter_buffer, buffer_size);
+        Decode_vkGetQueueCheckpointDataNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkInitializePerformanceApiINTEL:
-        Decode_vkInitializePerformanceApiINTEL(parameter_buffer, buffer_size);
+        Decode_vkInitializePerformanceApiINTEL(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkUninitializePerformanceApiINTEL:
-        Decode_vkUninitializePerformanceApiINTEL(parameter_buffer, buffer_size);
+        Decode_vkUninitializePerformanceApiINTEL(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetPerformanceMarkerINTEL:
-        Decode_vkCmdSetPerformanceMarkerINTEL(parameter_buffer, buffer_size);
+        Decode_vkCmdSetPerformanceMarkerINTEL(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetPerformanceStreamMarkerINTEL:
-        Decode_vkCmdSetPerformanceStreamMarkerINTEL(parameter_buffer, buffer_size);
+        Decode_vkCmdSetPerformanceStreamMarkerINTEL(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetPerformanceOverrideINTEL:
-        Decode_vkCmdSetPerformanceOverrideINTEL(parameter_buffer, buffer_size);
+        Decode_vkCmdSetPerformanceOverrideINTEL(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkAcquirePerformanceConfigurationINTEL:
-        Decode_vkAcquirePerformanceConfigurationINTEL(parameter_buffer, buffer_size);
+        Decode_vkAcquirePerformanceConfigurationINTEL(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkReleasePerformanceConfigurationINTEL:
-        Decode_vkReleasePerformanceConfigurationINTEL(parameter_buffer, buffer_size);
+        Decode_vkReleasePerformanceConfigurationINTEL(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkQueueSetPerformanceConfigurationINTEL:
-        Decode_vkQueueSetPerformanceConfigurationINTEL(parameter_buffer, buffer_size);
+        Decode_vkQueueSetPerformanceConfigurationINTEL(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPerformanceParameterINTEL:
-        Decode_vkGetPerformanceParameterINTEL(parameter_buffer, buffer_size);
+        Decode_vkGetPerformanceParameterINTEL(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkSetLocalDimmingAMD:
-        Decode_vkSetLocalDimmingAMD(parameter_buffer, buffer_size);
+        Decode_vkSetLocalDimmingAMD(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateImagePipeSurfaceFUCHSIA:
-        Decode_vkCreateImagePipeSurfaceFUCHSIA(parameter_buffer, buffer_size);
+        Decode_vkCreateImagePipeSurfaceFUCHSIA(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateMetalSurfaceEXT:
-        Decode_vkCreateMetalSurfaceEXT(parameter_buffer, buffer_size);
+        Decode_vkCreateMetalSurfaceEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetBufferDeviceAddressEXT:
-        Decode_vkGetBufferDeviceAddressEXT(parameter_buffer, buffer_size);
+        Decode_vkGetBufferDeviceAddressEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceToolPropertiesEXT:
-        Decode_vkGetPhysicalDeviceToolPropertiesEXT(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceToolPropertiesEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV:
-        Decode_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV:
-        Decode_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceSurfacePresentModes2EXT:
-        Decode_vkGetPhysicalDeviceSurfacePresentModes2EXT(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceSurfacePresentModes2EXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkAcquireFullScreenExclusiveModeEXT:
-        Decode_vkAcquireFullScreenExclusiveModeEXT(parameter_buffer, buffer_size);
+        Decode_vkAcquireFullScreenExclusiveModeEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkReleaseFullScreenExclusiveModeEXT:
-        Decode_vkReleaseFullScreenExclusiveModeEXT(parameter_buffer, buffer_size);
+        Decode_vkReleaseFullScreenExclusiveModeEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceGroupSurfacePresentModes2EXT:
-        Decode_vkGetDeviceGroupSurfacePresentModes2EXT(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceGroupSurfacePresentModes2EXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateHeadlessSurfaceEXT:
-        Decode_vkCreateHeadlessSurfaceEXT(parameter_buffer, buffer_size);
+        Decode_vkCreateHeadlessSurfaceEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetLineStippleEXT:
-        Decode_vkCmdSetLineStippleEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetLineStippleEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkResetQueryPoolEXT:
-        Decode_vkResetQueryPoolEXT(parameter_buffer, buffer_size);
+        Decode_vkResetQueryPoolEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetCullModeEXT:
-        Decode_vkCmdSetCullModeEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetCullModeEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetFrontFaceEXT:
-        Decode_vkCmdSetFrontFaceEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetFrontFaceEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetPrimitiveTopologyEXT:
-        Decode_vkCmdSetPrimitiveTopologyEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetPrimitiveTopologyEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetViewportWithCountEXT:
-        Decode_vkCmdSetViewportWithCountEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetViewportWithCountEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetScissorWithCountEXT:
-        Decode_vkCmdSetScissorWithCountEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetScissorWithCountEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBindVertexBuffers2EXT:
-        Decode_vkCmdBindVertexBuffers2EXT(parameter_buffer, buffer_size);
+        Decode_vkCmdBindVertexBuffers2EXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetDepthTestEnableEXT:
-        Decode_vkCmdSetDepthTestEnableEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetDepthTestEnableEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetDepthWriteEnableEXT:
-        Decode_vkCmdSetDepthWriteEnableEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetDepthWriteEnableEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetDepthCompareOpEXT:
-        Decode_vkCmdSetDepthCompareOpEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetDepthCompareOpEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetDepthBoundsTestEnableEXT:
-        Decode_vkCmdSetDepthBoundsTestEnableEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetDepthBoundsTestEnableEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetStencilTestEnableEXT:
-        Decode_vkCmdSetStencilTestEnableEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetStencilTestEnableEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetStencilOpEXT:
-        Decode_vkCmdSetStencilOpEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetStencilOpEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetGeneratedCommandsMemoryRequirementsNV:
-        Decode_vkGetGeneratedCommandsMemoryRequirementsNV(parameter_buffer, buffer_size);
+        Decode_vkGetGeneratedCommandsMemoryRequirementsNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdPreprocessGeneratedCommandsNV:
-        Decode_vkCmdPreprocessGeneratedCommandsNV(parameter_buffer, buffer_size);
+        Decode_vkCmdPreprocessGeneratedCommandsNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdExecuteGeneratedCommandsNV:
-        Decode_vkCmdExecuteGeneratedCommandsNV(parameter_buffer, buffer_size);
+        Decode_vkCmdExecuteGeneratedCommandsNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBindPipelineShaderGroupNV:
-        Decode_vkCmdBindPipelineShaderGroupNV(parameter_buffer, buffer_size);
+        Decode_vkCmdBindPipelineShaderGroupNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateIndirectCommandsLayoutNV:
-        Decode_vkCreateIndirectCommandsLayoutNV(parameter_buffer, buffer_size);
+        Decode_vkCreateIndirectCommandsLayoutNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyIndirectCommandsLayoutNV:
-        Decode_vkDestroyIndirectCommandsLayoutNV(parameter_buffer, buffer_size);
+        Decode_vkDestroyIndirectCommandsLayoutNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkAcquireDrmDisplayEXT:
-        Decode_vkAcquireDrmDisplayEXT(parameter_buffer, buffer_size);
+        Decode_vkAcquireDrmDisplayEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDrmDisplayEXT:
-        Decode_vkGetDrmDisplayEXT(parameter_buffer, buffer_size);
+        Decode_vkGetDrmDisplayEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreatePrivateDataSlotEXT:
-        Decode_vkCreatePrivateDataSlotEXT(parameter_buffer, buffer_size);
+        Decode_vkCreatePrivateDataSlotEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyPrivateDataSlotEXT:
-        Decode_vkDestroyPrivateDataSlotEXT(parameter_buffer, buffer_size);
+        Decode_vkDestroyPrivateDataSlotEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkSetPrivateDataEXT:
-        Decode_vkSetPrivateDataEXT(parameter_buffer, buffer_size);
+        Decode_vkSetPrivateDataEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPrivateDataEXT:
-        Decode_vkGetPrivateDataEXT(parameter_buffer, buffer_size);
+        Decode_vkGetPrivateDataEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetFragmentShadingRateEnumNV:
-        Decode_vkCmdSetFragmentShadingRateEnumNV(parameter_buffer, buffer_size);
+        Decode_vkCmdSetFragmentShadingRateEnumNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkAcquireWinrtDisplayNV:
-        Decode_vkAcquireWinrtDisplayNV(parameter_buffer, buffer_size);
+        Decode_vkAcquireWinrtDisplayNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetWinrtDisplayNV:
-        Decode_vkGetWinrtDisplayNV(parameter_buffer, buffer_size);
+        Decode_vkGetWinrtDisplayNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateDirectFBSurfaceEXT:
-        Decode_vkCreateDirectFBSurfaceEXT(parameter_buffer, buffer_size);
+        Decode_vkCreateDirectFBSurfaceEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceDirectFBPresentationSupportEXT:
-        Decode_vkGetPhysicalDeviceDirectFBPresentationSupportEXT(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceDirectFBPresentationSupportEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetVertexInputEXT:
-        Decode_vkCmdSetVertexInputEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetVertexInputEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetMemoryZirconHandleFUCHSIA:
-        Decode_vkGetMemoryZirconHandleFUCHSIA(parameter_buffer, buffer_size);
+        Decode_vkGetMemoryZirconHandleFUCHSIA(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetMemoryZirconHandlePropertiesFUCHSIA:
-        Decode_vkGetMemoryZirconHandlePropertiesFUCHSIA(parameter_buffer, buffer_size);
+        Decode_vkGetMemoryZirconHandlePropertiesFUCHSIA(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkImportSemaphoreZirconHandleFUCHSIA:
-        Decode_vkImportSemaphoreZirconHandleFUCHSIA(parameter_buffer, buffer_size);
+        Decode_vkImportSemaphoreZirconHandleFUCHSIA(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetSemaphoreZirconHandleFUCHSIA:
-        Decode_vkGetSemaphoreZirconHandleFUCHSIA(parameter_buffer, buffer_size);
+        Decode_vkGetSemaphoreZirconHandleFUCHSIA(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBindInvocationMaskHUAWEI:
-        Decode_vkCmdBindInvocationMaskHUAWEI(parameter_buffer, buffer_size);
+        Decode_vkCmdBindInvocationMaskHUAWEI(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetMemoryRemoteAddressNV:
-        Decode_vkGetMemoryRemoteAddressNV(parameter_buffer, buffer_size);
+        Decode_vkGetMemoryRemoteAddressNV(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetPatchControlPointsEXT:
-        Decode_vkCmdSetPatchControlPointsEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetPatchControlPointsEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetRasterizerDiscardEnableEXT:
-        Decode_vkCmdSetRasterizerDiscardEnableEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetRasterizerDiscardEnableEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetDepthBiasEnableEXT:
-        Decode_vkCmdSetDepthBiasEnableEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetDepthBiasEnableEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetLogicOpEXT:
-        Decode_vkCmdSetLogicOpEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetLogicOpEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetPrimitiveRestartEnableEXT:
-        Decode_vkCmdSetPrimitiveRestartEnableEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetPrimitiveRestartEnableEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateScreenSurfaceQNX:
-        Decode_vkCreateScreenSurfaceQNX(parameter_buffer, buffer_size);
+        Decode_vkCreateScreenSurfaceQNX(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPhysicalDeviceScreenPresentationSupportQNX:
-        Decode_vkGetPhysicalDeviceScreenPresentationSupportQNX(parameter_buffer, buffer_size);
+        Decode_vkGetPhysicalDeviceScreenPresentationSupportQNX(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetColorWriteEnableEXT:
-        Decode_vkCmdSetColorWriteEnableEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdSetColorWriteEnableEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDrawMultiEXT:
-        Decode_vkCmdDrawMultiEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdDrawMultiEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdDrawMultiIndexedEXT:
-        Decode_vkCmdDrawMultiIndexedEXT(parameter_buffer, buffer_size);
+        Decode_vkCmdDrawMultiIndexedEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkSetDeviceMemoryPriorityEXT:
-        Decode_vkSetDeviceMemoryPriorityEXT(parameter_buffer, buffer_size);
+        Decode_vkSetDeviceMemoryPriorityEXT(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateAccelerationStructureKHR:
-        Decode_vkCreateAccelerationStructureKHR(parameter_buffer, buffer_size);
+        Decode_vkCreateAccelerationStructureKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkDestroyAccelerationStructureKHR:
-        Decode_vkDestroyAccelerationStructureKHR(parameter_buffer, buffer_size);
+        Decode_vkDestroyAccelerationStructureKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructuresKHR:
-        Decode_vkCmdBuildAccelerationStructuresKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdBuildAccelerationStructuresKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdBuildAccelerationStructuresIndirectKHR:
-        Decode_vkCmdBuildAccelerationStructuresIndirectKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdBuildAccelerationStructuresIndirectKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCopyAccelerationStructureToMemoryKHR:
-        Decode_vkCopyAccelerationStructureToMemoryKHR(parameter_buffer, buffer_size);
+        Decode_vkCopyAccelerationStructureToMemoryKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCopyMemoryToAccelerationStructureKHR:
-        Decode_vkCopyMemoryToAccelerationStructureKHR(parameter_buffer, buffer_size);
+        Decode_vkCopyMemoryToAccelerationStructureKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkWriteAccelerationStructuresPropertiesKHR:
-        Decode_vkWriteAccelerationStructuresPropertiesKHR(parameter_buffer, buffer_size);
+        Decode_vkWriteAccelerationStructuresPropertiesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyAccelerationStructureKHR:
-        Decode_vkCmdCopyAccelerationStructureKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyAccelerationStructureKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyAccelerationStructureToMemoryKHR:
-        Decode_vkCmdCopyAccelerationStructureToMemoryKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyAccelerationStructureToMemoryKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdCopyMemoryToAccelerationStructureKHR:
-        Decode_vkCmdCopyMemoryToAccelerationStructureKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdCopyMemoryToAccelerationStructureKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetAccelerationStructureDeviceAddressKHR:
-        Decode_vkGetAccelerationStructureDeviceAddressKHR(parameter_buffer, buffer_size);
+        Decode_vkGetAccelerationStructureDeviceAddressKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdWriteAccelerationStructuresPropertiesKHR:
-        Decode_vkCmdWriteAccelerationStructuresPropertiesKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdWriteAccelerationStructuresPropertiesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetDeviceAccelerationStructureCompatibilityKHR:
-        Decode_vkGetDeviceAccelerationStructureCompatibilityKHR(parameter_buffer, buffer_size);
+        Decode_vkGetDeviceAccelerationStructureCompatibilityKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetAccelerationStructureBuildSizesKHR:
-        Decode_vkGetAccelerationStructureBuildSizesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetAccelerationStructureBuildSizesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdTraceRaysKHR:
-        Decode_vkCmdTraceRaysKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdTraceRaysKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesKHR:
-        Decode_vkCreateRayTracingPipelinesKHR(parameter_buffer, buffer_size);
+        Decode_vkCreateRayTracingPipelinesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR:
-        Decode_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(parameter_buffer, buffer_size);
+        Decode_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdTraceRaysIndirectKHR:
-        Decode_vkCmdTraceRaysIndirectKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdTraceRaysIndirectKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetRayTracingShaderGroupStackSizeKHR:
-        Decode_vkGetRayTracingShaderGroupStackSizeKHR(parameter_buffer, buffer_size);
+        Decode_vkGetRayTracingShaderGroupStackSizeKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkCmdSetRayTracingPipelineStackSizeKHR:
-        Decode_vkCmdSetRayTracingPipelineStackSizeKHR(parameter_buffer, buffer_size);
+        Decode_vkCmdSetRayTracingPipelineStackSizeKHR(call_info, parameter_buffer, buffer_size);
         break;
     }
 }

--- a/framework/generated/generated_vulkan_decoder.h
+++ b/framework/generated/generated_vulkan_decoder.h
@@ -50,1015 +50,1015 @@ class VulkanDecoder : public VulkanDecoderBase
                                     size_t                        buffer_size) override;
 
   private:
-    size_t Decode_vkCreateInstance(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateInstance(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyInstance(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyInstance(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkEnumeratePhysicalDevices(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkEnumeratePhysicalDevices(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceFeatures(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceFeatures(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceFormatProperties(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceFormatProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceImageFormatProperties(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceImageFormatProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceProperties(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceQueueFamilyProperties(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceQueueFamilyProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceMemoryProperties(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceMemoryProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateDevice(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateDevice(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyDevice(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyDevice(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceQueue(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceQueue(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkQueueSubmit(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkQueueSubmit(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkQueueWaitIdle(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkQueueWaitIdle(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDeviceWaitIdle(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDeviceWaitIdle(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkAllocateMemory(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkAllocateMemory(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkFreeMemory(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkFreeMemory(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkMapMemory(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkMapMemory(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkUnmapMemory(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkUnmapMemory(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkFlushMappedMemoryRanges(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkFlushMappedMemoryRanges(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkInvalidateMappedMemoryRanges(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkInvalidateMappedMemoryRanges(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceMemoryCommitment(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceMemoryCommitment(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkBindBufferMemory(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkBindBufferMemory(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkBindImageMemory(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkBindImageMemory(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetBufferMemoryRequirements(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetBufferMemoryRequirements(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetImageMemoryRequirements(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetImageMemoryRequirements(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetImageSparseMemoryRequirements(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetImageSparseMemoryRequirements(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceSparseImageFormatProperties(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceSparseImageFormatProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkQueueBindSparse(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkQueueBindSparse(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateFence(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateFence(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyFence(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyFence(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkResetFences(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkResetFences(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetFenceStatus(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetFenceStatus(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkWaitForFences(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkWaitForFences(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateSemaphore(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateSemaphore(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroySemaphore(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroySemaphore(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateEvent(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateEvent(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyEvent(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyEvent(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetEventStatus(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetEventStatus(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkSetEvent(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkSetEvent(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkResetEvent(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkResetEvent(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateQueryPool(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateQueryPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyQueryPool(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyQueryPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetQueryPoolResults(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetQueryPoolResults(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateBuffer(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyBuffer(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateBufferView(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateBufferView(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyBufferView(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyBufferView(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateImage(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateImage(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyImage(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyImage(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetImageSubresourceLayout(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetImageSubresourceLayout(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateImageView(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateImageView(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyImageView(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyImageView(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateShaderModule(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateShaderModule(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyShaderModule(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyShaderModule(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreatePipelineCache(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreatePipelineCache(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyPipelineCache(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyPipelineCache(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPipelineCacheData(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPipelineCacheData(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkMergePipelineCaches(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkMergePipelineCaches(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateGraphicsPipelines(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateGraphicsPipelines(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateComputePipelines(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateComputePipelines(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyPipeline(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyPipeline(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreatePipelineLayout(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreatePipelineLayout(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyPipelineLayout(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyPipelineLayout(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateSampler(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateSampler(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroySampler(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroySampler(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateDescriptorSetLayout(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateDescriptorSetLayout(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyDescriptorSetLayout(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyDescriptorSetLayout(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateDescriptorPool(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateDescriptorPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyDescriptorPool(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyDescriptorPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkResetDescriptorPool(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkResetDescriptorPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkAllocateDescriptorSets(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkAllocateDescriptorSets(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkFreeDescriptorSets(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkFreeDescriptorSets(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkUpdateDescriptorSets(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkUpdateDescriptorSets(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateFramebuffer(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateFramebuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyFramebuffer(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyFramebuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateRenderPass(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateRenderPass(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyRenderPass(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyRenderPass(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetRenderAreaGranularity(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetRenderAreaGranularity(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateCommandPool(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateCommandPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyCommandPool(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyCommandPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkResetCommandPool(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkResetCommandPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkAllocateCommandBuffers(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkAllocateCommandBuffers(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkFreeCommandBuffers(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkFreeCommandBuffers(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkBeginCommandBuffer(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkBeginCommandBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkEndCommandBuffer(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkEndCommandBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkResetCommandBuffer(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkResetCommandBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBindPipeline(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBindPipeline(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetViewport(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetViewport(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetScissor(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetScissor(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetLineWidth(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetLineWidth(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetDepthBias(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetDepthBias(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetBlendConstants(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetBlendConstants(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetDepthBounds(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetDepthBounds(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetStencilCompareMask(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetStencilCompareMask(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetStencilWriteMask(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetStencilWriteMask(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetStencilReference(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetStencilReference(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBindDescriptorSets(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBindDescriptorSets(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBindIndexBuffer(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBindIndexBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBindVertexBuffers(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBindVertexBuffers(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDraw(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDraw(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDrawIndexed(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDrawIndexed(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDrawIndirect(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDrawIndirect(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDrawIndexedIndirect(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDrawIndexedIndirect(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDispatch(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDispatch(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDispatchIndirect(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDispatchIndirect(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyBuffer(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyImage(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyImage(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBlitImage(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBlitImage(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyBufferToImage(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyBufferToImage(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyImageToBuffer(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyImageToBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdUpdateBuffer(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdUpdateBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdFillBuffer(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdFillBuffer(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdClearColorImage(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdClearColorImage(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdClearDepthStencilImage(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdClearDepthStencilImage(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdClearAttachments(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdClearAttachments(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdResolveImage(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdResolveImage(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetEvent(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetEvent(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdResetEvent(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdResetEvent(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdWaitEvents(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdWaitEvents(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdPipelineBarrier(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdPipelineBarrier(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBeginQuery(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBeginQuery(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdEndQuery(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdEndQuery(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdResetQueryPool(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdResetQueryPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdWriteTimestamp(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdWriteTimestamp(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyQueryPoolResults(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyQueryPoolResults(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdPushConstants(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdPushConstants(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBeginRenderPass(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBeginRenderPass(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdNextSubpass(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdNextSubpass(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdEndRenderPass(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdEndRenderPass(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdExecuteCommands(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdExecuteCommands(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkBindBufferMemory2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkBindBufferMemory2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkBindImageMemory2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkBindImageMemory2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceGroupPeerMemoryFeatures(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceGroupPeerMemoryFeatures(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetDeviceMask(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetDeviceMask(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDispatchBase(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDispatchBase(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkEnumeratePhysicalDeviceGroups(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkEnumeratePhysicalDeviceGroups(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetImageMemoryRequirements2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetImageMemoryRequirements2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetBufferMemoryRequirements2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetBufferMemoryRequirements2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetImageSparseMemoryRequirements2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetImageSparseMemoryRequirements2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceFeatures2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceFeatures2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceProperties2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceProperties2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceFormatProperties2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceFormatProperties2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceImageFormatProperties2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceImageFormatProperties2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceQueueFamilyProperties2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceQueueFamilyProperties2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceMemoryProperties2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceMemoryProperties2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceSparseImageFormatProperties2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceSparseImageFormatProperties2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkTrimCommandPool(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkTrimCommandPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceQueue2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceQueue2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateSamplerYcbcrConversion(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateSamplerYcbcrConversion(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroySamplerYcbcrConversion(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroySamplerYcbcrConversion(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateDescriptorUpdateTemplate(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateDescriptorUpdateTemplate(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyDescriptorUpdateTemplate(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyDescriptorUpdateTemplate(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceExternalBufferProperties(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceExternalBufferProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceExternalFenceProperties(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceExternalFenceProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceExternalSemaphoreProperties(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceExternalSemaphoreProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDescriptorSetLayoutSupport(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDescriptorSetLayoutSupport(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDrawIndirectCount(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDrawIndirectCount(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDrawIndexedIndirectCount(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDrawIndexedIndirectCount(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateRenderPass2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateRenderPass2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBeginRenderPass2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBeginRenderPass2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdNextSubpass2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdNextSubpass2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdEndRenderPass2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdEndRenderPass2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkResetQueryPool(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkResetQueryPool(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetSemaphoreCounterValue(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetSemaphoreCounterValue(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkWaitSemaphores(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkWaitSemaphores(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkSignalSemaphore(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkSignalSemaphore(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetBufferDeviceAddress(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetBufferDeviceAddress(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetBufferOpaqueCaptureAddress(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetBufferOpaqueCaptureAddress(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceMemoryOpaqueCaptureAddress(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceMemoryOpaqueCaptureAddress(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceToolProperties(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceToolProperties(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreatePrivateDataSlot(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreatePrivateDataSlot(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyPrivateDataSlot(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyPrivateDataSlot(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkSetPrivateData(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkSetPrivateData(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPrivateData(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPrivateData(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetEvent2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetEvent2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdResetEvent2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdResetEvent2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdWaitEvents2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdWaitEvents2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdPipelineBarrier2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdPipelineBarrier2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdWriteTimestamp2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdWriteTimestamp2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkQueueSubmit2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkQueueSubmit2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyBuffer2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyBuffer2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyImage2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyImage2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyBufferToImage2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyBufferToImage2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyImageToBuffer2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyImageToBuffer2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBlitImage2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBlitImage2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdResolveImage2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdResolveImage2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBeginRendering(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBeginRendering(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdEndRendering(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdEndRendering(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetCullMode(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetCullMode(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetFrontFace(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetFrontFace(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetPrimitiveTopology(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetPrimitiveTopology(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetViewportWithCount(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetViewportWithCount(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetScissorWithCount(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetScissorWithCount(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBindVertexBuffers2(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBindVertexBuffers2(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetDepthTestEnable(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetDepthTestEnable(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetDepthWriteEnable(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetDepthWriteEnable(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetDepthCompareOp(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetDepthCompareOp(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetDepthBoundsTestEnable(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetDepthBoundsTestEnable(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetStencilTestEnable(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetStencilTestEnable(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetStencilOp(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetStencilOp(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetRasterizerDiscardEnable(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetRasterizerDiscardEnable(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetDepthBiasEnable(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetDepthBiasEnable(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetPrimitiveRestartEnable(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetPrimitiveRestartEnable(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceBufferMemoryRequirements(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceBufferMemoryRequirements(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceImageMemoryRequirements(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceImageMemoryRequirements(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceImageSparseMemoryRequirements(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceImageSparseMemoryRequirements(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroySurfaceKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroySurfaceKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceSurfaceSupportKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceSurfaceSupportKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceSurfaceFormatsKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceSurfaceFormatsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceSurfacePresentModesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceSurfacePresentModesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateSwapchainKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateSwapchainKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroySwapchainKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroySwapchainKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetSwapchainImagesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetSwapchainImagesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkAcquireNextImageKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkAcquireNextImageKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkQueuePresentKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkQueuePresentKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceGroupPresentCapabilitiesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceGroupPresentCapabilitiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceGroupSurfacePresentModesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceGroupSurfacePresentModesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDevicePresentRectanglesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDevicePresentRectanglesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkAcquireNextImage2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkAcquireNextImage2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceDisplayPropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceDisplayPropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDisplayPlaneSupportedDisplaysKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDisplayPlaneSupportedDisplaysKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDisplayModePropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDisplayModePropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateDisplayModeKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateDisplayModeKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDisplayPlaneCapabilitiesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDisplayPlaneCapabilitiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateDisplayPlaneSurfaceKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateDisplayPlaneSurfaceKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateSharedSwapchainsKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateSharedSwapchainsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateXlibSurfaceKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateXlibSurfaceKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceXlibPresentationSupportKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceXlibPresentationSupportKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateXcbSurfaceKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateXcbSurfaceKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceXcbPresentationSupportKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceXcbPresentationSupportKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateWaylandSurfaceKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateWaylandSurfaceKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceWaylandPresentationSupportKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceWaylandPresentationSupportKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateAndroidSurfaceKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateAndroidSurfaceKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateWin32SurfaceKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateWin32SurfaceKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceWin32PresentationSupportKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceWin32PresentationSupportKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBeginRenderingKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBeginRenderingKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdEndRenderingKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdEndRenderingKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceFeatures2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceFeatures2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceFormatProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceFormatProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceImageFormatProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceImageFormatProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceQueueFamilyProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceQueueFamilyProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceMemoryProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceMemoryProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceGroupPeerMemoryFeaturesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceGroupPeerMemoryFeaturesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetDeviceMaskKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetDeviceMaskKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDispatchBaseKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDispatchBaseKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkTrimCommandPoolKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkTrimCommandPoolKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkEnumeratePhysicalDeviceGroupsKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkEnumeratePhysicalDeviceGroupsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceExternalBufferPropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceExternalBufferPropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetMemoryWin32HandleKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetMemoryWin32HandleKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetMemoryWin32HandlePropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetMemoryWin32HandlePropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetMemoryFdKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetMemoryFdKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetMemoryFdPropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetMemoryFdPropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkImportSemaphoreWin32HandleKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkImportSemaphoreWin32HandleKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetSemaphoreWin32HandleKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetSemaphoreWin32HandleKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkImportSemaphoreFdKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkImportSemaphoreFdKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetSemaphoreFdKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetSemaphoreFdKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdPushDescriptorSetKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdPushDescriptorSetKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateDescriptorUpdateTemplateKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateDescriptorUpdateTemplateKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyDescriptorUpdateTemplateKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyDescriptorUpdateTemplateKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateRenderPass2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateRenderPass2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBeginRenderPass2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBeginRenderPass2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdNextSubpass2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdNextSubpass2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdEndRenderPass2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdEndRenderPass2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetSwapchainStatusKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetSwapchainStatusKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceExternalFencePropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceExternalFencePropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkImportFenceWin32HandleKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkImportFenceWin32HandleKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetFenceWin32HandleKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetFenceWin32HandleKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkImportFenceFdKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkImportFenceFdKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetFenceFdKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetFenceFdKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkAcquireProfilingLockKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkAcquireProfilingLockKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkReleaseProfilingLockKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkReleaseProfilingLockKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceSurfaceCapabilities2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceSurfaceCapabilities2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceSurfaceFormats2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceSurfaceFormats2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceDisplayProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceDisplayProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDisplayModeProperties2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDisplayModeProperties2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDisplayPlaneCapabilities2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDisplayPlaneCapabilities2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetImageMemoryRequirements2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetImageMemoryRequirements2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetBufferMemoryRequirements2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetBufferMemoryRequirements2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetImageSparseMemoryRequirements2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetImageSparseMemoryRequirements2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateSamplerYcbcrConversionKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateSamplerYcbcrConversionKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroySamplerYcbcrConversionKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroySamplerYcbcrConversionKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkBindBufferMemory2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkBindBufferMemory2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkBindImageMemory2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkBindImageMemory2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDescriptorSetLayoutSupportKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDescriptorSetLayoutSupportKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDrawIndirectCountKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDrawIndirectCountKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDrawIndexedIndirectCountKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDrawIndexedIndirectCountKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetSemaphoreCounterValueKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetSemaphoreCounterValueKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkWaitSemaphoresKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkWaitSemaphoresKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkSignalSemaphoreKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkSignalSemaphoreKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceFragmentShadingRatesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceFragmentShadingRatesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetFragmentShadingRateKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetFragmentShadingRateKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkWaitForPresentKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkWaitForPresentKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetBufferDeviceAddressKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetBufferDeviceAddressKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetBufferOpaqueCaptureAddressKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetBufferOpaqueCaptureAddressKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceMemoryOpaqueCaptureAddressKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceMemoryOpaqueCaptureAddressKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateDeferredOperationKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateDeferredOperationKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyDeferredOperationKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyDeferredOperationKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeferredOperationMaxConcurrencyKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeferredOperationMaxConcurrencyKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeferredOperationResultKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeferredOperationResultKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDeferredOperationJoinKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDeferredOperationJoinKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPipelineExecutablePropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPipelineExecutablePropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPipelineExecutableStatisticsKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPipelineExecutableStatisticsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPipelineExecutableInternalRepresentationsKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPipelineExecutableInternalRepresentationsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetEvent2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetEvent2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdResetEvent2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdResetEvent2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdWaitEvents2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdWaitEvents2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdPipelineBarrier2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdPipelineBarrier2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdWriteTimestamp2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdWriteTimestamp2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkQueueSubmit2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkQueueSubmit2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdWriteBufferMarker2AMD(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdWriteBufferMarker2AMD(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetQueueCheckpointData2NV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetQueueCheckpointData2NV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyBuffer2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyBuffer2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyImage2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyImage2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyBufferToImage2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyBufferToImage2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyImageToBuffer2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyImageToBuffer2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBlitImage2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBlitImage2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdResolveImage2KHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdResolveImage2KHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceBufferMemoryRequirementsKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceBufferMemoryRequirementsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceImageMemoryRequirementsKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceImageMemoryRequirementsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceImageSparseMemoryRequirementsKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceImageSparseMemoryRequirementsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateDebugReportCallbackEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateDebugReportCallbackEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyDebugReportCallbackEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyDebugReportCallbackEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDebugReportMessageEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDebugReportMessageEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDebugMarkerSetObjectTagEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDebugMarkerSetObjectTagEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDebugMarkerSetObjectNameEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDebugMarkerSetObjectNameEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDebugMarkerBeginEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDebugMarkerBeginEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDebugMarkerEndEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDebugMarkerEndEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDebugMarkerInsertEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDebugMarkerInsertEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBindTransformFeedbackBuffersEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBindTransformFeedbackBuffersEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBeginTransformFeedbackEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBeginTransformFeedbackEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdEndTransformFeedbackEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdEndTransformFeedbackEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBeginQueryIndexedEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBeginQueryIndexedEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdEndQueryIndexedEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdEndQueryIndexedEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDrawIndirectByteCountEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDrawIndirectByteCountEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetImageViewHandleNVX(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetImageViewHandleNVX(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetImageViewAddressNVX(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetImageViewAddressNVX(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDrawIndirectCountAMD(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDrawIndirectCountAMD(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDrawIndexedIndirectCountAMD(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDrawIndexedIndirectCountAMD(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetShaderInfoAMD(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetShaderInfoAMD(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateStreamDescriptorSurfaceGGP(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateStreamDescriptorSurfaceGGP(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetMemoryWin32HandleNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetMemoryWin32HandleNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateViSurfaceNN(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateViSurfaceNN(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBeginConditionalRenderingEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBeginConditionalRenderingEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdEndConditionalRenderingEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdEndConditionalRenderingEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetViewportWScalingNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetViewportWScalingNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkReleaseDisplayEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkReleaseDisplayEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkAcquireXlibDisplayEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkAcquireXlibDisplayEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetRandROutputDisplayEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetRandROutputDisplayEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceSurfaceCapabilities2EXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceSurfaceCapabilities2EXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDisplayPowerControlEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDisplayPowerControlEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkRegisterDeviceEventEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkRegisterDeviceEventEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkRegisterDisplayEventEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkRegisterDisplayEventEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetSwapchainCounterEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetSwapchainCounterEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetRefreshCycleDurationGOOGLE(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetRefreshCycleDurationGOOGLE(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPastPresentationTimingGOOGLE(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPastPresentationTimingGOOGLE(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetDiscardRectangleEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetDiscardRectangleEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkSetHdrMetadataEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkSetHdrMetadataEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateIOSSurfaceMVK(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateIOSSurfaceMVK(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateMacOSSurfaceMVK(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateMacOSSurfaceMVK(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkSetDebugUtilsObjectNameEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkSetDebugUtilsObjectNameEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkSetDebugUtilsObjectTagEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkSetDebugUtilsObjectTagEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkQueueBeginDebugUtilsLabelEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkQueueBeginDebugUtilsLabelEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkQueueEndDebugUtilsLabelEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkQueueEndDebugUtilsLabelEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkQueueInsertDebugUtilsLabelEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkQueueInsertDebugUtilsLabelEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBeginDebugUtilsLabelEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBeginDebugUtilsLabelEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdEndDebugUtilsLabelEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdEndDebugUtilsLabelEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdInsertDebugUtilsLabelEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdInsertDebugUtilsLabelEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateDebugUtilsMessengerEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateDebugUtilsMessengerEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyDebugUtilsMessengerEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyDebugUtilsMessengerEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkSubmitDebugUtilsMessageEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkSubmitDebugUtilsMessageEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetAndroidHardwareBufferPropertiesANDROID(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetAndroidHardwareBufferPropertiesANDROID(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetMemoryAndroidHardwareBufferANDROID(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetMemoryAndroidHardwareBufferANDROID(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetSampleLocationsEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetSampleLocationsEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceMultisamplePropertiesEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceMultisamplePropertiesEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetImageDrmFormatModifierPropertiesEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetImageDrmFormatModifierPropertiesEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateValidationCacheEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateValidationCacheEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyValidationCacheEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyValidationCacheEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkMergeValidationCachesEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkMergeValidationCachesEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetValidationCacheDataEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetValidationCacheDataEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBindShadingRateImageNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBindShadingRateImageNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetViewportShadingRatePaletteNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetViewportShadingRatePaletteNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetCoarseSampleOrderNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetCoarseSampleOrderNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateAccelerationStructureNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateAccelerationStructureNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyAccelerationStructureNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyAccelerationStructureNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetAccelerationStructureMemoryRequirementsNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetAccelerationStructureMemoryRequirementsNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkBindAccelerationStructureMemoryNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkBindAccelerationStructureMemoryNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBuildAccelerationStructureNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBuildAccelerationStructureNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyAccelerationStructureNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyAccelerationStructureNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdTraceRaysNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdTraceRaysNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateRayTracingPipelinesNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateRayTracingPipelinesNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetRayTracingShaderGroupHandlesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetRayTracingShaderGroupHandlesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetRayTracingShaderGroupHandlesNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetRayTracingShaderGroupHandlesNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetAccelerationStructureHandleNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetAccelerationStructureHandleNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdWriteAccelerationStructuresPropertiesNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdWriteAccelerationStructuresPropertiesNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCompileDeferredNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCompileDeferredNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetMemoryHostPointerPropertiesEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetMemoryHostPointerPropertiesEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdWriteBufferMarkerAMD(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdWriteBufferMarkerAMD(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetCalibratedTimestampsEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetCalibratedTimestampsEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDrawMeshTasksNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDrawMeshTasksNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDrawMeshTasksIndirectNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDrawMeshTasksIndirectNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDrawMeshTasksIndirectCountNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDrawMeshTasksIndirectCountNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetExclusiveScissorNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetExclusiveScissorNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetCheckpointNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetCheckpointNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetQueueCheckpointDataNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetQueueCheckpointDataNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkInitializePerformanceApiINTEL(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkInitializePerformanceApiINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkUninitializePerformanceApiINTEL(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkUninitializePerformanceApiINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetPerformanceMarkerINTEL(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetPerformanceMarkerINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetPerformanceStreamMarkerINTEL(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetPerformanceStreamMarkerINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetPerformanceOverrideINTEL(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetPerformanceOverrideINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkAcquirePerformanceConfigurationINTEL(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkAcquirePerformanceConfigurationINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkReleasePerformanceConfigurationINTEL(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkReleasePerformanceConfigurationINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkQueueSetPerformanceConfigurationINTEL(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkQueueSetPerformanceConfigurationINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPerformanceParameterINTEL(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPerformanceParameterINTEL(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkSetLocalDimmingAMD(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkSetLocalDimmingAMD(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateImagePipeSurfaceFUCHSIA(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateImagePipeSurfaceFUCHSIA(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateMetalSurfaceEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateMetalSurfaceEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetBufferDeviceAddressEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetBufferDeviceAddressEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceToolPropertiesEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceToolPropertiesEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceSurfacePresentModes2EXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceSurfacePresentModes2EXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkAcquireFullScreenExclusiveModeEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkAcquireFullScreenExclusiveModeEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkReleaseFullScreenExclusiveModeEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkReleaseFullScreenExclusiveModeEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceGroupSurfacePresentModes2EXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceGroupSurfacePresentModes2EXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateHeadlessSurfaceEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateHeadlessSurfaceEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetLineStippleEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetLineStippleEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkResetQueryPoolEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkResetQueryPoolEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetCullModeEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetCullModeEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetFrontFaceEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetFrontFaceEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetPrimitiveTopologyEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetPrimitiveTopologyEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetViewportWithCountEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetViewportWithCountEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetScissorWithCountEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetScissorWithCountEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBindVertexBuffers2EXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBindVertexBuffers2EXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetDepthTestEnableEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetDepthTestEnableEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetDepthWriteEnableEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetDepthWriteEnableEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetDepthCompareOpEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetDepthCompareOpEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetDepthBoundsTestEnableEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetDepthBoundsTestEnableEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetStencilTestEnableEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetStencilTestEnableEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetStencilOpEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetStencilOpEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetGeneratedCommandsMemoryRequirementsNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetGeneratedCommandsMemoryRequirementsNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdPreprocessGeneratedCommandsNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdPreprocessGeneratedCommandsNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdExecuteGeneratedCommandsNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdExecuteGeneratedCommandsNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBindPipelineShaderGroupNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBindPipelineShaderGroupNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateIndirectCommandsLayoutNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateIndirectCommandsLayoutNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyIndirectCommandsLayoutNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyIndirectCommandsLayoutNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkAcquireDrmDisplayEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkAcquireDrmDisplayEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDrmDisplayEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDrmDisplayEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreatePrivateDataSlotEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreatePrivateDataSlotEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyPrivateDataSlotEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyPrivateDataSlotEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkSetPrivateDataEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkSetPrivateDataEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPrivateDataEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPrivateDataEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetFragmentShadingRateEnumNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetFragmentShadingRateEnumNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkAcquireWinrtDisplayNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkAcquireWinrtDisplayNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetWinrtDisplayNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetWinrtDisplayNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateDirectFBSurfaceEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateDirectFBSurfaceEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceDirectFBPresentationSupportEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceDirectFBPresentationSupportEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetVertexInputEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetVertexInputEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetMemoryZirconHandleFUCHSIA(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetMemoryZirconHandleFUCHSIA(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetMemoryZirconHandlePropertiesFUCHSIA(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetMemoryZirconHandlePropertiesFUCHSIA(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkImportSemaphoreZirconHandleFUCHSIA(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkImportSemaphoreZirconHandleFUCHSIA(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetSemaphoreZirconHandleFUCHSIA(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetSemaphoreZirconHandleFUCHSIA(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBindInvocationMaskHUAWEI(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBindInvocationMaskHUAWEI(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetMemoryRemoteAddressNV(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetMemoryRemoteAddressNV(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetPatchControlPointsEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetPatchControlPointsEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetRasterizerDiscardEnableEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetRasterizerDiscardEnableEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetDepthBiasEnableEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetDepthBiasEnableEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetLogicOpEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetLogicOpEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetPrimitiveRestartEnableEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetPrimitiveRestartEnableEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateScreenSurfaceQNX(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateScreenSurfaceQNX(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetPhysicalDeviceScreenPresentationSupportQNX(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetPhysicalDeviceScreenPresentationSupportQNX(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetColorWriteEnableEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetColorWriteEnableEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDrawMultiEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDrawMultiEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdDrawMultiIndexedEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdDrawMultiIndexedEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkSetDeviceMemoryPriorityEXT(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkSetDeviceMemoryPriorityEXT(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateAccelerationStructureKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateAccelerationStructureKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDestroyAccelerationStructureKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkDestroyAccelerationStructureKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBuildAccelerationStructuresKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBuildAccelerationStructuresKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdBuildAccelerationStructuresIndirectKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdBuildAccelerationStructuresIndirectKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCopyAccelerationStructureToMemoryKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCopyAccelerationStructureToMemoryKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCopyMemoryToAccelerationStructureKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCopyMemoryToAccelerationStructureKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkWriteAccelerationStructuresPropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkWriteAccelerationStructuresPropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyAccelerationStructureKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyAccelerationStructureKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyAccelerationStructureToMemoryKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyAccelerationStructureToMemoryKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdCopyMemoryToAccelerationStructureKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdCopyMemoryToAccelerationStructureKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetAccelerationStructureDeviceAddressKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetAccelerationStructureDeviceAddressKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdWriteAccelerationStructuresPropertiesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdWriteAccelerationStructuresPropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetDeviceAccelerationStructureCompatibilityKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetDeviceAccelerationStructureCompatibilityKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetAccelerationStructureBuildSizesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetAccelerationStructureBuildSizesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdTraceRaysKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdTraceRaysKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateRayTracingPipelinesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCreateRayTracingPipelinesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdTraceRaysIndirectKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdTraceRaysIndirectKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkGetRayTracingShaderGroupStackSizeKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkGetRayTracingShaderGroupStackSizeKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCmdSetRayTracingPipelineStackSizeKHR(const uint8_t* parameter_buffer, size_t buffer_size);
+    size_t Decode_vkCmdSetRayTracingPipelineStackSizeKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
@@ -34,6 +34,7 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 void VulkanReferencedResourceConsumer::Process_vkBeginCommandBuffer(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo)
@@ -52,6 +53,7 @@ void VulkanReferencedResourceConsumer::Process_vkBeginCommandBuffer(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBindDescriptorSets(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineBindPoint                         pipelineBindPoint,
     format::HandleId                            layout,
@@ -82,6 +84,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBindDescriptorSets(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBindIndexBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -94,6 +97,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBindIndexBuffer(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBindVertexBuffers(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstBinding,
     uint32_t                                    bindingCount,
@@ -118,6 +122,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBindVertexBuffers(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndirect(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -132,6 +137,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndirect(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndexedIndirect(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -146,6 +152,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndexedIndirect(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdDispatchIndirect(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset)
@@ -156,6 +163,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdDispatchIndirect(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdCopyBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcBuffer,
     format::HandleId                            dstBuffer,
@@ -170,6 +178,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdCopyBuffer(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdCopyImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcImage,
     VkImageLayout                               srcImageLayout,
@@ -188,6 +197,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdCopyImage(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBlitImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcImage,
     VkImageLayout                               srcImageLayout,
@@ -208,6 +218,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBlitImage(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdCopyBufferToImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcBuffer,
     format::HandleId                            dstImage,
@@ -224,6 +235,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdCopyBufferToImage(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdCopyImageToBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcImage,
     VkImageLayout                               srcImageLayout,
@@ -240,6 +252,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdCopyImageToBuffer(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdUpdateBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            dstBuffer,
     VkDeviceSize                                dstOffset,
@@ -254,6 +267,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdUpdateBuffer(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdFillBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            dstBuffer,
     VkDeviceSize                                dstOffset,
@@ -268,6 +282,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdFillBuffer(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdClearColorImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            image,
     VkImageLayout                               imageLayout,
@@ -284,6 +299,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdClearColorImage(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdClearDepthStencilImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            image,
     VkImageLayout                               imageLayout,
@@ -300,6 +316,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdClearDepthStencilImage(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdResolveImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcImage,
     VkImageLayout                               srcImageLayout,
@@ -318,6 +335,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdResolveImage(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdWaitEvents(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    eventCount,
     HandlePointerDecoder<VkEvent>*              pEvents,
@@ -365,6 +383,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdWaitEvents(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdPipelineBarrier(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineStageFlags                        srcStageMask,
     VkPipelineStageFlags                        dstStageMask,
@@ -410,6 +429,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPipelineBarrier(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdCopyQueryPoolResults(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            queryPool,
     uint32_t                                    firstQuery,
@@ -430,6 +450,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdCopyQueryPoolResults(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBeginRenderPass(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
     VkSubpassContents                           contents)
@@ -474,6 +495,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBeginRenderPass(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdExecuteCommands(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    commandBufferCount,
     HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers)
@@ -494,6 +516,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdExecuteCommands(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndirectCount(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -512,6 +535,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndirectCount(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndexedIndirectCount(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -530,6 +554,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndexedIndirectCount(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBeginRenderPass2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
     StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo)
@@ -574,6 +599,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBeginRenderPass2(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdSetEvent2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            event,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo)
@@ -608,6 +634,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdSetEvent2(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdWaitEvents2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    eventCount,
     HandlePointerDecoder<VkEvent>*              pEvents,
@@ -648,6 +675,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdWaitEvents2(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdPipelineBarrier2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo)
 {
@@ -679,6 +707,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPipelineBarrier2(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdCopyBuffer2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyBufferInfo2>* pCopyBufferInfo)
 {
@@ -693,6 +722,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdCopyBuffer2(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdCopyImage2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyImageInfo2>* pCopyImageInfo)
 {
@@ -707,6 +737,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdCopyImage2(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdCopyBufferToImage2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2>* pCopyBufferToImageInfo)
 {
@@ -721,6 +752,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdCopyBufferToImage2(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdCopyImageToBuffer2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2>* pCopyImageToBufferInfo)
 {
@@ -735,6 +767,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdCopyImageToBuffer2(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBlitImage2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkBlitImageInfo2>* pBlitImageInfo)
 {
@@ -749,6 +782,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBlitImage2(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdResolveImage2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkResolveImageInfo2>* pResolveImageInfo)
 {
@@ -763,6 +797,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdResolveImage2(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBeginRendering(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo)
 {
@@ -826,6 +861,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBeginRendering(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBindVertexBuffers2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstBinding,
     uint32_t                                    bindingCount,
@@ -854,6 +890,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBindVertexBuffers2(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBeginRenderingKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo)
 {
@@ -917,6 +954,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBeginRenderingKHR(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdPushDescriptorSetKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineBindPoint                         pipelineBindPoint,
     format::HandleId                            layout,
@@ -973,6 +1011,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPushDescriptorSetKHR(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBeginRenderPass2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
     StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo)
@@ -1017,6 +1056,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBeginRenderPass2KHR(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndirectCountKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -1035,6 +1075,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndirectCountKHR(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndexedIndirectCountKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -1053,6 +1094,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndexedIndirectCountKHR(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdSetEvent2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            event,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo)
@@ -1087,6 +1129,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdSetEvent2KHR(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdWaitEvents2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    eventCount,
     HandlePointerDecoder<VkEvent>*              pEvents,
@@ -1127,6 +1170,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdWaitEvents2KHR(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdPipelineBarrier2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo)
 {
@@ -1158,6 +1202,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPipelineBarrier2KHR(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdWriteBufferMarker2AMD(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineStageFlags2                       stage,
     format::HandleId                            dstBuffer,
@@ -1172,6 +1217,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdWriteBufferMarker2AMD(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdCopyBuffer2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyBufferInfo2>* pCopyBufferInfo)
 {
@@ -1186,6 +1232,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdCopyBuffer2KHR(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdCopyImage2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyImageInfo2>* pCopyImageInfo)
 {
@@ -1200,6 +1247,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdCopyImage2KHR(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdCopyBufferToImage2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2>* pCopyBufferToImageInfo)
 {
@@ -1214,6 +1262,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdCopyBufferToImage2KHR(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdCopyImageToBuffer2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2>* pCopyImageToBufferInfo)
 {
@@ -1228,6 +1277,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdCopyImageToBuffer2KHR(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBlitImage2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkBlitImageInfo2>* pBlitImageInfo)
 {
@@ -1242,6 +1292,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBlitImage2KHR(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdResolveImage2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkResolveImageInfo2>* pResolveImageInfo)
 {
@@ -1256,6 +1307,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdResolveImage2KHR(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBindTransformFeedbackBuffersEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstBinding,
     uint32_t                                    bindingCount,
@@ -1282,6 +1334,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBindTransformFeedbackBuffers
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBeginTransformFeedbackEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstCounterBuffer,
     uint32_t                                    counterBufferCount,
@@ -1306,6 +1359,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBeginTransformFeedbackEXT(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdEndTransformFeedbackEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstCounterBuffer,
     uint32_t                                    counterBufferCount,
@@ -1330,6 +1384,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdEndTransformFeedbackEXT(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndirectByteCountEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    instanceCount,
     uint32_t                                    firstInstance,
@@ -1348,6 +1403,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndirectByteCountEXT(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndirectCountAMD(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -1366,6 +1422,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndirectCountAMD(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndexedIndirectCountAMD(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -1384,6 +1441,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdDrawIndexedIndirectCountAMD(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBeginConditionalRenderingEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>* pConditionalRenderingBegin)
 {
@@ -1397,6 +1455,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBeginConditionalRenderingEXT
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBindShadingRateImageNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            imageView,
     VkImageLayout                               imageLayout)
@@ -1407,6 +1466,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBindShadingRateImageNV(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBuildAccelerationStructureNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>* pInfo,
     format::HandleId                            instanceData,
@@ -1446,6 +1506,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBuildAccelerationStructureNV
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdTraceRaysNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            raygenShaderBindingTableBuffer,
     VkDeviceSize                                raygenShaderBindingOffset,
@@ -1480,6 +1541,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdTraceRaysNV(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdWriteBufferMarkerAMD(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineStageFlagBits                     pipelineStage,
     format::HandleId                            dstBuffer,
@@ -1494,6 +1556,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdWriteBufferMarkerAMD(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdDrawMeshTasksIndirectNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -1508,6 +1571,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdDrawMeshTasksIndirectNV(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdDrawMeshTasksIndirectCountNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -1526,6 +1590,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdDrawMeshTasksIndirectCountNV
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBindVertexBuffers2EXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstBinding,
     uint32_t                                    bindingCount,
@@ -1554,6 +1619,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdBindVertexBuffers2EXT(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdPreprocessGeneratedCommandsNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo)
 {
@@ -1578,6 +1644,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdPreprocessGeneratedCommandsN
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdExecuteGeneratedCommandsNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    isPreprocessed,
     StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo)
@@ -1605,6 +1672,7 @@ void VulkanReferencedResourceConsumer::Process_vkCmdExecuteGeneratedCommandsNV(
 }
 
 void VulkanReferencedResourceConsumer::Process_vkCmdBindInvocationMaskHUAWEI(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            imageView,
     VkImageLayout                               imageLayout)

--- a/framework/generated/generated_vulkan_referenced_resource_consumer.h
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.h
@@ -42,11 +42,13 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
     virtual ~VulkanReferencedResourceConsumer() override { }
 
     virtual void Process_vkBeginCommandBuffer(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo) override;
 
     virtual void Process_vkCmdBindDescriptorSets(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineBindPoint                         pipelineBindPoint,
         format::HandleId                            layout,
@@ -57,12 +59,14 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         PointerDecoder<uint32_t>*                   pDynamicOffsets) override;
 
     virtual void Process_vkCmdBindIndexBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
         VkIndexType                                 indexType) override;
 
     virtual void Process_vkCmdBindVertexBuffers(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
@@ -70,6 +74,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         PointerDecoder<VkDeviceSize>*               pOffsets) override;
 
     virtual void Process_vkCmdDrawIndirect(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -77,6 +82,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawIndexedIndirect(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -84,11 +90,13 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDispatchIndirect(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset) override;
 
     virtual void Process_vkCmdCopyBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcBuffer,
         format::HandleId                            dstBuffer,
@@ -96,6 +104,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         StructPointerDecoder<Decoded_VkBufferCopy>* pRegions) override;
 
     virtual void Process_vkCmdCopyImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcImage,
         VkImageLayout                               srcImageLayout,
@@ -105,6 +114,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         StructPointerDecoder<Decoded_VkImageCopy>*  pRegions) override;
 
     virtual void Process_vkCmdBlitImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcImage,
         VkImageLayout                               srcImageLayout,
@@ -115,6 +125,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         VkFilter                                    filter) override;
 
     virtual void Process_vkCmdCopyBufferToImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcBuffer,
         format::HandleId                            dstImage,
@@ -123,6 +134,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions) override;
 
     virtual void Process_vkCmdCopyImageToBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcImage,
         VkImageLayout                               srcImageLayout,
@@ -131,6 +143,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions) override;
 
     virtual void Process_vkCmdUpdateBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            dstBuffer,
         VkDeviceSize                                dstOffset,
@@ -138,6 +151,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkCmdFillBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            dstBuffer,
         VkDeviceSize                                dstOffset,
@@ -145,6 +159,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         uint32_t                                    data) override;
 
     virtual void Process_vkCmdClearColorImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            image,
         VkImageLayout                               imageLayout,
@@ -153,6 +168,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges) override;
 
     virtual void Process_vkCmdClearDepthStencilImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            image,
         VkImageLayout                               imageLayout,
@@ -161,6 +177,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges) override;
 
     virtual void Process_vkCmdResolveImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcImage,
         VkImageLayout                               srcImageLayout,
@@ -170,6 +187,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         StructPointerDecoder<Decoded_VkImageResolve>* pRegions) override;
 
     virtual void Process_vkCmdWaitEvents(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    eventCount,
         HandlePointerDecoder<VkEvent>*              pEvents,
@@ -183,6 +201,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers) override;
 
     virtual void Process_vkCmdPipelineBarrier(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlags                        srcStageMask,
         VkPipelineStageFlags                        dstStageMask,
@@ -195,6 +214,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers) override;
 
     virtual void Process_vkCmdCopyQueryPoolResults(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery,
@@ -205,16 +225,19 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         VkQueryResultFlags                          flags) override;
 
     virtual void Process_vkCmdBeginRenderPass(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
         VkSubpassContents                           contents) override;
 
     virtual void Process_vkCmdExecuteCommands(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    commandBufferCount,
         HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) override;
 
     virtual void Process_vkCmdDrawIndirectCount(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -224,6 +247,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawIndexedIndirectCount(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -233,54 +257,66 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdBeginRenderPass2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
         StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo) override;
 
     virtual void Process_vkCmdSetEvent2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo) override;
 
     virtual void Process_vkCmdWaitEvents2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    eventCount,
         HandlePointerDecoder<VkEvent>*              pEvents,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfos) override;
 
     virtual void Process_vkCmdPipelineBarrier2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo) override;
 
     virtual void Process_vkCmdCopyBuffer2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyBufferInfo2>* pCopyBufferInfo) override;
 
     virtual void Process_vkCmdCopyImage2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyImageInfo2>* pCopyImageInfo) override;
 
     virtual void Process_vkCmdCopyBufferToImage2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2>* pCopyBufferToImageInfo) override;
 
     virtual void Process_vkCmdCopyImageToBuffer2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2>* pCopyImageToBufferInfo) override;
 
     virtual void Process_vkCmdBlitImage2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkBlitImageInfo2>* pBlitImageInfo) override;
 
     virtual void Process_vkCmdResolveImage2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkResolveImageInfo2>* pResolveImageInfo) override;
 
     virtual void Process_vkCmdBeginRendering(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo) override;
 
     virtual void Process_vkCmdBindVertexBuffers2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
@@ -290,10 +326,12 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         PointerDecoder<VkDeviceSize>*               pStrides) override;
 
     virtual void Process_vkCmdBeginRenderingKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo) override;
 
     virtual void Process_vkCmdPushDescriptorSetKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineBindPoint                         pipelineBindPoint,
         format::HandleId                            layout,
@@ -302,11 +340,13 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites) override;
 
     virtual void Process_vkCmdBeginRenderPass2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
         StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo) override;
 
     virtual void Process_vkCmdDrawIndirectCountKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -316,6 +356,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawIndexedIndirectCountKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -325,21 +366,25 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdSetEvent2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo) override;
 
     virtual void Process_vkCmdWaitEvents2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    eventCount,
         HandlePointerDecoder<VkEvent>*              pEvents,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfos) override;
 
     virtual void Process_vkCmdPipelineBarrier2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo) override;
 
     virtual void Process_vkCmdWriteBufferMarker2AMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlags2                       stage,
         format::HandleId                            dstBuffer,
@@ -347,30 +392,37 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         uint32_t                                    marker) override;
 
     virtual void Process_vkCmdCopyBuffer2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyBufferInfo2>* pCopyBufferInfo) override;
 
     virtual void Process_vkCmdCopyImage2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyImageInfo2>* pCopyImageInfo) override;
 
     virtual void Process_vkCmdCopyBufferToImage2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2>* pCopyBufferToImageInfo) override;
 
     virtual void Process_vkCmdCopyImageToBuffer2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2>* pCopyImageToBufferInfo) override;
 
     virtual void Process_vkCmdBlitImage2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkBlitImageInfo2>* pBlitImageInfo) override;
 
     virtual void Process_vkCmdResolveImage2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkResolveImageInfo2>* pResolveImageInfo) override;
 
     virtual void Process_vkCmdBindTransformFeedbackBuffersEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
@@ -379,6 +431,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         PointerDecoder<VkDeviceSize>*               pSizes) override;
 
     virtual void Process_vkCmdBeginTransformFeedbackEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstCounterBuffer,
         uint32_t                                    counterBufferCount,
@@ -386,6 +439,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets) override;
 
     virtual void Process_vkCmdEndTransformFeedbackEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstCounterBuffer,
         uint32_t                                    counterBufferCount,
@@ -393,6 +447,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets) override;
 
     virtual void Process_vkCmdDrawIndirectByteCountEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    instanceCount,
         uint32_t                                    firstInstance,
@@ -402,6 +457,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         uint32_t                                    vertexStride) override;
 
     virtual void Process_vkCmdDrawIndirectCountAMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -411,6 +467,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawIndexedIndirectCountAMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -420,15 +477,18 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdBeginConditionalRenderingEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>* pConditionalRenderingBegin) override;
 
     virtual void Process_vkCmdBindShadingRateImageNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            imageView,
         VkImageLayout                               imageLayout) override;
 
     virtual void Process_vkCmdBuildAccelerationStructureNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>* pInfo,
         format::HandleId                            instanceData,
@@ -440,6 +500,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         VkDeviceSize                                scratchOffset) override;
 
     virtual void Process_vkCmdTraceRaysNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            raygenShaderBindingTableBuffer,
         VkDeviceSize                                raygenShaderBindingOffset,
@@ -457,6 +518,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         uint32_t                                    depth) override;
 
     virtual void Process_vkCmdWriteBufferMarkerAMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlagBits                     pipelineStage,
         format::HandleId                            dstBuffer,
@@ -464,6 +526,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         uint32_t                                    marker) override;
 
     virtual void Process_vkCmdDrawMeshTasksIndirectNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -471,6 +534,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawMeshTasksIndirectCountNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -480,6 +544,7 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdBindVertexBuffers2EXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
@@ -489,15 +554,18 @@ class VulkanReferencedResourceConsumer : public VulkanReferencedResourceConsumer
         PointerDecoder<VkDeviceSize>*               pStrides) override;
 
     virtual void Process_vkCmdPreprocessGeneratedCommandsNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo) override;
 
     virtual void Process_vkCmdExecuteGeneratedCommandsNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    isPreprocessed,
         StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo) override;
 
     virtual void Process_vkCmdBindInvocationMaskHUAWEI(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            imageView,
         VkImageLayout                               imageLayout) override;

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -38,6 +38,7 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 void VulkanReplayConsumer::Process_vkCreateInstance(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     StructPointerDecoder<Decoded_VkInstanceCreateInfo>* pCreateInfo,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
@@ -54,6 +55,7 @@ void VulkanReplayConsumer::Process_vkCreateInstance(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyInstance(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
@@ -65,6 +67,7 @@ void VulkanReplayConsumer::Process_vkDestroyInstance(
 }
 
 void VulkanReplayConsumer::Process_vkEnumeratePhysicalDevices(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     PointerDecoder<uint32_t>*                   pPhysicalDeviceCount,
@@ -84,6 +87,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDevices(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFeatures(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures>* pFeatures)
 {
@@ -94,6 +98,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFeatures(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFormatProperties(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     VkFormat                                    format,
     StructPointerDecoder<Decoded_VkFormatProperties>* pFormatProperties)
@@ -105,6 +110,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFormatProperties(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     VkFormat                                    format,
@@ -122,6 +128,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceProperties(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceProperties>* pProperties)
 {
@@ -132,6 +139,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceProperties(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
     StructPointerDecoder<Decoded_VkQueueFamilyProperties>* pQueueFamilyProperties)
@@ -146,6 +154,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMemoryProperties(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties>* pMemoryProperties)
 {
@@ -156,6 +165,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMemoryProperties(
 }
 
 void VulkanReplayConsumer::Process_vkCreateDevice(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkDeviceCreateInfo>* pCreateInfo,
@@ -176,6 +186,7 @@ void VulkanReplayConsumer::Process_vkCreateDevice(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDevice(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
 {
@@ -186,6 +197,7 @@ void VulkanReplayConsumer::Process_vkDestroyDevice(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceQueue(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     uint32_t                                    queueFamilyIndex,
     uint32_t                                    queueIndex,
@@ -201,6 +213,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceQueue(
 }
 
 void VulkanReplayConsumer::Process_vkQueueSubmit(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            queue,
     uint32_t                                    submitCount,
@@ -217,6 +230,7 @@ void VulkanReplayConsumer::Process_vkQueueSubmit(
 }
 
 void VulkanReplayConsumer::Process_vkQueueWaitIdle(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            queue)
 {
@@ -227,6 +241,7 @@ void VulkanReplayConsumer::Process_vkQueueWaitIdle(
 }
 
 void VulkanReplayConsumer::Process_vkDeviceWaitIdle(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device)
 {
@@ -237,6 +252,7 @@ void VulkanReplayConsumer::Process_vkDeviceWaitIdle(
 }
 
 void VulkanReplayConsumer::Process_vkAllocateMemory(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkMemoryAllocateInfo>* pAllocateInfo,
@@ -257,6 +273,7 @@ void VulkanReplayConsumer::Process_vkAllocateMemory(
 }
 
 void VulkanReplayConsumer::Process_vkFreeMemory(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            memory,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -269,6 +286,7 @@ void VulkanReplayConsumer::Process_vkFreeMemory(
 }
 
 void VulkanReplayConsumer::Process_vkMapMemory(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            memory,
@@ -288,6 +306,7 @@ void VulkanReplayConsumer::Process_vkMapMemory(
 }
 
 void VulkanReplayConsumer::Process_vkUnmapMemory(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            memory)
 {
@@ -298,6 +317,7 @@ void VulkanReplayConsumer::Process_vkUnmapMemory(
 }
 
 void VulkanReplayConsumer::Process_vkFlushMappedMemoryRanges(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    memoryRangeCount,
@@ -312,6 +332,7 @@ void VulkanReplayConsumer::Process_vkFlushMappedMemoryRanges(
 }
 
 void VulkanReplayConsumer::Process_vkInvalidateMappedMemoryRanges(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    memoryRangeCount,
@@ -326,6 +347,7 @@ void VulkanReplayConsumer::Process_vkInvalidateMappedMemoryRanges(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceMemoryCommitment(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            memory,
     PointerDecoder<VkDeviceSize>*               pCommittedMemoryInBytes)
@@ -338,6 +360,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceMemoryCommitment(
 }
 
 void VulkanReplayConsumer::Process_vkBindBufferMemory(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            buffer,
@@ -353,6 +376,7 @@ void VulkanReplayConsumer::Process_vkBindBufferMemory(
 }
 
 void VulkanReplayConsumer::Process_vkBindImageMemory(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            image,
@@ -368,6 +392,7 @@ void VulkanReplayConsumer::Process_vkBindImageMemory(
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferMemoryRequirements(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            buffer,
     StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements)
@@ -380,6 +405,7 @@ void VulkanReplayConsumer::Process_vkGetBufferMemoryRequirements(
 }
 
 void VulkanReplayConsumer::Process_vkGetImageMemoryRequirements(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            image,
     StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements)
@@ -392,6 +418,7 @@ void VulkanReplayConsumer::Process_vkGetImageMemoryRequirements(
 }
 
 void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            image,
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
@@ -408,6 +435,7 @@ void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     VkFormat                                    format,
     VkImageType                                 type,
@@ -427,6 +455,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
 }
 
 void VulkanReplayConsumer::Process_vkQueueBindSparse(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            queue,
     uint32_t                                    bindInfoCount,
@@ -443,6 +472,7 @@ void VulkanReplayConsumer::Process_vkQueueBindSparse(
 }
 
 void VulkanReplayConsumer::Process_vkCreateFence(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkFenceCreateInfo>* pCreateInfo,
@@ -462,6 +492,7 @@ void VulkanReplayConsumer::Process_vkCreateFence(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyFence(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            fence,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -475,6 +506,7 @@ void VulkanReplayConsumer::Process_vkDestroyFence(
 }
 
 void VulkanReplayConsumer::Process_vkResetFences(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    fenceCount,
@@ -488,6 +520,7 @@ void VulkanReplayConsumer::Process_vkResetFences(
 }
 
 void VulkanReplayConsumer::Process_vkGetFenceStatus(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            fence)
@@ -500,6 +533,7 @@ void VulkanReplayConsumer::Process_vkGetFenceStatus(
 }
 
 void VulkanReplayConsumer::Process_vkWaitForFences(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    fenceCount,
@@ -515,6 +549,7 @@ void VulkanReplayConsumer::Process_vkWaitForFences(
 }
 
 void VulkanReplayConsumer::Process_vkCreateSemaphore(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreCreateInfo>* pCreateInfo,
@@ -534,6 +569,7 @@ void VulkanReplayConsumer::Process_vkCreateSemaphore(
 }
 
 void VulkanReplayConsumer::Process_vkDestroySemaphore(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            semaphore,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -547,6 +583,7 @@ void VulkanReplayConsumer::Process_vkDestroySemaphore(
 }
 
 void VulkanReplayConsumer::Process_vkCreateEvent(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkEventCreateInfo>* pCreateInfo,
@@ -566,6 +603,7 @@ void VulkanReplayConsumer::Process_vkCreateEvent(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyEvent(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            event,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -579,6 +617,7 @@ void VulkanReplayConsumer::Process_vkDestroyEvent(
 }
 
 void VulkanReplayConsumer::Process_vkGetEventStatus(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            event)
@@ -591,6 +630,7 @@ void VulkanReplayConsumer::Process_vkGetEventStatus(
 }
 
 void VulkanReplayConsumer::Process_vkSetEvent(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            event)
@@ -603,6 +643,7 @@ void VulkanReplayConsumer::Process_vkSetEvent(
 }
 
 void VulkanReplayConsumer::Process_vkResetEvent(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            event)
@@ -615,6 +656,7 @@ void VulkanReplayConsumer::Process_vkResetEvent(
 }
 
 void VulkanReplayConsumer::Process_vkCreateQueryPool(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkQueryPoolCreateInfo>* pCreateInfo,
@@ -634,6 +676,7 @@ void VulkanReplayConsumer::Process_vkCreateQueryPool(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyQueryPool(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            queryPool,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -647,6 +690,7 @@ void VulkanReplayConsumer::Process_vkDestroyQueryPool(
 }
 
 void VulkanReplayConsumer::Process_vkGetQueryPoolResults(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            queryPool,
@@ -666,6 +710,7 @@ void VulkanReplayConsumer::Process_vkGetQueryPoolResults(
 }
 
 void VulkanReplayConsumer::Process_vkCreateBuffer(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferCreateInfo>* pCreateInfo,
@@ -686,6 +731,7 @@ void VulkanReplayConsumer::Process_vkCreateBuffer(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            buffer,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -698,6 +744,7 @@ void VulkanReplayConsumer::Process_vkDestroyBuffer(
 }
 
 void VulkanReplayConsumer::Process_vkCreateBufferView(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferViewCreateInfo>* pCreateInfo,
@@ -718,6 +765,7 @@ void VulkanReplayConsumer::Process_vkCreateBufferView(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyBufferView(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            bufferView,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -731,6 +779,7 @@ void VulkanReplayConsumer::Process_vkDestroyBufferView(
 }
 
 void VulkanReplayConsumer::Process_vkCreateImage(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImageCreateInfo>* pCreateInfo,
@@ -751,6 +800,7 @@ void VulkanReplayConsumer::Process_vkCreateImage(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            image,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -763,6 +813,7 @@ void VulkanReplayConsumer::Process_vkDestroyImage(
 }
 
 void VulkanReplayConsumer::Process_vkGetImageSubresourceLayout(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            image,
     StructPointerDecoder<Decoded_VkImageSubresource>* pSubresource,
@@ -776,6 +827,7 @@ void VulkanReplayConsumer::Process_vkGetImageSubresourceLayout(
 }
 
 void VulkanReplayConsumer::Process_vkCreateImageView(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImageViewCreateInfo>* pCreateInfo,
@@ -796,6 +848,7 @@ void VulkanReplayConsumer::Process_vkCreateImageView(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyImageView(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            imageView,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -809,6 +862,7 @@ void VulkanReplayConsumer::Process_vkDestroyImageView(
 }
 
 void VulkanReplayConsumer::Process_vkCreateShaderModule(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>* pCreateInfo,
@@ -829,6 +883,7 @@ void VulkanReplayConsumer::Process_vkCreateShaderModule(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyShaderModule(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            shaderModule,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -842,6 +897,7 @@ void VulkanReplayConsumer::Process_vkDestroyShaderModule(
 }
 
 void VulkanReplayConsumer::Process_vkCreatePipelineCache(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>* pCreateInfo,
@@ -860,6 +916,7 @@ void VulkanReplayConsumer::Process_vkCreatePipelineCache(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyPipelineCache(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            pipelineCache,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -873,6 +930,7 @@ void VulkanReplayConsumer::Process_vkDestroyPipelineCache(
 }
 
 void VulkanReplayConsumer::Process_vkGetPipelineCacheData(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipelineCache,
@@ -891,6 +949,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineCacheData(
 }
 
 void VulkanReplayConsumer::Process_vkMergePipelineCaches(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            dstCache,
@@ -906,6 +965,7 @@ void VulkanReplayConsumer::Process_vkMergePipelineCaches(
 }
 
 void VulkanReplayConsumer::Process_vkCreateGraphicsPipelines(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipelineCache,
@@ -929,6 +989,7 @@ void VulkanReplayConsumer::Process_vkCreateGraphicsPipelines(
 }
 
 void VulkanReplayConsumer::Process_vkCreateComputePipelines(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipelineCache,
@@ -952,6 +1013,7 @@ void VulkanReplayConsumer::Process_vkCreateComputePipelines(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyPipeline(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            pipeline,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -965,6 +1027,7 @@ void VulkanReplayConsumer::Process_vkDestroyPipeline(
 }
 
 void VulkanReplayConsumer::Process_vkCreatePipelineLayout(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPipelineLayoutCreateInfo>* pCreateInfo,
@@ -985,6 +1048,7 @@ void VulkanReplayConsumer::Process_vkCreatePipelineLayout(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyPipelineLayout(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            pipelineLayout,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -998,6 +1062,7 @@ void VulkanReplayConsumer::Process_vkDestroyPipelineLayout(
 }
 
 void VulkanReplayConsumer::Process_vkCreateSampler(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSamplerCreateInfo>* pCreateInfo,
@@ -1018,6 +1083,7 @@ void VulkanReplayConsumer::Process_vkCreateSampler(
 }
 
 void VulkanReplayConsumer::Process_vkDestroySampler(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            sampler,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1031,6 +1097,7 @@ void VulkanReplayConsumer::Process_vkDestroySampler(
 }
 
 void VulkanReplayConsumer::Process_vkCreateDescriptorSetLayout(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
@@ -1051,6 +1118,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorSetLayout(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDescriptorSetLayout(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            descriptorSetLayout,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1064,6 +1132,7 @@ void VulkanReplayConsumer::Process_vkDestroyDescriptorSetLayout(
 }
 
 void VulkanReplayConsumer::Process_vkCreateDescriptorPool(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>* pCreateInfo,
@@ -1082,6 +1151,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorPool(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDescriptorPool(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            descriptorPool,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1094,6 +1164,7 @@ void VulkanReplayConsumer::Process_vkDestroyDescriptorPool(
 }
 
 void VulkanReplayConsumer::Process_vkResetDescriptorPool(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            descriptorPool,
@@ -1107,6 +1178,7 @@ void VulkanReplayConsumer::Process_vkResetDescriptorPool(
 }
 
 void VulkanReplayConsumer::Process_vkAllocateDescriptorSets(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
@@ -1126,6 +1198,7 @@ void VulkanReplayConsumer::Process_vkAllocateDescriptorSets(
 }
 
 void VulkanReplayConsumer::Process_vkFreeDescriptorSets(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            descriptorPool,
@@ -1142,6 +1215,7 @@ void VulkanReplayConsumer::Process_vkFreeDescriptorSets(
 }
 
 void VulkanReplayConsumer::Process_vkUpdateDescriptorSets(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     uint32_t                                    descriptorWriteCount,
     StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites,
@@ -1158,6 +1232,7 @@ void VulkanReplayConsumer::Process_vkUpdateDescriptorSets(
 }
 
 void VulkanReplayConsumer::Process_vkCreateFramebuffer(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* pCreateInfo,
@@ -1178,6 +1253,7 @@ void VulkanReplayConsumer::Process_vkCreateFramebuffer(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyFramebuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            framebuffer,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1191,6 +1267,7 @@ void VulkanReplayConsumer::Process_vkDestroyFramebuffer(
 }
 
 void VulkanReplayConsumer::Process_vkCreateRenderPass(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkRenderPassCreateInfo>* pCreateInfo,
@@ -1210,6 +1287,7 @@ void VulkanReplayConsumer::Process_vkCreateRenderPass(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyRenderPass(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            renderPass,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1223,6 +1301,7 @@ void VulkanReplayConsumer::Process_vkDestroyRenderPass(
 }
 
 void VulkanReplayConsumer::Process_vkGetRenderAreaGranularity(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            renderPass,
     StructPointerDecoder<Decoded_VkExtent2D>*   pGranularity)
@@ -1235,6 +1314,7 @@ void VulkanReplayConsumer::Process_vkGetRenderAreaGranularity(
 }
 
 void VulkanReplayConsumer::Process_vkCreateCommandPool(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>* pCreateInfo,
@@ -1254,6 +1334,7 @@ void VulkanReplayConsumer::Process_vkCreateCommandPool(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyCommandPool(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            commandPool,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -1267,6 +1348,7 @@ void VulkanReplayConsumer::Process_vkDestroyCommandPool(
 }
 
 void VulkanReplayConsumer::Process_vkResetCommandPool(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            commandPool,
@@ -1280,6 +1362,7 @@ void VulkanReplayConsumer::Process_vkResetCommandPool(
 }
 
 void VulkanReplayConsumer::Process_vkAllocateCommandBuffers(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
@@ -1299,6 +1382,7 @@ void VulkanReplayConsumer::Process_vkAllocateCommandBuffers(
 }
 
 void VulkanReplayConsumer::Process_vkFreeCommandBuffers(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            commandPool,
     uint32_t                                    commandBufferCount,
@@ -1313,6 +1397,7 @@ void VulkanReplayConsumer::Process_vkFreeCommandBuffers(
 }
 
 void VulkanReplayConsumer::Process_vkBeginCommandBuffer(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo)
@@ -1326,6 +1411,7 @@ void VulkanReplayConsumer::Process_vkBeginCommandBuffer(
 }
 
 void VulkanReplayConsumer::Process_vkEndCommandBuffer(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer)
 {
@@ -1336,6 +1422,7 @@ void VulkanReplayConsumer::Process_vkEndCommandBuffer(
 }
 
 void VulkanReplayConsumer::Process_vkResetCommandBuffer(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer,
     VkCommandBufferResetFlags                   flags)
@@ -1347,6 +1434,7 @@ void VulkanReplayConsumer::Process_vkResetCommandBuffer(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBindPipeline(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineBindPoint                         pipelineBindPoint,
     format::HandleId                            pipeline)
@@ -1358,6 +1446,7 @@ void VulkanReplayConsumer::Process_vkCmdBindPipeline(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetViewport(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstViewport,
     uint32_t                                    viewportCount,
@@ -1370,6 +1459,7 @@ void VulkanReplayConsumer::Process_vkCmdSetViewport(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetScissor(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstScissor,
     uint32_t                                    scissorCount,
@@ -1382,6 +1472,7 @@ void VulkanReplayConsumer::Process_vkCmdSetScissor(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetLineWidth(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     float                                       lineWidth)
 {
@@ -1391,6 +1482,7 @@ void VulkanReplayConsumer::Process_vkCmdSetLineWidth(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDepthBias(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     float                                       depthBiasConstantFactor,
     float                                       depthBiasClamp,
@@ -1402,6 +1494,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBias(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetBlendConstants(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     PointerDecoder<float>*                      blendConstants)
 {
@@ -1412,6 +1505,7 @@ void VulkanReplayConsumer::Process_vkCmdSetBlendConstants(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDepthBounds(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     float                                       minDepthBounds,
     float                                       maxDepthBounds)
@@ -1422,6 +1516,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBounds(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetStencilCompareMask(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkStencilFaceFlags                          faceMask,
     uint32_t                                    compareMask)
@@ -1432,6 +1527,7 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilCompareMask(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetStencilWriteMask(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkStencilFaceFlags                          faceMask,
     uint32_t                                    writeMask)
@@ -1442,6 +1538,7 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilWriteMask(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetStencilReference(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkStencilFaceFlags                          faceMask,
     uint32_t                                    reference)
@@ -1452,6 +1549,7 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilReference(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBindDescriptorSets(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineBindPoint                         pipelineBindPoint,
     format::HandleId                            layout,
@@ -1470,6 +1568,7 @@ void VulkanReplayConsumer::Process_vkCmdBindDescriptorSets(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBindIndexBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -1482,6 +1581,7 @@ void VulkanReplayConsumer::Process_vkCmdBindIndexBuffer(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBindVertexBuffers(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstBinding,
     uint32_t                                    bindingCount,
@@ -1496,6 +1596,7 @@ void VulkanReplayConsumer::Process_vkCmdBindVertexBuffers(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDraw(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    vertexCount,
     uint32_t                                    instanceCount,
@@ -1508,6 +1609,7 @@ void VulkanReplayConsumer::Process_vkCmdDraw(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawIndexed(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    indexCount,
     uint32_t                                    instanceCount,
@@ -1521,6 +1623,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndexed(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawIndirect(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -1534,6 +1637,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndirect(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawIndexedIndirect(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -1547,6 +1651,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndexedIndirect(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDispatch(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    groupCountX,
     uint32_t                                    groupCountY,
@@ -1558,6 +1663,7 @@ void VulkanReplayConsumer::Process_vkCmdDispatch(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDispatchIndirect(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset)
@@ -1569,6 +1675,7 @@ void VulkanReplayConsumer::Process_vkCmdDispatchIndirect(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcBuffer,
     format::HandleId                            dstBuffer,
@@ -1584,6 +1691,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBuffer(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcImage,
     VkImageLayout                               srcImageLayout,
@@ -1601,6 +1709,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImage(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBlitImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcImage,
     VkImageLayout                               srcImageLayout,
@@ -1619,6 +1728,7 @@ void VulkanReplayConsumer::Process_vkCmdBlitImage(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyBufferToImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcBuffer,
     format::HandleId                            dstImage,
@@ -1635,6 +1745,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBufferToImage(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyImageToBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcImage,
     VkImageLayout                               srcImageLayout,
@@ -1651,6 +1762,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImageToBuffer(
 }
 
 void VulkanReplayConsumer::Process_vkCmdUpdateBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            dstBuffer,
     VkDeviceSize                                dstOffset,
@@ -1665,6 +1777,7 @@ void VulkanReplayConsumer::Process_vkCmdUpdateBuffer(
 }
 
 void VulkanReplayConsumer::Process_vkCmdFillBuffer(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            dstBuffer,
     VkDeviceSize                                dstOffset,
@@ -1678,6 +1791,7 @@ void VulkanReplayConsumer::Process_vkCmdFillBuffer(
 }
 
 void VulkanReplayConsumer::Process_vkCmdClearColorImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            image,
     VkImageLayout                               imageLayout,
@@ -1694,6 +1808,7 @@ void VulkanReplayConsumer::Process_vkCmdClearColorImage(
 }
 
 void VulkanReplayConsumer::Process_vkCmdClearDepthStencilImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            image,
     VkImageLayout                               imageLayout,
@@ -1710,6 +1825,7 @@ void VulkanReplayConsumer::Process_vkCmdClearDepthStencilImage(
 }
 
 void VulkanReplayConsumer::Process_vkCmdClearAttachments(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    attachmentCount,
     StructPointerDecoder<Decoded_VkClearAttachment>* pAttachments,
@@ -1724,6 +1840,7 @@ void VulkanReplayConsumer::Process_vkCmdClearAttachments(
 }
 
 void VulkanReplayConsumer::Process_vkCmdResolveImage(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            srcImage,
     VkImageLayout                               srcImageLayout,
@@ -1741,6 +1858,7 @@ void VulkanReplayConsumer::Process_vkCmdResolveImage(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetEvent(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            event,
     VkPipelineStageFlags                        stageMask)
@@ -1752,6 +1870,7 @@ void VulkanReplayConsumer::Process_vkCmdSetEvent(
 }
 
 void VulkanReplayConsumer::Process_vkCmdResetEvent(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            event,
     VkPipelineStageFlags                        stageMask)
@@ -1763,6 +1882,7 @@ void VulkanReplayConsumer::Process_vkCmdResetEvent(
 }
 
 void VulkanReplayConsumer::Process_vkCmdWaitEvents(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    eventCount,
     HandlePointerDecoder<VkEvent>*              pEvents,
@@ -1787,6 +1907,7 @@ void VulkanReplayConsumer::Process_vkCmdWaitEvents(
 }
 
 void VulkanReplayConsumer::Process_vkCmdPipelineBarrier(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineStageFlags                        srcStageMask,
     VkPipelineStageFlags                        dstStageMask,
@@ -1809,6 +1930,7 @@ void VulkanReplayConsumer::Process_vkCmdPipelineBarrier(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginQuery(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            queryPool,
     uint32_t                                    query,
@@ -1821,6 +1943,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginQuery(
 }
 
 void VulkanReplayConsumer::Process_vkCmdEndQuery(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            queryPool,
     uint32_t                                    query)
@@ -1832,6 +1955,7 @@ void VulkanReplayConsumer::Process_vkCmdEndQuery(
 }
 
 void VulkanReplayConsumer::Process_vkCmdResetQueryPool(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            queryPool,
     uint32_t                                    firstQuery,
@@ -1844,6 +1968,7 @@ void VulkanReplayConsumer::Process_vkCmdResetQueryPool(
 }
 
 void VulkanReplayConsumer::Process_vkCmdWriteTimestamp(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineStageFlagBits                     pipelineStage,
     format::HandleId                            queryPool,
@@ -1856,6 +1981,7 @@ void VulkanReplayConsumer::Process_vkCmdWriteTimestamp(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyQueryPoolResults(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            queryPool,
     uint32_t                                    firstQuery,
@@ -1873,6 +1999,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyQueryPoolResults(
 }
 
 void VulkanReplayConsumer::Process_vkCmdPushConstants(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            layout,
     VkShaderStageFlags                          stageFlags,
@@ -1888,6 +2015,7 @@ void VulkanReplayConsumer::Process_vkCmdPushConstants(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginRenderPass(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
     VkSubpassContents                           contents)
@@ -1900,6 +2028,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRenderPass(
 }
 
 void VulkanReplayConsumer::Process_vkCmdNextSubpass(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkSubpassContents                           contents)
 {
@@ -1909,6 +2038,7 @@ void VulkanReplayConsumer::Process_vkCmdNextSubpass(
 }
 
 void VulkanReplayConsumer::Process_vkCmdEndRenderPass(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
     VkCommandBuffer in_commandBuffer = MapHandle<CommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetCommandBufferInfo);
@@ -1917,6 +2047,7 @@ void VulkanReplayConsumer::Process_vkCmdEndRenderPass(
 }
 
 void VulkanReplayConsumer::Process_vkCmdExecuteCommands(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    commandBufferCount,
     HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers)
@@ -1928,6 +2059,7 @@ void VulkanReplayConsumer::Process_vkCmdExecuteCommands(
 }
 
 void VulkanReplayConsumer::Process_vkBindBufferMemory2(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    bindInfoCount,
@@ -1942,6 +2074,7 @@ void VulkanReplayConsumer::Process_vkBindBufferMemory2(
 }
 
 void VulkanReplayConsumer::Process_vkBindImageMemory2(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    bindInfoCount,
@@ -1956,6 +2089,7 @@ void VulkanReplayConsumer::Process_vkBindImageMemory2(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceGroupPeerMemoryFeatures(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     uint32_t                                    heapIndex,
     uint32_t                                    localDeviceIndex,
@@ -1969,6 +2103,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupPeerMemoryFeatures(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDeviceMask(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    deviceMask)
 {
@@ -1978,6 +2113,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDeviceMask(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDispatchBase(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    baseGroupX,
     uint32_t                                    baseGroupY,
@@ -1992,6 +2128,7 @@ void VulkanReplayConsumer::Process_vkCmdDispatchBase(
 }
 
 void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroups(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     PointerDecoder<uint32_t>*                   pPhysicalDeviceGroupCount,
@@ -2010,6 +2147,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroups(
 }
 
 void VulkanReplayConsumer::Process_vkGetImageMemoryRequirements2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -2023,6 +2161,7 @@ void VulkanReplayConsumer::Process_vkGetImageMemoryRequirements2(
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferMemoryRequirements2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -2036,6 +2175,7 @@ void VulkanReplayConsumer::Process_vkGetBufferMemoryRequirements2(
 }
 
 void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
@@ -2053,6 +2193,7 @@ void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements2(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFeatures2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures)
 {
@@ -2063,6 +2204,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFeatures2(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceProperties2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties)
 {
@@ -2073,6 +2215,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceProperties2(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFormatProperties2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     VkFormat                                    format,
     StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties)
@@ -2084,6 +2227,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFormatProperties2(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
@@ -2098,6 +2242,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
     StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties)
@@ -2112,6 +2257,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMemoryProperties2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties)
 {
@@ -2122,6 +2268,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMemoryProperties2(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
     PointerDecoder<uint32_t>*                   pPropertyCount,
@@ -2138,6 +2285,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
 }
 
 void VulkanReplayConsumer::Process_vkTrimCommandPool(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            commandPool,
     VkCommandPoolTrimFlags                      flags)
@@ -2149,6 +2297,7 @@ void VulkanReplayConsumer::Process_vkTrimCommandPool(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceQueue2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceQueueInfo2>* pQueueInfo,
     HandlePointerDecoder<VkQueue>*              pQueue)
@@ -2164,6 +2313,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceQueue2(
 }
 
 void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversion(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
@@ -2183,6 +2333,7 @@ void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversion(
 }
 
 void VulkanReplayConsumer::Process_vkDestroySamplerYcbcrConversion(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            ycbcrConversion,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -2196,6 +2347,7 @@ void VulkanReplayConsumer::Process_vkDestroySamplerYcbcrConversion(
 }
 
 void VulkanReplayConsumer::Process_vkCreateDescriptorUpdateTemplate(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
@@ -2216,6 +2368,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorUpdateTemplate(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDescriptorUpdateTemplate(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            descriptorUpdateTemplate,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -2228,6 +2381,7 @@ void VulkanReplayConsumer::Process_vkDestroyDescriptorUpdateTemplate(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalBufferProperties(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
     StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties)
@@ -2240,6 +2394,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalBufferProperties(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalFenceProperties(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
     StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties)
@@ -2252,6 +2407,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalFenceProperties(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalSemaphoreProperties(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
     StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties)
@@ -2264,6 +2420,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalSemaphorePropertie
 }
 
 void VulkanReplayConsumer::Process_vkGetDescriptorSetLayoutSupport(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport)
@@ -2277,6 +2434,7 @@ void VulkanReplayConsumer::Process_vkGetDescriptorSetLayoutSupport(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawIndirectCount(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -2293,6 +2451,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndirectCount(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawIndexedIndirectCount(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -2309,6 +2468,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndexedIndirectCount(
 }
 
 void VulkanReplayConsumer::Process_vkCreateRenderPass2(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkRenderPassCreateInfo2>* pCreateInfo,
@@ -2328,6 +2488,7 @@ void VulkanReplayConsumer::Process_vkCreateRenderPass2(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginRenderPass2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
     StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo)
@@ -2341,6 +2502,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRenderPass2(
 }
 
 void VulkanReplayConsumer::Process_vkCmdNextSubpass2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo,
     StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo)
@@ -2353,6 +2515,7 @@ void VulkanReplayConsumer::Process_vkCmdNextSubpass2(
 }
 
 void VulkanReplayConsumer::Process_vkCmdEndRenderPass2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo)
 {
@@ -2363,6 +2526,7 @@ void VulkanReplayConsumer::Process_vkCmdEndRenderPass2(
 }
 
 void VulkanReplayConsumer::Process_vkResetQueryPool(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            queryPool,
     uint32_t                                    firstQuery,
@@ -2375,6 +2539,7 @@ void VulkanReplayConsumer::Process_vkResetQueryPool(
 }
 
 void VulkanReplayConsumer::Process_vkGetSemaphoreCounterValue(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            semaphore,
@@ -2389,6 +2554,7 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreCounterValue(
 }
 
 void VulkanReplayConsumer::Process_vkWaitSemaphores(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreWaitInfo>* pWaitInfo,
@@ -2403,6 +2569,7 @@ void VulkanReplayConsumer::Process_vkWaitSemaphores(
 }
 
 void VulkanReplayConsumer::Process_vkSignalSemaphore(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreSignalInfo>* pSignalInfo)
@@ -2416,6 +2583,7 @@ void VulkanReplayConsumer::Process_vkSignalSemaphore(
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferDeviceAddress(
+    const ApiCallInfo&                          call_info,
     VkDeviceAddress                             returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
@@ -2428,6 +2596,7 @@ void VulkanReplayConsumer::Process_vkGetBufferDeviceAddress(
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferOpaqueCaptureAddress(
+    const ApiCallInfo&                          call_info,
     uint64_t                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
@@ -2440,6 +2609,7 @@ void VulkanReplayConsumer::Process_vkGetBufferOpaqueCaptureAddress(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddress(
+    const ApiCallInfo&                          call_info,
     uint64_t                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo>* pInfo)
@@ -2452,6 +2622,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddress(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceToolProperties(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pToolCount,
@@ -2468,6 +2639,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceToolProperties(
 }
 
 void VulkanReplayConsumer::Process_vkCreatePrivateDataSlot(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPrivateDataSlotCreateInfo>* pCreateInfo,
@@ -2487,6 +2659,7 @@ void VulkanReplayConsumer::Process_vkCreatePrivateDataSlot(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyPrivateDataSlot(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            privateDataSlot,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -2500,6 +2673,7 @@ void VulkanReplayConsumer::Process_vkDestroyPrivateDataSlot(
 }
 
 void VulkanReplayConsumer::Process_vkSetPrivateData(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     VkObjectType                                objectType,
@@ -2515,6 +2689,7 @@ void VulkanReplayConsumer::Process_vkSetPrivateData(
 }
 
 void VulkanReplayConsumer::Process_vkGetPrivateData(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     VkObjectType                                objectType,
     uint64_t                                    objectHandle,
@@ -2529,6 +2704,7 @@ void VulkanReplayConsumer::Process_vkGetPrivateData(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetEvent2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            event,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo)
@@ -2542,6 +2718,7 @@ void VulkanReplayConsumer::Process_vkCmdSetEvent2(
 }
 
 void VulkanReplayConsumer::Process_vkCmdResetEvent2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            event,
     VkPipelineStageFlags2                       stageMask)
@@ -2553,6 +2730,7 @@ void VulkanReplayConsumer::Process_vkCmdResetEvent2(
 }
 
 void VulkanReplayConsumer::Process_vkCmdWaitEvents2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    eventCount,
     HandlePointerDecoder<VkEvent>*              pEvents,
@@ -2567,6 +2745,7 @@ void VulkanReplayConsumer::Process_vkCmdWaitEvents2(
 }
 
 void VulkanReplayConsumer::Process_vkCmdPipelineBarrier2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo)
 {
@@ -2578,6 +2757,7 @@ void VulkanReplayConsumer::Process_vkCmdPipelineBarrier2(
 }
 
 void VulkanReplayConsumer::Process_vkCmdWriteTimestamp2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineStageFlags2                       stage,
     format::HandleId                            queryPool,
@@ -2590,6 +2770,7 @@ void VulkanReplayConsumer::Process_vkCmdWriteTimestamp2(
 }
 
 void VulkanReplayConsumer::Process_vkQueueSubmit2(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            queue,
     uint32_t                                    submitCount,
@@ -2606,6 +2787,7 @@ void VulkanReplayConsumer::Process_vkQueueSubmit2(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyBuffer2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyBufferInfo2>* pCopyBufferInfo)
 {
@@ -2617,6 +2799,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBuffer2(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyImage2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyImageInfo2>* pCopyImageInfo)
 {
@@ -2628,6 +2811,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImage2(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyBufferToImage2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2>* pCopyBufferToImageInfo)
 {
@@ -2639,6 +2823,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBufferToImage2(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyImageToBuffer2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2>* pCopyImageToBufferInfo)
 {
@@ -2650,6 +2835,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImageToBuffer2(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBlitImage2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkBlitImageInfo2>* pBlitImageInfo)
 {
@@ -2661,6 +2847,7 @@ void VulkanReplayConsumer::Process_vkCmdBlitImage2(
 }
 
 void VulkanReplayConsumer::Process_vkCmdResolveImage2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkResolveImageInfo2>* pResolveImageInfo)
 {
@@ -2672,6 +2859,7 @@ void VulkanReplayConsumer::Process_vkCmdResolveImage2(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginRendering(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo)
 {
@@ -2683,6 +2871,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRendering(
 }
 
 void VulkanReplayConsumer::Process_vkCmdEndRendering(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
     VkCommandBuffer in_commandBuffer = MapHandle<CommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetCommandBufferInfo);
@@ -2691,6 +2880,7 @@ void VulkanReplayConsumer::Process_vkCmdEndRendering(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetCullMode(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkCullModeFlags                             cullMode)
 {
@@ -2700,6 +2890,7 @@ void VulkanReplayConsumer::Process_vkCmdSetCullMode(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetFrontFace(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkFrontFace                                 frontFace)
 {
@@ -2709,6 +2900,7 @@ void VulkanReplayConsumer::Process_vkCmdSetFrontFace(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetPrimitiveTopology(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPrimitiveTopology                         primitiveTopology)
 {
@@ -2718,6 +2910,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPrimitiveTopology(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetViewportWithCount(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    viewportCount,
     StructPointerDecoder<Decoded_VkViewport>*   pViewports)
@@ -2729,6 +2922,7 @@ void VulkanReplayConsumer::Process_vkCmdSetViewportWithCount(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetScissorWithCount(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    scissorCount,
     StructPointerDecoder<Decoded_VkRect2D>*     pScissors)
@@ -2740,6 +2934,7 @@ void VulkanReplayConsumer::Process_vkCmdSetScissorWithCount(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBindVertexBuffers2(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstBinding,
     uint32_t                                    bindingCount,
@@ -2758,6 +2953,7 @@ void VulkanReplayConsumer::Process_vkCmdBindVertexBuffers2(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDepthTestEnable(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    depthTestEnable)
 {
@@ -2767,6 +2963,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthTestEnable(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDepthWriteEnable(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    depthWriteEnable)
 {
@@ -2776,6 +2973,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthWriteEnable(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDepthCompareOp(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkCompareOp                                 depthCompareOp)
 {
@@ -2785,6 +2983,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthCompareOp(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDepthBoundsTestEnable(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    depthBoundsTestEnable)
 {
@@ -2794,6 +2993,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBoundsTestEnable(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetStencilTestEnable(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    stencilTestEnable)
 {
@@ -2803,6 +3003,7 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilTestEnable(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetStencilOp(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkStencilFaceFlags                          faceMask,
     VkStencilOp                                 failOp,
@@ -2816,6 +3017,7 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilOp(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetRasterizerDiscardEnable(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    rasterizerDiscardEnable)
 {
@@ -2825,6 +3027,7 @@ void VulkanReplayConsumer::Process_vkCmdSetRasterizerDiscardEnable(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDepthBiasEnable(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    depthBiasEnable)
 {
@@ -2834,6 +3037,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBiasEnable(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetPrimitiveRestartEnable(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    primitiveRestartEnable)
 {
@@ -2843,6 +3047,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPrimitiveRestartEnable(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceBufferMemoryRequirements(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceBufferMemoryRequirements>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -2856,6 +3061,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceBufferMemoryRequirements(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceImageMemoryRequirements(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -2869,6 +3075,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceImageMemoryRequirements(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceImageSparseMemoryRequirements(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
@@ -2886,6 +3093,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceImageSparseMemoryRequirements(
 }
 
 void VulkanReplayConsumer::Process_vkDestroySurfaceKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            instance,
     format::HandleId                            surface,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -2898,6 +3106,7 @@ void VulkanReplayConsumer::Process_vkDestroySurfaceKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceSupportKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    queueFamilyIndex,
@@ -2914,6 +3123,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceSupportKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            surface,
@@ -2928,6 +3138,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            surface,
@@ -2947,6 +3158,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            surface,
@@ -2966,6 +3178,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCreateSwapchainKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfo,
@@ -2986,6 +3199,7 @@ void VulkanReplayConsumer::Process_vkCreateSwapchainKHR(
 }
 
 void VulkanReplayConsumer::Process_vkDestroySwapchainKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            swapchain,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -2998,6 +3212,7 @@ void VulkanReplayConsumer::Process_vkDestroySwapchainKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetSwapchainImagesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain,
@@ -3019,6 +3234,7 @@ void VulkanReplayConsumer::Process_vkGetSwapchainImagesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkAcquireNextImageKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain,
@@ -3038,6 +3254,7 @@ void VulkanReplayConsumer::Process_vkAcquireNextImageKHR(
 }
 
 void VulkanReplayConsumer::Process_vkQueuePresentKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            queue,
     StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo)
@@ -3051,6 +3268,7 @@ void VulkanReplayConsumer::Process_vkQueuePresentKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceGroupPresentCapabilitiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceGroupPresentCapabilitiesKHR>* pDeviceGroupPresentCapabilities)
@@ -3063,6 +3281,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupPresentCapabilitiesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceGroupSurfacePresentModesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            surface,
@@ -3078,6 +3297,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupSurfacePresentModesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            surface,
@@ -3097,6 +3317,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkAcquireNextImage2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>* pAcquireInfo,
@@ -3112,6 +3333,7 @@ void VulkanReplayConsumer::Process_vkAcquireNextImage2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pPropertyCount,
@@ -3129,6 +3351,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pPropertyCount,
@@ -3146,6 +3369,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    planeIndex,
@@ -3165,6 +3389,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetDisplayModePropertiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            display,
@@ -3184,6 +3409,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayModePropertiesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCreateDisplayModeKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            display,
@@ -3205,6 +3431,7 @@ void VulkanReplayConsumer::Process_vkCreateDisplayModeKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetDisplayPlaneCapabilitiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            mode,
@@ -3220,6 +3447,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayPlaneCapabilitiesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCreateDisplayPlaneSurfaceKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkDisplaySurfaceCreateInfoKHR>* pCreateInfo,
@@ -3240,6 +3468,7 @@ void VulkanReplayConsumer::Process_vkCreateDisplayPlaneSurfaceKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCreateSharedSwapchainsKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    swapchainCount,
@@ -3261,6 +3490,7 @@ void VulkanReplayConsumer::Process_vkCreateSharedSwapchainsKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCreateXlibSurfaceKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>* pCreateInfo,
@@ -3279,6 +3509,7 @@ void VulkanReplayConsumer::Process_vkCreateXlibSurfaceKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
+    const ApiCallInfo&                          call_info,
     VkBool32                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    queueFamilyIndex,
@@ -3292,6 +3523,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceXlibPresentationSupportKHR
 }
 
 void VulkanReplayConsumer::Process_vkCreateXcbSurfaceKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>* pCreateInfo,
@@ -3310,6 +3542,7 @@ void VulkanReplayConsumer::Process_vkCreateXcbSurfaceKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
+    const ApiCallInfo&                          call_info,
     VkBool32                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    queueFamilyIndex,
@@ -3323,6 +3556,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCreateWaylandSurfaceKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>* pCreateInfo,
@@ -3341,6 +3575,7 @@ void VulkanReplayConsumer::Process_vkCreateWaylandSurfaceKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceWaylandPresentationSupportKHR(
+    const ApiCallInfo&                          call_info,
     VkBool32                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    queueFamilyIndex,
@@ -3353,6 +3588,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceWaylandPresentationSupport
 }
 
 void VulkanReplayConsumer::Process_vkCreateAndroidSurfaceKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>* pCreateInfo,
@@ -3371,6 +3607,7 @@ void VulkanReplayConsumer::Process_vkCreateAndroidSurfaceKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCreateWin32SurfaceKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>* pCreateInfo,
@@ -3389,6 +3626,7 @@ void VulkanReplayConsumer::Process_vkCreateWin32SurfaceKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceWin32PresentationSupportKHR(
+    const ApiCallInfo&                          call_info,
     VkBool32                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    queueFamilyIndex)
@@ -3399,6 +3637,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceWin32PresentationSupportKH
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginRenderingKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo)
 {
@@ -3410,6 +3649,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRenderingKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdEndRenderingKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
     VkCommandBuffer in_commandBuffer = MapHandle<CommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetCommandBufferInfo);
@@ -3418,6 +3658,7 @@ void VulkanReplayConsumer::Process_vkCmdEndRenderingKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFeatures2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures)
 {
@@ -3428,6 +3669,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFeatures2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceProperties2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties)
 {
@@ -3438,6 +3680,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceProperties2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFormatProperties2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     VkFormat                                    format,
     StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties)
@@ -3449,6 +3692,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFormatProperties2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
@@ -3463,6 +3707,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
     StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties)
@@ -3477,6 +3722,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMemoryProperties2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties)
 {
@@ -3487,6 +3733,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMemoryProperties2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
     PointerDecoder<uint32_t>*                   pPropertyCount,
@@ -3503,6 +3750,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSparseImageFormatPropertie
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     uint32_t                                    heapIndex,
     uint32_t                                    localDeviceIndex,
@@ -3516,6 +3764,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDeviceMaskKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    deviceMask)
 {
@@ -3525,6 +3774,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDeviceMaskKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDispatchBaseKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    baseGroupX,
     uint32_t                                    baseGroupY,
@@ -3539,6 +3789,7 @@ void VulkanReplayConsumer::Process_vkCmdDispatchBaseKHR(
 }
 
 void VulkanReplayConsumer::Process_vkTrimCommandPoolKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            commandPool,
     VkCommandPoolTrimFlags                      flags)
@@ -3550,6 +3801,7 @@ void VulkanReplayConsumer::Process_vkTrimCommandPoolKHR(
 }
 
 void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     PointerDecoder<uint32_t>*                   pPhysicalDeviceGroupCount,
@@ -3568,6 +3820,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
     StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties)
@@ -3580,6 +3833,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalBufferPropertiesKH
 }
 
 void VulkanReplayConsumer::Process_vkGetMemoryWin32HandleKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkMemoryGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
@@ -3597,6 +3851,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryWin32HandleKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetMemoryWin32HandlePropertiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -3612,6 +3867,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryWin32HandlePropertiesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetMemoryFdKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkMemoryGetFdInfoKHR>* pGetFdInfo,
@@ -3627,6 +3883,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryFdKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetMemoryFdPropertiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -3641,6 +3898,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryFdPropertiesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
     StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties)
@@ -3653,6 +3911,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalSemaphorePropertie
 }
 
 void VulkanReplayConsumer::Process_vkImportSemaphoreWin32HandleKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>* pImportSemaphoreWin32HandleInfo)
@@ -3666,6 +3925,7 @@ void VulkanReplayConsumer::Process_vkImportSemaphoreWin32HandleKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetSemaphoreWin32HandleKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
@@ -3683,6 +3943,7 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreWin32HandleKHR(
 }
 
 void VulkanReplayConsumer::Process_vkImportSemaphoreFdKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>* pImportSemaphoreFdInfo)
@@ -3696,6 +3957,7 @@ void VulkanReplayConsumer::Process_vkImportSemaphoreFdKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetSemaphoreFdKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreGetFdInfoKHR>* pGetFdInfo,
@@ -3711,6 +3973,7 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreFdKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdPushDescriptorSetKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineBindPoint                         pipelineBindPoint,
     format::HandleId                            layout,
@@ -3727,6 +3990,7 @@ void VulkanReplayConsumer::Process_vkCmdPushDescriptorSetKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCreateDescriptorUpdateTemplateKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
@@ -3747,6 +4011,7 @@ void VulkanReplayConsumer::Process_vkCreateDescriptorUpdateTemplateKHR(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDescriptorUpdateTemplateKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            descriptorUpdateTemplate,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -3759,6 +4024,7 @@ void VulkanReplayConsumer::Process_vkDestroyDescriptorUpdateTemplateKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCreateRenderPass2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkRenderPassCreateInfo2>* pCreateInfo,
@@ -3778,6 +4044,7 @@ void VulkanReplayConsumer::Process_vkCreateRenderPass2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginRenderPass2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
     StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo)
@@ -3791,6 +4058,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginRenderPass2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdNextSubpass2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo,
     StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo)
@@ -3803,6 +4071,7 @@ void VulkanReplayConsumer::Process_vkCmdNextSubpass2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdEndRenderPass2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo)
 {
@@ -3813,6 +4082,7 @@ void VulkanReplayConsumer::Process_vkCmdEndRenderPass2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetSwapchainStatusKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain)
@@ -3826,6 +4096,7 @@ void VulkanReplayConsumer::Process_vkGetSwapchainStatusKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
     StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties)
@@ -3838,6 +4109,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalFencePropertiesKHR
 }
 
 void VulkanReplayConsumer::Process_vkImportFenceWin32HandleKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImportFenceWin32HandleInfoKHR>* pImportFenceWin32HandleInfo)
@@ -3851,6 +4123,7 @@ void VulkanReplayConsumer::Process_vkImportFenceWin32HandleKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetFenceWin32HandleKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkFenceGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
@@ -3868,6 +4141,7 @@ void VulkanReplayConsumer::Process_vkGetFenceWin32HandleKHR(
 }
 
 void VulkanReplayConsumer::Process_vkImportFenceFdKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImportFenceFdInfoKHR>* pImportFenceFdInfo)
@@ -3881,6 +4155,7 @@ void VulkanReplayConsumer::Process_vkImportFenceFdKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetFenceFdKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkFenceGetFdInfoKHR>* pGetFdInfo,
@@ -3896,6 +4171,7 @@ void VulkanReplayConsumer::Process_vkGetFenceFdKHR(
 }
 
 void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    queueFamilyIndex,
@@ -3916,6 +4192,7 @@ void VulkanReplayConsumer::Process_vkEnumeratePhysicalDeviceQueueFamilyPerforman
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkQueryPoolPerformanceCreateInfoKHR>* pPerformanceQueryCreateInfo,
     PointerDecoder<uint32_t>*                   pNumPasses)
@@ -3928,6 +4205,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceQueueFamilyPerformanceQuer
 }
 
 void VulkanReplayConsumer::Process_vkAcquireProfilingLockKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAcquireProfilingLockInfoKHR>* pInfo)
@@ -3940,6 +4218,7 @@ void VulkanReplayConsumer::Process_vkAcquireProfilingLockKHR(
 }
 
 void VulkanReplayConsumer::Process_vkReleaseProfilingLockKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device)
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
@@ -3948,6 +4227,7 @@ void VulkanReplayConsumer::Process_vkReleaseProfilingLockKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
@@ -3963,6 +4243,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
@@ -3982,6 +4263,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pPropertyCount,
@@ -3999,6 +4281,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pPropertyCount,
@@ -4016,6 +4299,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR
 }
 
 void VulkanReplayConsumer::Process_vkGetDisplayModeProperties2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            display,
@@ -4035,6 +4319,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayModeProperties2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkDisplayPlaneInfo2KHR>* pDisplayPlaneInfo,
@@ -4050,6 +4335,7 @@ void VulkanReplayConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetImageMemoryRequirements2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -4063,6 +4349,7 @@ void VulkanReplayConsumer::Process_vkGetImageMemoryRequirements2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferMemoryRequirements2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -4076,6 +4363,7 @@ void VulkanReplayConsumer::Process_vkGetBufferMemoryRequirements2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
@@ -4093,6 +4381,7 @@ void VulkanReplayConsumer::Process_vkGetImageSparseMemoryRequirements2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
@@ -4112,6 +4401,7 @@ void VulkanReplayConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
 }
 
 void VulkanReplayConsumer::Process_vkDestroySamplerYcbcrConversionKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            ycbcrConversion,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -4125,6 +4415,7 @@ void VulkanReplayConsumer::Process_vkDestroySamplerYcbcrConversionKHR(
 }
 
 void VulkanReplayConsumer::Process_vkBindBufferMemory2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    bindInfoCount,
@@ -4139,6 +4430,7 @@ void VulkanReplayConsumer::Process_vkBindBufferMemory2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkBindImageMemory2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    bindInfoCount,
@@ -4153,6 +4445,7 @@ void VulkanReplayConsumer::Process_vkBindImageMemory2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetDescriptorSetLayoutSupportKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
     StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport)
@@ -4166,6 +4459,7 @@ void VulkanReplayConsumer::Process_vkGetDescriptorSetLayoutSupportKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawIndirectCountKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -4182,6 +4476,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndirectCountKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawIndexedIndirectCountKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -4198,6 +4493,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndexedIndirectCountKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetSemaphoreCounterValueKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            semaphore,
@@ -4212,6 +4508,7 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreCounterValueKHR(
 }
 
 void VulkanReplayConsumer::Process_vkWaitSemaphoresKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreWaitInfo>* pWaitInfo,
@@ -4226,6 +4523,7 @@ void VulkanReplayConsumer::Process_vkWaitSemaphoresKHR(
 }
 
 void VulkanReplayConsumer::Process_vkSignalSemaphoreKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreSignalInfo>* pSignalInfo)
@@ -4239,6 +4537,7 @@ void VulkanReplayConsumer::Process_vkSignalSemaphoreKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pFragmentShadingRateCount,
@@ -4255,6 +4554,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetFragmentShadingRateKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkExtent2D>*   pFragmentSize,
     PointerDecoder<VkFragmentShadingRateCombinerOpKHR>* combinerOps)
@@ -4267,6 +4567,7 @@ void VulkanReplayConsumer::Process_vkCmdSetFragmentShadingRateKHR(
 }
 
 void VulkanReplayConsumer::Process_vkWaitForPresentKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain,
@@ -4282,6 +4583,7 @@ void VulkanReplayConsumer::Process_vkWaitForPresentKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferDeviceAddressKHR(
+    const ApiCallInfo&                          call_info,
     VkDeviceAddress                             returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
@@ -4294,6 +4596,7 @@ void VulkanReplayConsumer::Process_vkGetBufferDeviceAddressKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferOpaqueCaptureAddressKHR(
+    const ApiCallInfo&                          call_info,
     uint64_t                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
@@ -4306,6 +4609,7 @@ void VulkanReplayConsumer::Process_vkGetBufferOpaqueCaptureAddressKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddressKHR(
+    const ApiCallInfo&                          call_info,
     uint64_t                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo>* pInfo)
@@ -4318,6 +4622,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddressKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCreateDeferredOperationKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
@@ -4335,6 +4640,7 @@ void VulkanReplayConsumer::Process_vkCreateDeferredOperationKHR(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDeferredOperationKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            operation,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -4348,6 +4654,7 @@ void VulkanReplayConsumer::Process_vkDestroyDeferredOperationKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeferredOperationMaxConcurrencyKHR(
+    const ApiCallInfo&                          call_info,
     uint32_t                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            operation)
@@ -4359,6 +4666,7 @@ void VulkanReplayConsumer::Process_vkGetDeferredOperationMaxConcurrencyKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeferredOperationResultKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            operation)
@@ -4371,6 +4679,7 @@ void VulkanReplayConsumer::Process_vkGetDeferredOperationResultKHR(
 }
 
 void VulkanReplayConsumer::Process_vkDeferredOperationJoinKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            operation)
@@ -4383,6 +4692,7 @@ void VulkanReplayConsumer::Process_vkDeferredOperationJoinKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPipelineInfoKHR>* pPipelineInfo,
@@ -4402,6 +4712,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
@@ -4421,6 +4732,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetPipelineExecutableInternalRepresentationsKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
@@ -4440,6 +4752,7 @@ void VulkanReplayConsumer::Process_vkGetPipelineExecutableInternalRepresentation
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetEvent2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            event,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo)
@@ -4453,6 +4766,7 @@ void VulkanReplayConsumer::Process_vkCmdSetEvent2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdResetEvent2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            event,
     VkPipelineStageFlags2                       stageMask)
@@ -4464,6 +4778,7 @@ void VulkanReplayConsumer::Process_vkCmdResetEvent2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdWaitEvents2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    eventCount,
     HandlePointerDecoder<VkEvent>*              pEvents,
@@ -4478,6 +4793,7 @@ void VulkanReplayConsumer::Process_vkCmdWaitEvents2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdPipelineBarrier2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo)
 {
@@ -4489,6 +4805,7 @@ void VulkanReplayConsumer::Process_vkCmdPipelineBarrier2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdWriteTimestamp2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineStageFlags2                       stage,
     format::HandleId                            queryPool,
@@ -4501,6 +4818,7 @@ void VulkanReplayConsumer::Process_vkCmdWriteTimestamp2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkQueueSubmit2KHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            queue,
     uint32_t                                    submitCount,
@@ -4517,6 +4835,7 @@ void VulkanReplayConsumer::Process_vkQueueSubmit2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdWriteBufferMarker2AMD(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineStageFlags2                       stage,
     format::HandleId                            dstBuffer,
@@ -4530,6 +4849,7 @@ void VulkanReplayConsumer::Process_vkCmdWriteBufferMarker2AMD(
 }
 
 void VulkanReplayConsumer::Process_vkGetQueueCheckpointData2NV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            queue,
     PointerDecoder<uint32_t>*                   pCheckpointDataCount,
     StructPointerDecoder<Decoded_VkCheckpointData2NV>* pCheckpointData)
@@ -4544,6 +4864,7 @@ void VulkanReplayConsumer::Process_vkGetQueueCheckpointData2NV(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyBuffer2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyBufferInfo2>* pCopyBufferInfo)
 {
@@ -4555,6 +4876,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBuffer2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyImage2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyImageInfo2>* pCopyImageInfo)
 {
@@ -4566,6 +4888,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImage2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyBufferToImage2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2>* pCopyBufferToImageInfo)
 {
@@ -4577,6 +4900,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyBufferToImage2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyImageToBuffer2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2>* pCopyImageToBufferInfo)
 {
@@ -4588,6 +4912,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyImageToBuffer2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBlitImage2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkBlitImageInfo2>* pBlitImageInfo)
 {
@@ -4599,6 +4924,7 @@ void VulkanReplayConsumer::Process_vkCmdBlitImage2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdResolveImage2KHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkResolveImageInfo2>* pResolveImageInfo)
 {
@@ -4610,6 +4936,7 @@ void VulkanReplayConsumer::Process_vkCmdResolveImage2KHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceBufferMemoryRequirementsKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceBufferMemoryRequirements>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -4623,6 +4950,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceBufferMemoryRequirementsKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceImageMemoryRequirementsKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -4636,6 +4964,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceImageMemoryRequirementsKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceImageSparseMemoryRequirementsKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
     PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
@@ -4653,6 +4982,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceImageSparseMemoryRequirementsKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCreateDebugReportCallbackEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>* pCreateInfo,
@@ -4671,6 +5001,7 @@ void VulkanReplayConsumer::Process_vkCreateDebugReportCallbackEXT(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDebugReportCallbackEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            instance,
     format::HandleId                            callback,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -4684,6 +5015,7 @@ void VulkanReplayConsumer::Process_vkDestroyDebugReportCallbackEXT(
 }
 
 void VulkanReplayConsumer::Process_vkDebugReportMessageEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            instance,
     VkDebugReportFlagsEXT                       flags,
     VkDebugReportObjectTypeEXT                  objectType,
@@ -4702,6 +5034,7 @@ void VulkanReplayConsumer::Process_vkDebugReportMessageEXT(
 }
 
 void VulkanReplayConsumer::Process_vkDebugMarkerSetObjectTagEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDebugMarkerObjectTagInfoEXT>* pTagInfo)
@@ -4715,6 +5048,7 @@ void VulkanReplayConsumer::Process_vkDebugMarkerSetObjectTagEXT(
 }
 
 void VulkanReplayConsumer::Process_vkDebugMarkerSetObjectNameEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDebugMarkerObjectNameInfoEXT>* pNameInfo)
@@ -4728,6 +5062,7 @@ void VulkanReplayConsumer::Process_vkDebugMarkerSetObjectNameEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDebugMarkerBeginEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo)
 {
@@ -4738,6 +5073,7 @@ void VulkanReplayConsumer::Process_vkCmdDebugMarkerBeginEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDebugMarkerEndEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
     VkCommandBuffer in_commandBuffer = MapHandle<CommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetCommandBufferInfo);
@@ -4746,6 +5082,7 @@ void VulkanReplayConsumer::Process_vkCmdDebugMarkerEndEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDebugMarkerInsertEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo)
 {
@@ -4756,6 +5093,7 @@ void VulkanReplayConsumer::Process_vkCmdDebugMarkerInsertEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBindTransformFeedbackBuffersEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstBinding,
     uint32_t                                    bindingCount,
@@ -4772,6 +5110,7 @@ void VulkanReplayConsumer::Process_vkCmdBindTransformFeedbackBuffersEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginTransformFeedbackEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstCounterBuffer,
     uint32_t                                    counterBufferCount,
@@ -4786,6 +5125,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginTransformFeedbackEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdEndTransformFeedbackEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstCounterBuffer,
     uint32_t                                    counterBufferCount,
@@ -4800,6 +5140,7 @@ void VulkanReplayConsumer::Process_vkCmdEndTransformFeedbackEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginQueryIndexedEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            queryPool,
     uint32_t                                    query,
@@ -4813,6 +5154,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginQueryIndexedEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdEndQueryIndexedEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            queryPool,
     uint32_t                                    query,
@@ -4825,6 +5167,7 @@ void VulkanReplayConsumer::Process_vkCmdEndQueryIndexedEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawIndirectByteCountEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    instanceCount,
     uint32_t                                    firstInstance,
@@ -4840,6 +5183,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndirectByteCountEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetImageViewHandleNVX(
+    const ApiCallInfo&                          call_info,
     uint32_t                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>* pInfo)
@@ -4852,6 +5196,7 @@ void VulkanReplayConsumer::Process_vkGetImageViewHandleNVX(
 }
 
 void VulkanReplayConsumer::Process_vkGetImageViewAddressNVX(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            imageView,
@@ -4866,6 +5211,7 @@ void VulkanReplayConsumer::Process_vkGetImageViewAddressNVX(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawIndirectCountAMD(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -4882,6 +5228,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndirectCountAMD(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawIndexedIndirectCountAMD(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -4898,6 +5245,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawIndexedIndirectCountAMD(
 }
 
 void VulkanReplayConsumer::Process_vkGetShaderInfoAMD(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipeline,
@@ -4918,6 +5266,7 @@ void VulkanReplayConsumer::Process_vkGetShaderInfoAMD(
 }
 
 void VulkanReplayConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkStreamDescriptorSurfaceCreateInfoGGP>* pCreateInfo,
@@ -4937,6 +5286,7 @@ void VulkanReplayConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     VkFormat                                    format,
@@ -4955,6 +5305,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceExternalImageFormatPropert
 }
 
 void VulkanReplayConsumer::Process_vkGetMemoryWin32HandleNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            memory,
@@ -4972,6 +5323,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryWin32HandleNV(
 }
 
 void VulkanReplayConsumer::Process_vkCreateViSurfaceNN(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkViSurfaceCreateInfoNN>* pCreateInfo,
@@ -4991,6 +5343,7 @@ void VulkanReplayConsumer::Process_vkCreateViSurfaceNN(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginConditionalRenderingEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>* pConditionalRenderingBegin)
 {
@@ -5002,6 +5355,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginConditionalRenderingEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdEndConditionalRenderingEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
     VkCommandBuffer in_commandBuffer = MapHandle<CommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetCommandBufferInfo);
@@ -5010,6 +5364,7 @@ void VulkanReplayConsumer::Process_vkCmdEndConditionalRenderingEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetViewportWScalingNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstViewport,
     uint32_t                                    viewportCount,
@@ -5022,6 +5377,7 @@ void VulkanReplayConsumer::Process_vkCmdSetViewportWScalingNV(
 }
 
 void VulkanReplayConsumer::Process_vkReleaseDisplayEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            display)
@@ -5034,6 +5390,7 @@ void VulkanReplayConsumer::Process_vkReleaseDisplayEXT(
 }
 
 void VulkanReplayConsumer::Process_vkAcquireXlibDisplayEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     uint64_t                                    dpy,
@@ -5048,6 +5405,7 @@ void VulkanReplayConsumer::Process_vkAcquireXlibDisplayEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetRandROutputDisplayEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     uint64_t                                    dpy,
@@ -5067,6 +5425,7 @@ void VulkanReplayConsumer::Process_vkGetRandROutputDisplayEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            surface,
@@ -5082,6 +5441,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
 }
 
 void VulkanReplayConsumer::Process_vkDisplayPowerControlEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            display,
@@ -5096,6 +5456,7 @@ void VulkanReplayConsumer::Process_vkDisplayPowerControlEXT(
 }
 
 void VulkanReplayConsumer::Process_vkRegisterDeviceEventEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDeviceEventInfoEXT>* pDeviceEventInfo,
@@ -5115,6 +5476,7 @@ void VulkanReplayConsumer::Process_vkRegisterDeviceEventEXT(
 }
 
 void VulkanReplayConsumer::Process_vkRegisterDisplayEventEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            display,
@@ -5136,6 +5498,7 @@ void VulkanReplayConsumer::Process_vkRegisterDisplayEventEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetSwapchainCounterEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain,
@@ -5152,6 +5515,7 @@ void VulkanReplayConsumer::Process_vkGetSwapchainCounterEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetRefreshCycleDurationGOOGLE(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain,
@@ -5167,6 +5531,7 @@ void VulkanReplayConsumer::Process_vkGetRefreshCycleDurationGOOGLE(
 }
 
 void VulkanReplayConsumer::Process_vkGetPastPresentationTimingGOOGLE(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain,
@@ -5186,6 +5551,7 @@ void VulkanReplayConsumer::Process_vkGetPastPresentationTimingGOOGLE(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDiscardRectangleEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstDiscardRectangle,
     uint32_t                                    discardRectangleCount,
@@ -5198,6 +5564,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDiscardRectangleEXT(
 }
 
 void VulkanReplayConsumer::Process_vkSetHdrMetadataEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     uint32_t                                    swapchainCount,
     HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains,
@@ -5211,6 +5578,7 @@ void VulkanReplayConsumer::Process_vkSetHdrMetadataEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCreateIOSSurfaceMVK(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkIOSSurfaceCreateInfoMVK>* pCreateInfo,
@@ -5230,6 +5598,7 @@ void VulkanReplayConsumer::Process_vkCreateIOSSurfaceMVK(
 }
 
 void VulkanReplayConsumer::Process_vkCreateMacOSSurfaceMVK(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkMacOSSurfaceCreateInfoMVK>* pCreateInfo,
@@ -5249,6 +5618,7 @@ void VulkanReplayConsumer::Process_vkCreateMacOSSurfaceMVK(
 }
 
 void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectNameEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* pNameInfo)
@@ -5262,6 +5632,7 @@ void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectNameEXT(
 }
 
 void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectTagEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>* pTagInfo)
@@ -5275,6 +5646,7 @@ void VulkanReplayConsumer::Process_vkSetDebugUtilsObjectTagEXT(
 }
 
 void VulkanReplayConsumer::Process_vkQueueBeginDebugUtilsLabelEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            queue,
     StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo)
 {
@@ -5285,6 +5657,7 @@ void VulkanReplayConsumer::Process_vkQueueBeginDebugUtilsLabelEXT(
 }
 
 void VulkanReplayConsumer::Process_vkQueueEndDebugUtilsLabelEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            queue)
 {
     VkQueue in_queue = MapHandle<QueueInfo>(queue, &VulkanObjectInfoTable::GetQueueInfo);
@@ -5293,6 +5666,7 @@ void VulkanReplayConsumer::Process_vkQueueEndDebugUtilsLabelEXT(
 }
 
 void VulkanReplayConsumer::Process_vkQueueInsertDebugUtilsLabelEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            queue,
     StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo)
 {
@@ -5303,6 +5677,7 @@ void VulkanReplayConsumer::Process_vkQueueInsertDebugUtilsLabelEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBeginDebugUtilsLabelEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo)
 {
@@ -5313,6 +5688,7 @@ void VulkanReplayConsumer::Process_vkCmdBeginDebugUtilsLabelEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdEndDebugUtilsLabelEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer)
 {
     VkCommandBuffer in_commandBuffer = MapHandle<CommandBufferInfo>(commandBuffer, &VulkanObjectInfoTable::GetCommandBufferInfo);
@@ -5321,6 +5697,7 @@ void VulkanReplayConsumer::Process_vkCmdEndDebugUtilsLabelEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdInsertDebugUtilsLabelEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo)
 {
@@ -5331,6 +5708,7 @@ void VulkanReplayConsumer::Process_vkCmdInsertDebugUtilsLabelEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCreateDebugUtilsMessengerEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>* pCreateInfo,
@@ -5349,6 +5727,7 @@ void VulkanReplayConsumer::Process_vkCreateDebugUtilsMessengerEXT(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyDebugUtilsMessengerEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            instance,
     format::HandleId                            messenger,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -5362,6 +5741,7 @@ void VulkanReplayConsumer::Process_vkDestroyDebugUtilsMessengerEXT(
 }
 
 void VulkanReplayConsumer::Process_vkSubmitDebugUtilsMessageEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            instance,
     VkDebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,
     VkDebugUtilsMessageTypeFlagsEXT             messageTypes,
@@ -5374,6 +5754,7 @@ void VulkanReplayConsumer::Process_vkSubmitDebugUtilsMessageEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetAndroidHardwareBufferPropertiesANDROID(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint64_t                                    buffer,
@@ -5388,6 +5769,7 @@ void VulkanReplayConsumer::Process_vkGetAndroidHardwareBufferPropertiesANDROID(
 }
 
 void VulkanReplayConsumer::Process_vkGetMemoryAndroidHardwareBufferANDROID(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID>* pInfo,
@@ -5405,6 +5787,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryAndroidHardwareBufferANDROID(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetSampleLocationsEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkSampleLocationsInfoEXT>* pSampleLocationsInfo)
 {
@@ -5415,6 +5798,7 @@ void VulkanReplayConsumer::Process_vkCmdSetSampleLocationsEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            physicalDevice,
     VkSampleCountFlagBits                       samples,
     StructPointerDecoder<Decoded_VkMultisamplePropertiesEXT>* pMultisampleProperties)
@@ -5426,6 +5810,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetImageDrmFormatModifierPropertiesEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            image,
@@ -5440,6 +5825,7 @@ void VulkanReplayConsumer::Process_vkGetImageDrmFormatModifierPropertiesEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCreateValidationCacheEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkValidationCacheCreateInfoEXT>* pCreateInfo,
@@ -5459,6 +5845,7 @@ void VulkanReplayConsumer::Process_vkCreateValidationCacheEXT(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyValidationCacheEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            validationCache,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -5472,6 +5859,7 @@ void VulkanReplayConsumer::Process_vkDestroyValidationCacheEXT(
 }
 
 void VulkanReplayConsumer::Process_vkMergeValidationCachesEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            dstCache,
@@ -5487,6 +5875,7 @@ void VulkanReplayConsumer::Process_vkMergeValidationCachesEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetValidationCacheDataEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            validationCache,
@@ -5505,6 +5894,7 @@ void VulkanReplayConsumer::Process_vkGetValidationCacheDataEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBindShadingRateImageNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            imageView,
     VkImageLayout                               imageLayout)
@@ -5516,6 +5906,7 @@ void VulkanReplayConsumer::Process_vkCmdBindShadingRateImageNV(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetViewportShadingRatePaletteNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstViewport,
     uint32_t                                    viewportCount,
@@ -5528,6 +5919,7 @@ void VulkanReplayConsumer::Process_vkCmdSetViewportShadingRatePaletteNV(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetCoarseSampleOrderNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkCoarseSampleOrderTypeNV                   sampleOrderType,
     uint32_t                                    customSampleOrderCount,
@@ -5540,6 +5932,7 @@ void VulkanReplayConsumer::Process_vkCmdSetCoarseSampleOrderNV(
 }
 
 void VulkanReplayConsumer::Process_vkCreateAccelerationStructureNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoNV>* pCreateInfo,
@@ -5560,6 +5953,7 @@ void VulkanReplayConsumer::Process_vkCreateAccelerationStructureNV(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyAccelerationStructureNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            accelerationStructure,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -5573,6 +5967,7 @@ void VulkanReplayConsumer::Process_vkDestroyAccelerationStructureNV(
 }
 
 void VulkanReplayConsumer::Process_vkGetAccelerationStructureMemoryRequirementsNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAccelerationStructureMemoryRequirementsInfoNV>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2KHR>* pMemoryRequirements)
@@ -5586,6 +5981,7 @@ void VulkanReplayConsumer::Process_vkGetAccelerationStructureMemoryRequirementsN
 }
 
 void VulkanReplayConsumer::Process_vkBindAccelerationStructureMemoryNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    bindInfoCount,
@@ -5600,6 +5996,7 @@ void VulkanReplayConsumer::Process_vkBindAccelerationStructureMemoryNV(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBuildAccelerationStructureNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>* pInfo,
     format::HandleId                            instanceData,
@@ -5622,6 +6019,7 @@ void VulkanReplayConsumer::Process_vkCmdBuildAccelerationStructureNV(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyAccelerationStructureNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            dst,
     format::HandleId                            src,
@@ -5635,6 +6033,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyAccelerationStructureNV(
 }
 
 void VulkanReplayConsumer::Process_vkCmdTraceRaysNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            raygenShaderBindingTableBuffer,
     VkDeviceSize                                raygenShaderBindingOffset,
@@ -5661,6 +6060,7 @@ void VulkanReplayConsumer::Process_vkCmdTraceRaysNV(
 }
 
 void VulkanReplayConsumer::Process_vkCreateRayTracingPipelinesNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipelineCache,
@@ -5684,6 +6084,7 @@ void VulkanReplayConsumer::Process_vkCreateRayTracingPipelinesNV(
 }
 
 void VulkanReplayConsumer::Process_vkGetRayTracingShaderGroupHandlesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipeline,
@@ -5701,6 +6102,7 @@ void VulkanReplayConsumer::Process_vkGetRayTracingShaderGroupHandlesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetRayTracingShaderGroupHandlesNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipeline,
@@ -5718,6 +6120,7 @@ void VulkanReplayConsumer::Process_vkGetRayTracingShaderGroupHandlesNV(
 }
 
 void VulkanReplayConsumer::Process_vkGetAccelerationStructureHandleNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            accelerationStructure,
@@ -5733,6 +6136,7 @@ void VulkanReplayConsumer::Process_vkGetAccelerationStructureHandleNV(
 }
 
 void VulkanReplayConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    accelerationStructureCount,
     HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructures,
@@ -5748,6 +6152,7 @@ void VulkanReplayConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesNV(
 }
 
 void VulkanReplayConsumer::Process_vkCompileDeferredNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipeline,
@@ -5761,6 +6166,7 @@ void VulkanReplayConsumer::Process_vkCompileDeferredNV(
 }
 
 void VulkanReplayConsumer::Process_vkGetMemoryHostPointerPropertiesEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -5776,6 +6182,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryHostPointerPropertiesEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdWriteBufferMarkerAMD(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineStageFlagBits                     pipelineStage,
     format::HandleId                            dstBuffer,
@@ -5789,6 +6196,7 @@ void VulkanReplayConsumer::Process_vkCmdWriteBufferMarkerAMD(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pTimeDomainCount,
@@ -5805,6 +6213,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEX
 }
 
 void VulkanReplayConsumer::Process_vkGetCalibratedTimestampsEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    timestampCount,
@@ -5822,6 +6231,7 @@ void VulkanReplayConsumer::Process_vkGetCalibratedTimestampsEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    taskCount,
     uint32_t                                    firstTask)
@@ -5832,6 +6242,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksNV(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksIndirectNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -5845,6 +6256,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksIndirectNV(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksIndirectCountNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            buffer,
     VkDeviceSize                                offset,
@@ -5861,6 +6273,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawMeshTasksIndirectCountNV(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetExclusiveScissorNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstExclusiveScissor,
     uint32_t                                    exclusiveScissorCount,
@@ -5873,6 +6286,7 @@ void VulkanReplayConsumer::Process_vkCmdSetExclusiveScissorNV(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetCheckpointNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint64_t                                    pCheckpointMarker)
 {
@@ -5883,6 +6297,7 @@ void VulkanReplayConsumer::Process_vkCmdSetCheckpointNV(
 }
 
 void VulkanReplayConsumer::Process_vkGetQueueCheckpointDataNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            queue,
     PointerDecoder<uint32_t>*                   pCheckpointDataCount,
     StructPointerDecoder<Decoded_VkCheckpointDataNV>* pCheckpointData)
@@ -5897,6 +6312,7 @@ void VulkanReplayConsumer::Process_vkGetQueueCheckpointDataNV(
 }
 
 void VulkanReplayConsumer::Process_vkInitializePerformanceApiINTEL(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkInitializePerformanceApiInfoINTEL>* pInitializeInfo)
@@ -5909,6 +6325,7 @@ void VulkanReplayConsumer::Process_vkInitializePerformanceApiINTEL(
 }
 
 void VulkanReplayConsumer::Process_vkUninitializePerformanceApiINTEL(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device)
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
@@ -5917,6 +6334,7 @@ void VulkanReplayConsumer::Process_vkUninitializePerformanceApiINTEL(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetPerformanceMarkerINTEL(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkPerformanceMarkerInfoINTEL>* pMarkerInfo)
@@ -5929,6 +6347,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPerformanceMarkerINTEL(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkPerformanceStreamMarkerInfoINTEL>* pMarkerInfo)
@@ -5941,6 +6360,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkPerformanceOverrideInfoINTEL>* pOverrideInfo)
@@ -5953,6 +6373,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
 }
 
 void VulkanReplayConsumer::Process_vkAcquirePerformanceConfigurationINTEL(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPerformanceConfigurationAcquireInfoINTEL>* pAcquireInfo,
@@ -5970,6 +6391,7 @@ void VulkanReplayConsumer::Process_vkAcquirePerformanceConfigurationINTEL(
 }
 
 void VulkanReplayConsumer::Process_vkReleasePerformanceConfigurationINTEL(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            configuration)
@@ -5982,6 +6404,7 @@ void VulkanReplayConsumer::Process_vkReleasePerformanceConfigurationINTEL(
 }
 
 void VulkanReplayConsumer::Process_vkQueueSetPerformanceConfigurationINTEL(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            queue,
     format::HandleId                            configuration)
@@ -5994,6 +6417,7 @@ void VulkanReplayConsumer::Process_vkQueueSetPerformanceConfigurationINTEL(
 }
 
 void VulkanReplayConsumer::Process_vkGetPerformanceParameterINTEL(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     VkPerformanceParameterTypeINTEL             parameter,
@@ -6007,6 +6431,7 @@ void VulkanReplayConsumer::Process_vkGetPerformanceParameterINTEL(
 }
 
 void VulkanReplayConsumer::Process_vkSetLocalDimmingAMD(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            swapChain,
     VkBool32                                    localDimmingEnable)
@@ -6018,6 +6443,7 @@ void VulkanReplayConsumer::Process_vkSetLocalDimmingAMD(
 }
 
 void VulkanReplayConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA>* pCreateInfo,
@@ -6037,6 +6463,7 @@ void VulkanReplayConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
 }
 
 void VulkanReplayConsumer::Process_vkCreateMetalSurfaceEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>* pCreateInfo,
@@ -6056,6 +6483,7 @@ void VulkanReplayConsumer::Process_vkCreateMetalSurfaceEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetBufferDeviceAddressEXT(
+    const ApiCallInfo&                          call_info,
     VkDeviceAddress                             returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo)
@@ -6068,6 +6496,7 @@ void VulkanReplayConsumer::Process_vkGetBufferDeviceAddressEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceToolPropertiesEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pToolCount,
@@ -6084,6 +6513,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceToolPropertiesEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pPropertyCount,
@@ -6100,6 +6530,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixPropertie
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     PointerDecoder<uint32_t>*                   pCombinationCount,
@@ -6116,6 +6547,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedS
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
@@ -6135,6 +6567,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
 }
 
 void VulkanReplayConsumer::Process_vkAcquireFullScreenExclusiveModeEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain)
@@ -6148,6 +6581,7 @@ void VulkanReplayConsumer::Process_vkAcquireFullScreenExclusiveModeEXT(
 }
 
 void VulkanReplayConsumer::Process_vkReleaseFullScreenExclusiveModeEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            swapchain)
@@ -6161,6 +6595,7 @@ void VulkanReplayConsumer::Process_vkReleaseFullScreenExclusiveModeEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceGroupSurfacePresentModes2EXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
@@ -6176,6 +6611,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceGroupSurfacePresentModes2EXT(
 }
 
 void VulkanReplayConsumer::Process_vkCreateHeadlessSurfaceEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkHeadlessSurfaceCreateInfoEXT>* pCreateInfo,
@@ -6195,6 +6631,7 @@ void VulkanReplayConsumer::Process_vkCreateHeadlessSurfaceEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetLineStippleEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    lineStippleFactor,
     uint16_t                                    lineStipplePattern)
@@ -6205,6 +6642,7 @@ void VulkanReplayConsumer::Process_vkCmdSetLineStippleEXT(
 }
 
 void VulkanReplayConsumer::Process_vkResetQueryPoolEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            queryPool,
     uint32_t                                    firstQuery,
@@ -6217,6 +6655,7 @@ void VulkanReplayConsumer::Process_vkResetQueryPoolEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetCullModeEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkCullModeFlags                             cullMode)
 {
@@ -6226,6 +6665,7 @@ void VulkanReplayConsumer::Process_vkCmdSetCullModeEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetFrontFaceEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkFrontFace                                 frontFace)
 {
@@ -6235,6 +6675,7 @@ void VulkanReplayConsumer::Process_vkCmdSetFrontFaceEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetPrimitiveTopologyEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPrimitiveTopology                         primitiveTopology)
 {
@@ -6244,6 +6685,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPrimitiveTopologyEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetViewportWithCountEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    viewportCount,
     StructPointerDecoder<Decoded_VkViewport>*   pViewports)
@@ -6255,6 +6697,7 @@ void VulkanReplayConsumer::Process_vkCmdSetViewportWithCountEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetScissorWithCountEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    scissorCount,
     StructPointerDecoder<Decoded_VkRect2D>*     pScissors)
@@ -6266,6 +6709,7 @@ void VulkanReplayConsumer::Process_vkCmdSetScissorWithCountEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBindVertexBuffers2EXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    firstBinding,
     uint32_t                                    bindingCount,
@@ -6284,6 +6728,7 @@ void VulkanReplayConsumer::Process_vkCmdBindVertexBuffers2EXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDepthTestEnableEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    depthTestEnable)
 {
@@ -6293,6 +6738,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthTestEnableEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDepthWriteEnableEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    depthWriteEnable)
 {
@@ -6302,6 +6748,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthWriteEnableEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDepthCompareOpEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkCompareOp                                 depthCompareOp)
 {
@@ -6311,6 +6758,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthCompareOpEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDepthBoundsTestEnableEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    depthBoundsTestEnable)
 {
@@ -6320,6 +6768,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBoundsTestEnableEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetStencilTestEnableEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    stencilTestEnable)
 {
@@ -6329,6 +6778,7 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilTestEnableEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetStencilOpEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkStencilFaceFlags                          faceMask,
     VkStencilOp                                 failOp,
@@ -6342,6 +6792,7 @@ void VulkanReplayConsumer::Process_vkCmdSetStencilOpEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetGeneratedCommandsMemoryRequirementsNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkGeneratedCommandsMemoryRequirementsInfoNV>* pInfo,
     StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements)
@@ -6355,6 +6806,7 @@ void VulkanReplayConsumer::Process_vkGetGeneratedCommandsMemoryRequirementsNV(
 }
 
 void VulkanReplayConsumer::Process_vkCmdPreprocessGeneratedCommandsNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo)
 {
@@ -6366,6 +6818,7 @@ void VulkanReplayConsumer::Process_vkCmdPreprocessGeneratedCommandsNV(
 }
 
 void VulkanReplayConsumer::Process_vkCmdExecuteGeneratedCommandsNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    isPreprocessed,
     StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo)
@@ -6378,6 +6831,7 @@ void VulkanReplayConsumer::Process_vkCmdExecuteGeneratedCommandsNV(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBindPipelineShaderGroupNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkPipelineBindPoint                         pipelineBindPoint,
     format::HandleId                            pipeline,
@@ -6390,6 +6844,7 @@ void VulkanReplayConsumer::Process_vkCmdBindPipelineShaderGroupNV(
 }
 
 void VulkanReplayConsumer::Process_vkCreateIndirectCommandsLayoutNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkIndirectCommandsLayoutCreateInfoNV>* pCreateInfo,
@@ -6410,6 +6865,7 @@ void VulkanReplayConsumer::Process_vkCreateIndirectCommandsLayoutNV(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyIndirectCommandsLayoutNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            indirectCommandsLayout,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -6423,6 +6879,7 @@ void VulkanReplayConsumer::Process_vkDestroyIndirectCommandsLayoutNV(
 }
 
 void VulkanReplayConsumer::Process_vkAcquireDrmDisplayEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     int32_t                                     drmFd,
@@ -6436,6 +6893,7 @@ void VulkanReplayConsumer::Process_vkAcquireDrmDisplayEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetDrmDisplayEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     int32_t                                     drmFd,
@@ -6453,6 +6911,7 @@ void VulkanReplayConsumer::Process_vkGetDrmDisplayEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCreatePrivateDataSlotEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkPrivateDataSlotCreateInfo>* pCreateInfo,
@@ -6472,6 +6931,7 @@ void VulkanReplayConsumer::Process_vkCreatePrivateDataSlotEXT(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyPrivateDataSlotEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            privateDataSlot,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -6485,6 +6945,7 @@ void VulkanReplayConsumer::Process_vkDestroyPrivateDataSlotEXT(
 }
 
 void VulkanReplayConsumer::Process_vkSetPrivateDataEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     VkObjectType                                objectType,
@@ -6501,6 +6962,7 @@ void VulkanReplayConsumer::Process_vkSetPrivateDataEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetPrivateDataEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     VkObjectType                                objectType,
     uint64_t                                    objectHandle,
@@ -6516,6 +6978,7 @@ void VulkanReplayConsumer::Process_vkGetPrivateDataEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetFragmentShadingRateEnumNV(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkFragmentShadingRateNV                     shadingRate,
     PointerDecoder<VkFragmentShadingRateCombinerOpKHR>* combinerOps)
@@ -6527,6 +6990,7 @@ void VulkanReplayConsumer::Process_vkCmdSetFragmentShadingRateEnumNV(
 }
 
 void VulkanReplayConsumer::Process_vkAcquireWinrtDisplayNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     format::HandleId                            display)
@@ -6539,6 +7003,7 @@ void VulkanReplayConsumer::Process_vkAcquireWinrtDisplayNV(
 }
 
 void VulkanReplayConsumer::Process_vkGetWinrtDisplayNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    deviceRelativeId,
@@ -6555,6 +7020,7 @@ void VulkanReplayConsumer::Process_vkGetWinrtDisplayNV(
 }
 
 void VulkanReplayConsumer::Process_vkCreateDirectFBSurfaceEXT(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkDirectFBSurfaceCreateInfoEXT>* pCreateInfo,
@@ -6574,6 +7040,7 @@ void VulkanReplayConsumer::Process_vkCreateDirectFBSurfaceEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDirectFBPresentationSupportEXT(
+    const ApiCallInfo&                          call_info,
     VkBool32                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    queueFamilyIndex,
@@ -6586,6 +7053,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceDirectFBPresentationSuppor
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetVertexInputEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    vertexBindingDescriptionCount,
     StructPointerDecoder<Decoded_VkVertexInputBindingDescription2EXT>* pVertexBindingDescriptions,
@@ -6600,6 +7068,7 @@ void VulkanReplayConsumer::Process_vkCmdSetVertexInputEXT(
 }
 
 void VulkanReplayConsumer::Process_vkGetMemoryZirconHandleFUCHSIA(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkMemoryGetZirconHandleInfoFUCHSIA>* pGetZirconHandleInfo,
@@ -6615,6 +7084,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryZirconHandleFUCHSIA(
 }
 
 void VulkanReplayConsumer::Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -6629,6 +7099,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(
 }
 
 void VulkanReplayConsumer::Process_vkImportSemaphoreZirconHandleFUCHSIA(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkImportSemaphoreZirconHandleInfoFUCHSIA>* pImportSemaphoreZirconHandleInfo)
@@ -6642,6 +7113,7 @@ void VulkanReplayConsumer::Process_vkImportSemaphoreZirconHandleFUCHSIA(
 }
 
 void VulkanReplayConsumer::Process_vkGetSemaphoreZirconHandleFUCHSIA(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkSemaphoreGetZirconHandleInfoFUCHSIA>* pGetZirconHandleInfo,
@@ -6657,6 +7129,7 @@ void VulkanReplayConsumer::Process_vkGetSemaphoreZirconHandleFUCHSIA(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBindInvocationMaskHUAWEI(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     format::HandleId                            imageView,
     VkImageLayout                               imageLayout)
@@ -6668,6 +7141,7 @@ void VulkanReplayConsumer::Process_vkCmdBindInvocationMaskHUAWEI(
 }
 
 void VulkanReplayConsumer::Process_vkGetMemoryRemoteAddressNV(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkMemoryGetRemoteAddressInfoNV>* pMemoryGetRemoteAddressInfo,
@@ -6685,6 +7159,7 @@ void VulkanReplayConsumer::Process_vkGetMemoryRemoteAddressNV(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetPatchControlPointsEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    patchControlPoints)
 {
@@ -6694,6 +7169,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPatchControlPointsEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetRasterizerDiscardEnableEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    rasterizerDiscardEnable)
 {
@@ -6703,6 +7179,7 @@ void VulkanReplayConsumer::Process_vkCmdSetRasterizerDiscardEnableEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetDepthBiasEnableEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    depthBiasEnable)
 {
@@ -6712,6 +7189,7 @@ void VulkanReplayConsumer::Process_vkCmdSetDepthBiasEnableEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetLogicOpEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkLogicOp                                   logicOp)
 {
@@ -6721,6 +7199,7 @@ void VulkanReplayConsumer::Process_vkCmdSetLogicOpEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetPrimitiveRestartEnableEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     VkBool32                                    primitiveRestartEnable)
 {
@@ -6730,6 +7209,7 @@ void VulkanReplayConsumer::Process_vkCmdSetPrimitiveRestartEnableEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCreateScreenSurfaceQNX(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            instance,
     StructPointerDecoder<Decoded_VkScreenSurfaceCreateInfoQNX>* pCreateInfo,
@@ -6749,6 +7229,7 @@ void VulkanReplayConsumer::Process_vkCreateScreenSurfaceQNX(
 }
 
 void VulkanReplayConsumer::Process_vkGetPhysicalDeviceScreenPresentationSupportQNX(
+    const ApiCallInfo&                          call_info,
     VkBool32                                    returnValue,
     format::HandleId                            physicalDevice,
     uint32_t                                    queueFamilyIndex,
@@ -6761,6 +7242,7 @@ void VulkanReplayConsumer::Process_vkGetPhysicalDeviceScreenPresentationSupportQ
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetColorWriteEnableEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    attachmentCount,
     PointerDecoder<VkBool32>*                   pColorWriteEnables)
@@ -6772,6 +7254,7 @@ void VulkanReplayConsumer::Process_vkCmdSetColorWriteEnableEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawMultiEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    drawCount,
     StructPointerDecoder<Decoded_VkMultiDrawInfoEXT>* pVertexInfo,
@@ -6786,6 +7269,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawMultiEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCmdDrawMultiIndexedEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    drawCount,
     StructPointerDecoder<Decoded_VkMultiDrawIndexedInfoEXT>* pIndexInfo,
@@ -6802,6 +7286,7 @@ void VulkanReplayConsumer::Process_vkCmdDrawMultiIndexedEXT(
 }
 
 void VulkanReplayConsumer::Process_vkSetDeviceMemoryPriorityEXT(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            memory,
     float                                       priority)
@@ -6813,6 +7298,7 @@ void VulkanReplayConsumer::Process_vkSetDeviceMemoryPriorityEXT(
 }
 
 void VulkanReplayConsumer::Process_vkCreateAccelerationStructureKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoKHR>* pCreateInfo,
@@ -6833,6 +7319,7 @@ void VulkanReplayConsumer::Process_vkCreateAccelerationStructureKHR(
 }
 
 void VulkanReplayConsumer::Process_vkDestroyAccelerationStructureKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     format::HandleId                            accelerationStructure,
     StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator)
@@ -6846,6 +7333,7 @@ void VulkanReplayConsumer::Process_vkDestroyAccelerationStructureKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBuildAccelerationStructuresKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    infoCount,
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
@@ -6860,6 +7348,7 @@ void VulkanReplayConsumer::Process_vkCmdBuildAccelerationStructuresKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdBuildAccelerationStructuresIndirectKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    infoCount,
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
@@ -6878,6 +7367,7 @@ void VulkanReplayConsumer::Process_vkCmdBuildAccelerationStructuresIndirectKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCopyAccelerationStructureToMemoryKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            deferredOperation,
@@ -6893,6 +7383,7 @@ void VulkanReplayConsumer::Process_vkCopyAccelerationStructureToMemoryKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCopyMemoryToAccelerationStructureKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            deferredOperation,
@@ -6908,6 +7399,7 @@ void VulkanReplayConsumer::Process_vkCopyMemoryToAccelerationStructureKHR(
 }
 
 void VulkanReplayConsumer::Process_vkWriteAccelerationStructuresPropertiesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     uint32_t                                    accelerationStructureCount,
@@ -6926,6 +7418,7 @@ void VulkanReplayConsumer::Process_vkWriteAccelerationStructuresPropertiesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyAccelerationStructureKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo)
 {
@@ -6937,6 +7430,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyAccelerationStructureKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyAccelerationStructureToMemoryKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyAccelerationStructureToMemoryInfoKHR>* pInfo)
 {
@@ -6948,6 +7442,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyAccelerationStructureToMemoryKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdCopyMemoryToAccelerationStructureKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkCopyMemoryToAccelerationStructureInfoKHR>* pInfo)
 {
@@ -6959,6 +7454,7 @@ void VulkanReplayConsumer::Process_vkCmdCopyMemoryToAccelerationStructureKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetAccelerationStructureDeviceAddressKHR(
+    const ApiCallInfo&                          call_info,
     VkDeviceAddress                             returnValue,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAccelerationStructureDeviceAddressInfoKHR>* pInfo)
@@ -6971,6 +7467,7 @@ void VulkanReplayConsumer::Process_vkGetAccelerationStructureDeviceAddressKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    accelerationStructureCount,
     HandlePointerDecoder<VkAccelerationStructureKHR>* pAccelerationStructures,
@@ -6986,6 +7483,7 @@ void VulkanReplayConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesKHR
 }
 
 void VulkanReplayConsumer::Process_vkGetDeviceAccelerationStructureCompatibilityKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     StructPointerDecoder<Decoded_VkAccelerationStructureVersionInfoKHR>* pVersionInfo,
     PointerDecoder<VkAccelerationStructureCompatibilityKHR>* pCompatibility)
@@ -6998,6 +7496,7 @@ void VulkanReplayConsumer::Process_vkGetDeviceAccelerationStructureCompatibility
 }
 
 void VulkanReplayConsumer::Process_vkGetAccelerationStructureBuildSizesKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            device,
     VkAccelerationStructureBuildTypeKHR         buildType,
     StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pBuildInfo,
@@ -7014,6 +7513,7 @@ void VulkanReplayConsumer::Process_vkGetAccelerationStructureBuildSizesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdTraceRaysKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pRaygenShaderBindingTable,
     StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pMissShaderBindingTable,
@@ -7033,6 +7533,7 @@ void VulkanReplayConsumer::Process_vkCmdTraceRaysKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCreateRayTracingPipelinesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            deferredOperation,
@@ -7058,6 +7559,7 @@ void VulkanReplayConsumer::Process_vkCreateRayTracingPipelinesKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(
+    const ApiCallInfo&                          call_info,
     VkResult                                    returnValue,
     format::HandleId                            device,
     format::HandleId                            pipeline,
@@ -7075,6 +7577,7 @@ void VulkanReplayConsumer::Process_vkGetRayTracingCaptureReplayShaderGroupHandle
 }
 
 void VulkanReplayConsumer::Process_vkCmdTraceRaysIndirectKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pRaygenShaderBindingTable,
     StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pMissShaderBindingTable,
@@ -7092,6 +7595,7 @@ void VulkanReplayConsumer::Process_vkCmdTraceRaysIndirectKHR(
 }
 
 void VulkanReplayConsumer::Process_vkGetRayTracingShaderGroupStackSizeKHR(
+    const ApiCallInfo&                          call_info,
     VkDeviceSize                                returnValue,
     format::HandleId                            device,
     format::HandleId                            pipeline,
@@ -7105,6 +7609,7 @@ void VulkanReplayConsumer::Process_vkGetRayTracingShaderGroupStackSizeKHR(
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetRayTracingPipelineStackSizeKHR(
+    const ApiCallInfo&                          call_info,
     format::HandleId                            commandBuffer,
     uint32_t                                    pipelineStackSize)
 {

--- a/framework/generated/generated_vulkan_replay_consumer.h
+++ b/framework/generated/generated_vulkan_replay_consumer.h
@@ -45,31 +45,37 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
     virtual ~VulkanReplayConsumer() override { }
 
     virtual void Process_vkCreateInstance(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         StructPointerDecoder<Decoded_VkInstanceCreateInfo>* pCreateInfo,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkInstance>*           pInstance) override;
 
     virtual void Process_vkDestroyInstance(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkEnumeratePhysicalDevices(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         PointerDecoder<uint32_t>*                   pPhysicalDeviceCount,
         HandlePointerDecoder<VkPhysicalDevice>*     pPhysicalDevices) override;
 
     virtual void Process_vkGetPhysicalDeviceFeatures(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures>* pFeatures) override;
 
     virtual void Process_vkGetPhysicalDeviceFormatProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
         StructPointerDecoder<Decoded_VkFormatProperties>* pFormatProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
@@ -80,19 +86,23 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkImageFormatProperties>* pImageFormatProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceProperties>* pProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
         StructPointerDecoder<Decoded_VkQueueFamilyProperties>* pQueueFamilyProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceMemoryProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties>* pMemoryProperties) override;
 
     virtual void Process_vkCreateDevice(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkDeviceCreateInfo>* pCreateInfo,
@@ -100,16 +110,19 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkDevice>*             pDevice) override;
 
     virtual void Process_vkDestroyDevice(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetDeviceQueue(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         uint32_t                                    queueFamilyIndex,
         uint32_t                                    queueIndex,
         HandlePointerDecoder<VkQueue>*              pQueue) override;
 
     virtual void Process_vkQueueSubmit(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    submitCount,
@@ -117,14 +130,17 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            fence) override;
 
     virtual void Process_vkQueueWaitIdle(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue) override;
 
     virtual void Process_vkDeviceWaitIdle(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device) override;
 
     virtual void Process_vkAllocateMemory(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryAllocateInfo>* pAllocateInfo,
@@ -132,11 +148,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkDeviceMemory>*       pMemory) override;
 
     virtual void Process_vkFreeMemory(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            memory,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkMapMemory(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            memory,
@@ -146,27 +164,32 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint64_t, void*>*            ppData) override;
 
     virtual void Process_vkUnmapMemory(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            memory) override;
 
     virtual void Process_vkFlushMappedMemoryRanges(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    memoryRangeCount,
         StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges) override;
 
     virtual void Process_vkInvalidateMappedMemoryRanges(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    memoryRangeCount,
         StructPointerDecoder<Decoded_VkMappedMemoryRange>* pMemoryRanges) override;
 
     virtual void Process_vkGetDeviceMemoryCommitment(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            memory,
         PointerDecoder<VkDeviceSize>*               pCommittedMemoryInBytes) override;
 
     virtual void Process_vkBindBufferMemory(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            buffer,
@@ -174,6 +197,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkDeviceSize                                memoryOffset) override;
 
     virtual void Process_vkBindImageMemory(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            image,
@@ -181,22 +205,26 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkDeviceSize                                memoryOffset) override;
 
     virtual void Process_vkGetBufferMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            buffer,
         StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements) override;
 
     virtual void Process_vkGetImageMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            image,
         StructPointerDecoder<Decoded_VkMemoryRequirements>* pMemoryRequirements) override;
 
     virtual void Process_vkGetImageSparseMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            image,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements>* pSparseMemoryRequirements) override;
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
         VkImageType                                 type,
@@ -207,6 +235,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkSparseImageFormatProperties>* pProperties) override;
 
     virtual void Process_vkQueueBindSparse(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    bindInfoCount,
@@ -214,6 +243,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            fence) override;
 
     virtual void Process_vkCreateFence(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkFenceCreateInfo>* pCreateInfo,
@@ -221,22 +251,26 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkFence>*              pFence) override;
 
     virtual void Process_vkDestroyFence(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            fence,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkResetFences(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    fenceCount,
         HandlePointerDecoder<VkFence>*              pFences) override;
 
     virtual void Process_vkGetFenceStatus(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            fence) override;
 
     virtual void Process_vkWaitForFences(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    fenceCount,
@@ -245,6 +279,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint64_t                                    timeout) override;
 
     virtual void Process_vkCreateSemaphore(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreCreateInfo>* pCreateInfo,
@@ -252,11 +287,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSemaphore>*          pSemaphore) override;
 
     virtual void Process_vkDestroySemaphore(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            semaphore,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateEvent(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkEventCreateInfo>* pCreateInfo,
@@ -264,26 +301,31 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkEvent>*              pEvent) override;
 
     virtual void Process_vkDestroyEvent(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            event,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetEventStatus(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            event) override;
 
     virtual void Process_vkSetEvent(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            event) override;
 
     virtual void Process_vkResetEvent(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            event) override;
 
     virtual void Process_vkCreateQueryPool(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkQueryPoolCreateInfo>* pCreateInfo,
@@ -291,11 +333,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkQueryPool>*          pQueryPool) override;
 
     virtual void Process_vkDestroyQueryPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            queryPool,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetQueryPoolResults(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            queryPool,
@@ -307,6 +351,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkQueryResultFlags                          flags) override;
 
     virtual void Process_vkCreateBuffer(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferCreateInfo>* pCreateInfo,
@@ -314,11 +359,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkBuffer>*             pBuffer) override;
 
     virtual void Process_vkDestroyBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            buffer,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateBufferView(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferViewCreateInfo>* pCreateInfo,
@@ -326,11 +373,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkBufferView>*         pView) override;
 
     virtual void Process_vkDestroyBufferView(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            bufferView,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateImage(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageCreateInfo>* pCreateInfo,
@@ -338,17 +387,20 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkImage>*              pImage) override;
 
     virtual void Process_vkDestroyImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            image,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetImageSubresourceLayout(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            image,
         StructPointerDecoder<Decoded_VkImageSubresource>* pSubresource,
         StructPointerDecoder<Decoded_VkSubresourceLayout>* pLayout) override;
 
     virtual void Process_vkCreateImageView(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageViewCreateInfo>* pCreateInfo,
@@ -356,11 +408,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkImageView>*          pView) override;
 
     virtual void Process_vkDestroyImageView(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            imageView,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateShaderModule(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkShaderModuleCreateInfo>* pCreateInfo,
@@ -368,11 +422,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkShaderModule>*       pShaderModule) override;
 
     virtual void Process_vkDestroyShaderModule(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            shaderModule,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreatePipelineCache(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPipelineCacheCreateInfo>* pCreateInfo,
@@ -380,11 +436,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkPipelineCache>*      pPipelineCache) override;
 
     virtual void Process_vkDestroyPipelineCache(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetPipelineCacheData(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
@@ -392,6 +450,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkMergePipelineCaches(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            dstCache,
@@ -399,6 +458,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkPipelineCache>*      pSrcCaches) override;
 
     virtual void Process_vkCreateGraphicsPipelines(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
@@ -408,6 +468,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkPipeline>*           pPipelines) override;
 
     virtual void Process_vkCreateComputePipelines(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
@@ -417,11 +478,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkPipeline>*           pPipelines) override;
 
     virtual void Process_vkDestroyPipeline(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            pipeline,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreatePipelineLayout(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPipelineLayoutCreateInfo>* pCreateInfo,
@@ -429,11 +492,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkPipelineLayout>*     pPipelineLayout) override;
 
     virtual void Process_vkDestroyPipelineLayout(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            pipelineLayout,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateSampler(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSamplerCreateInfo>* pCreateInfo,
@@ -441,11 +506,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSampler>*            pSampler) override;
 
     virtual void Process_vkDestroySampler(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            sampler,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateDescriptorSetLayout(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
@@ -453,11 +520,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkDescriptorSetLayout>* pSetLayout) override;
 
     virtual void Process_vkDestroyDescriptorSetLayout(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            descriptorSetLayout,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateDescriptorPool(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorPoolCreateInfo>* pCreateInfo,
@@ -465,23 +534,27 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkDescriptorPool>*     pDescriptorPool) override;
 
     virtual void Process_vkDestroyDescriptorPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkResetDescriptorPool(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
         VkDescriptorPoolResetFlags                  flags) override;
 
     virtual void Process_vkAllocateDescriptorSets(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorSetAllocateInfo>* pAllocateInfo,
         HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) override;
 
     virtual void Process_vkFreeDescriptorSets(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            descriptorPool,
@@ -489,6 +562,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkDescriptorSet>*      pDescriptorSets) override;
 
     virtual void Process_vkUpdateDescriptorSets(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         uint32_t                                    descriptorWriteCount,
         StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites,
@@ -496,6 +570,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkCopyDescriptorSet>* pDescriptorCopies) override;
 
     virtual void Process_vkCreateFramebuffer(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkFramebufferCreateInfo>* pCreateInfo,
@@ -503,11 +578,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkFramebuffer>*        pFramebuffer) override;
 
     virtual void Process_vkDestroyFramebuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            framebuffer,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateRenderPass(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkRenderPassCreateInfo>* pCreateInfo,
@@ -515,16 +592,19 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkRenderPass>*         pRenderPass) override;
 
     virtual void Process_vkDestroyRenderPass(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            renderPass,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetRenderAreaGranularity(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            renderPass,
         StructPointerDecoder<Decoded_VkExtent2D>*   pGranularity) override;
 
     virtual void Process_vkCreateCommandPool(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkCommandPoolCreateInfo>* pCreateInfo,
@@ -532,94 +612,112 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkCommandPool>*        pCommandPool) override;
 
     virtual void Process_vkDestroyCommandPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            commandPool,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkResetCommandPool(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            commandPool,
         VkCommandPoolResetFlags                     flags) override;
 
     virtual void Process_vkAllocateCommandBuffers(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkCommandBufferAllocateInfo>* pAllocateInfo,
         HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) override;
 
     virtual void Process_vkFreeCommandBuffers(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            commandPool,
         uint32_t                                    commandBufferCount,
         HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) override;
 
     virtual void Process_vkBeginCommandBuffer(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCommandBufferBeginInfo>* pBeginInfo) override;
 
     virtual void Process_vkEndCommandBuffer(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkResetCommandBuffer(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
         VkCommandBufferResetFlags                   flags) override;
 
     virtual void Process_vkCmdBindPipeline(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineBindPoint                         pipelineBindPoint,
         format::HandleId                            pipeline) override;
 
     virtual void Process_vkCmdSetViewport(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
         StructPointerDecoder<Decoded_VkViewport>*   pViewports) override;
 
     virtual void Process_vkCmdSetScissor(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstScissor,
         uint32_t                                    scissorCount,
         StructPointerDecoder<Decoded_VkRect2D>*     pScissors) override;
 
     virtual void Process_vkCmdSetLineWidth(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         float                                       lineWidth) override;
 
     virtual void Process_vkCmdSetDepthBias(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         float                                       depthBiasConstantFactor,
         float                                       depthBiasClamp,
         float                                       depthBiasSlopeFactor) override;
 
     virtual void Process_vkCmdSetBlendConstants(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         PointerDecoder<float>*                      blendConstants) override;
 
     virtual void Process_vkCmdSetDepthBounds(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         float                                       minDepthBounds,
         float                                       maxDepthBounds) override;
 
     virtual void Process_vkCmdSetStencilCompareMask(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
         uint32_t                                    compareMask) override;
 
     virtual void Process_vkCmdSetStencilWriteMask(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
         uint32_t                                    writeMask) override;
 
     virtual void Process_vkCmdSetStencilReference(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
         uint32_t                                    reference) override;
 
     virtual void Process_vkCmdBindDescriptorSets(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineBindPoint                         pipelineBindPoint,
         format::HandleId                            layout,
@@ -630,12 +728,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint32_t>*                   pDynamicOffsets) override;
 
     virtual void Process_vkCmdBindIndexBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
         VkIndexType                                 indexType) override;
 
     virtual void Process_vkCmdBindVertexBuffers(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
@@ -643,6 +743,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<VkDeviceSize>*               pOffsets) override;
 
     virtual void Process_vkCmdDraw(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    vertexCount,
         uint32_t                                    instanceCount,
@@ -650,6 +751,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    firstInstance) override;
 
     virtual void Process_vkCmdDrawIndexed(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    indexCount,
         uint32_t                                    instanceCount,
@@ -658,6 +760,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    firstInstance) override;
 
     virtual void Process_vkCmdDrawIndirect(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -665,6 +768,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawIndexedIndirect(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -672,17 +776,20 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDispatch(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    groupCountX,
         uint32_t                                    groupCountY,
         uint32_t                                    groupCountZ) override;
 
     virtual void Process_vkCmdDispatchIndirect(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset) override;
 
     virtual void Process_vkCmdCopyBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcBuffer,
         format::HandleId                            dstBuffer,
@@ -690,6 +797,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkBufferCopy>* pRegions) override;
 
     virtual void Process_vkCmdCopyImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcImage,
         VkImageLayout                               srcImageLayout,
@@ -699,6 +807,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkImageCopy>*  pRegions) override;
 
     virtual void Process_vkCmdBlitImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcImage,
         VkImageLayout                               srcImageLayout,
@@ -709,6 +818,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkFilter                                    filter) override;
 
     virtual void Process_vkCmdCopyBufferToImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcBuffer,
         format::HandleId                            dstImage,
@@ -717,6 +827,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions) override;
 
     virtual void Process_vkCmdCopyImageToBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcImage,
         VkImageLayout                               srcImageLayout,
@@ -725,6 +836,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkBufferImageCopy>* pRegions) override;
 
     virtual void Process_vkCmdUpdateBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            dstBuffer,
         VkDeviceSize                                dstOffset,
@@ -732,6 +844,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkCmdFillBuffer(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            dstBuffer,
         VkDeviceSize                                dstOffset,
@@ -739,6 +852,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    data) override;
 
     virtual void Process_vkCmdClearColorImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            image,
         VkImageLayout                               imageLayout,
@@ -747,6 +861,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges) override;
 
     virtual void Process_vkCmdClearDepthStencilImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            image,
         VkImageLayout                               imageLayout,
@@ -755,6 +870,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkImageSubresourceRange>* pRanges) override;
 
     virtual void Process_vkCmdClearAttachments(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    attachmentCount,
         StructPointerDecoder<Decoded_VkClearAttachment>* pAttachments,
@@ -762,6 +878,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkClearRect>*  pRects) override;
 
     virtual void Process_vkCmdResolveImage(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            srcImage,
         VkImageLayout                               srcImageLayout,
@@ -771,16 +888,19 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkImageResolve>* pRegions) override;
 
     virtual void Process_vkCmdSetEvent(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         VkPipelineStageFlags                        stageMask) override;
 
     virtual void Process_vkCmdResetEvent(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         VkPipelineStageFlags                        stageMask) override;
 
     virtual void Process_vkCmdWaitEvents(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    eventCount,
         HandlePointerDecoder<VkEvent>*              pEvents,
@@ -794,6 +914,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers) override;
 
     virtual void Process_vkCmdPipelineBarrier(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlags                        srcStageMask,
         VkPipelineStageFlags                        dstStageMask,
@@ -806,29 +927,34 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkImageMemoryBarrier>* pImageMemoryBarriers) override;
 
     virtual void Process_vkCmdBeginQuery(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    query,
         VkQueryControlFlags                         flags) override;
 
     virtual void Process_vkCmdEndQuery(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    query) override;
 
     virtual void Process_vkCmdResetQueryPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery,
         uint32_t                                    queryCount) override;
 
     virtual void Process_vkCmdWriteTimestamp(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlagBits                     pipelineStage,
         format::HandleId                            queryPool,
         uint32_t                                    query) override;
 
     virtual void Process_vkCmdCopyQueryPoolResults(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery,
@@ -839,6 +965,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkQueryResultFlags                          flags) override;
 
     virtual void Process_vkCmdPushConstants(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            layout,
         VkShaderStageFlags                          stageFlags,
@@ -847,35 +974,42 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint8_t>*                    pValues) override;
 
     virtual void Process_vkCmdBeginRenderPass(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
         VkSubpassContents                           contents) override;
 
     virtual void Process_vkCmdNextSubpass(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkSubpassContents                           contents) override;
 
     virtual void Process_vkCmdEndRenderPass(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkCmdExecuteCommands(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    commandBufferCount,
         HandlePointerDecoder<VkCommandBuffer>*      pCommandBuffers) override;
 
     virtual void Process_vkBindBufferMemory2(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
         StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos) override;
 
     virtual void Process_vkBindImageMemory2(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
         StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos) override;
 
     virtual void Process_vkGetDeviceGroupPeerMemoryFeatures(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         uint32_t                                    heapIndex,
         uint32_t                                    localDeviceIndex,
@@ -883,10 +1017,12 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<VkPeerMemoryFeatureFlags>*   pPeerMemoryFeatures) override;
 
     virtual void Process_vkCmdSetDeviceMask(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    deviceMask) override;
 
     virtual void Process_vkCmdDispatchBase(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    baseGroupX,
         uint32_t                                    baseGroupY,
@@ -896,72 +1032,86 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    groupCountZ) override;
 
     virtual void Process_vkEnumeratePhysicalDeviceGroups(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         PointerDecoder<uint32_t>*                   pPhysicalDeviceGroupCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties) override;
 
     virtual void Process_vkGetImageMemoryRequirements2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetBufferMemoryRequirements2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetImageSparseMemoryRequirements2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) override;
 
     virtual void Process_vkGetPhysicalDeviceFeatures2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures) override;
 
     virtual void Process_vkGetPhysicalDeviceProperties2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceFormatProperties2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
         StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties2(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
         StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
         StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceMemoryProperties2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties) override;
 
     virtual void Process_vkTrimCommandPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            commandPool,
         VkCommandPoolTrimFlags                      flags) override;
 
     virtual void Process_vkGetDeviceQueue2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceQueueInfo2>* pQueueInfo,
         HandlePointerDecoder<VkQueue>*              pQueue) override;
 
     virtual void Process_vkCreateSamplerYcbcrConversion(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
@@ -969,11 +1119,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion) override;
 
     virtual void Process_vkDestroySamplerYcbcrConversion(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            ycbcrConversion,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateDescriptorUpdateTemplate(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
@@ -981,31 +1133,37 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate) override;
 
     virtual void Process_vkDestroyDescriptorUpdateTemplate(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            descriptorUpdateTemplate,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalBufferProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
         StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalFenceProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
         StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalSemaphoreProperties(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
         StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties) override;
 
     virtual void Process_vkGetDescriptorSetLayoutSupport(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport) override;
 
     virtual void Process_vkCmdDrawIndirectCount(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -1015,6 +1173,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawIndexedIndirectCount(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -1024,6 +1183,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCreateRenderPass2(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkRenderPassCreateInfo2>* pCreateInfo,
@@ -1031,64 +1191,76 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkRenderPass>*         pRenderPass) override;
 
     virtual void Process_vkCmdBeginRenderPass2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
         StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo) override;
 
     virtual void Process_vkCmdNextSubpass2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo,
         StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo) override;
 
     virtual void Process_vkCmdEndRenderPass2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo) override;
 
     virtual void Process_vkResetQueryPool(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery,
         uint32_t                                    queryCount) override;
 
     virtual void Process_vkGetSemaphoreCounterValue(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            semaphore,
         PointerDecoder<uint64_t>*                   pValue) override;
 
     virtual void Process_vkWaitSemaphores(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreWaitInfo>* pWaitInfo,
         uint64_t                                    timeout) override;
 
     virtual void Process_vkSignalSemaphore(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreSignalInfo>* pSignalInfo) override;
 
     virtual void Process_vkGetBufferDeviceAddress(
+        const ApiCallInfo&                          call_info,
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) override;
 
     virtual void Process_vkGetBufferOpaqueCaptureAddress(
+        const ApiCallInfo&                          call_info,
         uint64_t                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) override;
 
     virtual void Process_vkGetDeviceMemoryOpaqueCaptureAddress(
+        const ApiCallInfo&                          call_info,
         uint64_t                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo>* pInfo) override;
 
     virtual void Process_vkGetPhysicalDeviceToolProperties(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pToolCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceToolProperties>* pToolProperties) override;
 
     virtual void Process_vkCreatePrivateDataSlot(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPrivateDataSlotCreateInfo>* pCreateInfo,
@@ -1096,11 +1268,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkPrivateDataSlot>*    pPrivateDataSlot) override;
 
     virtual void Process_vkDestroyPrivateDataSlot(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            privateDataSlot,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkSetPrivateData(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkObjectType                                objectType,
@@ -1109,6 +1283,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint64_t                                    data) override;
 
     virtual void Process_vkGetPrivateData(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         VkObjectType                                objectType,
         uint64_t                                    objectHandle,
@@ -1116,32 +1291,38 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint64_t>*                   pData) override;
 
     virtual void Process_vkCmdSetEvent2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo) override;
 
     virtual void Process_vkCmdResetEvent2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         VkPipelineStageFlags2                       stageMask) override;
 
     virtual void Process_vkCmdWaitEvents2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    eventCount,
         HandlePointerDecoder<VkEvent>*              pEvents,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfos) override;
 
     virtual void Process_vkCmdPipelineBarrier2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo) override;
 
     virtual void Process_vkCmdWriteTimestamp2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlags2                       stage,
         format::HandleId                            queryPool,
         uint32_t                                    query) override;
 
     virtual void Process_vkQueueSubmit2(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    submitCount,
@@ -1149,59 +1330,73 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            fence) override;
 
     virtual void Process_vkCmdCopyBuffer2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyBufferInfo2>* pCopyBufferInfo) override;
 
     virtual void Process_vkCmdCopyImage2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyImageInfo2>* pCopyImageInfo) override;
 
     virtual void Process_vkCmdCopyBufferToImage2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2>* pCopyBufferToImageInfo) override;
 
     virtual void Process_vkCmdCopyImageToBuffer2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2>* pCopyImageToBufferInfo) override;
 
     virtual void Process_vkCmdBlitImage2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkBlitImageInfo2>* pBlitImageInfo) override;
 
     virtual void Process_vkCmdResolveImage2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkResolveImageInfo2>* pResolveImageInfo) override;
 
     virtual void Process_vkCmdBeginRendering(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo) override;
 
     virtual void Process_vkCmdEndRendering(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkCmdSetCullMode(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkCullModeFlags                             cullMode) override;
 
     virtual void Process_vkCmdSetFrontFace(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkFrontFace                                 frontFace) override;
 
     virtual void Process_vkCmdSetPrimitiveTopology(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPrimitiveTopology                         primitiveTopology) override;
 
     virtual void Process_vkCmdSetViewportWithCount(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    viewportCount,
         StructPointerDecoder<Decoded_VkViewport>*   pViewports) override;
 
     virtual void Process_vkCmdSetScissorWithCount(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    scissorCount,
         StructPointerDecoder<Decoded_VkRect2D>*     pScissors) override;
 
     virtual void Process_vkCmdBindVertexBuffers2(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
@@ -1211,26 +1406,32 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<VkDeviceSize>*               pStrides) override;
 
     virtual void Process_vkCmdSetDepthTestEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthTestEnable) override;
 
     virtual void Process_vkCmdSetDepthWriteEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthWriteEnable) override;
 
     virtual void Process_vkCmdSetDepthCompareOp(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkCompareOp                                 depthCompareOp) override;
 
     virtual void Process_vkCmdSetDepthBoundsTestEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthBoundsTestEnable) override;
 
     virtual void Process_vkCmdSetStencilTestEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    stencilTestEnable) override;
 
     virtual void Process_vkCmdSetStencilOp(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
         VkStencilOp                                 failOp,
@@ -1239,39 +1440,47 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkCompareOp                                 compareOp) override;
 
     virtual void Process_vkCmdSetRasterizerDiscardEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    rasterizerDiscardEnable) override;
 
     virtual void Process_vkCmdSetDepthBiasEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthBiasEnable) override;
 
     virtual void Process_vkCmdSetPrimitiveRestartEnable(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    primitiveRestartEnable) override;
 
     virtual void Process_vkGetDeviceBufferMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceBufferMemoryRequirements>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetDeviceImageMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetDeviceImageSparseMemoryRequirements(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) override;
 
     virtual void Process_vkDestroySurfaceKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         format::HandleId                            surface,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceSupportKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
@@ -1279,12 +1488,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<VkBool32>*                   pSupported) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
         StructPointerDecoder<Decoded_VkSurfaceCapabilitiesKHR>* pSurfaceCapabilities) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
@@ -1292,6 +1503,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkSurfaceFormatKHR>* pSurfaceFormats) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
@@ -1299,6 +1511,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<VkPresentModeKHR>*           pPresentModes) override;
 
     virtual void Process_vkCreateSwapchainKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSwapchainCreateInfoKHR>* pCreateInfo,
@@ -1306,11 +1519,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSwapchainKHR>*       pSwapchain) override;
 
     virtual void Process_vkDestroySwapchainKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            swapchain,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetSwapchainImagesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
@@ -1318,6 +1533,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkImage>*              pSwapchainImages) override;
 
     virtual void Process_vkAcquireNextImageKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
@@ -1327,22 +1543,26 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint32_t>*                   pImageIndex) override;
 
     virtual void Process_vkQueuePresentKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         StructPointerDecoder<Decoded_VkPresentInfoKHR>* pPresentInfo) override;
 
     virtual void Process_vkGetDeviceGroupPresentCapabilitiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceGroupPresentCapabilitiesKHR>* pDeviceGroupPresentCapabilities) override;
 
     virtual void Process_vkGetDeviceGroupSurfacePresentModesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            surface,
         PointerDecoder<VkDeviceGroupPresentModeFlagsKHR>* pModes) override;
 
     virtual void Process_vkGetPhysicalDevicePresentRectanglesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
@@ -1350,24 +1570,28 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkRect2D>*     pRects) override;
 
     virtual void Process_vkAcquireNextImage2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAcquireNextImageInfoKHR>* pAcquireInfo,
         PointerDecoder<uint32_t>*                   pImageIndex) override;
 
     virtual void Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkDisplayPropertiesKHR>* pProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkDisplayPlanePropertiesKHR>* pProperties) override;
 
     virtual void Process_vkGetDisplayPlaneSupportedDisplaysKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    planeIndex,
@@ -1375,6 +1599,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkDisplayKHR>*         pDisplays) override;
 
     virtual void Process_vkGetDisplayModePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display,
@@ -1382,6 +1607,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkDisplayModePropertiesKHR>* pProperties) override;
 
     virtual void Process_vkCreateDisplayModeKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display,
@@ -1390,6 +1616,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkDisplayModeKHR>*     pMode) override;
 
     virtual void Process_vkGetDisplayPlaneCapabilitiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            mode,
@@ -1397,6 +1624,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkDisplayPlaneCapabilitiesKHR>* pCapabilities) override;
 
     virtual void Process_vkCreateDisplayPlaneSurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkDisplaySurfaceCreateInfoKHR>* pCreateInfo,
@@ -1404,6 +1632,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCreateSharedSwapchainsKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    swapchainCount,
@@ -1412,6 +1641,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains) override;
 
     virtual void Process_vkCreateXlibSurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkXlibSurfaceCreateInfoKHR>* pCreateInfo,
@@ -1419,6 +1649,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
@@ -1426,6 +1657,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         size_t                                      visualID) override;
 
     virtual void Process_vkCreateXcbSurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkXcbSurfaceCreateInfoKHR>* pCreateInfo,
@@ -1433,6 +1665,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
@@ -1440,6 +1673,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    visual_id) override;
 
     virtual void Process_vkCreateWaylandSurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkWaylandSurfaceCreateInfoKHR>* pCreateInfo,
@@ -1447,12 +1681,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceWaylandPresentationSupportKHR(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
         uint64_t                                    display) override;
 
     virtual void Process_vkCreateAndroidSurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkAndroidSurfaceCreateInfoKHR>* pCreateInfo,
@@ -1460,6 +1696,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCreateWin32SurfaceKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkWin32SurfaceCreateInfoKHR>* pCreateInfo,
@@ -1467,52 +1704,63 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceWin32PresentationSupportKHR(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex) override;
 
     virtual void Process_vkCmdBeginRenderingKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderingInfo>* pRenderingInfo) override;
 
     virtual void Process_vkCmdEndRenderingKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkGetPhysicalDeviceFeatures2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceFeatures2>* pFeatures) override;
 
     virtual void Process_vkGetPhysicalDeviceProperties2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceProperties2>* pProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceFormatProperties2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
         StructPointerDecoder<Decoded_VkFormatProperties2>* pFormatProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceImageFormatInfo2>* pImageFormatInfo,
         StructPointerDecoder<Decoded_VkImageFormatProperties2>* pImageFormatProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pQueueFamilyPropertyCount,
         StructPointerDecoder<Decoded_VkQueueFamilyProperties2>* pQueueFamilyProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceMemoryProperties2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceMemoryProperties2>* pMemoryProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceSparseImageFormatProperties2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSparseImageFormatInfo2>* pFormatInfo,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkSparseImageFormatProperties2>* pProperties) override;
 
     virtual void Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         uint32_t                                    heapIndex,
         uint32_t                                    localDeviceIndex,
@@ -1520,10 +1768,12 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<VkPeerMemoryFeatureFlags>*   pPeerMemoryFeatures) override;
 
     virtual void Process_vkCmdSetDeviceMaskKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    deviceMask) override;
 
     virtual void Process_vkCmdDispatchBaseKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    baseGroupX,
         uint32_t                                    baseGroupY,
@@ -1533,28 +1783,33 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    groupCountZ) override;
 
     virtual void Process_vkTrimCommandPoolKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            commandPool,
         VkCommandPoolTrimFlags                      flags) override;
 
     virtual void Process_vkEnumeratePhysicalDeviceGroupsKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         PointerDecoder<uint32_t>*                   pPhysicalDeviceGroupCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceGroupProperties>* pPhysicalDeviceGroupProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalBufferInfo>* pExternalBufferInfo,
         StructPointerDecoder<Decoded_VkExternalBufferProperties>* pExternalBufferProperties) override;
 
     virtual void Process_vkGetMemoryWin32HandleKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) override;
 
     virtual void Process_vkGetMemoryWin32HandlePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -1562,12 +1817,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkMemoryWin32HandlePropertiesKHR>* pMemoryWin32HandleProperties) override;
 
     virtual void Process_vkGetMemoryFdKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) override;
 
     virtual void Process_vkGetMemoryFdPropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -1575,33 +1832,39 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkMemoryFdPropertiesKHR>* pMemoryFdProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalSemaphorePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalSemaphoreInfo>* pExternalSemaphoreInfo,
         StructPointerDecoder<Decoded_VkExternalSemaphoreProperties>* pExternalSemaphoreProperties) override;
 
     virtual void Process_vkImportSemaphoreWin32HandleKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImportSemaphoreWin32HandleInfoKHR>* pImportSemaphoreWin32HandleInfo) override;
 
     virtual void Process_vkGetSemaphoreWin32HandleKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) override;
 
     virtual void Process_vkImportSemaphoreFdKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImportSemaphoreFdInfoKHR>* pImportSemaphoreFdInfo) override;
 
     virtual void Process_vkGetSemaphoreFdKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) override;
 
     virtual void Process_vkCmdPushDescriptorSetKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineBindPoint                         pipelineBindPoint,
         format::HandleId                            layout,
@@ -1610,6 +1873,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkWriteDescriptorSet>* pDescriptorWrites) override;
 
     virtual void Process_vkCreateDescriptorUpdateTemplateKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorUpdateTemplateCreateInfo>* pCreateInfo,
@@ -1617,11 +1881,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkDescriptorUpdateTemplate>* pDescriptorUpdateTemplate) override;
 
     virtual void Process_vkDestroyDescriptorUpdateTemplateKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            descriptorUpdateTemplate,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCreateRenderPass2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkRenderPassCreateInfo2>* pCreateInfo,
@@ -1629,52 +1895,62 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkRenderPass>*         pRenderPass) override;
 
     virtual void Process_vkCmdBeginRenderPass2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkRenderPassBeginInfo>* pRenderPassBegin,
         StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo) override;
 
     virtual void Process_vkCmdNextSubpass2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkSubpassBeginInfo>* pSubpassBeginInfo,
         StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo) override;
 
     virtual void Process_vkCmdEndRenderPass2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkSubpassEndInfo>* pSubpassEndInfo) override;
 
     virtual void Process_vkGetSwapchainStatusKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceExternalFenceInfo>* pExternalFenceInfo,
         StructPointerDecoder<Decoded_VkExternalFenceProperties>* pExternalFenceProperties) override;
 
     virtual void Process_vkImportFenceWin32HandleKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImportFenceWin32HandleInfoKHR>* pImportFenceWin32HandleInfo) override;
 
     virtual void Process_vkGetFenceWin32HandleKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkFenceGetWin32HandleInfoKHR>* pGetWin32HandleInfo,
         PointerDecoder<uint64_t, void*>*            pHandle) override;
 
     virtual void Process_vkImportFenceFdKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImportFenceFdInfoKHR>* pImportFenceFdInfo) override;
 
     virtual void Process_vkGetFenceFdKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkFenceGetFdInfoKHR>* pGetFdInfo,
         PointerDecoder<int>*                        pFd) override;
 
     virtual void Process_vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
@@ -1683,25 +1959,30 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkPerformanceCounterDescriptionKHR>* pCounterDescriptions) override;
 
     virtual void Process_vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkQueryPoolPerformanceCreateInfoKHR>* pPerformanceQueryCreateInfo,
         PointerDecoder<uint32_t>*                   pNumPasses) override;
 
     virtual void Process_vkAcquireProfilingLockKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAcquireProfilingLockInfoKHR>* pInfo) override;
 
     virtual void Process_vkReleaseProfilingLockKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         StructPointerDecoder<Decoded_VkSurfaceCapabilities2KHR>* pSurfaceCapabilities) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
@@ -1709,18 +1990,21 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkSurfaceFormat2KHR>* pSurfaceFormats) override;
 
     virtual void Process_vkGetPhysicalDeviceDisplayProperties2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkDisplayProperties2KHR>* pProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkDisplayPlaneProperties2KHR>* pProperties) override;
 
     virtual void Process_vkGetDisplayModeProperties2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display,
@@ -1728,28 +2012,33 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkDisplayModeProperties2KHR>* pProperties) override;
 
     virtual void Process_vkGetDisplayPlaneCapabilities2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkDisplayPlaneInfo2KHR>* pDisplayPlaneInfo,
         StructPointerDecoder<Decoded_VkDisplayPlaneCapabilities2KHR>* pCapabilities) override;
 
     virtual void Process_vkGetImageMemoryRequirements2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetBufferMemoryRequirements2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferMemoryRequirementsInfo2>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetImageSparseMemoryRequirements2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageSparseMemoryRequirementsInfo2>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) override;
 
     virtual void Process_vkCreateSamplerYcbcrConversionKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSamplerYcbcrConversionCreateInfo>* pCreateInfo,
@@ -1757,28 +2046,33 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSamplerYcbcrConversion>* pYcbcrConversion) override;
 
     virtual void Process_vkDestroySamplerYcbcrConversionKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            ycbcrConversion,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkBindBufferMemory2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
         StructPointerDecoder<Decoded_VkBindBufferMemoryInfo>* pBindInfos) override;
 
     virtual void Process_vkBindImageMemory2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
         StructPointerDecoder<Decoded_VkBindImageMemoryInfo>* pBindInfos) override;
 
     virtual void Process_vkGetDescriptorSetLayoutSupportKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutCreateInfo>* pCreateInfo,
         StructPointerDecoder<Decoded_VkDescriptorSetLayoutSupport>* pSupport) override;
 
     virtual void Process_vkCmdDrawIndirectCountKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -1788,6 +2082,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawIndexedIndirectCountKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -1797,34 +2092,40 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkGetSemaphoreCounterValueKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            semaphore,
         PointerDecoder<uint64_t>*                   pValue) override;
 
     virtual void Process_vkWaitSemaphoresKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreWaitInfo>* pWaitInfo,
         uint64_t                                    timeout) override;
 
     virtual void Process_vkSignalSemaphoreKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreSignalInfo>* pSignalInfo) override;
 
     virtual void Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pFragmentShadingRateCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceFragmentShadingRateKHR>* pFragmentShadingRates) override;
 
     virtual void Process_vkCmdSetFragmentShadingRateKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkExtent2D>*   pFragmentSize,
         PointerDecoder<VkFragmentShadingRateCombinerOpKHR>* combinerOps) override;
 
     virtual void Process_vkWaitForPresentKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
@@ -1832,47 +2133,56 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint64_t                                    timeout) override;
 
     virtual void Process_vkGetBufferDeviceAddressKHR(
+        const ApiCallInfo&                          call_info,
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) override;
 
     virtual void Process_vkGetBufferOpaqueCaptureAddressKHR(
+        const ApiCallInfo&                          call_info,
         uint64_t                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) override;
 
     virtual void Process_vkGetDeviceMemoryOpaqueCaptureAddressKHR(
+        const ApiCallInfo&                          call_info,
         uint64_t                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceMemoryOpaqueCaptureAddressInfo>* pInfo) override;
 
     virtual void Process_vkCreateDeferredOperationKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator,
         HandlePointerDecoder<VkDeferredOperationKHR>* pDeferredOperation) override;
 
     virtual void Process_vkDestroyDeferredOperationKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            operation,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetDeferredOperationMaxConcurrencyKHR(
+        const ApiCallInfo&                          call_info,
         uint32_t                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            operation) override;
 
     virtual void Process_vkGetDeferredOperationResultKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            operation) override;
 
     virtual void Process_vkDeferredOperationJoinKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            operation) override;
 
     virtual void Process_vkGetPipelineExecutablePropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPipelineInfoKHR>* pPipelineInfo,
@@ -1880,6 +2190,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkPipelineExecutablePropertiesKHR>* pProperties) override;
 
     virtual void Process_vkGetPipelineExecutableStatisticsKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
@@ -1887,6 +2198,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkPipelineExecutableStatisticKHR>* pStatistics) override;
 
     virtual void Process_vkGetPipelineExecutableInternalRepresentationsKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPipelineExecutableInfoKHR>* pExecutableInfo,
@@ -1894,32 +2206,38 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkPipelineExecutableInternalRepresentationKHR>* pInternalRepresentations) override;
 
     virtual void Process_vkCmdSetEvent2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo) override;
 
     virtual void Process_vkCmdResetEvent2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            event,
         VkPipelineStageFlags2                       stageMask) override;
 
     virtual void Process_vkCmdWaitEvents2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    eventCount,
         HandlePointerDecoder<VkEvent>*              pEvents,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfos) override;
 
     virtual void Process_vkCmdPipelineBarrier2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDependencyInfo>* pDependencyInfo) override;
 
     virtual void Process_vkCmdWriteTimestamp2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlags2                       stage,
         format::HandleId                            queryPool,
         uint32_t                                    query) override;
 
     virtual void Process_vkQueueSubmit2KHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         uint32_t                                    submitCount,
@@ -1927,6 +2245,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         format::HandleId                            fence) override;
 
     virtual void Process_vkCmdWriteBufferMarker2AMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlags2                       stage,
         format::HandleId                            dstBuffer,
@@ -1934,51 +2253,62 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    marker) override;
 
     virtual void Process_vkGetQueueCheckpointData2NV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            queue,
         PointerDecoder<uint32_t>*                   pCheckpointDataCount,
         StructPointerDecoder<Decoded_VkCheckpointData2NV>* pCheckpointData) override;
 
     virtual void Process_vkCmdCopyBuffer2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyBufferInfo2>* pCopyBufferInfo) override;
 
     virtual void Process_vkCmdCopyImage2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyImageInfo2>* pCopyImageInfo) override;
 
     virtual void Process_vkCmdCopyBufferToImage2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyBufferToImageInfo2>* pCopyBufferToImageInfo) override;
 
     virtual void Process_vkCmdCopyImageToBuffer2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyImageToBufferInfo2>* pCopyImageToBufferInfo) override;
 
     virtual void Process_vkCmdBlitImage2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkBlitImageInfo2>* pBlitImageInfo) override;
 
     virtual void Process_vkCmdResolveImage2KHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkResolveImageInfo2>* pResolveImageInfo) override;
 
     virtual void Process_vkGetDeviceBufferMemoryRequirementsKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceBufferMemoryRequirements>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetDeviceImageMemoryRequirementsKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkGetDeviceImageSparseMemoryRequirementsKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceImageMemoryRequirements>* pInfo,
         PointerDecoder<uint32_t>*                   pSparseMemoryRequirementCount,
         StructPointerDecoder<Decoded_VkSparseImageMemoryRequirements2>* pSparseMemoryRequirements) override;
 
     virtual void Process_vkCreateDebugReportCallbackEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkDebugReportCallbackCreateInfoEXT>* pCreateInfo,
@@ -1986,11 +2316,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkDebugReportCallbackEXT>* pCallback) override;
 
     virtual void Process_vkDestroyDebugReportCallbackEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         format::HandleId                            callback,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkDebugReportMessageEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         VkDebugReportFlagsEXT                       flags,
         VkDebugReportObjectTypeEXT                  objectType,
@@ -2001,27 +2333,33 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StringDecoder*                              pMessage) override;
 
     virtual void Process_vkDebugMarkerSetObjectTagEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDebugMarkerObjectTagInfoEXT>* pTagInfo) override;
 
     virtual void Process_vkDebugMarkerSetObjectNameEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDebugMarkerObjectNameInfoEXT>* pNameInfo) override;
 
     virtual void Process_vkCmdDebugMarkerBeginEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo) override;
 
     virtual void Process_vkCmdDebugMarkerEndEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkCmdDebugMarkerInsertEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDebugMarkerMarkerInfoEXT>* pMarkerInfo) override;
 
     virtual void Process_vkCmdBindTransformFeedbackBuffersEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
@@ -2030,6 +2368,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<VkDeviceSize>*               pSizes) override;
 
     virtual void Process_vkCmdBeginTransformFeedbackEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstCounterBuffer,
         uint32_t                                    counterBufferCount,
@@ -2037,6 +2376,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets) override;
 
     virtual void Process_vkCmdEndTransformFeedbackEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstCounterBuffer,
         uint32_t                                    counterBufferCount,
@@ -2044,6 +2384,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<VkDeviceSize>*               pCounterBufferOffsets) override;
 
     virtual void Process_vkCmdBeginQueryIndexedEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    query,
@@ -2051,12 +2392,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    index) override;
 
     virtual void Process_vkCmdEndQueryIndexedEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            queryPool,
         uint32_t                                    query,
         uint32_t                                    index) override;
 
     virtual void Process_vkCmdDrawIndirectByteCountEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    instanceCount,
         uint32_t                                    firstInstance,
@@ -2066,17 +2409,20 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    vertexStride) override;
 
     virtual void Process_vkGetImageViewHandleNVX(
+        const ApiCallInfo&                          call_info,
         uint32_t                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImageViewHandleInfoNVX>* pInfo) override;
 
     virtual void Process_vkGetImageViewAddressNVX(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            imageView,
         StructPointerDecoder<Decoded_VkImageViewAddressPropertiesNVX>* pProperties) override;
 
     virtual void Process_vkCmdDrawIndirectCountAMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -2086,6 +2432,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawIndexedIndirectCountAMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -2095,6 +2442,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkGetShaderInfoAMD(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
@@ -2104,6 +2452,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint8_t>*                    pInfo) override;
 
     virtual void Process_vkCreateStreamDescriptorSurfaceGGP(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkStreamDescriptorSurfaceCreateInfoGGP>* pCreateInfo,
@@ -2111,6 +2460,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceExternalImageFormatPropertiesNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         VkFormat                                    format,
@@ -2122,6 +2472,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkExternalImageFormatPropertiesNV>* pExternalImageFormatProperties) override;
 
     virtual void Process_vkGetMemoryWin32HandleNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            memory,
@@ -2129,6 +2480,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint64_t, void*>*            pHandle) override;
 
     virtual void Process_vkCreateViSurfaceNN(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkViSurfaceCreateInfoNN>* pCreateInfo,
@@ -2136,30 +2488,36 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCmdBeginConditionalRenderingEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkConditionalRenderingBeginInfoEXT>* pConditionalRenderingBegin) override;
 
     virtual void Process_vkCmdEndConditionalRenderingEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkCmdSetViewportWScalingNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
         StructPointerDecoder<Decoded_VkViewportWScalingNV>* pViewportWScalings) override;
 
     virtual void Process_vkReleaseDisplayEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display) override;
 
     virtual void Process_vkAcquireXlibDisplayEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint64_t                                    dpy,
         format::HandleId                            display) override;
 
     virtual void Process_vkGetRandROutputDisplayEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint64_t                                    dpy,
@@ -2167,18 +2525,21 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkDisplayKHR>*         pDisplay) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            surface,
         StructPointerDecoder<Decoded_VkSurfaceCapabilities2EXT>* pSurfaceCapabilities) override;
 
     virtual void Process_vkDisplayPowerControlEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            display,
         StructPointerDecoder<Decoded_VkDisplayPowerInfoEXT>* pDisplayPowerInfo) override;
 
     virtual void Process_vkRegisterDeviceEventEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDeviceEventInfoEXT>* pDeviceEventInfo,
@@ -2186,6 +2547,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkFence>*              pFence) override;
 
     virtual void Process_vkRegisterDisplayEventEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            display,
@@ -2194,6 +2556,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkFence>*              pFence) override;
 
     virtual void Process_vkGetSwapchainCounterEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
@@ -2201,12 +2564,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint64_t>*                   pCounterValue) override;
 
     virtual void Process_vkGetRefreshCycleDurationGOOGLE(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
         StructPointerDecoder<Decoded_VkRefreshCycleDurationGOOGLE>* pDisplayTimingProperties) override;
 
     virtual void Process_vkGetPastPresentationTimingGOOGLE(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain,
@@ -2214,18 +2579,21 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkPastPresentationTimingGOOGLE>* pPresentationTimings) override;
 
     virtual void Process_vkCmdSetDiscardRectangleEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstDiscardRectangle,
         uint32_t                                    discardRectangleCount,
         StructPointerDecoder<Decoded_VkRect2D>*     pDiscardRectangles) override;
 
     virtual void Process_vkSetHdrMetadataEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         uint32_t                                    swapchainCount,
         HandlePointerDecoder<VkSwapchainKHR>*       pSwapchains,
         StructPointerDecoder<Decoded_VkHdrMetadataEXT>* pMetadata) override;
 
     virtual void Process_vkCreateIOSSurfaceMVK(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkIOSSurfaceCreateInfoMVK>* pCreateInfo,
@@ -2233,6 +2601,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCreateMacOSSurfaceMVK(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkMacOSSurfaceCreateInfoMVK>* pCreateInfo,
@@ -2240,38 +2609,47 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkSetDebugUtilsObjectNameEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDebugUtilsObjectNameInfoEXT>* pNameInfo) override;
 
     virtual void Process_vkSetDebugUtilsObjectTagEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkDebugUtilsObjectTagInfoEXT>* pTagInfo) override;
 
     virtual void Process_vkQueueBeginDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            queue,
         StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) override;
 
     virtual void Process_vkQueueEndDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            queue) override;
 
     virtual void Process_vkQueueInsertDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            queue,
         StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) override;
 
     virtual void Process_vkCmdBeginDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) override;
 
     virtual void Process_vkCmdEndDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer) override;
 
     virtual void Process_vkCmdInsertDebugUtilsLabelEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkDebugUtilsLabelEXT>* pLabelInfo) override;
 
     virtual void Process_vkCreateDebugUtilsMessengerEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkDebugUtilsMessengerCreateInfoEXT>* pCreateInfo,
@@ -2279,44 +2657,52 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkDebugUtilsMessengerEXT>* pMessenger) override;
 
     virtual void Process_vkDestroyDebugUtilsMessengerEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         format::HandleId                            messenger,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkSubmitDebugUtilsMessageEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            instance,
         VkDebugUtilsMessageSeverityFlagBitsEXT      messageSeverity,
         VkDebugUtilsMessageTypeFlagsEXT             messageTypes,
         StructPointerDecoder<Decoded_VkDebugUtilsMessengerCallbackDataEXT>* pCallbackData) override;
 
     virtual void Process_vkGetAndroidHardwareBufferPropertiesANDROID(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint64_t                                    buffer,
         StructPointerDecoder<Decoded_VkAndroidHardwareBufferPropertiesANDROID>* pProperties) override;
 
     virtual void Process_vkGetMemoryAndroidHardwareBufferANDROID(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryGetAndroidHardwareBufferInfoANDROID>* pInfo,
         PointerDecoder<uint64_t, void*>*            pBuffer) override;
 
     virtual void Process_vkCmdSetSampleLocationsEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkSampleLocationsInfoEXT>* pSampleLocationsInfo) override;
 
     virtual void Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            physicalDevice,
         VkSampleCountFlagBits                       samples,
         StructPointerDecoder<Decoded_VkMultisamplePropertiesEXT>* pMultisampleProperties) override;
 
     virtual void Process_vkGetImageDrmFormatModifierPropertiesEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            image,
         StructPointerDecoder<Decoded_VkImageDrmFormatModifierPropertiesEXT>* pProperties) override;
 
     virtual void Process_vkCreateValidationCacheEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkValidationCacheCreateInfoEXT>* pCreateInfo,
@@ -2324,11 +2710,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkValidationCacheEXT>* pValidationCache) override;
 
     virtual void Process_vkDestroyValidationCacheEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            validationCache,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkMergeValidationCachesEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            dstCache,
@@ -2336,6 +2724,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkValidationCacheEXT>* pSrcCaches) override;
 
     virtual void Process_vkGetValidationCacheDataEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            validationCache,
@@ -2343,23 +2732,27 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkCmdBindShadingRateImageNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            imageView,
         VkImageLayout                               imageLayout) override;
 
     virtual void Process_vkCmdSetViewportShadingRatePaletteNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstViewport,
         uint32_t                                    viewportCount,
         StructPointerDecoder<Decoded_VkShadingRatePaletteNV>* pShadingRatePalettes) override;
 
     virtual void Process_vkCmdSetCoarseSampleOrderNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkCoarseSampleOrderTypeNV                   sampleOrderType,
         uint32_t                                    customSampleOrderCount,
         StructPointerDecoder<Decoded_VkCoarseSampleOrderCustomNV>* pCustomSampleOrders) override;
 
     virtual void Process_vkCreateAccelerationStructureNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoNV>* pCreateInfo,
@@ -2367,22 +2760,26 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructure) override;
 
     virtual void Process_vkDestroyAccelerationStructureNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            accelerationStructure,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkGetAccelerationStructureMemoryRequirementsNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAccelerationStructureMemoryRequirementsInfoNV>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2KHR>* pMemoryRequirements) override;
 
     virtual void Process_vkBindAccelerationStructureMemoryNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    bindInfoCount,
         StructPointerDecoder<Decoded_VkBindAccelerationStructureMemoryInfoNV>* pBindInfos) override;
 
     virtual void Process_vkCmdBuildAccelerationStructureNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkAccelerationStructureInfoNV>* pInfo,
         format::HandleId                            instanceData,
@@ -2394,12 +2791,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkDeviceSize                                scratchOffset) override;
 
     virtual void Process_vkCmdCopyAccelerationStructureNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            dst,
         format::HandleId                            src,
         VkCopyAccelerationStructureModeKHR          mode) override;
 
     virtual void Process_vkCmdTraceRaysNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            raygenShaderBindingTableBuffer,
         VkDeviceSize                                raygenShaderBindingOffset,
@@ -2417,6 +2816,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    depth) override;
 
     virtual void Process_vkCreateRayTracingPipelinesNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipelineCache,
@@ -2426,6 +2826,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkPipeline>*           pPipelines) override;
 
     virtual void Process_vkGetRayTracingShaderGroupHandlesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
@@ -2435,6 +2836,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkGetRayTracingShaderGroupHandlesNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
@@ -2444,6 +2846,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkGetAccelerationStructureHandleNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            accelerationStructure,
@@ -2451,6 +2854,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkCmdWriteAccelerationStructuresPropertiesNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    accelerationStructureCount,
         HandlePointerDecoder<VkAccelerationStructureNV>* pAccelerationStructures,
@@ -2459,12 +2863,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    firstQuery) override;
 
     virtual void Process_vkCompileDeferredNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
         uint32_t                                    shader) override;
 
     virtual void Process_vkGetMemoryHostPointerPropertiesEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -2472,6 +2878,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkMemoryHostPointerPropertiesEXT>* pMemoryHostPointerProperties) override;
 
     virtual void Process_vkCmdWriteBufferMarkerAMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineStageFlagBits                     pipelineStage,
         format::HandleId                            dstBuffer,
@@ -2479,12 +2886,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    marker) override;
 
     virtual void Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pTimeDomainCount,
         PointerDecoder<VkTimeDomainEXT>*            pTimeDomains) override;
 
     virtual void Process_vkGetCalibratedTimestampsEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    timestampCount,
@@ -2493,11 +2902,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint64_t>*                   pMaxDeviation) override;
 
     virtual void Process_vkCmdDrawMeshTasksNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    taskCount,
         uint32_t                                    firstTask) override;
 
     virtual void Process_vkCmdDrawMeshTasksIndirectNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -2505,6 +2916,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawMeshTasksIndirectCountNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            buffer,
         VkDeviceSize                                offset,
@@ -2514,71 +2926,85 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdSetExclusiveScissorNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstExclusiveScissor,
         uint32_t                                    exclusiveScissorCount,
         StructPointerDecoder<Decoded_VkRect2D>*     pExclusiveScissors) override;
 
     virtual void Process_vkCmdSetCheckpointNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint64_t                                    pCheckpointMarker) override;
 
     virtual void Process_vkGetQueueCheckpointDataNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            queue,
         PointerDecoder<uint32_t>*                   pCheckpointDataCount,
         StructPointerDecoder<Decoded_VkCheckpointDataNV>* pCheckpointData) override;
 
     virtual void Process_vkInitializePerformanceApiINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkInitializePerformanceApiInfoINTEL>* pInitializeInfo) override;
 
     virtual void Process_vkUninitializePerformanceApiINTEL(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device) override;
 
     virtual void Process_vkCmdSetPerformanceMarkerINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkPerformanceMarkerInfoINTEL>* pMarkerInfo) override;
 
     virtual void Process_vkCmdSetPerformanceStreamMarkerINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkPerformanceStreamMarkerInfoINTEL>* pMarkerInfo) override;
 
     virtual void Process_vkCmdSetPerformanceOverrideINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkPerformanceOverrideInfoINTEL>* pOverrideInfo) override;
 
     virtual void Process_vkAcquirePerformanceConfigurationINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPerformanceConfigurationAcquireInfoINTEL>* pAcquireInfo,
         HandlePointerDecoder<VkPerformanceConfigurationINTEL>* pConfiguration) override;
 
     virtual void Process_vkReleasePerformanceConfigurationINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            configuration) override;
 
     virtual void Process_vkQueueSetPerformanceConfigurationINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            queue,
         format::HandleId                            configuration) override;
 
     virtual void Process_vkGetPerformanceParameterINTEL(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkPerformanceParameterTypeINTEL             parameter,
         StructPointerDecoder<Decoded_VkPerformanceValueINTEL>* pValue) override;
 
     virtual void Process_vkSetLocalDimmingAMD(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            swapChain,
         VkBool32                                    localDimmingEnable) override;
 
     virtual void Process_vkCreateImagePipeSurfaceFUCHSIA(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkImagePipeSurfaceCreateInfoFUCHSIA>* pCreateInfo,
@@ -2586,6 +3012,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCreateMetalSurfaceEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkMetalSurfaceCreateInfoEXT>* pCreateInfo,
@@ -2593,29 +3020,34 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetBufferDeviceAddressEXT(
+        const ApiCallInfo&                          call_info,
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkBufferDeviceAddressInfo>* pInfo) override;
 
     virtual void Process_vkGetPhysicalDeviceToolPropertiesEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pToolCount,
         StructPointerDecoder<Decoded_VkPhysicalDeviceToolProperties>* pToolProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceCooperativeMatrixPropertiesNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pPropertyCount,
         StructPointerDecoder<Decoded_VkCooperativeMatrixPropertiesNV>* pProperties) override;
 
     virtual void Process_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         PointerDecoder<uint32_t>*                   pCombinationCount,
         StructPointerDecoder<Decoded_VkFramebufferMixedSamplesCombinationNV>* pCombinations) override;
 
     virtual void Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
@@ -2623,22 +3055,26 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<VkPresentModeKHR>*           pPresentModes) override;
 
     virtual void Process_vkAcquireFullScreenExclusiveModeEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain) override;
 
     virtual void Process_vkReleaseFullScreenExclusiveModeEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            swapchain) override;
 
     virtual void Process_vkGetDeviceGroupSurfacePresentModes2EXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPhysicalDeviceSurfaceInfo2KHR>* pSurfaceInfo,
         PointerDecoder<VkDeviceGroupPresentModeFlagsKHR>* pModes) override;
 
     virtual void Process_vkCreateHeadlessSurfaceEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkHeadlessSurfaceCreateInfoEXT>* pCreateInfo,
@@ -2646,39 +3082,47 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkCmdSetLineStippleEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    lineStippleFactor,
         uint16_t                                    lineStipplePattern) override;
 
     virtual void Process_vkResetQueryPoolEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            queryPool,
         uint32_t                                    firstQuery,
         uint32_t                                    queryCount) override;
 
     virtual void Process_vkCmdSetCullModeEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkCullModeFlags                             cullMode) override;
 
     virtual void Process_vkCmdSetFrontFaceEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkFrontFace                                 frontFace) override;
 
     virtual void Process_vkCmdSetPrimitiveTopologyEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPrimitiveTopology                         primitiveTopology) override;
 
     virtual void Process_vkCmdSetViewportWithCountEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    viewportCount,
         StructPointerDecoder<Decoded_VkViewport>*   pViewports) override;
 
     virtual void Process_vkCmdSetScissorWithCountEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    scissorCount,
         StructPointerDecoder<Decoded_VkRect2D>*     pScissors) override;
 
     virtual void Process_vkCmdBindVertexBuffers2EXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    firstBinding,
         uint32_t                                    bindingCount,
@@ -2688,26 +3132,32 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<VkDeviceSize>*               pStrides) override;
 
     virtual void Process_vkCmdSetDepthTestEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthTestEnable) override;
 
     virtual void Process_vkCmdSetDepthWriteEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthWriteEnable) override;
 
     virtual void Process_vkCmdSetDepthCompareOpEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkCompareOp                                 depthCompareOp) override;
 
     virtual void Process_vkCmdSetDepthBoundsTestEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthBoundsTestEnable) override;
 
     virtual void Process_vkCmdSetStencilTestEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    stencilTestEnable) override;
 
     virtual void Process_vkCmdSetStencilOpEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkStencilFaceFlags                          faceMask,
         VkStencilOp                                 failOp,
@@ -2716,26 +3166,31 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkCompareOp                                 compareOp) override;
 
     virtual void Process_vkGetGeneratedCommandsMemoryRequirementsNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkGeneratedCommandsMemoryRequirementsInfoNV>* pInfo,
         StructPointerDecoder<Decoded_VkMemoryRequirements2>* pMemoryRequirements) override;
 
     virtual void Process_vkCmdPreprocessGeneratedCommandsNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo) override;
 
     virtual void Process_vkCmdExecuteGeneratedCommandsNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    isPreprocessed,
         StructPointerDecoder<Decoded_VkGeneratedCommandsInfoNV>* pGeneratedCommandsInfo) override;
 
     virtual void Process_vkCmdBindPipelineShaderGroupNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkPipelineBindPoint                         pipelineBindPoint,
         format::HandleId                            pipeline,
         uint32_t                                    groupIndex) override;
 
     virtual void Process_vkCreateIndirectCommandsLayoutNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkIndirectCommandsLayoutCreateInfoNV>* pCreateInfo,
@@ -2743,17 +3198,20 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkIndirectCommandsLayoutNV>* pIndirectCommandsLayout) override;
 
     virtual void Process_vkDestroyIndirectCommandsLayoutNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            indirectCommandsLayout,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkAcquireDrmDisplayEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         int32_t                                     drmFd,
         format::HandleId                            display) override;
 
     virtual void Process_vkGetDrmDisplayEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         int32_t                                     drmFd,
@@ -2761,6 +3219,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkDisplayKHR>*         display) override;
 
     virtual void Process_vkCreatePrivateDataSlotEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkPrivateDataSlotCreateInfo>* pCreateInfo,
@@ -2768,11 +3227,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkPrivateDataSlot>*    pPrivateDataSlot) override;
 
     virtual void Process_vkDestroyPrivateDataSlotEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            privateDataSlot,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkSetPrivateDataEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkObjectType                                objectType,
@@ -2781,6 +3242,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint64_t                                    data) override;
 
     virtual void Process_vkGetPrivateDataEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         VkObjectType                                objectType,
         uint64_t                                    objectHandle,
@@ -2788,22 +3250,26 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint64_t>*                   pData) override;
 
     virtual void Process_vkCmdSetFragmentShadingRateEnumNV(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkFragmentShadingRateNV                     shadingRate,
         PointerDecoder<VkFragmentShadingRateCombinerOpKHR>* combinerOps) override;
 
     virtual void Process_vkAcquireWinrtDisplayNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         format::HandleId                            display) override;
 
     virtual void Process_vkGetWinrtDisplayNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    deviceRelativeId,
         HandlePointerDecoder<VkDisplayKHR>*         pDisplay) override;
 
     virtual void Process_vkCreateDirectFBSurfaceEXT(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkDirectFBSurfaceCreateInfoEXT>* pCreateInfo,
@@ -2811,12 +3277,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceDirectFBPresentationSupportEXT(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
         uint64_t                                    dfb) override;
 
     virtual void Process_vkCmdSetVertexInputEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    vertexBindingDescriptionCount,
         StructPointerDecoder<Decoded_VkVertexInputBindingDescription2EXT>* pVertexBindingDescriptions,
@@ -2824,12 +3292,14 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkVertexInputAttributeDescription2EXT>* pVertexAttributeDescriptions) override;
 
     virtual void Process_vkGetMemoryZirconHandleFUCHSIA(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryGetZirconHandleInfoFUCHSIA>* pGetZirconHandleInfo,
         PointerDecoder<uint32_t>*                   pZirconHandle) override;
 
     virtual void Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         VkExternalMemoryHandleTypeFlagBits          handleType,
@@ -2837,48 +3307,58 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkMemoryZirconHandlePropertiesFUCHSIA>* pMemoryZirconHandleProperties) override;
 
     virtual void Process_vkImportSemaphoreZirconHandleFUCHSIA(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkImportSemaphoreZirconHandleInfoFUCHSIA>* pImportSemaphoreZirconHandleInfo) override;
 
     virtual void Process_vkGetSemaphoreZirconHandleFUCHSIA(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkSemaphoreGetZirconHandleInfoFUCHSIA>* pGetZirconHandleInfo,
         PointerDecoder<uint32_t>*                   pZirconHandle) override;
 
     virtual void Process_vkCmdBindInvocationMaskHUAWEI(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         format::HandleId                            imageView,
         VkImageLayout                               imageLayout) override;
 
     virtual void Process_vkGetMemoryRemoteAddressNV(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkMemoryGetRemoteAddressInfoNV>* pMemoryGetRemoteAddressInfo,
         PointerDecoder<uint64_t, void*>*            pAddress) override;
 
     virtual void Process_vkCmdSetPatchControlPointsEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    patchControlPoints) override;
 
     virtual void Process_vkCmdSetRasterizerDiscardEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    rasterizerDiscardEnable) override;
 
     virtual void Process_vkCmdSetDepthBiasEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    depthBiasEnable) override;
 
     virtual void Process_vkCmdSetLogicOpEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkLogicOp                                   logicOp) override;
 
     virtual void Process_vkCmdSetPrimitiveRestartEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         VkBool32                                    primitiveRestartEnable) override;
 
     virtual void Process_vkCreateScreenSurfaceQNX(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            instance,
         StructPointerDecoder<Decoded_VkScreenSurfaceCreateInfoQNX>* pCreateInfo,
@@ -2886,17 +3366,20 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkSurfaceKHR>*         pSurface) override;
 
     virtual void Process_vkGetPhysicalDeviceScreenPresentationSupportQNX(
+        const ApiCallInfo&                          call_info,
         VkBool32                                    returnValue,
         format::HandleId                            physicalDevice,
         uint32_t                                    queueFamilyIndex,
         uint64_t                                    window) override;
 
     virtual void Process_vkCmdSetColorWriteEnableEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    attachmentCount,
         PointerDecoder<VkBool32>*                   pColorWriteEnables) override;
 
     virtual void Process_vkCmdDrawMultiEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    drawCount,
         StructPointerDecoder<Decoded_VkMultiDrawInfoEXT>* pVertexInfo,
@@ -2905,6 +3388,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    stride) override;
 
     virtual void Process_vkCmdDrawMultiIndexedEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    drawCount,
         StructPointerDecoder<Decoded_VkMultiDrawIndexedInfoEXT>* pIndexInfo,
@@ -2914,11 +3398,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<int32_t>*                    pVertexOffset) override;
 
     virtual void Process_vkSetDeviceMemoryPriorityEXT(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            memory,
         float                                       priority) override;
 
     virtual void Process_vkCreateAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAccelerationStructureCreateInfoKHR>* pCreateInfo,
@@ -2926,17 +3412,20 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkAccelerationStructureKHR>* pAccelerationStructure) override;
 
     virtual void Process_vkDestroyAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         format::HandleId                            accelerationStructure,
         StructPointerDecoder<Decoded_VkAllocationCallbacks>* pAllocator) override;
 
     virtual void Process_vkCmdBuildAccelerationStructuresKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    infoCount,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildRangeInfoKHR*>* ppBuildRangeInfos) override;
 
     virtual void Process_vkCmdBuildAccelerationStructuresIndirectKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    infoCount,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pInfos,
@@ -2945,18 +3434,21 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint32_t*>*                  ppMaxPrimitiveCounts) override;
 
     virtual void Process_vkCopyAccelerationStructureToMemoryKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            deferredOperation,
         StructPointerDecoder<Decoded_VkCopyAccelerationStructureToMemoryInfoKHR>* pInfo) override;
 
     virtual void Process_vkCopyMemoryToAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            deferredOperation,
         StructPointerDecoder<Decoded_VkCopyMemoryToAccelerationStructureInfoKHR>* pInfo) override;
 
     virtual void Process_vkWriteAccelerationStructuresPropertiesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         uint32_t                                    accelerationStructureCount,
@@ -2967,23 +3459,28 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         size_t                                      stride) override;
 
     virtual void Process_vkCmdCopyAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyAccelerationStructureInfoKHR>* pInfo) override;
 
     virtual void Process_vkCmdCopyAccelerationStructureToMemoryKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyAccelerationStructureToMemoryInfoKHR>* pInfo) override;
 
     virtual void Process_vkCmdCopyMemoryToAccelerationStructureKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkCopyMemoryToAccelerationStructureInfoKHR>* pInfo) override;
 
     virtual void Process_vkGetAccelerationStructureDeviceAddressKHR(
+        const ApiCallInfo&                          call_info,
         VkDeviceAddress                             returnValue,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAccelerationStructureDeviceAddressInfoKHR>* pInfo) override;
 
     virtual void Process_vkCmdWriteAccelerationStructuresPropertiesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    accelerationStructureCount,
         HandlePointerDecoder<VkAccelerationStructureKHR>* pAccelerationStructures,
@@ -2992,11 +3489,13 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    firstQuery) override;
 
     virtual void Process_vkGetDeviceAccelerationStructureCompatibilityKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         StructPointerDecoder<Decoded_VkAccelerationStructureVersionInfoKHR>* pVersionInfo,
         PointerDecoder<VkAccelerationStructureCompatibilityKHR>* pCompatibility) override;
 
     virtual void Process_vkGetAccelerationStructureBuildSizesKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            device,
         VkAccelerationStructureBuildTypeKHR         buildType,
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildGeometryInfoKHR>* pBuildInfo,
@@ -3004,6 +3503,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         StructPointerDecoder<Decoded_VkAccelerationStructureBuildSizesInfoKHR>* pSizeInfo) override;
 
     virtual void Process_vkCmdTraceRaysKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pRaygenShaderBindingTable,
         StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pMissShaderBindingTable,
@@ -3014,6 +3514,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         uint32_t                                    depth) override;
 
     virtual void Process_vkCreateRayTracingPipelinesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            deferredOperation,
@@ -3024,6 +3525,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         HandlePointerDecoder<VkPipeline>*           pPipelines) override;
 
     virtual void Process_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(
+        const ApiCallInfo&                          call_info,
         VkResult                                    returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
@@ -3033,6 +3535,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         PointerDecoder<uint8_t>*                    pData) override;
 
     virtual void Process_vkCmdTraceRaysIndirectKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pRaygenShaderBindingTable,
         StructPointerDecoder<Decoded_VkStridedDeviceAddressRegionKHR>* pMissShaderBindingTable,
@@ -3041,6 +3544,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkDeviceAddress                             indirectDeviceAddress) override;
 
     virtual void Process_vkGetRayTracingShaderGroupStackSizeKHR(
+        const ApiCallInfo&                          call_info,
         VkDeviceSize                                returnValue,
         format::HandleId                            device,
         format::HandleId                            pipeline,
@@ -3048,6 +3552,7 @@ class VulkanReplayConsumer : public VulkanReplayConsumerBase
         VkShaderGroupShaderKHR                      groupShader) override;
 
     virtual void Process_vkCmdSetRayTracingPipelineStackSizeKHR(
+        const ApiCallInfo&                          call_info,
         format::HandleId                            commandBuffer,
         uint32_t                                    pipelineStackSize) override;
 };

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -1104,6 +1104,11 @@ class BaseGenerator(OutputGenerator):
         Generate VulkanConsumer class member function declaration.
         """
         param_decls = []
+        param_decl = self.make_aligned_param_decl(
+            'const ApiCallInfo&', 'call_info', self.INDENT_SIZE,
+            self.genOpts.align_func_param
+        )
+        param_decls.append(param_decl)
 
         if dx12_method:
             param_decl = self.make_aligned_param_decl(

--- a/framework/generated/vulkan_generators/vulkan_ascii_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_ascii_consumer_body_generator.py
@@ -144,7 +144,7 @@ class VulkanAsciiConsumerBodyGenerator(BaseGenerator):
                         ToStringFlags toStringFlags = kToString_Default;
                         uint32_t tabCount = 0;
                         uint32_t tabSize = 4;
-                        WriteApiCallToFile("{0}", toStringFlags, tabCount, tabSize,
+                        WriteApiCallToFile(call_info, "{0}", toStringFlags, tabCount, tabSize,
                             [&](std::stringstream& strStrm)
                             {{
                     '''.format(cmd)

--- a/framework/generated/vulkan_generators/vulkan_decoder_header_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_decoder_header_generator.py
@@ -131,7 +131,7 @@ class VulkanDecoderHeaderGenerator(BaseGenerator):
         first = True
         for cmd in self.get_filtered_cmd_names():
             cmddef = '' if first else '\n'
-            cmddef += '    size_t Decode_{}(const uint8_t* parameter_buffer, size_t buffer_size);'.format(
+            cmddef += '    size_t Decode_{}(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);'.format(
                 cmd
             )
             write(cmddef, file=self.outFile)

--- a/tools/extract/main.cpp
+++ b/tools/extract/main.cpp
@@ -114,6 +114,7 @@ class VulkanExtractConsumer : public gfxrecon::decode::VulkanConsumer
     VulkanExtractConsumer(std::string& extract_dir) : extract_dir_(extract_dir) {}
 
     virtual void Process_vkCreateShaderModule(
+        const gfxrecon::decode::ApiCallInfo&                                                        call_info,
         VkResult                                                                                    returnValue,
         gfxrecon::format::HandleId                                                                  shaderModule,
         gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkShaderModuleCreateInfo>* pCreateInfo,

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -151,6 +151,7 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
     }
 
     virtual void Process_vkCreateInstance(
+        const gfxrecon::decode::ApiCallInfo&                                                    call_info,
         VkResult                                                                                returnValue,
         gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkInstanceCreateInfo>* pCreateInfo,
         gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>*,
@@ -180,6 +181,7 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
     }
 
     virtual void Process_vkGetPhysicalDeviceProperties(
+        const gfxrecon::decode::ApiCallInfo&                                                          call_info,
         gfxrecon::format::HandleId                                                                    physicalDevice,
         gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkPhysicalDeviceProperties>* pProperties)
         override
@@ -191,6 +193,7 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
     }
 
     virtual void Process_vkGetPhysicalDeviceProperties2(
+        const gfxrecon::decode::ApiCallInfo&                                                           call_info,
         gfxrecon::format::HandleId                                                                     physicalDevice,
         gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkPhysicalDeviceProperties2>* pProperties)
         override
@@ -203,6 +206,7 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
     }
 
     virtual void Process_vkGetPhysicalDeviceProperties2KHR(
+        const gfxrecon::decode::ApiCallInfo&                                                           call_info,
         gfxrecon::format::HandleId                                                                     physicalDevice,
         gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkPhysicalDeviceProperties2>* pProperties)
         override
@@ -215,8 +219,9 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
     }
 
     virtual void
-    Process_vkCreateDevice(VkResult                   returnValue,
-                           gfxrecon::format::HandleId physicalDevice,
+    Process_vkCreateDevice(const gfxrecon::decode::ApiCallInfo& call_info,
+                           VkResult                             returnValue,
+                           gfxrecon::format::HandleId           physicalDevice,
                            gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkDeviceCreateInfo>*,
                            gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>*,
                            gfxrecon::decode::HandlePointerDecoder<VkDevice>*) override
@@ -228,7 +233,8 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
     }
 
     virtual void Process_vkCreateGraphicsPipelines(
-        VkResult returnValue,
+        const gfxrecon::decode::ApiCallInfo& call_info,
+        VkResult                             returnValue,
         gfxrecon::format::HandleId,
         gfxrecon::format::HandleId,
         uint32_t createInfoCount,
@@ -243,7 +249,8 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
     }
 
     virtual void Process_vkCreateComputePipelines(
-        VkResult returnValue,
+        const gfxrecon::decode::ApiCallInfo& call_info,
+        VkResult                             returnValue,
         gfxrecon::format::HandleId,
         gfxrecon::format::HandleId,
         uint32_t createInfoCount,
@@ -257,30 +264,49 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
         }
     }
 
-    virtual void Process_vkCmdDraw(gfxrecon::format::HandleId, uint32_t, uint32_t, uint32_t, uint32_t) override
+    virtual void Process_vkCmdDraw(const gfxrecon::decode::ApiCallInfo& call_info,
+                                   gfxrecon::format::HandleId,
+                                   uint32_t,
+                                   uint32_t,
+                                   uint32_t,
+                                   uint32_t) override
     {
         ++draw_count_;
     }
 
-    virtual void
-        Process_vkCmdDrawIndexed(gfxrecon::format::HandleId, uint32_t, uint32_t, uint32_t, int32_t, uint32_t) override
+    virtual void Process_vkCmdDrawIndexed(const gfxrecon::decode::ApiCallInfo& call_info,
+                                          gfxrecon::format::HandleId,
+                                          uint32_t,
+                                          uint32_t,
+                                          uint32_t,
+                                          int32_t,
+                                          uint32_t) override
     {
         ++draw_count_;
     }
 
-    virtual void Process_vkCmdDrawIndirect(
-        gfxrecon::format::HandleId, gfxrecon::format::HandleId, VkDeviceSize, uint32_t, uint32_t) override
+    virtual void Process_vkCmdDrawIndirect(const gfxrecon::decode::ApiCallInfo& call_info,
+                                           gfxrecon::format::HandleId,
+                                           gfxrecon::format::HandleId,
+                                           VkDeviceSize,
+                                           uint32_t,
+                                           uint32_t) override
     {
         ++draw_count_;
     }
 
-    virtual void Process_vkCmdDrawIndexedIndirect(
-        gfxrecon::format::HandleId, gfxrecon::format::HandleId, VkDeviceSize, uint32_t, uint32_t) override
+    virtual void Process_vkCmdDrawIndexedIndirect(const gfxrecon::decode::ApiCallInfo& call_info,
+                                                  gfxrecon::format::HandleId,
+                                                  gfxrecon::format::HandleId,
+                                                  VkDeviceSize,
+                                                  uint32_t,
+                                                  uint32_t) override
     {
         ++draw_count_;
     }
 
-    virtual void Process_vkCmdDrawIndirectCountKHR(gfxrecon::format::HandleId,
+    virtual void Process_vkCmdDrawIndirectCountKHR(const gfxrecon::decode::ApiCallInfo& call_info,
+                                                   gfxrecon::format::HandleId,
                                                    gfxrecon::format::HandleId,
                                                    VkDeviceSize,
                                                    gfxrecon::format::HandleId,
@@ -291,7 +317,8 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
         ++draw_count_;
     }
 
-    virtual void Process_vkCmdDrawIndexedIndirectCountKHR(gfxrecon::format::HandleId,
+    virtual void Process_vkCmdDrawIndexedIndirectCountKHR(const gfxrecon::decode::ApiCallInfo& call_info,
+                                                          gfxrecon::format::HandleId,
                                                           gfxrecon::format::HandleId,
                                                           VkDeviceSize,
                                                           gfxrecon::format::HandleId,
@@ -302,7 +329,8 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
         ++draw_count_;
     }
 
-    virtual void Process_vkCmdDrawIndirectByteCountEXT(gfxrecon::format::HandleId,
+    virtual void Process_vkCmdDrawIndirectByteCountEXT(const gfxrecon::decode::ApiCallInfo& call_info,
+                                                       gfxrecon::format::HandleId,
                                                        uint32_t,
                                                        uint32_t,
                                                        gfxrecon::format::HandleId,
@@ -313,7 +341,8 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
         ++draw_count_;
     }
 
-    virtual void Process_vkCmdDrawIndirectCountAMD(gfxrecon::format::HandleId,
+    virtual void Process_vkCmdDrawIndirectCountAMD(const gfxrecon::decode::ApiCallInfo& call_info,
+                                                   gfxrecon::format::HandleId,
                                                    gfxrecon::format::HandleId,
                                                    VkDeviceSize,
                                                    gfxrecon::format::HandleId,
@@ -324,7 +353,8 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
         ++draw_count_;
     }
 
-    virtual void Process_vkCmdDrawIndexedIndirectCountAMD(gfxrecon::format::HandleId,
+    virtual void Process_vkCmdDrawIndexedIndirectCountAMD(const gfxrecon::decode::ApiCallInfo& call_info,
+                                                          gfxrecon::format::HandleId,
                                                           gfxrecon::format::HandleId,
                                                           VkDeviceSize,
                                                           gfxrecon::format::HandleId,
@@ -335,18 +365,26 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
         ++draw_count_;
     }
 
-    virtual void Process_vkCmdDrawMeshTasksNV(gfxrecon::format::HandleId, uint32_t, uint32_t) override
+    virtual void Process_vkCmdDrawMeshTasksNV(const gfxrecon::decode::ApiCallInfo& call_info,
+                                              gfxrecon::format::HandleId,
+                                              uint32_t,
+                                              uint32_t) override
     {
         ++draw_count_;
     }
 
-    virtual void Process_vkCmdDrawMeshTasksIndirectNV(
-        gfxrecon::format::HandleId, gfxrecon::format::HandleId, VkDeviceSize, uint32_t, uint32_t) override
+    virtual void Process_vkCmdDrawMeshTasksIndirectNV(const gfxrecon::decode::ApiCallInfo& call_info,
+                                                      gfxrecon::format::HandleId,
+                                                      gfxrecon::format::HandleId,
+                                                      VkDeviceSize,
+                                                      uint32_t,
+                                                      uint32_t) override
     {
         ++draw_count_;
     }
 
-    virtual void Process_vkCmdDrawMeshTasksIndirectCountNV(gfxrecon::format::HandleId,
+    virtual void Process_vkCmdDrawMeshTasksIndirectCountNV(const gfxrecon::decode::ApiCallInfo& call_info,
+                                                           gfxrecon::format::HandleId,
                                                            gfxrecon::format::HandleId,
                                                            VkDeviceSize,
                                                            gfxrecon::format::HandleId,
@@ -357,31 +395,50 @@ class VulkanStatsConsumer : public gfxrecon::decode::VulkanConsumer
         ++draw_count_;
     }
 
-    virtual void Process_vkCmdDispatch(gfxrecon::format::HandleId, uint32_t, uint32_t, uint32_t) override
+    virtual void Process_vkCmdDispatch(const gfxrecon::decode::ApiCallInfo& call_info,
+                                       gfxrecon::format::HandleId,
+                                       uint32_t,
+                                       uint32_t,
+                                       uint32_t) override
     {
         ++dispatch_count_;
     }
 
-    virtual void
-        Process_vkCmdDispatchIndirect(gfxrecon::format::HandleId, gfxrecon::format::HandleId, VkDeviceSize) override
+    virtual void Process_vkCmdDispatchIndirect(const gfxrecon::decode::ApiCallInfo& call_info,
+                                               gfxrecon::format::HandleId,
+                                               gfxrecon::format::HandleId,
+                                               VkDeviceSize) override
     {
         ++dispatch_count_;
     }
 
-    virtual void Process_vkCmdDispatchBase(
-        gfxrecon::format::HandleId, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t) override
+    virtual void Process_vkCmdDispatchBase(const gfxrecon::decode::ApiCallInfo& call_info,
+                                           gfxrecon::format::HandleId,
+                                           uint32_t,
+                                           uint32_t,
+                                           uint32_t,
+                                           uint32_t,
+                                           uint32_t,
+                                           uint32_t) override
     {
         ++dispatch_count_;
     }
 
-    virtual void Process_vkCmdDispatchBaseKHR(
-        gfxrecon::format::HandleId, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t) override
+    virtual void Process_vkCmdDispatchBaseKHR(const gfxrecon::decode::ApiCallInfo& call_info,
+                                              gfxrecon::format::HandleId,
+                                              uint32_t,
+                                              uint32_t,
+                                              uint32_t,
+                                              uint32_t,
+                                              uint32_t,
+                                              uint32_t) override
     {
         ++dispatch_count_;
     }
 
     virtual void Process_vkAllocateMemory(
-        VkResult returnValue,
+        const gfxrecon::decode::ApiCallInfo& call_info,
+        VkResult                             returnValue,
         gfxrecon::format::HandleId,
         gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkMemoryAllocateInfo>* pAllocateInfo,
         gfxrecon::decode::StructPointerDecoder<gfxrecon::decode::Decoded_VkAllocationCallbacks>*,


### PR DESCRIPTION
This PR adds an `ApiCallInfo` member to `FileProcessor` that can be updated and passed to api call handlers.