### PR TITLE
Make IsArgumentSet() Behave Like IsOptionSet()

### DIFF
--- a/framework/util/argument_parser.cpp
+++ b/framework/util/argument_parser.cpp
@@ -185,6 +185,7 @@ void ArgumentParser::Init(std::vector<std::string> command_line_args,
             argument_index++;
         }
     }
+    arguments_present_.resize(argument_index);
     argument_values_.resize(argument_index);
 
     for (size_t cur_arg = 0; cur_arg < command_line_args.size(); ++cur_arg)
@@ -245,7 +246,8 @@ void ArgumentParser::Init(std::vector<std::string> command_line_args,
                             }
                             argument_values_[cur_argument.second] = argument_value;
                         }
-                        is_argument = true;
+                        arguments_present_[cur_argument.second] = true;
+                        is_argument                             = true;
                         break;
                     }
                 }
@@ -280,7 +282,14 @@ bool ArgumentParser::IsOptionSet(const std::string& option) const
 
 bool ArgumentParser::IsArgumentSet(const std::string& argument) const
 {
-    return static_cast<bool>(arguments_indices_.count(argument));
+    auto ret_iterator = arguments_indices_.find(argument);
+
+    if (ret_iterator != arguments_indices_.end())
+    {
+        return arguments_present_[ret_iterator->second];
+    }
+
+    return false;
 }
 
 const std::string& ArgumentParser::GetArgumentValue(const std::string& argument) const

--- a/framework/util/argument_parser.cpp
+++ b/framework/util/argument_parser.cpp
@@ -244,10 +244,10 @@ void ArgumentParser::Init(std::vector<std::string> command_line_args,
                                     argument_value.pop_back();
                                 }
                             }
-                            argument_values_[cur_argument.second] = argument_value;
+                            arguments_present_[cur_argument.second] = true;
+                            argument_values_[cur_argument.second]   = argument_value;
                         }
-                        arguments_present_[cur_argument.second] = true;
-                        is_argument                             = true;
+                        is_argument = true;
                         break;
                     }
                 }

--- a/framework/util/argument_parser.h
+++ b/framework/util/argument_parser.h
@@ -67,6 +67,7 @@ class ArgumentParser
     std::unordered_map<std::string, uint32_t> options_indices_;
     std::vector<bool>                         options_present_;
     std::unordered_map<std::string, uint32_t> arguments_indices_;
+    std::vector<bool>                         arguments_present_;
     std::vector<std::string>                  argument_values_;
     std::vector<std::string>                  positional_arguments_present_;
 };

--- a/tools/toascii/main.cpp
+++ b/tools/toascii/main.cpp
@@ -67,8 +67,8 @@ static std::string GetOutputFileName(const gfxrecon::util::ArgumentParser& arg_p
     }
     else
     {
-        std::string output_filename = input_filename;
-        size_t      suffix_pos      = output_filename.find(GFXRECON_FILE_EXTENSION);
+        output_filename   = input_filename;
+        size_t suffix_pos = output_filename.find(GFXRECON_FILE_EXTENSION);
         if (suffix_pos != std::string::npos)
         {
             output_filename = output_filename.substr(0, suffix_pos);
@@ -89,27 +89,24 @@ int main(int argc, const char** argv)
         gfxrecon::util::Log::Release();
         exit(0);
     }
-    else if (arg_parser.IsInvalid() || (arg_parser.GetPositionalArgumentsCount() != 1))
+    if (arg_parser.IsInvalid() || (arg_parser.GetPositionalArgumentsCount() != 1))
     {
         PrintUsage(argv[0]);
         gfxrecon::util::Log::Release();
         exit(-1);
     }
-    else if (arg_parser.IsArgumentSet(kOutput) && arg_parser.GetArgumentValue(kOutput).empty())
+    if (arg_parser.IsArgumentSet(kOutput) && arg_parser.GetArgumentValue(kOutput).empty())
     {
         GFXRECON_LOG_ERROR("Empty string given for argument \"--output\"; must be a valid path or 'stdout'");
         gfxrecon::util::Log::Release();
         exit(-1);
     }
-    else
-    {
 #if defined(WIN32) && defined(_DEBUG)
-        if (arg_parser.IsOptionSet(kNoDebugPopup))
-        {
-            _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
-        }
-#endif
+    if (arg_parser.IsOptionSet(kNoDebugPopup))
+    {
+        _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
     }
+#endif
 
     const auto& positional_arguments = arg_parser.GetPositionalArguments();
     std::string input_filename       = positional_arguments[0];


### PR DESCRIPTION
This PR makes `IsArgumentSet()` behave like `IsOptionSet()`.

`IsOptionSet()` returns `true` when a given option has been set by the user on the cmd line and returns `false` when a given option has not be set by the user. 

`IsArgumentSet()` currenlty returns `true` for any valid argument, regardless of whether or not the argument is set.

This PR adds a member variable called `arguments_present_` and gives it the same treatment as the existing `options_present_` member variable.