### PR TITLE
restore trimming with NONE compression

### DIFF
--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -87,7 +87,6 @@ VulkanStateWriter::VulkanStateWriter(util::FileOutputStream* output_stream,
     compressor_(compressor), thread_id_(thread_id), encoder_(&parameter_stream_)
 {
     assert(output_stream != nullptr);
-    assert(compressor != nullptr);
 }
 
 VulkanStateWriter::~VulkanStateWriter() {}


### PR DESCRIPTION
compressor == nullptr is a legal construction parameter for VulkanStateWriter (in the case there is no compressor) so remove an assert.