### PR TITLE
temporarily disable toascii

### DIFF
--- a/USAGE_desktop.md
+++ b/USAGE_desktop.md
@@ -547,27 +547,6 @@ Optional arguments:
   --version             Print version information and exit.
 ```
 
-### To ASCII
-
-The `gfxrecon-toascii.exe` converts GFXReconstruct capture files to text.
-The text output is formatted as JSON and written by default to a .txt file in the directory of the specified GFXReconstruct capture file. Use `--output` to override the default filename for the output.
-
-```text
-gfxrecon-toascii.exe - A tool to convert GFXReconstruct capture files to text.
-
-Usage:
-  gfxrecon-toascii.exe [-h | --help] [--version] [--output filename] <file>
-
-Required arguments:
-  <file>                Path to the GFXReconstruct capture file to be converted
-                        to text.
-
-Optional arguments:
-  -h                    Print usage information and exit (same as --help).
-  --version             Print version information and exit.
-  --output filename     Write output to the provided filename.
-```
-
 ### Command Launcher
 
 The `gfxrecon.py` tool is a utility that can be used to launch all of the

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,8 +1,12 @@
 add_subdirectory(replay)
-add_subdirectory(toascii)
 add_subdirectory(compress)
 add_subdirectory(info)
 add_subdirectory(extract)
 add_subdirectory(optimize)
 add_subdirectory(capture)
 add_subdirectory(gfxrecon)
+
+# TOASCII build is currently disabled pending resolution of some issues
+if(BUILD_TOASCII)
+add_subdirectory(toascii)
+endif()

--- a/tools/toascii/README.md
+++ b/tools/toascii/README.md
@@ -1,0 +1,21 @@
+### To ASCII
+
+The `gfxrecon-toascii.exe` converts GFXReconstruct capture files to text.
+The text output is formatted as JSON and written by default to a .txt file in the directory of the specified GFXReconstruct capture file. Use `--output` to override the default filename for the output.
+
+```text
+gfxrecon-toascii.exe - A tool to convert GFXReconstruct capture files to text.
+
+Usage:
+  gfxrecon-toascii.exe [-h | --help] [--version] [--output filename] <file>
+
+Required arguments:
+  <file>                Path to the GFXReconstruct capture file to be converted
+                        to text.
+
+Optional arguments:
+  -h                    Print usage information and exit (same as --help).
+  --version             Print version information and exit.
+  --output filename     Write output to the provided filename.
+```
+


### PR DESCRIPTION
Because of identified issues with the current `gfxrecon-toascii` implementation, `gfxrecon-toascii `is now temporarily removed from the build as we discussed in December.  Until resolved, build `gfxrecon-toascii`, provide the option `BUILD_TOASCII` with a non-false value during `cmake`, e.g.
```
cmake -Bbuild -DBUILD_TOASCII=true
```

Fixes #667 