### PR TITLE
restore hash as filename suffix for shader replacement

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -4403,8 +4403,8 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShaderModule(
     std::unique_ptr<char[]> file_code;
     const uint32_t*         orig_code = original_info->pCode;
     size_t                  orig_size = original_info->codeSize;
-    uint32_t                check_sum = util::hash::CheckSum(orig_code, orig_size);
-    std::string             file_name = "sh" + std::to_string(check_sum);
+    uint64_t                handle_id = *pShaderModule->GetPointer();
+    std::string             file_name = "sh" + std::to_string(handle_id);
     std::string             file_path = util::filepath::Join(options_.replace_dir, file_name);
 
     FILE*   fp     = nullptr;


### PR DESCRIPTION
["Use handle id in filename for shader extract and replace." had transitioned from a hash of the shader contents to using the shader module handle.](https://github.com/LunarG/gfxreconstruct/commit/84fb52ddded424ebf68d7c7c84d708da9827e371

#668 reports a regression in shader replacement.  It looks like 9e1a0316bc54926cafc33bd872e2e6aabcd441ab in #342 changed the filename suffix to be the ShaderModule handle (it had previously been a hash of the shader blob).  https://github.com/LunarG/gfxreconstruct/commit/84fb52ddded424ebf68d7c7c84d708da9827e371 changed the code in `VulkanReplayConsumerBase::OverrideCreateShaderModule` back to using a hash.

Since 84fb52d doesn't change `gfxrecon-extract` back to using a hash, I think it's reasonable to assume this was a mistake.

This PR restores the handle behavior.