### PR TITLE
Remove unused variable message_written that prevents building with strict checking

### DIFF
--- a/framework/util/logging.cpp
+++ b/framework/util/logging.cpp
@@ -144,7 +144,6 @@ void Log::LogMessage(
 {
     bool  opened_file      = false;
     bool  write_indent     = settings_.use_indent && (settings_.indent > 0);
-    bool  message_written  = false;
     bool  output_to_stderr = false;
     FILE* log_file_ptr;
 


### PR DESCRIPTION
Remove unused variable `message_written` that prevents building with strict checking