### PR TITLE
Issue-506: Fix for XCloseDisplay segfaults

### DIFF
--- a/framework/decode/vulkan_object_cleanup_util.cpp
+++ b/framework/decode/vulkan_object_cleanup_util.cpp
@@ -684,16 +684,6 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
                                       table->DestroyDevice(object_info->handle, nullptr);
                                   });
 
-    FreeParentObjects<InstanceInfo>(table,
-                                    remove_entries,
-                                    &VulkanObjectInfoTable::VisitInstanceInfo,
-                                    &VulkanObjectInfoTable::RemoveInstanceInfo,
-                                    [&](const InstanceInfo* object_info) {
-                                        assert(object_info != nullptr);
-                                        auto table = get_instance_table(object_info->handle);
-                                        table->DestroyInstance(object_info->handle, nullptr);
-                                    });
-
     // Remove the objects that are not destroyed from the table.
     if (remove_entries)
     {
@@ -724,6 +714,23 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
         // Clear the remaining swap chain images.
         ClearObjects<ImageInfo>(table, &VulkanObjectInfoTable::VisitImageInfo, &VulkanObjectInfoTable::RemoveImageInfo);
     }
+}
+
+void FreeAllLiveInstances(VulkanObjectInfoTable*                                   table,
+                          bool                                                     remove_entries,
+                          bool                                                     report_leaks,
+                          std::function<const encode::InstanceTable*(const void*)> get_instance_table,
+                          std::function<const encode::DeviceTable*(const void*)>   get_device_table)
+{
+    FreeParentObjects<InstanceInfo>(table,
+                                    remove_entries,
+                                    &VulkanObjectInfoTable::VisitInstanceInfo,
+                                    &VulkanObjectInfoTable::RemoveInstanceInfo,
+                                    [&](const InstanceInfo* object_info) {
+                                        assert(object_info != nullptr);
+                                        auto table = get_instance_table(object_info->handle);
+                                        table->DestroyInstance(object_info->handle, nullptr);
+                                    });
 }
 
 GFXRECON_END_NAMESPACE(object_cleanup)

--- a/framework/decode/vulkan_object_cleanup_util.h
+++ b/framework/decode/vulkan_object_cleanup_util.h
@@ -39,6 +39,12 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
                         std::function<const encode::InstanceTable*(const void*)> get_instance_table,
                         std::function<const encode::DeviceTable*(const void*)>   get_device_table);
 
+void FreeAllLiveInstances(VulkanObjectInfoTable*                                   table,
+                          bool                                                     remove_entries,
+                          bool                                                     report_leaks,
+                          std::function<const encode::InstanceTable*(const void*)> get_instance_table,
+                          std::function<const encode::DeviceTable*(const void*)>   get_device_table);
+
 GFXRECON_END_NAMESPACE(object_cleanup)
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -196,6 +196,14 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
         window_factory->Destroy(window);
     }
 
+    // Finally destroy vkInstances
+    object_cleanup::FreeAllLiveInstances(
+        &object_info_table_,
+        false,
+        true,
+        [this](const void* handle) { return GetInstanceTable(handle); },
+        [this](const void* handle) { return GetDeviceTable(handle); });
+
     if (loader_handle_ != nullptr)
     {
         graphics::ReleaseLoader(loader_handle_);


### PR DESCRIPTION
Turns out we have dealt [with the same issue](https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/issues/1894) in the past.
The problem is that the nvidia driver adds some XDisplay extensions along with a callback that is called when `XCloseDisplay` is called and for that reason we must first terminate the connection with X11 (call `XCloseDisplay`) and the destroy the `vkInstance` which effectively unloads the driver, causing the callbacks to segfault when called.