### PR TITLE
issue-515: Picking wrong physical device when multiple are present

### DIFF
--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1912,7 +1912,7 @@ void VulkanReplayConsumerBase::GetMatchingDevice(InstanceInfo* instance_info, Ph
                 if (entry.second.properties == nullptr)
                 {
                     entry.second.properties = std::make_unique<VkPhysicalDeviceProperties>();
-                    table->GetPhysicalDeviceProperties(physical_device_info->handle, entry.second.properties.get());
+                    table->GetPhysicalDeviceProperties(entry.first, entry.second.properties.get());
                 }
 
                 replay_properties = entry.second.properties.get();


### PR DESCRIPTION
This is a minor bug that could trigger in setups with multiple ICDs
present.

The logic in GetMatchingDevice was erroneously querying the physical
device information of the currently selected physical device, instead of
the one currently in its valuation list. As a result it was possible to
make a perfect match between two completely different physical devices.