### PR TITLE
Trimming VK_KHR_synchronization2

### DIFF
--- a/framework/decode/vulkan_referenced_resource_consumer_base.cpp
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.cpp
@@ -66,6 +66,38 @@ void VulkanReferencedResourceConsumerBase::Process_vkQueueSubmit(const ApiCallIn
     }
 }
 
+void VulkanReferencedResourceConsumerBase::Process_vkQueueSubmit2(const ApiCallInfo& call_info,
+                                                                  VkResult           returnValue,
+                                                                  format::HandleId   queue,
+                                                                  uint32_t           submitCount,
+                                                                  StructPointerDecoder<Decoded_VkSubmitInfo2>* pSubmits,
+                                                                  format::HandleId                             fence)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(returnValue);
+    GFXRECON_UNREFERENCED_PARAMETER(queue);
+    GFXRECON_UNREFERENCED_PARAMETER(submitCount);
+    GFXRECON_UNREFERENCED_PARAMETER(fence);
+
+    assert(pSubmits != nullptr);
+
+    if (!pSubmits->IsNull() && pSubmits->HasData())
+    {
+        size_t     submit_count = pSubmits->GetLength();
+        const auto submits      = pSubmits->GetMetaStructPointer();
+
+        for (size_t i = 0; i < submit_count; ++i)
+        {
+            size_t     command_buffer_count = submits[i].pCommandBufferInfos->GetLength();
+            const auto command_buffers      = submits[i].pCommandBufferInfos->GetMetaStructPointer();
+
+            for (size_t j = 0; j < command_buffer_count; ++j)
+            {
+                table_.ProcessUserSubmission(command_buffers[j].commandBuffer);
+            }
+        }
+    }
+}
+
 void VulkanReferencedResourceConsumerBase::Process_vkCreateBuffer(
     const ApiCallInfo&                                   call_info,
     VkResult                                             returnValue,

--- a/framework/decode/vulkan_referenced_resource_consumer_base.h
+++ b/framework/decode/vulkan_referenced_resource_consumer_base.h
@@ -63,6 +63,13 @@ class VulkanReferencedResourceConsumerBase : public VulkanConsumer
                                        StructPointerDecoder<Decoded_VkSubmitInfo>* pSubmits,
                                        format::HandleId                            fence) override;
 
+    virtual void Process_vkQueueSubmit2(const ApiCallInfo&                           call_info,
+                                        VkResult                                     returnValue,
+                                        format::HandleId                             queue,
+                                        uint32_t                                     submitCount,
+                                        StructPointerDecoder<Decoded_VkSubmitInfo2>* pSubmits,
+                                        format::HandleId                             fence) override;
+
     virtual void Process_vkCreateBuffer(const ApiCallInfo&                                   call_info,
                                         VkResult                                             returnValue,
                                         format::HandleId                                     device,

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -3235,6 +3235,141 @@ VkResult VulkanReplayConsumerBase::OverrideQueueSubmit(PFN_vkQueueSubmit func,
     return result;
 }
 
+VkResult VulkanReplayConsumerBase::OverrideQueueSubmit2(PFN_vkQueueSubmit2 func,
+                                                        VkResult           original_result,
+                                                        const QueueInfo*   queue_info,
+                                                        uint32_t           submitCount,
+                                                        const StructPointerDecoder<Decoded_VkSubmitInfo2>* pSubmits,
+                                                        const FenceInfo*                                   fence_info)
+{
+    assert((queue_info != nullptr) && (pSubmits != nullptr));
+
+    VkResult             result       = VK_SUCCESS;
+    const VkSubmitInfo2* submit_infos = pSubmits->GetPointer();
+    assert(submitCount == 0 || submit_infos != nullptr);
+    auto    submit_info_data = pSubmits->GetMetaStructPointer();
+    VkFence fence            = VK_NULL_HANDLE;
+
+    if (fence_info != nullptr)
+    {
+        fence = fence_info->handle;
+    }
+
+    // Only attempt to filter imported semaphores if we know at least one has been imported.
+    // If rendering is restricted to a specific surface, shadow semaphore and forward progress state will need to be
+    // tracked.
+    if ((!have_imported_semaphores_) && (options_.surface_index == -1))
+    {
+        result = func(queue_info->handle, submitCount, submit_infos, fence);
+    }
+    else
+    {
+        // Check for imported semaphores in the current submission list, mapping the pSubmits array index to a vector of
+        // imported semaphore info structures.
+        std::unordered_map<uint32_t, std::vector<const SemaphoreInfo*>> altered_submits;
+        std::vector<const SemaphoreInfo*>                               removed_semaphores;
+
+        if (submit_info_data != nullptr)
+        {
+            for (uint32_t i = 0; i < submitCount; i++)
+            {
+                GetImportedSemaphores(submit_info_data[i].pWaitSemaphoreInfos, &removed_semaphores);
+                GetShadowSemaphores(submit_info_data[i].pWaitSemaphoreInfos, &removed_semaphores);
+
+                // If rendering is restricted to a specific surface, need to track forward progress for semaphores that
+                // have been submitted with a null-swapchain.
+                TrackSemaphoreForwardProgress(submit_info_data[i].pWaitSemaphoreInfos, &removed_semaphores);
+
+                // Remove non-forward progress of signal semaphores.
+                GetNonForwardProgress(submit_info_data[i].pWaitSemaphoreInfos, &removed_semaphores);
+
+                if (!removed_semaphores.empty())
+                {
+                    altered_submits[i].swap(removed_semaphores);
+                    assert(removed_semaphores.empty());
+                }
+            }
+        }
+
+        if (altered_submits.empty())
+        {
+            result = func(queue_info->handle, submitCount, submit_infos, fence);
+        }
+        else
+        {
+            // Make shallow copies of the VkSubmit info structures and change pWaitSemaphores to reference a copy of the
+            // original semaphore array with the imported semaphores omitted.
+            std::vector<VkSubmitInfo2> modified_submit_infos(submit_infos, std::next(submit_infos, submitCount));
+            std::vector<std::vector<VkSemaphore>> semaphore_memory(altered_submits.size());
+
+            std::vector<VkSemaphoreSubmitInfo> wait_semaphore_infos;
+            std::vector<VkSemaphoreSubmitInfo> signal_semaphore_infos;
+
+            for (const auto& submit_iter : altered_submits)
+            {
+                // Shallow copy with filtered copy of pWaitSemaphores for submission info with imported semaphores.
+                VkSubmitInfo2& modified_submit_info = modified_submit_infos[submit_iter.first];
+                auto           semaphore_iter       = submit_iter.second.begin();
+
+                for (uint32_t i = 0; i < modified_submit_info.waitSemaphoreInfoCount; ++i)
+                {
+                    VkSemaphore semaphore = modified_submit_info.pWaitSemaphoreInfos[i].semaphore;
+
+                    if ((semaphore_iter == submit_iter.second.end()) || ((*semaphore_iter)->handle != semaphore))
+                    {
+                        VkSemaphoreSubmitInfo info{};
+                        info.sType     = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
+                        info.semaphore = semaphore;
+
+                        wait_semaphore_infos.emplace_back(info);
+                    }
+                    else
+                    {
+                        // Omit the ignored semaphore from the current submission.
+                        ++semaphore_iter;
+                    }
+                }
+
+                for (uint32_t i = 0; i < modified_submit_info.signalSemaphoreInfoCount; ++i)
+                {
+                    VkSemaphore semaphore = modified_submit_info.pSignalSemaphoreInfos[i].semaphore;
+
+                    if ((semaphore_iter == submit_iter.second.end()) || ((*semaphore_iter)->handle != semaphore))
+                    {
+                        VkSemaphoreSubmitInfo info{};
+                        info.sType     = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO;
+                        info.semaphore = semaphore;
+
+                        signal_semaphore_infos.emplace_back(info);
+                    }
+                    else
+                    {
+                        // Omit the ignored semaphore from the current submission.
+                        ++semaphore_iter;
+                    }
+                }
+
+                modified_submit_info.waitSemaphoreInfoCount   = static_cast<uint32_t>(wait_semaphore_infos.size());
+                modified_submit_info.pWaitSemaphoreInfos      = wait_semaphore_infos.data();
+                modified_submit_info.signalSemaphoreInfoCount = static_cast<uint32_t>(signal_semaphore_infos.size());
+                modified_submit_info.pSignalSemaphoreInfos    = signal_semaphore_infos.data();
+            }
+
+            result = func(queue_info->handle,
+                          static_cast<uint32_t>(modified_submit_infos.size()),
+                          modified_submit_infos.data(),
+                          fence);
+        }
+    }
+
+    if ((options_.sync_queue_submissions) && (result == VK_SUCCESS))
+    {
+        GetDeviceTable(queue_info->handle)->QueueWaitIdle(queue_info->handle);
+    }
+
+    return result;
+}
+
 VkResult
 VulkanReplayConsumerBase::OverrideQueueBindSparse(PFN_vkQueueBindSparse                                 func,
                                                   VkResult                                              original_result,
@@ -5928,6 +6063,28 @@ void VulkanReplayConsumerBase::GetImportedSemaphores(const HandlePointerDecoder<
     }
 }
 
+void VulkanReplayConsumerBase::GetImportedSemaphores(
+    const StructPointerDecoder<Decoded_VkSemaphoreSubmitInfo>* semaphore_info_data,
+    std::vector<const SemaphoreInfo*>*                         imported_semaphores)
+{
+    assert(imported_semaphores != nullptr);
+
+    const Decoded_VkSemaphoreSubmitInfo* semaphore_infos = semaphore_info_data->GetMetaStructPointer();
+    if (semaphore_infos != nullptr)
+    {
+        size_t count = semaphore_info_data->GetLength();
+
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            const SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(semaphore_infos[i].semaphore);
+            if ((semaphore_info != nullptr) && semaphore_info->is_external)
+            {
+                imported_semaphores->push_back(semaphore_info);
+            }
+        }
+    }
+}
+
 void VulkanReplayConsumerBase::GetShadowSemaphores(const HandlePointerDecoder<VkSemaphore>& semaphore_data,
                                                    std::vector<const SemaphoreInfo*>*       shadow_semaphores)
 {
@@ -5941,6 +6098,31 @@ void VulkanReplayConsumerBase::GetShadowSemaphores(const HandlePointerDecoder<Vk
         for (uint32_t i = 0; i < count; ++i)
         {
             SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(semaphore_ids[i]);
+            if ((semaphore_info != nullptr) && (semaphore_info->shadow_signaled == true))
+            {
+                // If found, unsignal the semaphore to represent it being used.
+                shadow_semaphores->push_back(semaphore_info);
+                semaphore_info->shadow_signaled = false;
+                shadow_semaphores_.erase(semaphore_info->handle);
+            }
+        }
+    }
+}
+
+void VulkanReplayConsumerBase::GetShadowSemaphores(
+    const StructPointerDecoder<Decoded_VkSemaphoreSubmitInfo>* semaphore_info_data,
+    std::vector<const SemaphoreInfo*>*                         shadow_semaphores)
+{
+    assert(shadow_semaphores != nullptr);
+
+    const Decoded_VkSemaphoreSubmitInfo* semaphore_infos = semaphore_info_data->GetMetaStructPointer();
+    if (semaphore_infos != nullptr)
+    {
+        size_t count = semaphore_info_data->GetLength();
+
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(semaphore_infos[i].semaphore);
             if ((semaphore_info != nullptr) && (semaphore_info->shadow_signaled == true))
             {
                 // If found, unsignal the semaphore to represent it being used.
@@ -5990,6 +6172,45 @@ void VulkanReplayConsumerBase::TrackSemaphoreForwardProgress(const HandlePointer
     }
 }
 
+void VulkanReplayConsumerBase::TrackSemaphoreForwardProgress(
+    const StructPointerDecoder<Decoded_VkSemaphoreSubmitInfo>* semaphore_info_data,
+    std::vector<const SemaphoreInfo*>*                         removed_semaphores)
+{
+    assert(removed_semaphores != nullptr);
+
+    const Decoded_VkSemaphoreSubmitInfo* semaphore_infos = semaphore_info_data->GetMetaStructPointer();
+    if (semaphore_infos != nullptr)
+    {
+        size_t count = semaphore_info_data->GetLength();
+
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(semaphore_infos[i].semaphore);
+            if (semaphore_info != nullptr)
+            {
+                VkSemaphore semaphore = semaphore_info->handle;
+                // Need to ignore if removed.
+                bool removed = false;
+                for (const SemaphoreInfo* remove_semaphore : *removed_semaphores)
+                {
+                    if (semaphore == remove_semaphore->handle)
+                    {
+                        removed                          = true;
+                        semaphore_info->forward_progress = false;
+                        break;
+                    }
+                }
+
+                // If not removed, mark as forward progress.
+                if (removed == false)
+                {
+                    semaphore_info->forward_progress = true;
+                }
+            }
+        }
+    }
+}
+
 void VulkanReplayConsumerBase::GetNonForwardProgress(const HandlePointerDecoder<VkSemaphore>& semaphore_data,
                                                      std::vector<const SemaphoreInfo*>* non_forward_progress_semaphores)
 {
@@ -6003,6 +6224,28 @@ void VulkanReplayConsumerBase::GetNonForwardProgress(const HandlePointerDecoder<
         for (uint32_t i = 0; i < count; ++i)
         {
             const SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(semaphore_ids[i]);
+            if ((semaphore_info != nullptr) && (semaphore_info->forward_progress == false))
+            {
+                non_forward_progress_semaphores->push_back(semaphore_info);
+            }
+        }
+    }
+}
+
+void VulkanReplayConsumerBase::GetNonForwardProgress(
+    const StructPointerDecoder<Decoded_VkSemaphoreSubmitInfo>* semaphore_info_data,
+    std::vector<const SemaphoreInfo*>*                         non_forward_progress_semaphores)
+{
+    assert(non_forward_progress_semaphores != nullptr);
+
+    const Decoded_VkSemaphoreSubmitInfo* semaphore_infos = semaphore_info_data->GetMetaStructPointer();
+    if (semaphore_infos != nullptr)
+    {
+        size_t count = semaphore_info_data->GetLength();
+
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            const SemaphoreInfo* semaphore_info = object_info_table_.GetSemaphoreInfo(semaphore_infos[i].semaphore);
             if ((semaphore_info != nullptr) && (semaphore_info->forward_progress == false))
             {
                 non_forward_progress_semaphores->push_back(semaphore_info);

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -504,6 +504,13 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                  const StructPointerDecoder<Decoded_VkSubmitInfo>* pSubmits,
                                  const FenceInfo*                                  fence_info);
 
+    VkResult OverrideQueueSubmit2(PFN_vkQueueSubmit2                                 func,
+                                  VkResult                                           original_result,
+                                  const QueueInfo*                                   queue_info,
+                                  uint32_t                                           submitCount,
+                                  const StructPointerDecoder<Decoded_VkSubmitInfo2>* pSubmits,
+                                  const FenceInfo*                                   fence_info);
+
     VkResult OverrideQueueBindSparse(PFN_vkQueueBindSparse                                 func,
                                      VkResult                                              original_result,
                                      const QueueInfo*                                      queue_info,
@@ -922,14 +929,26 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     void GetImportedSemaphores(const HandlePointerDecoder<VkSemaphore>& semaphore_data,
                                std::vector<const SemaphoreInfo*>*       imported_semaphores);
 
+    void GetImportedSemaphores(const StructPointerDecoder<Decoded_VkSemaphoreSubmitInfo>* semaphore_info_data,
+                               std::vector<const SemaphoreInfo*>*                         imported_semaphores);
+
     void GetShadowSemaphores(const HandlePointerDecoder<VkSemaphore>& semaphore_data,
                              std::vector<const SemaphoreInfo*>*       shadow_semaphores);
+
+    void GetShadowSemaphores(const StructPointerDecoder<Decoded_VkSemaphoreSubmitInfo>* semaphore_info_data,
+                             std::vector<const SemaphoreInfo*>*                         shadow_semaphores);
 
     void TrackSemaphoreForwardProgress(const HandlePointerDecoder<VkSemaphore>& semaphore_data,
                                        std::vector<const SemaphoreInfo*>*       removed_semaphores);
 
+    void TrackSemaphoreForwardProgress(const StructPointerDecoder<Decoded_VkSemaphoreSubmitInfo>* semaphore_info_data,
+                                       std::vector<const SemaphoreInfo*>*                         removed_semaphores);
+
     void GetNonForwardProgress(const HandlePointerDecoder<VkSemaphore>& semaphore_data,
                                std::vector<const SemaphoreInfo*>*       non_forward_progress_semaphores);
+
+    void GetNonForwardProgress(const StructPointerDecoder<Decoded_VkSemaphoreSubmitInfo>* semaphore_info_data,
+                               std::vector<const SemaphoreInfo*>* non_forward_progress_semaphores);
 
     VkResult CreateSwapchainImage(const DeviceInfo*        device_info,
                                   const VkImageCreateInfo* image_create_info,

--- a/framework/encode/custom_vulkan_encoder_commands.h
+++ b/framework/encode/custom_vulkan_encoder_commands.h
@@ -421,6 +421,16 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPipelineBarrier2KHR
 };
 
 template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdPipelineBarrier2>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdPipelineBarrier2KHR(args...);
+    }
+};
+
+template <>
 struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdExecuteCommands>
 {
     template <typename... Args>
@@ -507,6 +517,46 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueSubmit>
     static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
     {
         manager->PostProcess_vkQueueSubmit(result, args...);
+    }
+};
+
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueSubmit2>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PreProcess_vkQueueSubmit2(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueueSubmit2KHR>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PreProcess_vkQueueSubmit2(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueSubmit2>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkQueueSubmit2(result, args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkQueueSubmit2KHR>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, VkResult result, Args... args)
+    {
+        manager->PostProcess_vkQueueSubmit2(result, args...);
     }
 };
 
@@ -627,6 +677,26 @@ struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWriteTimestamp>
     static void Dispatch(VulkanCaptureManager* manager, Args... args)
     {
         manager->PostProcess_vkCmdWriteTimestamp(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWriteTimestamp2>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdWriteTimestamp2(args...);
+    }
+};
+
+template <>
+struct CustomEncoderPostCall<format::ApiCallId::ApiCall_vkCmdWriteTimestamp2KHR>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PostProcess_vkCmdWriteTimestamp2(args...);
     }
 };
 

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1914,6 +1914,24 @@ void VulkanCaptureManager::PreProcess_vkQueueSubmit(VkQueue             queue,
     GFXRECON_UNREFERENCED_PARAMETER(pSubmits);
     GFXRECON_UNREFERENCED_PARAMETER(fence);
 
+    QueueSubmitWriteFillMemoryCmd();
+}
+
+void VulkanCaptureManager::PreProcess_vkQueueSubmit2(VkQueue              queue,
+                                                     uint32_t             submitCount,
+                                                     const VkSubmitInfo2* pSubmits,
+                                                     VkFence              fence)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(queue);
+    GFXRECON_UNREFERENCED_PARAMETER(submitCount);
+    GFXRECON_UNREFERENCED_PARAMETER(pSubmits);
+    GFXRECON_UNREFERENCED_PARAMETER(fence);
+
+    QueueSubmitWriteFillMemoryCmd();
+}
+
+void VulkanCaptureManager::QueueSubmitWriteFillMemoryCmd()
+{
     if (GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kPageGuard)
     {
         util::PageGuardManager* manager = util::PageGuardManager::Get();

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -328,6 +328,8 @@ class VulkanStateTracker
 
     void TrackCommandBufferSubmissions(uint32_t submit_count, const VkSubmitInfo* submits);
 
+    void TrackCommandBufferSubmissions2(uint32_t submit_count, const VkSubmitInfo2* submits);
+
     void TrackUpdateDescriptorSets(uint32_t                    write_count,
                                    const VkWriteDescriptorSet* writes,
                                    uint32_t                    copy_count,
@@ -356,6 +358,11 @@ class VulkanStateTracker
                                    const VkSemaphore* waits,
                                    uint32_t           signal_count,
                                    const VkSemaphore* signals);
+
+    void TrackSemaphoreInfoSignalState(uint32_t                     wait_count,
+                                       const VkSemaphoreSubmitInfo* wait_infos,
+                                       uint32_t                     signal_count,
+                                       const VkSemaphoreSubmitInfo* signal_infos);
 
     void TrackAcquireImage(
         uint32_t image_index, VkSwapchainKHR swapchain, VkSemaphore semaphore, VkFence fence, uint32_t deviceMask);
@@ -439,6 +446,8 @@ class VulkanStateTracker
     void DestroyState(SwapchainKHRWrapper* wrapper);
 
   private:
+    void TrackQuerySubmissions(CommandBufferWrapper* command_wrapper);
+
     std::mutex       state_table_mutex_;
     VulkanStateTable state_table_;
 };

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -2777,12 +2777,12 @@ void VulkanReplayConsumer::Process_vkQueueSubmit2(
     StructPointerDecoder<Decoded_VkSubmitInfo2>* pSubmits,
     format::HandleId                            fence)
 {
-    VkQueue in_queue = MapHandle<QueueInfo>(queue, &VulkanObjectInfoTable::GetQueueInfo);
-    const VkSubmitInfo2* in_pSubmits = pSubmits->GetPointer();
-    MapStructArrayHandles(pSubmits->GetMetaStructPointer(), pSubmits->GetLength(), GetObjectInfoTable());
-    VkFence in_fence = MapHandle<FenceInfo>(fence, &VulkanObjectInfoTable::GetFenceInfo);
+    auto in_queue = GetObjectInfoTable().GetQueueInfo(queue);
 
-    VkResult replay_result = GetDeviceTable(in_queue)->QueueSubmit2(in_queue, submitCount, in_pSubmits, in_fence);
+    MapStructArrayHandles(pSubmits->GetMetaStructPointer(), pSubmits->GetLength(), GetObjectInfoTable());
+    auto in_fence = GetObjectInfoTable().GetFenceInfo(fence);
+
+    VkResult replay_result = OverrideQueueSubmit2(GetDeviceTable(in_queue->handle)->QueueSubmit2, returnValue, in_queue, submitCount, pSubmits, in_fence);
     CheckResult("vkQueueSubmit2", returnValue, replay_result);
 }
 
@@ -4825,12 +4825,12 @@ void VulkanReplayConsumer::Process_vkQueueSubmit2KHR(
     StructPointerDecoder<Decoded_VkSubmitInfo2>* pSubmits,
     format::HandleId                            fence)
 {
-    VkQueue in_queue = MapHandle<QueueInfo>(queue, &VulkanObjectInfoTable::GetQueueInfo);
-    const VkSubmitInfo2* in_pSubmits = pSubmits->GetPointer();
-    MapStructArrayHandles(pSubmits->GetMetaStructPointer(), pSubmits->GetLength(), GetObjectInfoTable());
-    VkFence in_fence = MapHandle<FenceInfo>(fence, &VulkanObjectInfoTable::GetFenceInfo);
+    auto in_queue = GetObjectInfoTable().GetQueueInfo(queue);
 
-    VkResult replay_result = GetDeviceTable(in_queue)->QueueSubmit2KHR(in_queue, submitCount, in_pSubmits, in_fence);
+    MapStructArrayHandles(pSubmits->GetMetaStructPointer(), pSubmits->GetLength(), GetObjectInfoTable());
+    auto in_fence = GetObjectInfoTable().GetFenceInfo(fence);
+
+    VkResult replay_result = OverrideQueueSubmit2(GetDeviceTable(in_queue->handle)->QueueSubmit2KHR, returnValue, in_queue, submitCount, pSubmits, in_fence);
     CheckResult("vkQueueSubmit2KHR", returnValue, replay_result);
 }
 

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -19,6 +19,8 @@
     "vkGetEventStatus": "OverrideGetEventStatus",
     "vkGetQueryPoolResults": "OverrideGetQueryPoolResults",
     "vkQueueSubmit": "OverrideQueueSubmit",
+    "vkQueueSubmit2": "OverrideQueueSubmit2",
+    "vkQueueSubmit2KHR": "OverrideQueueSubmit2",
     "vkQueueBindSparse": "OverrideQueueBindSparse",
     "vkCreateDescriptorPool": "OverrideCreateDescriptorPool",
     "vkDestroyDescriptorPool": "OverrideDestroyDescriptorPool",


### PR DESCRIPTION
Test code:
https://github.com/locke-lunarg/Vulkan-Tools/tree/sync2

The main stuff in this PR is vkQueueSubmit2.  The code is similar to what it did for QueueSubmit. The different is that vkQueueSubmit2 pack VkSemaphore and VkCommandBuffer to VkSemaphoreSubmitInfo and VkCommandBufferSubmitInfo. The two new features are timeline semaphore and device group. Nothing need to do for timeline semaphore. I prefer to leave device group to the following PR. https://github.com/LunarG/gfxreconstruct/issues/693