### PR TITLE
Framerange support

### DIFF
--- a/framework/application/application.cpp
+++ b/framework/application/application.cpp
@@ -132,30 +132,33 @@ void Application::Run()
         // Only process the next frame if a quit event was not processed or not paused.
         if (running_ && !paused_)
         {
+            // Add one to match "trim frame range semantic"
+            uint32_t frame_number = file_processor_->GetCurrentFrameNumber() + 1;
 
             if (fps_info_ != nullptr)
             {
-                if (fps_info_->ShouldQuit(file_processor_->GetCurrentFrameNumber()))
+                if (fps_info_->ShouldQuit(frame_number))
                 {
                     running_ = false;
                     break;
                 }
 
-                if (fps_info_->ShouldWaitIdleBeforeFrame(file_processor_->GetCurrentFrameNumber()))
+                if (fps_info_->ShouldWaitIdleBeforeFrame(frame_number))
                 {
                     file_processor_->WaitDecodersIdle();
                 }
 
-                fps_info_->BeginFrame(file_processor_->GetCurrentFrameNumber());
+                fps_info_->BeginFrame(frame_number);
             }
 
+            // PlaySingleFrame() increments this->current_frame_number_ *if* there's an end-of-frame
             PlaySingleFrame();
 
             if (fps_info_ != nullptr)
             {
-                fps_info_->EndFrame(file_processor_->GetCurrentFrameNumber());
+                fps_info_->EndFrame(frame_number);
 
-                if (fps_info_->ShouldWaitIdleAfterFrame(file_processor_->GetCurrentFrameNumber()))
+                if (fps_info_->ShouldWaitIdleAfterFrame(frame_number))
                 {
                     file_processor_->WaitDecodersIdle();
                 }

--- a/framework/application/application.cpp
+++ b/framework/application/application.cpp
@@ -110,6 +110,18 @@ WsiContext* Application::GetWsiContext(const std::string& wsi_extension, bool au
     return const_cast<WsiContext*>(wsi_context);
 }
 
+void Application::SetFpsInfo(graphics::FpsInfo* fps_info)
+{
+    if (file_processor_ == nullptr)
+    {
+        GFXRECON_LOG_WARNING("Application file processor not set, cannot set FpsInfo object.");
+        return;
+    }
+
+    fps_info->SetFileProcessor(file_processor_);
+    fps_info_ = fps_info;
+}
+
 void Application::Run()
 {
     running_ = true;
@@ -121,6 +133,18 @@ void Application::Run()
         // Only process the next frame if a quit event was not processed or not paused.
         if (running_ && !paused_)
         {
+
+            if (fps_info_ != nullptr)
+            {
+                fps_info_->HandleMeasurementRange();
+
+                if (fps_info_->ShouldQuit())
+                {
+                    running_ = false;
+                    break;
+                }
+            }
+
             PlaySingleFrame();
         }
     }

--- a/framework/application/application.cpp
+++ b/framework/application/application.cpp
@@ -118,7 +118,6 @@ void Application::SetFpsInfo(graphics::FpsInfo* fps_info)
         return;
     }
 
-    fps_info->SetFileProcessor(file_processor_);
     fps_info_ = fps_info;
 }
 
@@ -136,16 +135,31 @@ void Application::Run()
 
             if (fps_info_ != nullptr)
             {
-                fps_info_->HandleMeasurementRange();
-
-                if (fps_info_->ShouldQuit())
+                if (fps_info_->ShouldQuit(file_processor_->GetCurrentFrameNumber()))
                 {
                     running_ = false;
                     break;
                 }
+
+                if (fps_info_->ShouldWaitIdleBeforeFrame(file_processor_->GetCurrentFrameNumber()))
+                {
+                    file_processor_->WaitDecodersIdle();
+                }
+
+                fps_info_->BeginFrame(file_processor_->GetCurrentFrameNumber());
             }
 
             PlaySingleFrame();
+
+            if (fps_info_ != nullptr)
+            {
+                fps_info_->EndFrame(file_processor_->GetCurrentFrameNumber());
+
+                if (fps_info_->ShouldWaitIdleAfterFrame(file_processor_->GetCurrentFrameNumber()))
+                {
+                    file_processor_->WaitDecodersIdle();
+                }
+            }
         }
     }
 }

--- a/framework/application/application.h
+++ b/framework/application/application.h
@@ -76,7 +76,6 @@ class Application final
 
     void InitializeWsiContext(const char* surfaceExtensionName, void* pPlatformSpecificData = nullptr);
 
-  protected:
     void StopRunning() { running_ = false; }
 
   private:

--- a/framework/application/application.h
+++ b/framework/application/application.h
@@ -28,12 +28,15 @@
 #include "decode/file_processor.h"
 #include "decode/window.h"
 #include "util/defines.h"
+#include "util/date_time.h"
+#include "graphics/fps_info.h"
 
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <limits>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(application)
@@ -71,6 +74,11 @@ class Application final
 
     void ProcessEvents(bool wait_for_input);
 
+    void SetFpsInfo(graphics::FpsInfo* fps_info);
+
+  protected:
+    void StopRunning() { running_ = false; }
+
     void InitializeWsiContext(const char* surfaceExtensionName, void* pPlatformSpecificData = nullptr);
 
   private:
@@ -82,6 +90,8 @@ class Application final
     uint32_t                                                     pause_frame_;       ///< The number for a frame that replay should pause after.
     std::unordered_map<std::string, std::unique_ptr<WsiContext>> wsi_contexts_;      ///< Loaded WSI contexts from CLI and VkInstanceCreateInfo
     std::string                                                  cli_wsi_extension_; ///< WSI extension selected on CLI, empty string if no CLI selection
+    graphics::FpsInfo*           fps_info_;                 ///< A optional FPS info object that logs the FPS across a configured framerange.
+                                                            ///< capture file data.
     // clang-format on
 };
 

--- a/framework/application/application.h
+++ b/framework/application/application.h
@@ -62,8 +62,6 @@ class Application final
 
     void Run();
 
-    void StopRunning() { running_ = false; }
-
     bool GetPaused() const { return paused_; }
 
     void SetPaused(bool paused);
@@ -76,10 +74,10 @@ class Application final
 
     void SetFpsInfo(graphics::FpsInfo* fps_info);
 
+    void InitializeWsiContext(const char* surfaceExtensionName, void* pPlatformSpecificData = nullptr);
+
   protected:
     void StopRunning() { running_ = false; }
-
-    void InitializeWsiContext(const char* surfaceExtensionName, void* pPlatformSpecificData = nullptr);
 
   private:
     // clang-format off

--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -46,6 +46,8 @@ class ApiDecoder
   public:
     virtual ~ApiDecoder() {}
 
+    virtual void WaitIdle() = 0;
+
     virtual bool SupportsApiCall(format::ApiCallId id) = 0;
 
     virtual bool SupportsMetaDataId(format::MetaDataId meta_data_id) = 0;

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -56,6 +56,14 @@ FileProcessor::~FileProcessor()
     DecodeAllocator::DestroyInstance();
 }
 
+void FileProcessor::WaitDecodersIdle()
+{
+    for (auto decoder : decoders_)
+    {
+        decoder->WaitIdle();
+    }
+};
+
 bool FileProcessor::Initialize(const std::string& filename)
 {
     bool success = false;

--- a/framework/decode/file_processor.h
+++ b/framework/decode/file_processor.h
@@ -62,6 +62,8 @@ class FileProcessor
 
     ~FileProcessor();
 
+    void WaitDecodersIdle();
+
     void SetAnnotationProcessor(AnnotationHandler* handler) { annotation_handler_ = handler; }
 
     void AddDecoder(ApiDecoder* decoder) { decoders_.push_back(decoder); }

--- a/framework/decode/replay_options.h
+++ b/framework/decode/replay_options.h
@@ -49,6 +49,8 @@ struct ReplayOptions
     bool enable_debug_device_lost{ false };
     bool create_dummy_allocations{ false };
     bool omit_null_hardware_buffers{ false };
+    bool quit_after_measurement_frame_range{ false };
+    bool flush_measurement_frame_range{ false };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -47,6 +47,8 @@ class VulkanConsumerBase
 
     virtual ~VulkanConsumerBase() {}
 
+    virtual void WaitDevicesIdle() {}
+
     virtual void ProcessStateBeginMarker(uint64_t frame_number) {}
 
     virtual void ProcessStateEndMarker(uint64_t frame_number) {}

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -30,6 +30,14 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
+void VulkanDecoderBase::WaitIdle()
+{
+    for (auto consumer : consumers_)
+    {
+        consumer->WaitDevicesIdle();
+    }
+}
+
 void VulkanDecoderBase::DispatchStateBeginMarker(uint64_t frame_number)
 {
     for (auto consumer : consumers_)

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -53,6 +53,8 @@ class VulkanDecoderBase : public ApiDecoder
         consumers_.erase(std::remove(consumers_.begin(), consumers_.end(), consumer));
     }
 
+    virtual void WaitIdle() override;
+
     virtual bool SupportsApiCall(format::ApiCallId call_id) override
     {
         return (format::GetApiCallFamily(call_id) == format::ApiFamilyId::ApiFamily_Vulkan);

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -164,15 +164,16 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
                              create_surface_count_);
     }
 
-    // Idle all devices before destroying other resources, and cleanup screenshot resources before destroying device.
+    // Idle all devices before destroying other resources.
+    WaitDevicesIdle();
+
+    // Cleanup screenshot resources before destroying device.
     object_info_table_.VisitDeviceInfo([this](const DeviceInfo* info) {
         assert(info != nullptr);
         VkDevice device = info->handle;
 
         auto device_table = GetDeviceTable(device);
         assert(device_table != nullptr);
-
-        device_table->DeviceWaitIdle(device);
 
         if (screenshot_handler_ != nullptr)
         {
@@ -208,6 +209,19 @@ VulkanReplayConsumerBase::~VulkanReplayConsumerBase()
     {
         graphics::ReleaseLoader(loader_handle_);
     }
+}
+
+void VulkanReplayConsumerBase::WaitDevicesIdle()
+{
+    object_info_table_.VisitDeviceInfo([this](const DeviceInfo* info) {
+        assert(info != nullptr);
+        VkDevice device = info->handle;
+
+        auto device_table = GetDeviceTable(device);
+        assert(device_table != nullptr);
+
+        device_table->DeviceWaitIdle(device);
+    });
 }
 
 void VulkanReplayConsumerBase::ProcessStateBeginMarker(uint64_t frame_number)

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -76,6 +76,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     void SetFpsInfo(graphics::FpsInfo* fps_info) { fps_info_ = fps_info; }
 
+    virtual void WaitDevicesIdle() override;
+
     virtual void ProcessStateBeginMarker(uint64_t frame_number) override;
 
     virtual void ProcessStateEndMarker(uint64_t frame_number) override;

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -47,6 +47,8 @@ struct VulkanReplayOptions : public ReplayOptions
     bool                         skip_failed_allocations{ false };
     bool                         omit_pipeline_cache_data{ false };
     bool                         remove_unsupported_features{ false };
+    bool                         quit_after_measurement_frame_range{ false };
+    bool                         flush_measurement_frame_range{ false };
     int32_t                      override_gpu_index{ -1 };
     int32_t                      surface_index{ -1 };
     CreateResourceAllocator      create_resource_allocator;

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -47,8 +47,6 @@ struct VulkanReplayOptions : public ReplayOptions
     bool                         skip_failed_allocations{ false };
     bool                         omit_pipeline_cache_data{ false };
     bool                         remove_unsupported_features{ false };
-    bool                         quit_after_measurement_frame_range{ false };
-    bool                         flush_measurement_frame_range{ false };
     int32_t                      override_gpu_index{ -1 };
     int32_t                      surface_index{ -1 };
     CreateResourceAllocator      create_resource_allocator;

--- a/framework/graphics/fps_info.cpp
+++ b/framework/graphics/fps_info.cpp
@@ -36,112 +36,138 @@ static double GetElapsedSeconds(uint64_t start_time, uint64_t end_time)
     return util::datetime::ConvertTimestampToSeconds(util::datetime::DiffTimestamps(start_time, end_time));
 }
 
-FpsInfo::FpsInfo(uint64_t measurement_start_frame,
-                 uint64_t measurement_end_frame,
-                 bool     quit_after_range,
-                 bool     flush_measurement_range) :
-    file_processor_(nullptr),
-    measurement_start_frame_(measurement_start_frame), measurement_end_frame_(measurement_end_frame),
-    measurement_start_time_(0), measurement_end_time_(0), quit_after_range_(quit_after_range),
-    flush_measurement_range_(flush_measurement_range)
-{}
-
-void FpsInfo::SetFileProcessor(gfxrecon::decode::FileProcessor* file_processor)
+static void
+WriteFpsToConsole(const char* prefix, uint64_t start_frame, uint64_t end_frame, int64_t start_time, int64_t end_time)
 {
-    file_processor_ = file_processor;
-}
+    assert(end_frame >= start_frame && end_time >= start_time);
 
-void FpsInfo::ProcessStateEndMarker(uint64_t frame)
-{
-    measurement_start_frame_ = frame;
-    measurement_start_time_  = util::datetime::GetTimestamp();
-}
-
-bool FpsInfo::ShouldQuit()
-{
-    return quit_after_range_ && (file_processor_->GetCurrentFrameNumber() >= measurement_end_frame_);
-}
-
-void FpsInfo::HandleMeasurementRange()
-{
-    if (file_processor_ == nullptr)
-    {
-        GFXRECON_LOG_WARNING("File processor is not set in FpsInfo object. Cannot calculate FPS statistics.");
-        return;
-    }
-
-    if (file_processor_->GetCurrentFrameNumber() == measurement_start_frame_)
-    {
-        if (flush_measurement_range_)
-        {
-            file_processor_->WaitDecodersIdle();
-        }
-
-        measurement_start_time_ = gfxrecon::util::datetime::GetTimestamp();
-    }
-    else if (file_processor_->GetCurrentFrameNumber() == measurement_end_frame_)
-    {
-        // End before replay -> non inclusive range
-        if (flush_measurement_range_)
-        {
-            file_processor_->WaitDecodersIdle();
-        }
-
-        measurement_end_time_ = gfxrecon::util::datetime::GetTimestamp();
-    }
-}
-
-void FpsInfo::WriteMeasurementRangeFpsToConsole()
-{
-    if (file_processor_ == nullptr)
-    {
-        GFXRECON_LOG_WARNING("File processor is not set in FpsInfo object. Cannot calculate FPS statistics.");
-        return;
-    }
-
-    if (file_processor_->GetErrorState() != gfxrecon::decode::FileProcessor::kErrorNone)
-    {
-        GFXRECON_LOG_ERROR("A failure has occurred during replay, cannot calculate measurement range FPS.");
-        return;
-    }
-
-    if (measurement_start_frame_ >= measurement_end_frame_)
-    {
-        GFXRECON_LOG_WARNING("Measurement start frame (%u) is greater than or equal to the end frame (%u). "
-                             "Cannot calculate measurement range FPS.",
-                             measurement_start_frame_,
-                             measurement_end_frame_);
-
-        return;
-    }
-
-    if (file_processor_->GetCurrentFrameNumber() < measurement_start_frame_)
-    {
-        GFXRECON_LOG_WARNING("Measurement range start frame (%u) is greater than the last replayed frame (%u). "
-                             "Measurements were never started, cannot calculate measurement range FPS.",
-                             measurement_start_frame_,
-                             file_processor_->GetCurrentFrameNumber());
-        return;
-    }
-
-    // Here we clip the range for convenience.
-    if (file_processor_->GetCurrentFrameNumber() < measurement_end_frame_)
-    {
-        file_processor_->WaitDecodersIdle();
-        measurement_end_time_  = gfxrecon::util::datetime::GetTimestamp();
-        measurement_end_frame_ = file_processor_->GetCurrentFrameNumber() + 1;
-    }
-
-    double   diff_time_sec = GetElapsedSeconds(measurement_start_time_, measurement_end_time_);
-    uint64_t total_frames  = measurement_end_frame_ - measurement_start_frame_;
-    double   fps           = static_cast<double>(total_frames) / diff_time_sec;
-    GFXRECON_WRITE_CONSOLE("Measurement range FPS: %f fps, %f seconds, %lu frame%s, 1 loop, framerange [%lu-%lu)",
+    double   diff_time_sec = GetElapsedSeconds(start_time, end_time);
+    uint64_t total_frames  = (end_frame - start_frame) + 1;
+    double   fps           = (diff_time_sec > 0.0) ? (static_cast<double>(total_frames) / diff_time_sec) : 0.0;
+    GFXRECON_WRITE_CONSOLE("%s %f fps, %f seconds, %" PRIu64 " frame%s, framerange %" PRIu64 "-%" PRIu64,
+                           prefix,
                            fps,
                            diff_time_sec,
                            total_frames,
                            total_frames > 1 ? "s" : "",
-                           measurement_start_frame_,
-                           measurement_end_frame_);
+                           start_frame,
+                           end_frame);
+}
+
+FpsInfo::FpsInfo(uint64_t measurement_start_frame,
+                 uint64_t measurement_end_frame,
+                 bool     quit_after_range,
+                 bool     flush_measurement_range) :
+    measurement_start_frame_(measurement_start_frame),
+    measurement_end_frame_(measurement_end_frame), measurement_start_time_(0), measurement_end_time_(0),
+    quit_after_range_(quit_after_range), flush_measurement_range_(flush_measurement_range), started_measurement_(false),
+    ended_measurement_(false)
+{}
+
+void FpsInfo::BeginFile()
+{
+    replay_start_frame_ = 1;
+    replay_start_time_ = start_time_ = util::datetime::GetTimestamp();
+}
+
+bool FpsInfo::ShouldWaitIdleBeforeFrame(uint64_t file_processor_frame)
+{
+    uint64_t frame           = file_processor_frame + 1;
+    bool     range_beginning = frame == measurement_start_frame_;
+    return flush_measurement_range_ && range_beginning;
+}
+
+bool FpsInfo::ShouldQuit(uint64_t file_processor_frame)
+{
+    uint64_t frame = file_processor_frame + 1;
+    return quit_after_range_ && (frame > measurement_end_frame_);
+}
+
+void FpsInfo::BeginFrame(uint64_t file_processor_frame)
+{
+    uint64_t frame = file_processor_frame + 1;
+    if (!started_measurement_)
+    {
+        if (frame >= measurement_start_frame_)
+        {
+            measurement_start_time_ = util::datetime::GetTimestamp();
+            started_measurement_    = true;
+        }
+    }
+}
+
+void FpsInfo::EndFrame(uint64_t file_processor_frame)
+{
+    uint64_t frame = file_processor_frame + 1;
+    if (started_measurement_ && !ended_measurement_)
+    {
+        if (file_processor_frame > measurement_end_frame_)
+        {
+            measurement_end_time_ = util::datetime::GetTimestamp();
+            ended_measurement_    = true;
+        }
+    }
+}
+
+bool FpsInfo::ShouldWaitIdleAfterFrame(uint64_t file_processor_frame)
+{
+    uint64_t frame       = file_processor_frame + 1;
+    bool     range_ended = frame == measurement_end_frame_;
+    return flush_measurement_range_ && range_ended;
+}
+
+void FpsInfo::EndFile(uint64_t file_processor_frame)
+{
+    uint64_t frame = file_processor_frame + 1;
+    if (!ended_measurement_)
+    {
+        measurement_end_time_  = gfxrecon::util::datetime::GetTimestamp();
+        measurement_end_frame_ = frame;
+    }
+}
+
+void FpsInfo::ProcessStateEndMarker(uint64_t file_processor_frame)
+{
+    replay_start_frame_ = file_processor_frame;
+    replay_start_time_  = util::datetime::GetTimestamp();
+}
+
+void FpsInfo::LogToConsole()
+{
+    if (measurement_start_frame_ == 1)
+    {
+
+        // No measurement range or no end limit to range, include trimmed
+        // range load statistics.
+
+        if (replay_start_time_ != start_time_)
+        {
+            GFXRECON_WRITE_CONSOLE("Load time:  %f seconds", GetElapsedSeconds(start_time_, replay_start_time_));
+        }
+        GFXRECON_WRITE_CONSOLE("Total time: %f seconds", GetElapsedSeconds(start_time_, measurement_end_time_));
+
+        WriteFpsToConsole("Replay FPS:",
+                          replay_start_frame_,
+                          measurement_end_frame_ - 1 + replay_start_frame_ - 1,
+                          replay_start_time_,
+                          measurement_end_time_);
+    }
+    else
+    {
+
+        // There was a measurement range, emit only statistics about the
+        // measurement range
+        double   diff_time_sec = GetElapsedSeconds(measurement_start_time_, measurement_end_time_);
+        uint64_t total_frames  = measurement_end_frame_ - measurement_start_frame_;
+        double   fps           = static_cast<double>(total_frames) / diff_time_sec;
+        GFXRECON_WRITE_CONSOLE("Measurement range FPS: %f fps, %f seconds, %lu frame%s, 1 loop, framerange [%lu-%lu)",
+                               fps,
+                               diff_time_sec,
+                               total_frames,
+                               total_frames > 1 ? "s" : "",
+                               measurement_start_frame_,
+                               measurement_end_frame_);
+    }
 }
 
 GFXRECON_END_NAMESPACE(graphics)

--- a/framework/graphics/fps_info.cpp
+++ b/framework/graphics/fps_info.cpp
@@ -36,51 +36,112 @@ static double GetElapsedSeconds(uint64_t start_time, uint64_t end_time)
     return util::datetime::ConvertTimestampToSeconds(util::datetime::DiffTimestamps(start_time, end_time));
 }
 
-static void
-WriteFpsToConsole(const char* prefix, uint64_t start_frame, uint64_t end_frame, int64_t start_time, int64_t end_time)
+FpsInfo::FpsInfo(uint64_t measurement_start_frame,
+                 uint64_t measurement_end_frame,
+                 bool     quit_after_range,
+                 bool     flush_measurement_range) :
+    file_processor_(nullptr),
+    measurement_start_frame_(measurement_start_frame), measurement_end_frame_(measurement_end_frame),
+    measurement_start_time_(0), measurement_end_time_(0), quit_after_range_(quit_after_range),
+    flush_measurement_range_(flush_measurement_range)
+{}
+
+void FpsInfo::SetFileProcessor(gfxrecon::decode::FileProcessor* file_processor)
 {
-    assert(end_frame >= start_frame && end_time >= start_time);
-
-    double   diff_time_sec = GetElapsedSeconds(start_time, end_time);
-    uint64_t total_frames  = (end_frame - start_frame) + 1;
-    double   fps           = (diff_time_sec > 0.0) ? (static_cast<double>(total_frames) / diff_time_sec) : 0.0;
-    GFXRECON_WRITE_CONSOLE("%s %f fps, %f seconds, %" PRIu64 " frame%s, framerange %" PRIu64 "-%" PRIu64,
-                           prefix,
-                           fps,
-                           diff_time_sec,
-                           total_frames,
-                           total_frames > 1 ? "s" : "",
-                           start_frame,
-                           end_frame);
-}
-
-void FpsInfo::Begin(uint64_t start_frame)
-{
-    // Save the start frame/time information for the FPS result.
-    replay_start_frame_ = start_frame;
-    start_time_         = util::datetime::GetTimestamp();
-    replay_start_time_  = start_time_;
-}
-
-void FpsInfo::EndAndLog(uint64_t end_frame)
-{
-    // Get the end frame/time information and calculate FPS.
-    int64_t end_time = util::datetime::GetTimestamp();
-
-    if (replay_start_time_ != start_time_)
-    {
-        GFXRECON_WRITE_CONSOLE("Load time:  %f seconds", GetElapsedSeconds(start_time_, replay_start_time_));
-    }
-    GFXRECON_WRITE_CONSOLE("Total time: %f seconds", GetElapsedSeconds(start_time_, end_time));
-
-    WriteFpsToConsole(
-        "Replay FPS:", replay_start_frame_, end_frame + replay_start_frame_ - 1, replay_start_time_, end_time);
+    file_processor_ = file_processor;
 }
 
 void FpsInfo::ProcessStateEndMarker(uint64_t frame)
 {
-    replay_start_frame_ = frame;
-    replay_start_time_  = util::datetime::GetTimestamp();
+    measurement_start_frame_ = frame;
+    measurement_start_time_  = util::datetime::GetTimestamp();
+}
+
+bool FpsInfo::ShouldQuit()
+{
+    return quit_after_range_ && (file_processor_->GetCurrentFrameNumber() >= measurement_end_frame_);
+}
+
+void FpsInfo::HandleMeasurementRange()
+{
+    if (file_processor_ == nullptr)
+    {
+        GFXRECON_LOG_WARNING("File processor is not set in FpsInfo object. Cannot calculate FPS statistics.");
+        return;
+    }
+
+    if (file_processor_->GetCurrentFrameNumber() == measurement_start_frame_)
+    {
+        if (flush_measurement_range_)
+        {
+            file_processor_->WaitDecodersIdle();
+        }
+
+        measurement_start_time_ = gfxrecon::util::datetime::GetTimestamp();
+    }
+    else if (file_processor_->GetCurrentFrameNumber() == measurement_end_frame_)
+    {
+        // End before replay -> non inclusive range
+        if (flush_measurement_range_)
+        {
+            file_processor_->WaitDecodersIdle();
+        }
+
+        measurement_end_time_ = gfxrecon::util::datetime::GetTimestamp();
+    }
+}
+
+void FpsInfo::WriteMeasurementRangeFpsToConsole()
+{
+    if (file_processor_ == nullptr)
+    {
+        GFXRECON_LOG_WARNING("File processor is not set in FpsInfo object. Cannot calculate FPS statistics.");
+        return;
+    }
+
+    if (file_processor_->GetErrorState() != gfxrecon::decode::FileProcessor::kErrorNone)
+    {
+        GFXRECON_LOG_ERROR("A failure has occurred during replay, cannot calculate measurement range FPS.");
+        return;
+    }
+
+    if (measurement_start_frame_ >= measurement_end_frame_)
+    {
+        GFXRECON_LOG_WARNING("Measurement start frame (%u) is greater than or equal to the end frame (%u). "
+                             "Cannot calculate measurement range FPS.",
+                             measurement_start_frame_,
+                             measurement_end_frame_);
+
+        return;
+    }
+
+    if (file_processor_->GetCurrentFrameNumber() < measurement_start_frame_)
+    {
+        GFXRECON_LOG_WARNING("Measurement range start frame (%u) is greater than the last replayed frame (%u). "
+                             "Measurements were never started, cannot calculate measurement range FPS.",
+                             measurement_start_frame_,
+                             file_processor_->GetCurrentFrameNumber());
+        return;
+    }
+
+    // Here we clip the range for convenience.
+    if (file_processor_->GetCurrentFrameNumber() < measurement_end_frame_)
+    {
+        file_processor_->WaitDecodersIdle();
+        measurement_end_time_  = gfxrecon::util::datetime::GetTimestamp();
+        measurement_end_frame_ = file_processor_->GetCurrentFrameNumber() + 1;
+    }
+
+    double   diff_time_sec = GetElapsedSeconds(measurement_start_time_, measurement_end_time_);
+    uint64_t total_frames  = measurement_end_frame_ - measurement_start_frame_;
+    double   fps           = static_cast<double>(total_frames) / diff_time_sec;
+    GFXRECON_WRITE_CONSOLE("Measurement range FPS: %f fps, %f seconds, %lu frame%s, 1 loop, framerange [%lu-%lu)",
+                           fps,
+                           diff_time_sec,
+                           total_frames,
+                           total_frames > 1 ? "s" : "",
+                           measurement_start_frame_,
+                           measurement_end_frame_);
 }
 
 GFXRECON_END_NAMESPACE(graphics)

--- a/framework/graphics/fps_info.cpp
+++ b/framework/graphics/fps_info.cpp
@@ -101,7 +101,7 @@ void FpsInfo::EndFrame(uint64_t file_processor_frame)
     uint64_t frame = file_processor_frame + 1;
     if (started_measurement_ && !ended_measurement_)
     {
-        if (file_processor_frame > measurement_end_frame_)
+        if (frame > measurement_end_frame_)
         {
             measurement_end_time_ = util::datetime::GetTimestamp();
             ended_measurement_    = true;

--- a/framework/graphics/fps_info.cpp
+++ b/framework/graphics/fps_info.cpp
@@ -56,12 +56,13 @@ WriteFpsToConsole(const char* prefix, uint64_t start_frame, uint64_t end_frame, 
 
 FpsInfo::FpsInfo(uint64_t measurement_start_frame,
                  uint64_t measurement_end_frame,
+                 bool     has_measurement_range,
                  bool     quit_after_range,
                  bool     flush_measurement_range) :
     measurement_start_frame_(measurement_start_frame),
     measurement_end_frame_(measurement_end_frame), measurement_start_time_(0), measurement_end_time_(0),
-    quit_after_range_(quit_after_range), flush_measurement_range_(flush_measurement_range), started_measurement_(false),
-    ended_measurement_(false)
+    quit_after_range_(quit_after_range), flush_measurement_range_(flush_measurement_range),
+    has_measurement_range_(has_measurement_range), started_measurement_(false), ended_measurement_(false)
 {}
 
 void FpsInfo::BeginFile()
@@ -129,9 +130,8 @@ void FpsInfo::ProcessStateEndMarker(uint64_t frame_number)
 
 void FpsInfo::LogToConsole()
 {
-    if (measurement_start_frame_ == 1)
+    if (!has_measurement_range_)
     {
-
         // No measurement range or no end limit to range, include trimmed
         // range load statistics.
 
@@ -143,13 +143,12 @@ void FpsInfo::LogToConsole()
 
         WriteFpsToConsole("Replay FPS:",
                           replay_start_frame_,
-                          measurement_end_frame_ + replay_start_frame_ - 1,
+                          measurement_end_frame_ - 1 + replay_start_frame_ - 1,
                           replay_start_time_,
                           measurement_end_time_);
     }
     else
     {
-
         // There was a measurement range, emit only statistics about the
         // measurement range
         double   diff_time_sec = GetElapsedSeconds(measurement_start_time_, measurement_end_time_);

--- a/framework/graphics/fps_info.h
+++ b/framework/graphics/fps_info.h
@@ -25,6 +25,7 @@
 #define GFXRECON_GRAPHICS_FPS_INFO_H
 
 #include "util/defines.h"
+#include "decode/file_processor.h"
 
 #include <limits>
 
@@ -34,15 +35,31 @@ GFXRECON_BEGIN_NAMESPACE(graphics)
 class FpsInfo
 {
   public:
-    void Begin(uint64_t start_frame = 1);
-    void EndAndLog(uint64_t current_frame);
+    FpsInfo(uint64_t measurement_start_frame = 1,
+            uint64_t measurement_end_frame   = std::numeric_limits<uint64_t>::max(),
+            bool     quit_after_range        = false,
+            bool     flush_measurement_range = false);
+
+    void SetFileProcessor(gfxrecon::decode::FileProcessor* file_processor);
+
+    void HandleMeasurementRange();
+    void WriteMeasurementRangeFpsToConsole();
 
     void ProcessStateEndMarker(uint64_t frame);
 
+    bool ShouldQuit();
+
   private:
-    int64_t  start_time_;
-    uint64_t replay_start_frame_;
-    int64_t  replay_start_time_;
+    gfxrecon::decode::FileProcessor* file_processor_;
+
+    uint64_t measurement_start_frame_;
+    uint64_t measurement_end_frame_;
+
+    int64_t measurement_start_time_;
+    int64_t measurement_end_time_;
+
+    bool quit_after_range_;
+    bool flush_measurement_range_;
 };
 
 GFXRECON_END_NAMESPACE(graphics)

--- a/framework/graphics/fps_info.h
+++ b/framework/graphics/fps_info.h
@@ -40,17 +40,19 @@ class FpsInfo
             bool     quit_after_range        = false,
             bool     flush_measurement_range = false);
 
-    void SetFileProcessor(gfxrecon::decode::FileProcessor* file_processor);
+    void LogToConsole();
 
-    void HandleMeasurementRange();
-    void WriteMeasurementRangeFpsToConsole();
-
-    void ProcessStateEndMarker(uint64_t frame);
-
-    bool ShouldQuit();
+    void BeginFile();
+    bool ShouldWaitIdleBeforeFrame(uint64_t file_processor_frame);
+    bool ShouldWaitIdleAfterFrame(uint64_t file_processor_frame);
+    bool ShouldQuit(uint64_t file_processor_frame);
+    void BeginFrame(uint64_t file_processor_frame);
+    void EndFrame(uint64_t file_processor_frame);
+    void EndFile(uint64_t end_file_processor_frame);
+    void ProcessStateEndMarker(uint64_t file_processor_frame);
 
   private:
-    gfxrecon::decode::FileProcessor* file_processor_;
+    uint64_t start_time_;
 
     uint64_t measurement_start_frame_;
     uint64_t measurement_end_frame_;
@@ -58,8 +60,14 @@ class FpsInfo
     int64_t measurement_start_time_;
     int64_t measurement_end_time_;
 
+    uint64_t replay_start_time_;
+    int64_t  replay_start_frame_;
+
     bool quit_after_range_;
     bool flush_measurement_range_;
+
+    bool started_measurement_;
+    bool ended_measurement_;
 };
 
 GFXRECON_END_NAMESPACE(graphics)

--- a/framework/graphics/fps_info.h
+++ b/framework/graphics/fps_info.h
@@ -37,6 +37,7 @@ class FpsInfo
   public:
     FpsInfo(uint64_t measurement_start_frame = 1,
             uint64_t measurement_end_frame   = std::numeric_limits<uint64_t>::max(),
+            bool     has_measurement_range   = false,
             bool     quit_after_range        = false,
             bool     flush_measurement_range = false);
 
@@ -63,6 +64,7 @@ class FpsInfo
     uint64_t replay_start_time_;
     int64_t  replay_start_frame_;
 
+    bool has_measurement_range_;
     bool quit_after_range_;
     bool flush_measurement_range_;
 

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -111,10 +111,12 @@ void android_main(struct android_app* app)
                     GetVulkanReplayOptions(arg_parser, filename, &tracked_object_info_table);
                 gfxrecon::decode::VulkanReplayConsumer replay_consumer(application, replay_options);
                 gfxrecon::decode::VulkanDecoder        decoder;
-                std::pair<uint32_t, uint32_t>          measurement_frame_range = GetMeasurementFrameRange(arg_parser);
+                uint32_t                               start_frame, end_frame;
+                bool has_mfr = GetMeasurementFrameRange(arg_parser, start_frame, end_frame);
 
-                gfxrecon::graphics::FpsInfo fps_info(static_cast<uint64_t>(measurement_frame_range.first),
-                                                     static_cast<uint64_t>(measurement_frame_range.second),
+                gfxrecon::graphics::FpsInfo fps_info(static_cast<uint64_t>(start_frame),
+                                                     static_cast<uint64_t>(end_frame),
+                                                     has_mfr,
                                                      replay_options.quit_after_measurement_frame_range,
                                                      replay_options.flush_measurement_frame_range);
 
@@ -145,12 +147,12 @@ void android_main(struct android_app* app)
                 if ((final_frame_number > 0) &&
                     (file_processor.GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone))
                 {
-                    if (final_frame_number < measurement_frame_range.first)
+                    if (final_frame_number < start_frame)
                     {
                         GFXRECON_LOG_WARNING(
                             "Measurement range start frame (%u) is greater than the last replayed frame (%u). "
                             "Measurements were never started, cannot calculate measurement range FPS.",
-                            measurement_frame_range.first,
+                            start_frame,
                             final_frame_number);
                     }
                     else

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -138,18 +138,20 @@ void android_main(struct android_app* app)
 
                 application->Run();
 
-                fps_info.EndFile(file_processor.GetCurrentFrameNumber());
+                // Add one so that it matches the trim range frame number semantic
+                uint32_t final_frame_number = file_processor.GetCurrentFrameNumber() + 1;
+                fps_info.EndFile(final_frame_number);
 
-                if ((file_processor.GetCurrentFrameNumber() > 0) &&
+                if ((final_frame_number > 0) &&
                     (file_processor.GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone))
                 {
-                    if (file_processor.GetCurrentFrameNumber() < measurement_frame_range.first)
+                    if (final_frame_number < measurement_frame_range.first)
                     {
                         GFXRECON_LOG_WARNING(
                             "Measurement range start frame (%u) is greater than the last replayed frame (%u). "
                             "Measurements were never started, cannot calculate measurement range FPS.",
                             measurement_frame_range.first,
-                            file_processor.GetCurrentFrameNumber());
+                            final_frame_number);
                     }
                     else
                     {

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -107,11 +107,13 @@ void android_main(struct android_app* app)
                 application->InitializeWsiContext(VK_KHR_ANDROID_SURFACE_EXTENSION_NAME, app);
 
                 gfxrecon::decode::VulkanTrackedObjectInfoTable tracked_object_info_table;
-                gfxrecon::decode::VulkanReplayConsumer         replay_consumer(
-                    application, GetVulkanReplayOptions(arg_parser, filename, &tracked_object_info_table));
-                gfxrecon::decode::VulkanDecoder decoder;
+                gfxrecon::decode::VulkanReplayOptions          replay_options =
+                    GetVulkanReplayOptions(arg_parser, filename, &tracked_object_info_table);
+                gfxrecon::decode::VulkanReplayConsumer replay_consumer(application, replay_options);
+                gfxrecon::decode::VulkanDecoder        decoder;
                 std::pair<uint32_t, uint32_t>          measurement_frame_range = GetMeasurementFrameRange(arg_parser);
-                gfxrecon::graphics::FpsInfo   fps_info(static_cast<uint64_t>(measurement_frame_range.first),
+
+                gfxrecon::graphics::FpsInfo fps_info(static_cast<uint64_t>(measurement_frame_range.first),
                                                      static_cast<uint64_t>(measurement_frame_range.second),
                                                      replay_options.quit_after_measurement_frame_range,
                                                      replay_options.flush_measurement_frame_range);
@@ -124,7 +126,6 @@ void android_main(struct android_app* app)
 
                 // Warn if the capture layer is active.
                 CheckActiveLayers(kLayerProperty);
-
 
                 // Start the application in the paused state, preventing replay from starting before the app
                 // gained focus event is received.

--- a/tools/replay/android_main.cpp
+++ b/tools/replay/android_main.cpp
@@ -141,19 +141,18 @@ void android_main(struct android_app* app)
                 application->Run();
 
                 // Add one so that it matches the trim range frame number semantic
-                uint32_t final_frame_number = file_processor.GetCurrentFrameNumber() + 1;
-                fps_info.EndFile(final_frame_number);
+                fps_info.EndFile(file_processor.GetCurrentFrameNumber() + 1);
 
-                if ((final_frame_number > 0) &&
+                if ((file_processor.GetCurrentFrameNumber() > 0) &&
                     (file_processor.GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone))
                 {
-                    if (final_frame_number < start_frame)
+                    if (file_processor.GetCurrentFrameNumber() < start_frame)
                     {
                         GFXRECON_LOG_WARNING(
                             "Measurement range start frame (%u) is greater than the last replayed frame (%u). "
                             "Measurements were never started, cannot calculate measurement range FPS.",
                             start_frame,
-                            final_frame_number);
+                            file_processor.GetCurrentFrameNumber());
                     }
                     else
                     {

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -145,19 +145,18 @@ int main(int argc, const char** argv)
 
             // XXX if the final frame ended with a Present, this would be the *next* frame
             // Add one so that it matches the trim range frame number semantic
-            uint32_t final_frame_number = file_processor.GetCurrentFrameNumber() + 1;
-            fps_info.EndFile(final_frame_number);
+            fps_info.EndFile(file_processor.GetCurrentFrameNumber() + 1);
 
-            if ((final_frame_number > 0) &&
+            if ((file_processor.GetCurrentFrameNumber() > 0) &&
                 (file_processor.GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone))
             {
-                if (final_frame_number < start_frame)
+                if (file_processor.GetCurrentFrameNumber() < start_frame)
                 {
                     GFXRECON_LOG_WARNING(
                         "Measurement range start frame (%u) is greater than the last replayed frame (%u). "
                         "Measurements were never started, cannot calculate measurement range FPS.",
                         start_frame,
-                        final_frame_number);
+                        file_processor.GetCurrentFrameNumber());
                 }
                 else
                 {

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -114,9 +114,10 @@ int main(int argc, const char** argv)
                 std::make_shared<gfxrecon::application::Application>(kApplicationName, wsi_extension, &file_processor);
 
             gfxrecon::decode::VulkanTrackedObjectInfoTable tracked_object_info_table;
-            gfxrecon::decode::VulkanReplayConsumer         replay_consumer(
-                application, GetVulkanReplayOptions(arg_parser, filename, &tracked_object_info_table));
-            gfxrecon::decode::VulkanDecoder decoder;
+            gfxrecon::decode::VulkanReplayOptions          replay_options =
+                GetVulkanReplayOptions(arg_parser, filename, &tracked_object_info_table);
+            gfxrecon::decode::VulkanReplayConsumer replay_consumer(application, replay_options);
+            gfxrecon::decode::VulkanDecoder        decoder;
 
             std::pair<uint32_t, uint32_t> measurement_frame_range = GetMeasurementFrameRange(arg_parser);
 

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -113,14 +113,14 @@ int main(int argc, const char** argv)
             auto        application =
                 std::make_shared<gfxrecon::application::Application>(kApplicationName, wsi_extension, &file_processor);
 
-            gfxrecon::graphics::FpsInfo                    fps_info;
             gfxrecon::decode::VulkanTrackedObjectInfoTable tracked_object_info_table;
             gfxrecon::decode::VulkanReplayConsumer         replay_consumer(
                 application, GetVulkanReplayOptions(arg_parser, filename, &tracked_object_info_table));
             gfxrecon::decode::VulkanDecoder decoder;
 
             std::pair<uint32_t, uint32_t> measurement_frame_range = GetMeasurementFrameRange(arg_parser);
-            gfxrecon::graphics::FpsInfo   fps_info(static_cast<uint64_t>(measurement_frame_range.first),
+
+            gfxrecon::graphics::FpsInfo fps_info(static_cast<uint64_t>(measurement_frame_range.first),
                                                  static_cast<uint64_t>(measurement_frame_range.second),
                                                  replay_options.quit_after_measurement_frame_range,
                                                  replay_options.flush_measurement_frame_range);
@@ -135,16 +135,28 @@ int main(int argc, const char** argv)
             // Warn if the capture layer is active.
             CheckActiveLayers(gfxrecon::util::platform::GetEnv(kLayerEnvVar));
 
-            fps_info.Begin();
+            fps_info.BeginFile();
 
             application->SetFpsInfo(&fps_info);
             application->Run();
 
+            fps_info.EndFile(file_processor.GetCurrentFrameNumber());
 
             if ((file_processor.GetCurrentFrameNumber() > 0) &&
                 (file_processor.GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone))
             {
-                fps_info.WriteMeasurementRangeFpsToConsole();
+                if (file_processor.GetCurrentFrameNumber() < measurement_frame_range.first)
+                {
+                    GFXRECON_LOG_WARNING(
+                        "Measurement range start frame (%u) is greater than the last replayed frame (%u). "
+                        "Measurements were never started, cannot calculate measurement range FPS.",
+                        measurement_frame_range.first,
+                        file_processor.GetCurrentFrameNumber());
+                }
+                else
+                {
+                    fps_info.LogToConsole();
+                }
             }
             else if (file_processor.GetErrorState() != gfxrecon::decode::FileProcessor::kErrorNone)
             {

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -141,18 +141,21 @@ int main(int argc, const char** argv)
             application->SetFpsInfo(&fps_info);
             application->Run();
 
-            fps_info.EndFile(file_processor.GetCurrentFrameNumber());
+            // XXX if the final frame ended with a Present, this would be the *next* frame
+            // Add one so that it matches the trim range frame number semantic
+            uint32_t final_frame_number = file_processor.GetCurrentFrameNumber() + 1;
+            fps_info.EndFile(final_frame_number);
 
-            if ((file_processor.GetCurrentFrameNumber() > 0) &&
+            if ((final_frame_number > 0) &&
                 (file_processor.GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone))
             {
-                if (file_processor.GetCurrentFrameNumber() < measurement_frame_range.first)
+                if (final_frame_number < measurement_frame_range.first)
                 {
                     GFXRECON_LOG_WARNING(
                         "Measurement range start frame (%u) is greater than the last replayed frame (%u). "
                         "Measurements were never started, cannot calculate measurement range FPS.",
                         measurement_frame_range.first,
-                        file_processor.GetCurrentFrameNumber());
+                        final_frame_number);
                 }
                 else
                 {

--- a/tools/replay/desktop_main.cpp
+++ b/tools/replay/desktop_main.cpp
@@ -119,10 +119,12 @@ int main(int argc, const char** argv)
             gfxrecon::decode::VulkanReplayConsumer replay_consumer(application, replay_options);
             gfxrecon::decode::VulkanDecoder        decoder;
 
-            std::pair<uint32_t, uint32_t> measurement_frame_range = GetMeasurementFrameRange(arg_parser);
+            uint32_t start_frame, end_frame;
+            bool     has_mfr = GetMeasurementFrameRange(arg_parser, start_frame, end_frame);
 
-            gfxrecon::graphics::FpsInfo fps_info(static_cast<uint64_t>(measurement_frame_range.first),
-                                                 static_cast<uint64_t>(measurement_frame_range.second),
+            gfxrecon::graphics::FpsInfo fps_info(static_cast<uint64_t>(start_frame),
+                                                 static_cast<uint64_t>(end_frame),
+                                                 has_mfr,
                                                  replay_options.quit_after_measurement_frame_range,
                                                  replay_options.flush_measurement_frame_range);
 
@@ -149,12 +151,12 @@ int main(int argc, const char** argv)
             if ((final_frame_number > 0) &&
                 (file_processor.GetErrorState() == gfxrecon::decode::FileProcessor::kErrorNone))
             {
-                if (final_frame_number < measurement_frame_range.first)
+                if (final_frame_number < start_frame)
                 {
                     GFXRECON_LOG_WARNING(
                         "Measurement range start frame (%u) is greater than the last replayed frame (%u). "
                         "Measurements were never started, cannot calculate measurement range FPS.",
-                        measurement_frame_range.first,
+                        start_frame,
                         final_frame_number);
                 }
                 else

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -28,8 +28,8 @@
 const char kOptions[] =
     "-h|--help,--version,--log-debugview,--no-debug-popup,--paused,--sync,--sfa|--skip-failed-allocations,--"
     "opcd|--omit-pipeline-cache-data,--remove-unsupported,--validate,--debug-device-lost,--create-dummy-allocations,--"
-    "screenshot-all,--dcp,--discard-cached-psos,--onhb|--omit-null-hardware-buffers|--quit-after-measurement-range,"
-    "--fmr|--flush-measurement-range";
+    "screenshot-all,--dcp,--discard-cached-psos,--onhb|--omit-null-hardware-buffers,--qamr|--quit-after-measurement-"
+    "range,--fmr|--flush-measurement-range";
 const char kArguments[] = "--log-level,--log-file,--gpu,--pause-frame,--wsi,--surface-index,-m|--memory-translation,--"
                           "replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
                           "screenshot-dir,--screenshot-prefix,--mfr|--measurement-frame-range";

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -28,10 +28,11 @@
 const char kOptions[] =
     "-h|--help,--version,--log-debugview,--no-debug-popup,--paused,--sync,--sfa|--skip-failed-allocations,--"
     "opcd|--omit-pipeline-cache-data,--remove-unsupported,--validate,--debug-device-lost,--create-dummy-allocations,--"
-    "screenshot-all,--dcp,--discard-cached-psos,--onhb|--omit-null-hardware-buffers";
+    "screenshot-all,--dcp,--discard-cached-psos,--onhb|--omit-null-hardware-buffers|--quit-after-measurement-range,"
+    "--fmr|--flush-measurement-range";
 const char kArguments[] = "--log-level,--log-file,--gpu,--pause-frame,--wsi,--surface-index,-m|--memory-translation,--"
                           "replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
-                          "screenshot-dir,--screenshot-prefix";
+                          "screenshot-dir,--screenshot-prefix,--mfr|--measurement-frame-range";
 
 static void PrintUsage(const char* exe_name)
 {
@@ -78,6 +79,21 @@ static void PrintUsage(const char* exe_name)
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("  --log-debugview\tLog messages with OutputDebugStringA.");
 #endif
+    GFXRECON_WRITE_CONSOLE("  --measurement-frame-range <start_frame>-<end_frame>");
+    GFXRECON_WRITE_CONSOLE("          \t\tCustom framerange to measure FPS for.");
+    GFXRECON_WRITE_CONSOLE("          \t\tThis range will include the start frame but not the end frame.");
+    GFXRECON_WRITE_CONSOLE("          \t\tThe measurement frame range defaults to all frames except the loading");
+    GFXRECON_WRITE_CONSOLE("          \t\tframe but can be configured for any range. If the end frame is past the");
+    GFXRECON_WRITE_CONSOLE("          \t\tlast frame in the trace it will be clamped to the frame after the last");
+    GFXRECON_WRITE_CONSOLE("          \t\t(so in that case the results would include the last frame).");
+    GFXRECON_WRITE_CONSOLE("  --quit-after-measurement-range");
+    GFXRECON_WRITE_CONSOLE("          \t\tIf this is specified the replayer will abort");
+    GFXRECON_WRITE_CONSOLE("          \t\twhen it reaches the <end_frame> specified in");
+    GFXRECON_WRITE_CONSOLE("          \t\tthe --measurement-frame-range argument.");
+    GFXRECON_WRITE_CONSOLE("  --flush-measurement-range");
+    GFXRECON_WRITE_CONSOLE("          \t\tIf this is specified the replayer will flush")
+    GFXRECON_WRITE_CONSOLE("          \t\tand wait for all current GPU work to finish at the");
+    GFXRECON_WRITE_CONSOLE("          \t\tstart and end of the measurement range.");
     GFXRECON_WRITE_CONSOLE("  --gpu <index>\t\tUse the specified device for replay, where index");
     GFXRECON_WRITE_CONSOLE("          \t\tis the zero-based index to the array of physical devices");
     GFXRECON_WRITE_CONSOLE("          \t\treturned by vkEnumeratePhysicalDevices.  Replay may fail");

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -474,9 +474,11 @@ GetScreenshotRanges(const gfxrecon::util::ArgumentParser& arg_parser)
     return ranges;
 }
 
-static std::pair<uint32_t, uint32_t> GetMeasurementFrameRange(const gfxrecon::util::ArgumentParser& arg_parser)
+static bool
+GetMeasurementFrameRange(const gfxrecon::util::ArgumentParser& arg_parser, uint32_t& start_frame, uint32_t& end_frame)
 {
-    std::pair<uint32_t, uint32_t> measurement_frame_range(1, std::numeric_limits<uint32_t>::max());
+    start_frame = 1;
+    end_frame   = std::numeric_limits<uint32_t>::max();
 
     const auto& value = arg_parser.GetArgumentValue(kMeasurementRangeArgument);
     if (!value.empty())
@@ -488,7 +490,7 @@ static std::pair<uint32_t, uint32_t> GetMeasurementFrameRange(const gfxrecon::ut
             GFXRECON_LOG_WARNING(
                 "Ignoring invalid measurement frame range \"%s\". Must have format: <start_frame>-<end_frame>",
                 range.c_str());
-            return measurement_frame_range;
+            return false;
         }
 
         // Remove whitespace.
@@ -533,20 +535,21 @@ static std::pair<uint32_t, uint32_t> GetMeasurementFrameRange(const gfxrecon::ut
 
         if (!invalid)
         {
-            uint32_t start_frame = std::stoi(values[0]);
-            uint32_t end_frame   = std::stoi(values[1]);
+            uint32_t start_frame_arg = std::stoi(values[0]);
+            uint32_t end_frame_arg   = std::stoi(values[1]);
 
-            if (start_frame >= end_frame)
+            if (start_frame_arg >= end_frame_arg)
             {
                 GFXRECON_LOG_WARNING("Ignoring invalid measurement frame range \"%s\", where first frame is "
                                      "greater than or equal to the last frame",
                                      range.c_str());
 
-                return measurement_frame_range;
+                return false;
             }
 
-            measurement_frame_range.first  = start_frame;
-            measurement_frame_range.second = end_frame;
+            start_frame = start_frame_arg;
+            end_frame   = end_frame_arg;
+            return true;
         }
         else
         {
@@ -554,7 +557,7 @@ static std::pair<uint32_t, uint32_t> GetMeasurementFrameRange(const gfxrecon::ut
         }
     }
 
-    return measurement_frame_range;
+    return false;
 }
 static gfxrecon::decode::CreateResourceAllocator
 GetCreateResourceAllocatorFunc(const gfxrecon::util::ArgumentParser&           arg_parser,

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -87,6 +87,9 @@ const char kScreenshotFormatArgument[]           = "--screenshot-format";
 const char kScreenshotDirArgument[]              = "--screenshot-dir";
 const char kScreenshotFilePrefixArgument[]       = "--screenshot-prefix";
 const char kOutput[]                             = "--output";
+const char kMeasurementRangeArgument[]           = "--measurement-frame-range";
+const char kQuitAfterMeasurementRangeOption[]    = "--quit-after-measurement-range";
+const char kFlushMeasurementRangeOption[]        = "--flush-measurement-range";
 #if defined(WIN32)
 const char kApiFamilyOption[] = "--api";
 #endif
@@ -471,6 +474,88 @@ GetScreenshotRanges(const gfxrecon::util::ArgumentParser& arg_parser)
     return ranges;
 }
 
+static std::pair<uint32_t, uint32_t> GetMeasurementFrameRange(const gfxrecon::util::ArgumentParser& arg_parser)
+{
+    std::pair<uint32_t, uint32_t> measurement_frame_range(1, std::numeric_limits<uint32_t>::max());
+
+    const auto& value = arg_parser.GetArgumentValue(kMeasurementRangeArgument);
+    if (!value.empty())
+    {
+        std::string range = value;
+
+        if (std::count(range.begin(), range.end(), '-') != 1)
+        {
+            GFXRECON_LOG_WARNING(
+                "Ignoring invalid measurement frame range \"%s\". Must have format: <start_frame>-<end_frame>",
+                range.c_str());
+            return measurement_frame_range;
+        }
+
+        // Remove whitespace.
+        range.erase(std::remove_if(range.begin(), range.end(), ::isspace), range.end());
+
+        // Split string on '-' delimiter.
+        bool                     invalid = false;
+        std::vector<std::string> values;
+        std::istringstream       range_input;
+        range_input.str(range);
+
+        for (std::string token; std::getline(range_input, token, '-');)
+        {
+            if (token.empty())
+            {
+                break;
+            }
+
+            // Check that the range string only contains numbers.
+            size_t count = std::count_if(token.begin(), token.end(), ::isdigit);
+            if (count == token.length())
+            {
+                values.push_back(token);
+            }
+            else
+            {
+                GFXRECON_LOG_WARNING(
+                    "Ignoring invalid measurement frame range \"%s\", which contains non-numeric values",
+                    range.c_str());
+                invalid = true;
+                break;
+            }
+        }
+
+        if (values.size() < 2)
+        {
+            GFXRECON_LOG_WARNING("Ignoring invalid measurement frame range \"%s\", does not have two values.",
+                                 range.c_str());
+
+            invalid = true;
+        }
+
+        if (!invalid)
+        {
+            uint32_t start_frame = std::stoi(values[0]);
+            uint32_t end_frame   = std::stoi(values[1]);
+
+            if (start_frame >= end_frame)
+            {
+                GFXRECON_LOG_WARNING("Ignoring invalid measurement frame range \"%s\", where first frame is "
+                                     "greater than or equal to the last frame",
+                                     range.c_str());
+
+                return measurement_frame_range;
+            }
+
+            measurement_frame_range.first  = start_frame;
+            measurement_frame_range.second = end_frame;
+        }
+        else
+        {
+            GFXRECON_LOG_WARNING("Ignoring invalid measurement frame range \"%s\".", range.c_str());
+        }
+    }
+
+    return measurement_frame_range;
+}
 static gfxrecon::decode::CreateResourceAllocator
 GetCreateResourceAllocatorFunc(const gfxrecon::util::ArgumentParser&           arg_parser,
                                const std::string&                              filename,
@@ -588,6 +673,16 @@ static void GetReplayOptions(gfxrecon::decode::ReplayOptions& options, const gfx
         arg_parser.IsOptionSet(kOmitNullHardwareBuffersShortOption))
     {
         options.omit_null_hardware_buffers = true;
+    }
+
+    if (arg_parser.IsOptionSet(kQuitAfterMeasurementRangeOption))
+    {
+        replay_options.quit_after_measurement_frame_range = true;
+    }
+
+    if (arg_parser.IsOptionSet(kFlushMeasurementRangeOption))
+    {
+        replay_options.flush_measurement_frame_range = true;
     }
 }
 

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -731,6 +731,15 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
     replay_options.screenshot_format      = GetScreenshotFormat(arg_parser);
     replay_options.screenshot_dir         = GetScreenshotDir(arg_parser);
     replay_options.screenshot_file_prefix = arg_parser.GetArgumentValue(kScreenshotFilePrefixArgument);
+    if (arg_parser.IsOptionSet(kQuitAfterMeasurementRangeOption))
+    {
+        replay_options.quit_after_measurement_frame_range = true;
+    }
+
+    if (arg_parser.IsOptionSet(kFlushMeasurementRangeOption))
+    {
+        replay_options.flush_measurement_frame_range = true;
+    }
 
     std::string surface_index = arg_parser.GetArgumentValue(kSurfaceIndexArgument);
     if (!surface_index.empty())

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -677,12 +677,12 @@ static void GetReplayOptions(gfxrecon::decode::ReplayOptions& options, const gfx
 
     if (arg_parser.IsOptionSet(kQuitAfterMeasurementRangeOption))
     {
-        replay_options.quit_after_measurement_frame_range = true;
+        options.quit_after_measurement_frame_range = true;
     }
 
     if (arg_parser.IsOptionSet(kFlushMeasurementRangeOption))
     {
-        replay_options.flush_measurement_frame_range = true;
+        options.flush_measurement_frame_range = true;
     }
 }
 


### PR DESCRIPTION
@bradgrantham-lunarg @tomped01

I created a new PR for the framerange support PR submitted by @tomped01 
This PR incorporates all commits by Tom, the changes from Brad and a couple of fixes by me that fix a few issues I discovered:

1. There was no way to distinguish a measurement for frameranges that began from frame 1 and when the `--mfr` parameter was not specified.
2. Traces with no frames (i.e. vulkaninfo) were reported as traces with 1 frame, which was confusing.
3. Brad's changes were causing the report of the total frames replayed when the `--mfr` option was not specified to be off-by-1

The PR by @bradgrantham-lunarg that I tried to piggyback was causing some strange conflicts when trying to merge back to dev so I created a new one.
If you all agree with the changes I propose to submit this PR.