### PR TITLE
Provide a GetPhysicalDeviceProcAddr function [Fixes #688]

### DIFF
--- a/framework/generated/generated_layer_func_table.h
+++ b/framework/generated/generated_layer_func_table.h
@@ -561,6 +561,7 @@ const std::unordered_map<std::string, PFN_vkVoidFunction> func_table = {
     { "vkCmdTraceRaysIndirectKHR",                                                                           reinterpret_cast<PFN_vkVoidFunction>(encode::CmdTraceRaysIndirectKHR) },
     { "vkGetRayTracingShaderGroupStackSizeKHR",                                                              reinterpret_cast<PFN_vkVoidFunction>(encode::GetRayTracingShaderGroupStackSizeKHR) },
     { "vkCmdSetRayTracingPipelineStackSizeKHR",                                                              reinterpret_cast<PFN_vkVoidFunction>(encode::CmdSetRayTracingPipelineStackSizeKHR) },
+    { "vk_layerGetPhysicalDeviceProcAddr",                                                                   reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceProcAddr) },
 };
 
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/generated_layer_func_table.h
+++ b/framework/generated/generated_layer_func_table.h
@@ -561,7 +561,6 @@ const std::unordered_map<std::string, PFN_vkVoidFunction> func_table = {
     { "vkCmdTraceRaysIndirectKHR",                                                                           reinterpret_cast<PFN_vkVoidFunction>(encode::CmdTraceRaysIndirectKHR) },
     { "vkGetRayTracingShaderGroupStackSizeKHR",                                                              reinterpret_cast<PFN_vkVoidFunction>(encode::GetRayTracingShaderGroupStackSizeKHR) },
     { "vkCmdSetRayTracingPipelineStackSizeKHR",                                                              reinterpret_cast<PFN_vkVoidFunction>(encode::CmdSetRayTracingPipelineStackSizeKHR) },
-    { "vk_layerGetPhysicalDeviceProcAddr",                                                                   reinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceProcAddr) },
 };
 
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/vulkan_generators/layer_func_table_generator.py
+++ b/framework/generated/vulkan_generators/layer_func_table_generator.py
@@ -112,6 +112,11 @@ class LayerFuncTableGenerator(BaseGenerator):
 
     def endFile(self):
         """Method override."""
+        # Manually output the physical device proc address function as its name doesn't
+        # match the scheme used by self.LAYER_FUNCTIONS:
+        align = 100 - len('vk_layerGetPhysicalDeviceProcAddr')
+        write('    { "vk_layerGetPhysicalDeviceProcAddr",%sreinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceProcAddr) },' % (' ' * align), file=self.outFile)
+
         write('};', file=self.outFile)
         self.newline()
         write('GFXRECON_END_NAMESPACE(gfxrecon)', file=self.outFile)

--- a/framework/generated/vulkan_generators/layer_func_table_generator.py
+++ b/framework/generated/vulkan_generators/layer_func_table_generator.py
@@ -111,12 +111,6 @@ class LayerFuncTableGenerator(BaseGenerator):
         )
 
     def endFile(self):
-        """Method override."""
-        # Manually output the physical device proc address function as its name doesn't
-        # match the scheme used by self.LAYER_FUNCTIONS:
-        align = 100 - len('vk_layerGetPhysicalDeviceProcAddr')
-        write('    { "vk_layerGetPhysicalDeviceProcAddr",%sreinterpret_cast<PFN_vkVoidFunction>(GetPhysicalDeviceProcAddr) },' % (' ' * align), file=self.outFile)
-
         write('};', file=self.outFile)
         self.newline()
         write('GFXRECON_END_NAMESPACE(gfxrecon)', file=self.outFile)

--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -98,7 +98,7 @@ static VkInstance get_instance_handle(const void* handle)
     return (entry != instance_handles.end()) ? entry->second : VK_NULL_HANDLE;
 }
 
-// The vk_layerGetPhysicalDeviceProcAddr of the next layer in the chain.
+// The GetPhysicalDeviceProcAddr of the next layer in the chain.
 // Retrieved during instance creation and forwarded to by this layer's
 // GetPhysicalDeviceProcAddr() after unwrapping its VkInstance parameter.
 static std::mutex                                                    gpdpa_lock;
@@ -426,7 +426,7 @@ extern "C"
         return VK_SUCCESS;
     }
 
-    // The following three functions are not directly invoked by the desktop loader, which instead uses the function
+    // The following two functions are not directly invoked by the desktop loader, which instead uses the function
     // pointers returned by the negotiate function.
     VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance  instance,
                                                                                    const char* pName)
@@ -437,12 +437,6 @@ extern "C"
     VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice device, const char* pName)
     {
         return gfxrecon::GetDeviceProcAddr(device, pName);
-    }
-
-    VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vk_layerGetPhysicalDeviceProcAddr(VkInstance  instance,
-                                                                                               const char* pName)
-    {
-        return gfxrecon::GetPhysicalDeviceProcAddr(instance, pName);
     }
 
     // The following four functions are not invoked by the desktop loader, which retrieves the layer specific properties

--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -106,14 +106,14 @@ static std::unordered_map<VkInstance, PFN_GetPhysicalDeviceProcAddr> next_gpdpa;
 
 static void set_instance_next_gpdpa(const VkInstance instance, PFN_GetPhysicalDeviceProcAddr p_next_gpdpa)
 {
-    assert(instance != VK_NULL_HANDLE);
+    GFXRECON_ASSERT(instance != VK_NULL_HANDLE);
     std::lock_guard<std::mutex> lock(gpdpa_lock);
     next_gpdpa[instance] = p_next_gpdpa;
 }
 
 static PFN_GetPhysicalDeviceProcAddr get_instance_next_gpdpa(const VkInstance instance)
 {
-    assert(instance != VK_NULL_HANDLE);
+    GFXRECON_ASSERT(instance != VK_NULL_HANDLE);
     std::lock_guard<std::mutex> lock(gpdpa_lock);
     auto                        it_gpdpa = next_gpdpa.find(instance);
     if (it_gpdpa == next_gpdpa.end())

--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -115,7 +115,7 @@ static PFN_GetPhysicalDeviceProcAddr get_next_gpdpa(const VkInstance instance)
 {
     assert(instance != VK_NULL_HANDLE);
     std::lock_guard<std::mutex> lock(gpdpa_lock);
-    auto it_gpdpa = next_gpdpa.find(instance);
+    auto                        it_gpdpa = next_gpdpa.find(instance);
     if (it_gpdpa == next_gpdpa.end())
     {
         return nullptr;

--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -101,7 +101,7 @@ static VkInstance get_instance_handle(const void* handle)
 // The vk_layerGetPhysicalDeviceProcAddr of the next layer in the chain.
 // Retrieved during instance creation and forwarded to by this layer's
 // GetPhysicalDeviceProcAddr() after unwrapping its VkInstance parameter.
-static std::mutex                    gpdpa_lock;
+static std::mutex                                                    gpdpa_lock;
 static std::unordered_map<VkInstance, PFN_GetPhysicalDeviceProcAddr> next_gpdpa;
 
 static void set_next_gpdpa(const VkInstance instance, PFN_GetPhysicalDeviceProcAddr p_next_gpdpa)
@@ -145,7 +145,7 @@ VKAPI_ATTR VkResult VKAPI_CALL dispatch_CreateInstance(const VkInstanceCreateInf
             if (fpCreateInstance)
             {
                 // Advance the link info for the next element on the chain
-                auto pLayerInfo = chain_info->u.pLayerInfo;
+                auto pLayerInfo          = chain_info->u.pLayerInfo;
                 chain_info->u.pLayerInfo = chain_info->u.pLayerInfo->pNext;
 
                 result = fpCreateInstance(pCreateInfo, pAllocator, pInstance);
@@ -284,7 +284,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetPhysicalDeviceProcAddr(VkInstance ou
     {
         const VkInstance              nextLayersInstance = encode::GetWrappedHandle<VkInstance>(ourInstanceWrapper);
         PFN_GetPhysicalDeviceProcAddr next_gpdpa         = get_next_gpdpa(ourInstanceWrapper);
-        if(next_gpdpa)
+        if (next_gpdpa)
         {
             result = next_gpdpa(nextLayersInstance, pName);
         }
@@ -441,7 +441,7 @@ extern "C"
     }
 
     VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vk_layerGetPhysicalDeviceProcAddr(VkInstance  instance,
-                                                                                           const char* pName)
+                                                                                               const char* pName)
     {
         return gfxrecon::GetPhysicalDeviceProcAddr(instance, pName);
     }

--- a/layer/trace_layer.h
+++ b/layer/trace_layer.h
@@ -34,6 +34,7 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 // functions which are defined in trace_layer.cpp
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetInstanceProcAddr(VkInstance instance, const char* pName);
 VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice device, const char* pName);
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetPhysicalDeviceProcAddr(VkInstance ourInstanceWrapper, const char* pName);
 VKAPI_ATTR VkResult VKAPI_CALL EnumerateDeviceExtensionProperties(VkPhysicalDevice       physicalDevice,
                                                                   const char*            pLayerName,
                                                                   uint32_t*              pPropertyCount,


### PR DESCRIPTION
Provides a GetPhysicalDeviceProcAddr function which unwraps the
instance and passes it through to the next layer.

Fixes #688

Hoping this is ready to go in and looking for feedback on that.

The Loader PR that this previously depended on has been re-implemented and merged to Loader main.