### PR TITLE
Fix Wolf2 texture missing issue

### DIFF
--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1,7 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
-** Copyright (c) 2019 Advanced Micro Devices, Inc. All rights reserved.
+** Copyright (c) 2019-2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -109,7 +109,7 @@ void VulkanCaptureManager::InitVkInstance(VkInstance* instance, PFN_vkGetInstanc
     CreateWrappedHandle<NoParentWrapper, NoParentWrapper, InstanceWrapper>(
         NoParentWrapper::kHandleValue, NoParentWrapper::kHandleValue, instance, GetUniqueId);
 
-    auto wrapper = reinterpret_cast<InstanceWrapper*>(*instance);
+    auto wrapper = getWrapperPointerFromHandle<InstanceWrapper*>(*instance);
     LoadInstanceTable(gpa, wrapper->handle, &wrapper->layer_table);
 }
 
@@ -120,7 +120,7 @@ void VulkanCaptureManager::InitVkDevice(VkDevice* device, PFN_vkGetDeviceProcAdd
     CreateWrappedHandle<PhysicalDeviceWrapper, NoParentWrapper, DeviceWrapper>(
         VK_NULL_HANDLE, NoParentWrapper::kHandleValue, device, GetUniqueId);
 
-    auto wrapper = reinterpret_cast<DeviceWrapper*>(*device);
+    auto wrapper = getWrapperPointerFromHandle<DeviceWrapper*>(*device);
     LoadDeviceTable(gpa, wrapper->handle, &wrapper->layer_table);
 }
 
@@ -408,8 +408,9 @@ void VulkanCaptureManager::SetDescriptorUpdateTemplateInfo(VkDescriptorUpdateTem
 
     if (create_info->descriptorUpdateEntryCount > 0)
     {
-        DescriptorUpdateTemplateWrapper* wrapper = reinterpret_cast<DescriptorUpdateTemplateWrapper*>(update_template);
-        UpdateTemplateInfo*              info    = &wrapper->info;
+        DescriptorUpdateTemplateWrapper* wrapper =
+            getWrapperPointerFromHandle<DescriptorUpdateTemplateWrapper*>(update_template);
+        UpdateTemplateInfo* info = &wrapper->info;
 
         for (size_t i = 0; i < create_info->descriptorUpdateEntryCount; ++i)
         {
@@ -512,7 +513,8 @@ bool VulkanCaptureManager::GetDescriptorUpdateTemplateInfo(VkDescriptorUpdateTem
 
     if (update_template != VK_NULL_HANDLE)
     {
-        DescriptorUpdateTemplateWrapper* wrapper = reinterpret_cast<DescriptorUpdateTemplateWrapper*>(update_template);
+        DescriptorUpdateTemplateWrapper* wrapper =
+            getWrapperPointerFromHandle<DescriptorUpdateTemplateWrapper*>(update_template);
 
         (*info) = &wrapper->info;
         found   = true;
@@ -585,7 +587,7 @@ VkResult VulkanCaptureManager::OverrideCreateInstance(const VkInstanceCreateInfo
     if ((result == VK_SUCCESS) && (pCreateInfo->pApplicationInfo != nullptr))
     {
         auto api_version              = pCreateInfo->pApplicationInfo->apiVersion;
-        auto instance_wrapper         = reinterpret_cast<InstanceWrapper*>(*pInstance);
+        auto instance_wrapper         = getWrapperPointerFromHandle<InstanceWrapper*>(*pInstance);
         instance_wrapper->api_version = api_version;
 
         // Warn when enabled API version is newer than the supported API version.
@@ -617,7 +619,7 @@ VkResult VulkanCaptureManager::OverrideCreateDevice(VkPhysicalDevice            
     assert(pCreateInfo_unwrapped != nullptr);
 
     const InstanceTable* instance_table          = GetInstanceTable(physicalDevice);
-    auto                 physical_device_wrapper = reinterpret_cast<PhysicalDeviceWrapper*>(physicalDevice);
+    auto                 physical_device_wrapper = getWrapperPointerFromHandle<PhysicalDeviceWrapper*>(physicalDevice);
 
     graphics::VulkanDeviceUtil                device_util;
     graphics::VulkanDevicePropertyFeatureInfo property_feature_info = device_util.EnableRequiredPhysicalDeviceFeatures(
@@ -682,7 +684,7 @@ VkResult VulkanCaptureManager::OverrideCreateDevice(VkPhysicalDevice            
     {
         assert((pDevice != nullptr) && (*pDevice != VK_NULL_HANDLE));
 
-        auto wrapper = reinterpret_cast<DeviceWrapper*>(*pDevice);
+        auto wrapper = getWrapperPointerFromHandle<DeviceWrapper*>(*pDevice);
 
         // Track state of physical device properties and features at device creation
         wrapper->property_feature_info = property_feature_info;
@@ -707,7 +709,7 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
                                                     VkBuffer*                    pBuffer)
 {
     VkResult result           = VK_SUCCESS;
-    auto     device_wrapper   = reinterpret_cast<DeviceWrapper*>(device);
+    auto     device_wrapper   = getWrapperPointerFromHandle<DeviceWrapper*>(device);
     VkDevice device_unwrapped = device_wrapper->handle;
     auto     device_table     = GetDeviceTable(device);
 
@@ -763,7 +765,7 @@ VkResult VulkanCaptureManager::OverrideCreateBuffer(VkDevice                    
             // If the buffer has a device address, write the 'set buffer address' command before writing the API call to
             // create the buffer.  The address will need to be passed to vkCreateBuffer through the pCreateInfo pNext
             // list.
-            auto                      buffer_wrapper = reinterpret_cast<BufferWrapper*>(*pBuffer);
+            auto                      buffer_wrapper = getWrapperPointerFromHandle<BufferWrapper*>(*pBuffer);
             VkBufferDeviceAddressInfo info           = { VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO };
             info.pNext                               = nullptr;
             info.buffer                              = buffer_wrapper->handle;
@@ -797,7 +799,7 @@ VulkanCaptureManager::OverrideCreateAccelerationStructureKHR(VkDevice           
                                                              VkAccelerationStructureKHR* pAccelerationStructureKHR)
 {
     auto               handle_unwrap_memory = VulkanCaptureManager::Get()->GetHandleUnwrapMemory();
-    auto               device_wrapper       = reinterpret_cast<DeviceWrapper*>(device);
+    auto               device_wrapper       = getWrapperPointerFromHandle<DeviceWrapper*>(device);
     VkDevice           device_unwrapped     = device_wrapper->handle;
     const DeviceTable* device_table         = GetDeviceTable(device);
     const VkAccelerationStructureCreateInfoKHR* pCreateInfo_unwrapped =
@@ -826,7 +828,7 @@ VulkanCaptureManager::OverrideCreateAccelerationStructureKHR(VkDevice           
         if (device_wrapper->property_feature_info.feature_accelerationStructureCaptureReplay)
         {
             AccelerationStructureKHRWrapper* accel_struct_wrapper =
-                reinterpret_cast<AccelerationStructureKHRWrapper*>(*pAccelerationStructureKHR);
+                getWrapperPointerFromHandle<AccelerationStructureKHRWrapper*>(*pAccelerationStructureKHR);
 
             VkAccelerationStructureDeviceAddressInfoKHR address_info{
                 VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR, nullptr, accel_struct_wrapper->handle
@@ -857,7 +859,7 @@ VkResult VulkanCaptureManager::OverrideAllocateMemory(VkDevice                  
     void*                            external_memory = nullptr;
     VkImportMemoryHostPointerInfoEXT import_info;
 
-    auto                  device_wrapper       = reinterpret_cast<DeviceWrapper*>(device);
+    auto                  device_wrapper       = getWrapperPointerFromHandle<DeviceWrapper*>(device);
     VkDevice              device_unwrapped     = device_wrapper->handle;
     auto                  handle_unwrap_memory = VulkanCaptureManager::Get()->GetHandleUnwrapMemory();
     VkMemoryAllocateInfo* pAllocateInfo_unwrapped =
@@ -944,7 +946,7 @@ VkResult VulkanCaptureManager::OverrideAllocateMemory(VkDevice                  
             device, NoParentWrapper::kHandleValue, pMemory, GetUniqueId);
 
         assert(pMemory != nullptr);
-        auto memory_wrapper = reinterpret_cast<DeviceMemoryWrapper*>(*pMemory);
+        auto memory_wrapper = getWrapperPointerFromHandle<DeviceMemoryWrapper*>(*pMemory);
 
         if (uses_address)
         {
@@ -1066,7 +1068,7 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
                                                            const VkAllocationCallbacks*             pAllocator,
                                                            VkPipeline*                              pPipelines)
 {
-    auto                   device_wrapper              = reinterpret_cast<DeviceWrapper*>(device);
+    auto                   device_wrapper              = getWrapperPointerFromHandle<DeviceWrapper*>(device);
     VkDevice               device_unwrapped            = device_wrapper->handle;
     const DeviceTable*     device_table                = GetDeviceTable(device);
     auto                   handle_unwrap_memory        = VulkanCaptureManager::Get()->GetHandleUnwrapMemory();
@@ -1112,7 +1114,7 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
         {
             for (uint32_t i = 0; i < createInfoCount; ++i)
             {
-                PipelineWrapper* pipeline_wrapper = reinterpret_cast<PipelineWrapper*>(pPipelines[i]);
+                PipelineWrapper* pipeline_wrapper = getWrapperPointerFromHandle<PipelineWrapper*>(pPipelines[i]);
 
                 uint32_t data_size = device_wrapper->property_feature_info.property_shaderGroupHandleCaptureReplaySize *
                                      pCreateInfos[i].groupCount;
@@ -1142,7 +1144,7 @@ void VulkanCaptureManager::ProcessEnumeratePhysicalDevices(VkResult          res
 {
     assert(devices != nullptr);
 
-    auto instance_wrapper = reinterpret_cast<InstanceWrapper*>(instance);
+    auto instance_wrapper = getWrapperPointerFromHandle<InstanceWrapper*>(instance);
     assert(instance_wrapper != nullptr);
 
     // Write meta-data describing physical device properties on first call to vkEnumeratePhysicalDevices or
@@ -1164,10 +1166,10 @@ void VulkanCaptureManager::ProcessEnumeratePhysicalDevices(VkResult          res
                 const InstanceTable* instance_table = GetInstanceTable(physical_device);
                 assert(instance_table != nullptr);
 
-                auto             physical_device_wrapper = reinterpret_cast<PhysicalDeviceWrapper*>(physical_device);
-                format::HandleId physical_device_id      = physical_device_wrapper->handle_id;
-                VkPhysicalDevice physical_device_handle  = physical_device_wrapper->handle;
-                uint32_t         count                   = 0;
+                auto physical_device_wrapper = getWrapperPointerFromHandle<PhysicalDeviceWrapper*>(physical_device);
+                format::HandleId physical_device_id     = physical_device_wrapper->handle_id;
+                VkPhysicalDevice physical_device_handle = physical_device_wrapper->handle;
+                uint32_t         count                  = 0;
 
                 VkPhysicalDeviceProperties       properties;
                 VkPhysicalDeviceMemoryProperties memory_properties;
@@ -1238,7 +1240,7 @@ void VulkanCaptureManager::ProcessImportAndroidHardwareBuffer(VkDevice         d
                                                               AHardwareBuffer* hardware_buffer)
 {
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-    auto memory_wrapper = reinterpret_cast<DeviceMemoryWrapper*>(memory);
+    auto memory_wrapper = getWrapperPointerFromHandle<DeviceMemoryWrapper*>(memory);
     assert((memory_wrapper != nullptr) && (hardware_buffer != nullptr));
 
     auto entry = hardware_buffers_.find(hardware_buffer);
@@ -1503,7 +1505,7 @@ void VulkanCaptureManager::PostProcess_vkMapMemory(VkResult         result,
 {
     if ((result == VK_SUCCESS) && (ppData != nullptr))
     {
-        auto wrapper = reinterpret_cast<DeviceMemoryWrapper*>(memory);
+        auto wrapper = getWrapperPointerFromHandle<DeviceMemoryWrapper*>(memory);
         assert(wrapper != nullptr);
 
         if (wrapper->mapped_data == nullptr)
@@ -1618,7 +1620,8 @@ void VulkanCaptureManager::PreProcess_vkFlushMappedMemoryRanges(VkDevice        
 
             for (uint32_t i = 0; i < memoryRangeCount; ++i)
             {
-                auto next_memory_wrapper = reinterpret_cast<const DeviceMemoryWrapper*>(pMemoryRanges[i].memory);
+                auto next_memory_wrapper =
+                    getWrapperPointerFromHandle<const DeviceMemoryWrapper*>(pMemoryRanges[i].memory);
 
                 // Currently processing all dirty pages for the mapped memory, so filter multiple ranges from the same
                 // object.
@@ -1647,7 +1650,8 @@ void VulkanCaptureManager::PreProcess_vkFlushMappedMemoryRanges(VkDevice        
 
             for (uint32_t i = 0; i < memoryRangeCount; ++i)
             {
-                current_memory_wrapper = reinterpret_cast<const DeviceMemoryWrapper*>(pMemoryRanges[i].memory);
+                current_memory_wrapper =
+                    getWrapperPointerFromHandle<const DeviceMemoryWrapper*>(pMemoryRanges[i].memory);
 
                 if ((current_memory_wrapper != nullptr) && (current_memory_wrapper->mapped_data != nullptr))
                 {
@@ -1674,7 +1678,7 @@ void VulkanCaptureManager::PreProcess_vkFlushMappedMemoryRanges(VkDevice        
 
 void VulkanCaptureManager::PreProcess_vkUnmapMemory(VkDevice device, VkDeviceMemory memory)
 {
-    auto wrapper = reinterpret_cast<DeviceMemoryWrapper*>(memory);
+    auto wrapper = getWrapperPointerFromHandle<DeviceMemoryWrapper*>(memory);
     assert(wrapper != nullptr);
 
     if (wrapper->mapped_data != nullptr)
@@ -1740,7 +1744,7 @@ void VulkanCaptureManager::PreProcess_vkFreeMemory(VkDevice                     
 
     if (memory != VK_NULL_HANDLE)
     {
-        auto wrapper = reinterpret_cast<DeviceMemoryWrapper*>(memory);
+        auto wrapper = getWrapperPointerFromHandle<DeviceMemoryWrapper*>(memory);
 
         if (wrapper->mapped_data != nullptr)
         {
@@ -1771,7 +1775,7 @@ void VulkanCaptureManager::PostProcess_vkFreeMemory(VkDevice                    
     if (memory != VK_NULL_HANDLE)
     {
         // Destroy external resources.
-        auto wrapper = reinterpret_cast<DeviceMemoryWrapper*>(memory);
+        auto wrapper = getWrapperPointerFromHandle<DeviceMemoryWrapper*>(memory);
 
         if (GetMemoryTrackingMode() == CaptureSettings::MemoryTrackingMode::kPageGuard)
         {
@@ -1977,7 +1981,7 @@ void VulkanCaptureManager::PreProcess_vkCreateDescriptorUpdateTemplateKHR(
 
 void VulkanCaptureManager::PreProcess_vkGetBufferDeviceAddress(VkDevice device, const VkBufferDeviceAddressInfo* pInfo)
 {
-    auto device_wrapper = reinterpret_cast<DeviceWrapper*>(device);
+    auto device_wrapper = getWrapperPointerFromHandle<DeviceWrapper*>(device);
     if (!device_wrapper->property_feature_info.feature_bufferDeviceAddressCaptureReplay)
     {
         GFXRECON_LOG_ERROR_ONCE(
@@ -2018,7 +2022,7 @@ void VulkanCaptureManager::PreProcess_vkGetDeviceMemoryOpaqueCaptureAddress(
 void VulkanCaptureManager::PreProcess_vkGetAccelerationStructureDeviceAddressKHR(
     VkDevice device, const VkAccelerationStructureDeviceAddressInfoKHR* pInfo)
 {
-    auto device_wrapper = reinterpret_cast<DeviceWrapper*>(device);
+    auto device_wrapper = getWrapperPointerFromHandle<DeviceWrapper*>(device);
     if (!device_wrapper->property_feature_info.feature_accelerationStructureCaptureReplay)
     {
         GFXRECON_LOG_WARNING_ONCE(
@@ -2031,7 +2035,7 @@ void VulkanCaptureManager::PreProcess_vkGetAccelerationStructureDeviceAddressKHR
 void VulkanCaptureManager::PreProcess_vkGetRayTracingShaderGroupHandlesKHR(
     VkDevice device, VkPipeline pipeline, uint32_t firstGroup, uint32_t groupCount, size_t dataSize, void* pData)
 {
-    auto device_wrapper = reinterpret_cast<DeviceWrapper*>(device);
+    auto device_wrapper = getWrapperPointerFromHandle<DeviceWrapper*>(device);
     if (!device_wrapper->property_feature_info.feature_rayTracingPipelineShaderGroupHandleCaptureReplay)
     {
         GFXRECON_LOG_WARNING_ONCE(

--- a/framework/encode/vulkan_handle_wrapper_util.cpp
+++ b/framework/encode/vulkan_handle_wrapper_util.cpp
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2020 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -24,6 +25,8 @@
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
+
+WrapperManager* WrapperManager::instance = new WrapperManager();
 
 uint64_t GetWrappedHandle(uint64_t object, VkObjectType object_type)
 {

--- a/framework/encode/vulkan_handle_wrapper_util.cpp
+++ b/framework/encode/vulkan_handle_wrapper_util.cpp
@@ -26,7 +26,7 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-WrapperManager* WrapperManager::instance = new WrapperManager();
+WrapperManager* WrapperManager::instance_ = new WrapperManager();
 
 uint64_t GetWrappedHandle(uint64_t object, VkObjectType object_type)
 {

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -39,18 +39,16 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(encode)
 
-// TODO:FAKE_HANDLE: VK_HANDLE_TO_UINT64 is not correct for 32bit dispatch handle.
-
 #if VK_USE_64_BIT_PTR_DEFINES == 1
 // Vulkan non-dispatch handle is a pointer in its define for 64bit Vulkan, so
 // we need to use reinterpret_cast for the conversion.
 #define VK_HANDLE_TO_UINT64(handle) reinterpret_cast<uint64_t>(handle)
-#define UINT64_TO_VK_HANDLE(handleType, value) reinterpret_cast<handleType>(value)
+#define UINT64_TO_VK_HANDLE(handle_type, value) reinterpret_cast<handle_type>(value)
 #else
 // non-dispatch handle is not a pointer for 32bit Vulkan, so we need to use
 // static_cast for the conversion.
 #define VK_HANDLE_TO_UINT64(handle) static_cast<uint64_t>(handle)
-#define UINT64_TO_VK_HANDLE(handleType, value) static_cast<handleType>(value)
+#define UINT64_TO_VK_HANDLE(handle_type, value) static_cast<handle_type>(value)
 #endif
 
 // When capturing some title with GFXR, the target title will actually get
@@ -103,7 +101,7 @@ T GetWrapperPointerFromHandle(typename std::remove_pointer<T>::type::HandleType 
     if (wrapper == nullptr)
     {
         GFXRECON_LOG_WARNING("The Vulkan object with the following handle %" PRId64
-                             " was already destroyed but still being used.",
+                             " was already destroyed but is still being used.",
                              handle);
     }
     return wrapper;
@@ -178,20 +176,17 @@ T GetWrappedHandle(const T& handle)
     // it's not a pointer to wrapper struct.
     if (handle != VK_NULL_HANDLE)
     {
-        void* wrapperPointer = WrapperManager::GetInstance()->Get(VK_HANDLE_TO_UINT64(handle));
-        if (wrapperPointer == nullptr)
+        void* wrapper_pointer = WrapperManager::GetInstance()->Get(VK_HANDLE_TO_UINT64(handle));
+        if (wrapper_pointer == nullptr)
         {
             GFXRECON_LOG_WARNING("The Vulkan object with the following handle %" PRId64
-                                 " was already destroyed but still being used.",
+                                 " was already destroyed but is still being used.",
                                  VK_HANDLE_TO_UINT64(handle));
         }
-        return (wrapperPointer != nullptr) ? reinterpret_cast<HandleWrapper<T>*>(wrapperPointer)->handle
-                                           : VK_NULL_HANDLE;
+        return (wrapper_pointer != nullptr) ? reinterpret_cast<HandleWrapper<T>*>(wrapper_pointer)->handle
+                                            : VK_NULL_HANDLE;
     }
-    else
-    {
-        return VK_NULL_HANDLE;
-    }
+    return VK_NULL_HANDLE;
 }
 
 template <>
@@ -233,19 +228,16 @@ format::HandleId GetWrappedId(const T& handle)
     {
         // The parameter handle is a handle ID for non-dispatch handle,
         // it's not a pointer to wrapper struct.
-        void* wrapperPointer = WrapperManager::GetInstance()->Get(VK_HANDLE_TO_UINT64(handle));
-        if (wrapperPointer == nullptr)
+        void* wrapper_pointer = WrapperManager::GetInstance()->Get(VK_HANDLE_TO_UINT64(handle));
+        if (wrapper_pointer == nullptr)
         {
             GFXRECON_LOG_WARNING("The Vulkan object with the following handle %" PRId64
-                                 " was already destroyed but still being used.",
+                                 " was already destroyed but is still being used.",
                                  VK_HANDLE_TO_UINT64(handle));
         }
-        return (wrapperPointer != nullptr) ? reinterpret_cast<HandleWrapper<T>*>(wrapperPointer)->handle_id : 0;
+        return (wrapper_pointer != nullptr) ? reinterpret_cast<HandleWrapper<T>*>(wrapper_pointer)->handle_id : 0;
     }
-    else
-    {
-        return 0;
-    }
+    return 0;
 }
 
 template <>

--- a/framework/encode/vulkan_handle_wrapper_util.h
+++ b/framework/encode/vulkan_handle_wrapper_util.h
@@ -97,7 +97,7 @@ class WrapperManager
 };
 
 template <typename T>
-T getWrapperPointerFromHandle(typename std::remove_pointer<T>::type::HandleType handle)
+T GetWrapperPointerFromHandle(typename std::remove_pointer<T>::type::HandleType handle)
 {
     T wrapper = reinterpret_cast<T>(WrapperManager::GetInstance()->Get(VK_HANDLE_TO_UINT64(handle)));
     if (wrapper == nullptr)
@@ -110,61 +110,61 @@ T getWrapperPointerFromHandle(typename std::remove_pointer<T>::type::HandleType 
 }
 
 template <>
-inline InstanceWrapper* getWrapperPointerFromHandle<InstanceWrapper*>(VkInstance handle)
+inline InstanceWrapper* GetWrapperPointerFromHandle<InstanceWrapper*>(VkInstance handle)
 {
     return reinterpret_cast<InstanceWrapper*>(handle);
 }
 
 template <>
-inline const InstanceWrapper* getWrapperPointerFromHandle<const InstanceWrapper*>(VkInstance handle)
+inline const InstanceWrapper* GetWrapperPointerFromHandle<const InstanceWrapper*>(VkInstance handle)
 {
     return reinterpret_cast<const InstanceWrapper*>(handle);
 }
 
 template <>
-inline PhysicalDeviceWrapper* getWrapperPointerFromHandle<PhysicalDeviceWrapper*>(VkPhysicalDevice handle)
+inline PhysicalDeviceWrapper* GetWrapperPointerFromHandle<PhysicalDeviceWrapper*>(VkPhysicalDevice handle)
 {
     return reinterpret_cast<PhysicalDeviceWrapper*>(handle);
 }
 
 template <>
-inline const PhysicalDeviceWrapper* getWrapperPointerFromHandle<const PhysicalDeviceWrapper*>(VkPhysicalDevice handle)
+inline const PhysicalDeviceWrapper* GetWrapperPointerFromHandle<const PhysicalDeviceWrapper*>(VkPhysicalDevice handle)
 {
     return reinterpret_cast<const PhysicalDeviceWrapper*>(handle);
 }
 
 template <>
-inline DeviceWrapper* getWrapperPointerFromHandle<DeviceWrapper*>(VkDevice handle)
+inline DeviceWrapper* GetWrapperPointerFromHandle<DeviceWrapper*>(VkDevice handle)
 {
     return reinterpret_cast<DeviceWrapper*>(handle);
 }
 
 template <>
-inline const DeviceWrapper* getWrapperPointerFromHandle<const DeviceWrapper*>(VkDevice handle)
+inline const DeviceWrapper* GetWrapperPointerFromHandle<const DeviceWrapper*>(VkDevice handle)
 {
     return reinterpret_cast<const DeviceWrapper*>(handle);
 }
 
 template <>
-inline QueueWrapper* getWrapperPointerFromHandle<QueueWrapper*>(VkQueue handle)
+inline QueueWrapper* GetWrapperPointerFromHandle<QueueWrapper*>(VkQueue handle)
 {
     return reinterpret_cast<QueueWrapper*>(handle);
 }
 
 template <>
-inline const QueueWrapper* getWrapperPointerFromHandle<const QueueWrapper*>(VkQueue handle)
+inline const QueueWrapper* GetWrapperPointerFromHandle<const QueueWrapper*>(VkQueue handle)
 {
     return reinterpret_cast<const QueueWrapper*>(handle);
 }
 
 template <>
-inline CommandBufferWrapper* getWrapperPointerFromHandle<CommandBufferWrapper*>(VkCommandBuffer handle)
+inline CommandBufferWrapper* GetWrapperPointerFromHandle<CommandBufferWrapper*>(VkCommandBuffer handle)
 {
     return reinterpret_cast<CommandBufferWrapper*>(handle);
 }
 
 template <>
-inline const CommandBufferWrapper* getWrapperPointerFromHandle<const CommandBufferWrapper*>(VkCommandBuffer handle)
+inline const CommandBufferWrapper* GetWrapperPointerFromHandle<const CommandBufferWrapper*>(VkCommandBuffer handle)
 {
     return reinterpret_cast<const CommandBufferWrapper*>(handle);
 }
@@ -289,14 +289,14 @@ uint64_t GetWrappedId(uint64_t object, VkDebugReportObjectTypeEXT object_type);
 inline const InstanceTable* GetInstanceTable(VkInstance handle)
 {
     assert(handle != VK_NULL_HANDLE);
-    auto wrapper = getWrapperPointerFromHandle<const InstanceWrapper*>(handle);
+    auto wrapper = GetWrapperPointerFromHandle<const InstanceWrapper*>(handle);
     return &wrapper->layer_table;
 }
 
 inline const InstanceTable* GetInstanceTable(VkPhysicalDevice handle)
 {
     assert(handle != VK_NULL_HANDLE);
-    auto wrapper = getWrapperPointerFromHandle<const PhysicalDeviceWrapper*>(handle);
+    auto wrapper = GetWrapperPointerFromHandle<const PhysicalDeviceWrapper*>(handle);
     assert(wrapper->layer_table_ref != nullptr);
     return wrapper->layer_table_ref;
 }
@@ -304,14 +304,14 @@ inline const InstanceTable* GetInstanceTable(VkPhysicalDevice handle)
 inline const DeviceTable* GetDeviceTable(VkDevice handle)
 {
     assert(handle != VK_NULL_HANDLE);
-    auto wrapper = getWrapperPointerFromHandle<const DeviceWrapper*>(handle);
+    auto wrapper = GetWrapperPointerFromHandle<const DeviceWrapper*>(handle);
     return &wrapper->layer_table;
 }
 
 inline const DeviceTable* GetDeviceTable(VkQueue handle)
 {
     assert(handle != VK_NULL_HANDLE);
-    auto wrapper = getWrapperPointerFromHandle<const QueueWrapper*>(handle);
+    auto wrapper = GetWrapperPointerFromHandle<const QueueWrapper*>(handle);
     assert(wrapper->layer_table_ref != nullptr);
     return wrapper->layer_table_ref;
 }
@@ -319,7 +319,7 @@ inline const DeviceTable* GetDeviceTable(VkQueue handle)
 inline const DeviceTable* GetDeviceTable(VkCommandBuffer handle)
 {
     assert(handle != VK_NULL_HANDLE);
-    auto wrapper = getWrapperPointerFromHandle<const CommandBufferWrapper*>(handle);
+    auto wrapper = GetWrapperPointerFromHandle<const CommandBufferWrapper*>(handle);
     assert(wrapper->layer_table_ref != nullptr);
     return wrapper->layer_table_ref;
 }
@@ -400,7 +400,7 @@ inline void CreateWrappedHandle<InstanceWrapper, NoParentWrapper, PhysicalDevice
     assert(parent != VK_NULL_HANDLE);
     assert(handle != nullptr);
 
-    auto parent_wrapper = getWrapperPointerFromHandle<InstanceWrapper*>(parent);
+    auto parent_wrapper = GetWrapperPointerFromHandle<InstanceWrapper*>(parent);
 
     // Filter duplicate physical device retrieval.
     PhysicalDeviceWrapper* wrapper = nullptr;
@@ -421,7 +421,7 @@ inline void CreateWrappedHandle<InstanceWrapper, NoParentWrapper, PhysicalDevice
     {
         CreateWrappedDispatchHandle<InstanceWrapper, PhysicalDeviceWrapper>(parent, handle, get_id);
 
-        wrapper                  = getWrapperPointerFromHandle<PhysicalDeviceWrapper*>(*handle);
+        wrapper                  = GetWrapperPointerFromHandle<PhysicalDeviceWrapper*>(*handle);
         wrapper->layer_table_ref = &parent_wrapper->layer_table;
         parent_wrapper->child_physical_devices.push_back(wrapper);
     }
@@ -447,7 +447,7 @@ inline void CreateWrappedHandle<DeviceWrapper, NoParentWrapper, QueueWrapper>(
     assert(parent != VK_NULL_HANDLE);
     assert(handle != nullptr);
 
-    auto parent_wrapper = getWrapperPointerFromHandle<DeviceWrapper*>(parent);
+    auto parent_wrapper = GetWrapperPointerFromHandle<DeviceWrapper*>(parent);
 
     // Filter duplicate physical device retrieval.
     QueueWrapper* wrapper = nullptr;
@@ -468,7 +468,7 @@ inline void CreateWrappedHandle<DeviceWrapper, NoParentWrapper, QueueWrapper>(
     {
         CreateWrappedDispatchHandle<DeviceWrapper, QueueWrapper>(parent, handle, get_id);
 
-        wrapper                  = getWrapperPointerFromHandle<QueueWrapper*>(*handle);
+        wrapper                  = GetWrapperPointerFromHandle<QueueWrapper*>(*handle);
         wrapper->layer_table_ref = &parent_wrapper->layer_table;
         parent_wrapper->child_queues.push_back(wrapper);
     }
@@ -487,10 +487,10 @@ inline void CreateWrappedHandle<DeviceWrapper, CommandPoolWrapper, CommandBuffer
 
     // The command pool must keep track of allocated command buffers, whose wrappers will need to be destroyed when the
     // pool is destroyed.
-    auto parent_wrapper    = getWrapperPointerFromHandle<DeviceWrapper*>(parent);
-    auto co_parent_wrapper = getWrapperPointerFromHandle<CommandPoolWrapper*>(co_parent);
+    auto parent_wrapper    = GetWrapperPointerFromHandle<DeviceWrapper*>(parent);
+    auto co_parent_wrapper = GetWrapperPointerFromHandle<CommandPoolWrapper*>(co_parent);
 
-    auto wrapper = getWrapperPointerFromHandle<CommandBufferWrapper*>(*handle);
+    auto wrapper = GetWrapperPointerFromHandle<CommandBufferWrapper*>(*handle);
 
     wrapper->layer_table_ref = &parent_wrapper->layer_table;
     wrapper->parent_pool     = co_parent_wrapper;
@@ -511,9 +511,9 @@ inline void CreateWrappedHandle<DeviceWrapper, DescriptorPoolWrapper, Descriptor
 
     // The descriptor pool must keep track of allocated command buffers, whose wrappers will need to be destroyed when
     // the pool is destroyed.
-    auto parent_wrapper = getWrapperPointerFromHandle<DescriptorPoolWrapper*>(co_parent);
+    auto parent_wrapper = GetWrapperPointerFromHandle<DescriptorPoolWrapper*>(co_parent);
 
-    auto wrapper = getWrapperPointerFromHandle<DescriptorSetWrapper*>(*handle);
+    auto wrapper = GetWrapperPointerFromHandle<DescriptorSetWrapper*>(*handle);
 
     parent_wrapper->child_sets.insert(std::make_pair(wrapper->handle_id, wrapper));
     wrapper->parent_pool = parent_wrapper;
@@ -535,7 +535,7 @@ inline void CreateWrappedHandle<PhysicalDeviceWrapper, NoParentWrapper, DisplayK
     if ((*handle) != VK_NULL_HANDLE)
     {
         assert(parent != VK_NULL_HANDLE);
-        auto parent_wrapper = getWrapperPointerFromHandle<PhysicalDeviceWrapper*>(parent);
+        auto parent_wrapper = GetWrapperPointerFromHandle<PhysicalDeviceWrapper*>(parent);
 
         // Filter duplicate display retrieval.
         DisplayKHRWrapper* wrapper = nullptr;
@@ -555,7 +555,7 @@ inline void CreateWrappedHandle<PhysicalDeviceWrapper, NoParentWrapper, DisplayK
         else
         {
             CreateWrappedNonDispatchHandle<DisplayKHRWrapper>(handle, get_id);
-            parent_wrapper->child_displays.push_back(getWrapperPointerFromHandle<DisplayKHRWrapper*>(*handle));
+            parent_wrapper->child_displays.push_back(GetWrapperPointerFromHandle<DisplayKHRWrapper*>(*handle));
         }
     }
 }
@@ -572,7 +572,7 @@ CreateWrappedHandle<DeviceWrapper, SwapchainKHRWrapper, ImageWrapper>(VkDevice, 
     assert(co_parent != VK_NULL_HANDLE);
     assert(handle != nullptr);
 
-    auto parent_wrapper = getWrapperPointerFromHandle<SwapchainKHRWrapper*>(co_parent);
+    auto parent_wrapper = GetWrapperPointerFromHandle<SwapchainKHRWrapper*>(co_parent);
 
     // Filter duplicate display retrieval.
     ImageWrapper* wrapper = nullptr;
@@ -592,7 +592,7 @@ CreateWrappedHandle<DeviceWrapper, SwapchainKHRWrapper, ImageWrapper>(VkDevice, 
     else
     {
         CreateWrappedNonDispatchHandle<ImageWrapper>(handle, get_id);
-        auto image_wrapper                = getWrapperPointerFromHandle<ImageWrapper*>(*handle);
+        auto image_wrapper                = GetWrapperPointerFromHandle<ImageWrapper*>(*handle);
         image_wrapper->is_swapchain_image = true;
         parent_wrapper->child_images.push_back(image_wrapper);
     }
@@ -610,7 +610,7 @@ inline void CreateWrappedHandle<PhysicalDeviceWrapper, DisplayKHRWrapper, Displa
     assert(co_parent != VK_NULL_HANDLE);
     assert(handle != nullptr);
 
-    auto parent_wrapper = getWrapperPointerFromHandle<DisplayKHRWrapper*>(co_parent);
+    auto parent_wrapper = GetWrapperPointerFromHandle<DisplayKHRWrapper*>(co_parent);
 
     // Display modes can either be retrieved or created; filter duplicate display mode retrieval.
     DisplayModeKHRWrapper* wrapper = nullptr;
@@ -630,7 +630,7 @@ inline void CreateWrappedHandle<PhysicalDeviceWrapper, DisplayKHRWrapper, Displa
     else
     {
         CreateWrappedNonDispatchHandle<DisplayModeKHRWrapper>(handle, get_id);
-        parent_wrapper->child_display_modes.push_back(getWrapperPointerFromHandle<DisplayModeKHRWrapper*>(*handle));
+        parent_wrapper->child_display_modes.push_back(GetWrapperPointerFromHandle<DisplayModeKHRWrapper*>(*handle));
     }
 }
 
@@ -658,7 +658,7 @@ void DestroyWrappedHandle(typename Wrapper::HandleType handle)
     // and VkCommandBuffer.
     if (handle != VK_NULL_HANDLE)
     {
-        Wrapper* wrapper = getWrapperPointerFromHandle<Wrapper*>(handle);
+        Wrapper* wrapper = GetWrapperPointerFromHandle<Wrapper*>(handle);
         if (wrapper != nullptr)
         {
             WrapperManager::GetInstance()->Remove(VK_HANDLE_TO_UINT64(handle));
@@ -679,7 +679,7 @@ inline void DestroyWrappedHandle<InstanceWrapper>(VkInstance handle)
     if (handle != VK_NULL_HANDLE)
     {
         // Destroy child wrappers.
-        auto wrapper = getWrapperPointerFromHandle<InstanceWrapper*>(handle);
+        auto wrapper = GetWrapperPointerFromHandle<InstanceWrapper*>(handle);
 
         for (auto physical_device_wrapper : wrapper->child_physical_devices)
         {
@@ -707,7 +707,7 @@ inline void DestroyWrappedHandle<DeviceWrapper>(VkDevice handle)
     if (handle != VK_NULL_HANDLE)
     {
         // Destroy child wrappers.
-        auto wrapper = getWrapperPointerFromHandle<DeviceWrapper*>(handle);
+        auto wrapper = GetWrapperPointerFromHandle<DeviceWrapper*>(handle);
 
         for (auto queue_wrapper : wrapper->child_queues)
         {
@@ -725,7 +725,7 @@ inline void DestroyWrappedHandle<CommandBufferWrapper>(VkCommandBuffer handle)
     if (handle != VK_NULL_HANDLE)
     {
         // Remove from parent list.
-        auto wrapper = getWrapperPointerFromHandle<CommandBufferWrapper*>(handle);
+        auto wrapper = GetWrapperPointerFromHandle<CommandBufferWrapper*>(handle);
         wrapper->parent_pool->child_buffers.erase(wrapper->handle_id);
         WrapperManager::GetInstance()->Remove(static_cast<uint64_t>(wrapper->handle_id));
         delete wrapper;
@@ -738,7 +738,7 @@ inline void DestroyWrappedHandle<CommandPoolWrapper>(VkCommandPool handle)
     if (handle != VK_NULL_HANDLE)
     {
         // Destroy child wrappers.
-        auto wrapper = getWrapperPointerFromHandle<CommandPoolWrapper*>(handle);
+        auto wrapper = GetWrapperPointerFromHandle<CommandPoolWrapper*>(handle);
         if (wrapper != nullptr)
         {
             for (const auto& buffer_wrapper : wrapper->child_buffers)
@@ -764,7 +764,7 @@ inline void DestroyWrappedHandle<DescriptorSetWrapper>(VkDescriptorSet handle)
     if (handle != VK_NULL_HANDLE)
     {
         // Remove from parent list.
-        auto wrapper = getWrapperPointerFromHandle<DescriptorSetWrapper*>(handle);
+        auto wrapper = GetWrapperPointerFromHandle<DescriptorSetWrapper*>(handle);
         if (wrapper != nullptr)
         {
             wrapper->parent_pool->child_sets.erase(wrapper->handle_id);
@@ -786,7 +786,7 @@ inline void DestroyWrappedHandle<DescriptorPoolWrapper>(VkDescriptorPool handle)
     if (handle != VK_NULL_HANDLE)
     {
         // Destroy child wrappers.
-        auto wrapper = getWrapperPointerFromHandle<DescriptorPoolWrapper*>(handle);
+        auto wrapper = GetWrapperPointerFromHandle<DescriptorPoolWrapper*>(handle);
         if (wrapper != nullptr)
         {
             for (const auto& set_wrapper : wrapper->child_sets)
@@ -812,7 +812,7 @@ inline void DestroyWrappedHandle<SwapchainKHRWrapper>(VkSwapchainKHR handle)
     if (handle != VK_NULL_HANDLE)
     {
         // Destroy child wrappers.
-        auto wrapper = getWrapperPointerFromHandle<SwapchainKHRWrapper*>(handle);
+        auto wrapper = GetWrapperPointerFromHandle<SwapchainKHRWrapper*>(handle);
         if (wrapper != nullptr)
         {
             for (auto image_wrapper : wrapper->child_images)
@@ -849,7 +849,7 @@ inline void ResetDescriptorPoolWrapper(VkDescriptorPool handle)
     assert(handle != VK_NULL_HANDLE);
 
     // Destroy child wrappers.
-    auto wrapper = getWrapperPointerFromHandle<DescriptorPoolWrapper*>(handle);
+    auto wrapper = GetWrapperPointerFromHandle<DescriptorPoolWrapper*>(handle);
     for (const auto& set_wrapper : wrapper->child_sets)
     {
         WrapperManager::GetInstance()->Remove(set_wrapper.second->handle_id);

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -70,7 +70,7 @@ void VulkanStateTracker::TrackResetCommandPool(VkCommandPool command_pool)
 {
     assert(command_pool != VK_NULL_HANDLE);
 
-    auto wrapper = getWrapperPointerFromHandle<CommandPoolWrapper*>(command_pool);
+    auto wrapper = GetWrapperPointerFromHandle<CommandPoolWrapper*>(command_pool);
 
     for (const auto& entry : wrapper->child_buffers)
     {
@@ -90,7 +90,7 @@ void VulkanStateTracker::TrackPhysicalDeviceMemoryProperties(VkPhysicalDevice   
 {
     assert((physical_device != VK_NULL_HANDLE) && (properties != nullptr));
 
-    auto wrapper = getWrapperPointerFromHandle<PhysicalDeviceWrapper*>(physical_device);
+    auto wrapper = GetWrapperPointerFromHandle<PhysicalDeviceWrapper*>(physical_device);
 
     wrapper->memory_properties = *properties;
 }
@@ -101,7 +101,7 @@ void VulkanStateTracker::TrackPhysicalDeviceQueueFamilyProperties(VkPhysicalDevi
 {
     assert((physical_device != VK_NULL_HANDLE) && (properties != nullptr));
 
-    auto wrapper                             = getWrapperPointerFromHandle<PhysicalDeviceWrapper*>(physical_device);
+    auto wrapper                             = GetWrapperPointerFromHandle<PhysicalDeviceWrapper*>(physical_device);
     wrapper->queue_family_properties_call_id = format::ApiCallId::ApiCall_vkGetPhysicalDeviceQueueFamilyProperties;
     wrapper->queue_family_properties_count   = property_count;
     wrapper->queue_family_properties         = std::make_unique<VkQueueFamilyProperties[]>(property_count);
@@ -115,7 +115,7 @@ void VulkanStateTracker::TrackPhysicalDeviceQueueFamilyProperties2(format::ApiCa
 {
     assert((physical_device != VK_NULL_HANDLE) && (properties != nullptr));
 
-    auto wrapper                             = getWrapperPointerFromHandle<PhysicalDeviceWrapper*>(physical_device);
+    auto wrapper                             = GetWrapperPointerFromHandle<PhysicalDeviceWrapper*>(physical_device);
     wrapper->queue_family_properties_call_id = call_id;
     wrapper->queue_family_properties_count   = property_count;
     wrapper->queue_family_properties2        = std::make_unique<VkQueueFamilyProperties2[]>(property_count);
@@ -162,7 +162,7 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfaceSupport(VkPhysicalDevice phys
 {
     assert((physical_device != VK_NULL_HANDLE) && (surface != VK_NULL_HANDLE));
 
-    auto  wrapper             = getWrapperPointerFromHandle<SurfaceKHRWrapper*>(surface);
+    auto  wrapper             = GetWrapperPointerFromHandle<SurfaceKHRWrapper*>(surface);
     auto& entry               = wrapper->surface_support[GetWrappedId(physical_device)];
     entry[queue_family_index] = supported;
 }
@@ -175,7 +175,7 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfaceCapabilities(VkPhysicalDevice
 {
     assert((physical_device != VK_NULL_HANDLE) && (surface != VK_NULL_HANDLE));
 
-    auto  wrapper      = getWrapperPointerFromHandle<SurfaceKHRWrapper*>(surface);
+    auto  wrapper      = GetWrapperPointerFromHandle<SurfaceKHRWrapper*>(surface);
     auto& entry        = wrapper->surface_capabilities[GetWrappedId(physical_device)];
     entry.capabilities = capabilities;
 
@@ -201,7 +201,7 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfaceFormats(VkPhysicalDevice     
 {
     assert((physical_device != VK_NULL_HANDLE) && (surface != VK_NULL_HANDLE) && (formats != nullptr));
 
-    auto  wrapper = getWrapperPointerFromHandle<SurfaceKHRWrapper*>(surface);
+    auto  wrapper = GetWrapperPointerFromHandle<SurfaceKHRWrapper*>(surface);
     auto& entry   = wrapper->surface_formats[GetWrappedId(physical_device)];
     entry.assign(formats, formats + format_count);
 }
@@ -214,7 +214,7 @@ void VulkanStateTracker::TrackPhysicalDeviceSurfacePresentModes(VkPhysicalDevice
 {
     assert((physical_device != VK_NULL_HANDLE) && (surface != VK_NULL_HANDLE) && (modes != nullptr));
 
-    auto  wrapper = getWrapperPointerFromHandle<SurfaceKHRWrapper*>(surface);
+    auto  wrapper = GetWrapperPointerFromHandle<SurfaceKHRWrapper*>(surface);
     auto& entry   = wrapper->surface_present_modes[GetWrappedId(physical_device)];
     entry.present_modes.assign(modes, modes + mode_count);
 
@@ -233,7 +233,7 @@ void VulkanStateTracker::TrackDeviceGroupSurfacePresentModes(VkDevice           
 {
     assert((device != VK_NULL_HANDLE) && (surface != VK_NULL_HANDLE) && (pModes != nullptr));
 
-    auto  wrapper       = getWrapperPointerFromHandle<SurfaceKHRWrapper*>(surface);
+    auto  wrapper       = GetWrapperPointerFromHandle<SurfaceKHRWrapper*>(surface);
     auto& entry         = wrapper->group_surface_present_modes[GetWrappedId(device)];
     entry.present_modes = *pModes;
 
@@ -249,7 +249,7 @@ void VulkanStateTracker::TrackBufferDeviceAddress(VkDevice device, VkBuffer buff
 {
     assert((device != VK_NULL_HANDLE) && (buffer != VK_NULL_HANDLE));
 
-    auto wrapper       = getWrapperPointerFromHandle<BufferWrapper*>(buffer);
+    auto wrapper       = GetWrapperPointerFromHandle<BufferWrapper*>(buffer);
     wrapper->device_id = GetWrappedId(device);
     wrapper->address   = address;
 }
@@ -259,8 +259,8 @@ void VulkanStateTracker::TrackBufferMemoryBinding(
 {
     assert((device != VK_NULL_HANDLE) && (buffer != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
 
-    auto wrapper            = getWrapperPointerFromHandle<BufferWrapper*>(buffer);
-    wrapper->bind_device    = getWrapperPointerFromHandle<DeviceWrapper*>(device);
+    auto wrapper            = GetWrapperPointerFromHandle<BufferWrapper*>(buffer);
+    wrapper->bind_device    = GetWrapperPointerFromHandle<DeviceWrapper*>(device);
     wrapper->bind_memory_id = GetWrappedId(memory);
     wrapper->bind_offset    = memoryOffset;
     wrapper->bind_pnext     = nullptr;
@@ -278,8 +278,8 @@ void VulkanStateTracker::TrackImageMemoryBinding(
     // If VkBindImageMemorySwapchainInfoKHR is in pnext, memory must be VK_NULL_HANDLE.
     assert((device != VK_NULL_HANDLE) && (image != VK_NULL_HANDLE));
 
-    auto wrapper            = getWrapperPointerFromHandle<ImageWrapper*>(image);
-    wrapper->bind_device    = getWrapperPointerFromHandle<DeviceWrapper*>(device);
+    auto wrapper            = GetWrapperPointerFromHandle<ImageWrapper*>(image);
+    wrapper->bind_device    = GetWrapperPointerFromHandle<DeviceWrapper*>(device);
     wrapper->bind_memory_id = GetWrappedId(memory);
     wrapper->bind_offset    = memoryOffset;
     wrapper->bind_pnext     = nullptr;
@@ -300,8 +300,8 @@ void VulkanStateTracker::TrackMappedMemory(VkDevice         device,
 {
     assert((device != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
 
-    auto wrapper           = getWrapperPointerFromHandle<DeviceMemoryWrapper*>(memory);
-    wrapper->map_device    = getWrapperPointerFromHandle<DeviceWrapper*>(device);
+    auto wrapper           = GetWrapperPointerFromHandle<DeviceMemoryWrapper*>(memory);
+    wrapper->map_device    = GetWrapperPointerFromHandle<DeviceWrapper*>(device);
     wrapper->mapped_data   = mapped_data;
     wrapper->mapped_offset = mapped_offset;
     wrapper->mapped_size   = mapped_size;
@@ -312,16 +312,16 @@ void VulkanStateTracker::TrackBeginRenderPass(VkCommandBuffer command_buffer, co
 {
     assert((command_buffer != VK_NULL_HANDLE) && (begin_info != nullptr));
 
-    auto wrapper                     = getWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
-    wrapper->active_render_pass      = getWrapperPointerFromHandle<RenderPassWrapper*>(begin_info->renderPass);
-    wrapper->render_pass_framebuffer = getWrapperPointerFromHandle<FramebufferWrapper*>(begin_info->framebuffer);
+    auto wrapper                     = GetWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
+    wrapper->active_render_pass      = GetWrapperPointerFromHandle<RenderPassWrapper*>(begin_info->renderPass);
+    wrapper->render_pass_framebuffer = GetWrapperPointerFromHandle<FramebufferWrapper*>(begin_info->framebuffer);
 }
 
 void VulkanStateTracker::TrackEndRenderPass(VkCommandBuffer command_buffer)
 {
     assert(command_buffer != VK_NULL_HANDLE);
 
-    auto wrapper = getWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
+    auto wrapper = GetWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
     assert((wrapper->active_render_pass != VK_NULL_HANDLE) && (wrapper->render_pass_framebuffer != VK_NULL_HANDLE));
 
     auto render_pass_wrapper = wrapper->active_render_pass;
@@ -348,11 +348,11 @@ void VulkanStateTracker::TrackExecuteCommands(VkCommandBuffer        command_buf
 {
     assert((command_buffer != VK_NULL_HANDLE) && (command_buffers != nullptr));
 
-    auto primary_wrapper = getWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
+    auto primary_wrapper = GetWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
 
     for (uint32_t i = 0; i < command_buffer_count; ++i)
     {
-        auto secondary_wrapper = getWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffers[i]);
+        auto secondary_wrapper = GetWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffers[i]);
         assert(secondary_wrapper != nullptr);
 
         for (const auto& layout_entry : secondary_wrapper->pending_layouts)
@@ -388,11 +388,11 @@ void VulkanStateTracker::TrackImageBarriers(VkCommandBuffer             command_
 
     if ((image_barrier_count > 0) && (image_barriers != nullptr))
     {
-        auto wrapper = getWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
+        auto wrapper = GetWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
 
         for (uint32_t i = 0; i < image_barrier_count; ++i)
         {
-            auto image_wrapper = getWrapperPointerFromHandle<ImageWrapper*>(image_barriers[i].image);
+            auto image_wrapper = GetWrapperPointerFromHandle<ImageWrapper*>(image_barriers[i].image);
             wrapper->pending_layouts[image_wrapper] = image_barriers[i].newLayout;
         }
     }
@@ -406,11 +406,11 @@ void VulkanStateTracker::TrackImageBarriers2KHR(VkCommandBuffer                 
 
     if ((image_barrier_count > 0) && (image_barriers != nullptr))
     {
-        auto wrapper = getWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
+        auto wrapper = GetWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
 
         for (uint32_t i = 0; i < image_barrier_count; ++i)
         {
-            auto image_wrapper = getWrapperPointerFromHandle<ImageWrapper*>(image_barriers[i].image);
+            auto image_wrapper = GetWrapperPointerFromHandle<ImageWrapper*>(image_barriers[i].image);
             wrapper->pending_layouts[image_wrapper] = image_barriers[i].newLayout;
         }
     }
@@ -427,7 +427,7 @@ void VulkanStateTracker::TrackCommandBufferSubmissions(uint32_t submit_count, co
 
             for (uint32_t cmd = 0; cmd < command_buffer_count; ++cmd)
             {
-                auto command_wrapper = getWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffers[cmd]);
+                auto command_wrapper = GetWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffers[cmd]);
                 assert(command_wrapper != nullptr);
 
                 // Apply pending image layouts.
@@ -476,7 +476,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
         for (uint32_t i = 0; i < write_count; ++i)
         {
             const VkWriteDescriptorSet* write   = &writes[i];
-            auto                        wrapper = getWrapperPointerFromHandle<DescriptorSetWrapper*>(write->dstSet);
+            auto                        wrapper = GetWrapperPointerFromHandle<DescriptorSetWrapper*>(write->dstSet);
             assert(wrapper != nullptr);
 
             // Descriptor update rules specify that a write descriptorCount that is greater than the binding's count
@@ -642,8 +642,8 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
         for (uint32_t i = 0; i < copy_count; ++i)
         {
             auto copy        = &copies[i];
-            auto dst_wrapper = getWrapperPointerFromHandle<DescriptorSetWrapper*>(copy->dstSet);
-            auto src_wrapper = getWrapperPointerFromHandle<DescriptorSetWrapper*>(copy->srcSet);
+            auto dst_wrapper = GetWrapperPointerFromHandle<DescriptorSetWrapper*>(copy->dstSet);
+            auto src_wrapper = GetWrapperPointerFromHandle<DescriptorSetWrapper*>(copy->srcSet);
             assert((dst_wrapper != nullptr) && (src_wrapper != nullptr));
 
             // Descriptor update rules specify that a write descriptorCount that is greater than the binding's count
@@ -756,7 +756,7 @@ void VulkanStateTracker::TrackUpdateDescriptorSetWithTemplate(VkDescriptorSet   
     // exists at state write time by checking for the ID in the active state table.
     if ((template_info != nullptr) && (data != nullptr))
     {
-        auto           wrapper = getWrapperPointerFromHandle<DescriptorSetWrapper*>(set);
+        auto           wrapper = GetWrapperPointerFromHandle<DescriptorSetWrapper*>(set);
         const uint8_t* bytes   = reinterpret_cast<const uint8_t*>(data);
 
         for (const auto& entry : template_info->image_info)
@@ -972,7 +972,7 @@ void VulkanStateTracker::TrackResetDescriptorPool(VkDescriptorPool descriptor_po
 {
     assert(descriptor_pool != VK_NULL_HANDLE);
 
-    auto wrapper = getWrapperPointerFromHandle<DescriptorPoolWrapper*>(descriptor_pool);
+    auto wrapper = GetWrapperPointerFromHandle<DescriptorPoolWrapper*>(descriptor_pool);
 
     // Pool reset implicitly frees descriptor sets, so remove all wrappers from the state tracker.
     std::unique_lock<std::mutex> lock(state_table_mutex_);
@@ -987,10 +987,10 @@ void VulkanStateTracker::TrackQueryActivation(
 {
     assert((command_buffer != VK_NULL_HANDLE) && (query_pool != VK_NULL_HANDLE));
 
-    auto                      wrapper              = getWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
+    auto                      wrapper              = GetWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
     const CommandPoolWrapper* command_pool_wrapper = wrapper->parent_pool;
 
-    auto& query_pool_info       = wrapper->recorded_queries[getWrapperPointerFromHandle<QueryPoolWrapper*>(query_pool)];
+    auto& query_pool_info       = wrapper->recorded_queries[GetWrapperPointerFromHandle<QueryPoolWrapper*>(query_pool)];
     auto& query_info            = query_pool_info[query];
     query_info.active           = true;
     query_info.flags            = flags;
@@ -1005,8 +1005,8 @@ void VulkanStateTracker::TrackQueryReset(VkCommandBuffer command_buffer,
 {
     assert((command_buffer != VK_NULL_HANDLE) && (query_pool != VK_NULL_HANDLE));
 
-    auto  wrapper         = getWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
-    auto& query_pool_info = wrapper->recorded_queries[getWrapperPointerFromHandle<QueryPoolWrapper*>(query_pool)];
+    auto  wrapper         = GetWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
+    auto& query_pool_info = wrapper->recorded_queries[GetWrapperPointerFromHandle<QueryPoolWrapper*>(query_pool)];
 
     for (uint32_t i = first_query; i < query_count; ++i)
     {
@@ -1018,7 +1018,7 @@ void VulkanStateTracker::TrackQueryReset(VkQueryPool query_pool, uint32_t first_
 {
     assert(query_pool != VK_NULL_HANDLE);
 
-    auto wrapper = getWrapperPointerFromHandle<QueryPoolWrapper*>(query_pool);
+    auto wrapper = GetWrapperPointerFromHandle<QueryPoolWrapper*>(query_pool);
     assert((first_query + query_count) <= wrapper->pending_queries.size());
 
     for (uint32_t i = first_query; i < query_count; ++i)
@@ -1031,7 +1031,7 @@ void VulkanStateTracker::TrackSemaphoreSignalState(VkSemaphore signal)
 {
     if (signal != VK_NULL_HANDLE)
     {
-        auto wrapper = getWrapperPointerFromHandle<SemaphoreWrapper*>(signal);
+        auto wrapper = GetWrapperPointerFromHandle<SemaphoreWrapper*>(signal);
         assert(wrapper != nullptr);
         wrapper->signaled = true;
     }
@@ -1048,7 +1048,7 @@ void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t           wait_count
         {
             for (uint32_t i = 0; i < wait_count; ++i)
             {
-                auto wrapper = getWrapperPointerFromHandle<SemaphoreWrapper*>(waits[i]);
+                auto wrapper = GetWrapperPointerFromHandle<SemaphoreWrapper*>(waits[i]);
                 assert(wrapper != nullptr);
                 wrapper->signaled = false;
             }
@@ -1058,7 +1058,7 @@ void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t           wait_count
         {
             for (uint32_t i = 0; i < signal_count; ++i)
             {
-                auto wrapper = getWrapperPointerFromHandle<SemaphoreWrapper*>(signals[i]);
+                auto wrapper = GetWrapperPointerFromHandle<SemaphoreWrapper*>(signals[i]);
                 assert(wrapper != nullptr);
                 wrapper->signaled = true;
             }
@@ -1069,7 +1069,7 @@ void VulkanStateTracker::TrackSemaphoreSignalState(uint32_t           wait_count
 void VulkanStateTracker::TrackAcquireImage(
     uint32_t image_index, VkSwapchainKHR swapchain, VkSemaphore semaphore, VkFence fence, uint32_t deviceMask)
 {
-    auto wrapper = getWrapperPointerFromHandle<SwapchainKHRWrapper*>(swapchain);
+    auto wrapper = GetWrapperPointerFromHandle<SwapchainKHRWrapper*>(swapchain);
 
     assert((wrapper != nullptr) && (image_index < wrapper->image_acquired_info.size()));
 
@@ -1088,7 +1088,7 @@ void VulkanStateTracker::TrackPresentedImages(uint32_t              count,
 
     for (uint32_t i = 0; i < count; ++i)
     {
-        auto     wrapper     = getWrapperPointerFromHandle<SwapchainKHRWrapper*>(swapchains[i]);
+        auto     wrapper     = GetWrapperPointerFromHandle<SwapchainKHRWrapper*>(swapchains[i]);
         uint32_t image_index = image_indices[i];
 
         assert((wrapper != nullptr) && (image_index < wrapper->image_acquired_info.size()));
@@ -1105,7 +1105,7 @@ void VulkanStateTracker::TrackAccelerationStructureKHRDeviceAddress(VkDevice    
 {
     assert((device != VK_NULL_HANDLE) && (accel_struct != VK_NULL_HANDLE));
 
-    auto wrapper       = getWrapperPointerFromHandle<AccelerationStructureKHRWrapper*>(accel_struct);
+    auto wrapper       = GetWrapperPointerFromHandle<AccelerationStructureKHRWrapper*>(accel_struct);
     wrapper->device_id = GetWrappedId(device);
     wrapper->address   = address;
 }
@@ -1114,7 +1114,7 @@ void VulkanStateTracker::TrackDeviceMemoryDeviceAddress(VkDevice device, VkDevic
 {
     assert((device != VK_NULL_HANDLE) && (memory != VK_NULL_HANDLE));
 
-    auto wrapper       = getWrapperPointerFromHandle<DeviceMemoryWrapper*>(memory);
+    auto wrapper       = GetWrapperPointerFromHandle<DeviceMemoryWrapper*>(memory);
     wrapper->device_id = GetWrappedId(device);
     wrapper->address   = address;
 }
@@ -1126,7 +1126,7 @@ void VulkanStateTracker::TrackRayTracingShaderGroupHandles(VkDevice    device,
 {
     assert((device != VK_NULL_HANDLE) && (pipeline != VK_NULL_HANDLE));
 
-    auto           wrapper   = getWrapperPointerFromHandle<PipelineWrapper*>(pipeline);
+    auto           wrapper   = GetWrapperPointerFromHandle<PipelineWrapper*>(pipeline);
     const uint8_t* byte_data = reinterpret_cast<const uint8_t*>(data);
     wrapper->device_id       = GetWrappedId(device);
     wrapper->shader_group_handle_data.assign(byte_data, byte_data + data_size);
@@ -1136,7 +1136,7 @@ void VulkanStateTracker::TrackAcquireFullScreenExclusiveMode(VkDevice device, Vk
 {
     assert(swapchain != VK_NULL_HANDLE);
 
-    auto wrapper                                = getWrapperPointerFromHandle<SwapchainKHRWrapper*>(swapchain);
+    auto wrapper                                = GetWrapperPointerFromHandle<SwapchainKHRWrapper*>(swapchain);
     wrapper->acquire_full_screen_exclusive_mode = true;
 }
 
@@ -1144,7 +1144,7 @@ void VulkanStateTracker::TrackReleaseFullScreenExclusiveMode(VkDevice device, Vk
 {
     assert(swapchain != VK_NULL_HANDLE);
 
-    auto wrapper                                = getWrapperPointerFromHandle<SwapchainKHRWrapper*>(swapchain);
+    auto wrapper                                = GetWrapperPointerFromHandle<SwapchainKHRWrapper*>(swapchain);
     wrapper->release_full_screen_exclusive_mode = true;
 }
 

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2019-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -73,7 +74,7 @@ class VulkanStateTracker
 
         if (*new_handle != VK_NULL_HANDLE)
         {
-            auto wrapper = reinterpret_cast<Wrapper*>(*new_handle);
+            auto wrapper = getWrapperPointerFromHandle<Wrapper*>(*new_handle);
 
             // Adds the handle wrapper to the object state table, filtering for duplicate handle retrieval.
             std::unique_lock<std::mutex> lock(state_table_mutex_);
@@ -109,7 +110,7 @@ class VulkanStateTracker
         {
             if (new_handles[i] != VK_NULL_HANDLE)
             {
-                auto wrapper = reinterpret_cast<Wrapper*>(new_handles[i]);
+                auto wrapper = getWrapperPointerFromHandle<Wrapper*>(new_handles[i]);
 
                 // Adds the handle wrapper to the object state table, filtering for duplicate handle retrieval.
                 if (state_table_.InsertWrapper(wrapper->handle_id, wrapper))
@@ -203,7 +204,7 @@ class VulkanStateTracker
     {
         if (handle != VK_NULL_HANDLE)
         {
-            auto wrapper = reinterpret_cast<Wrapper*>(handle);
+            auto wrapper = getWrapperPointerFromHandle<Wrapper*>(handle);
 
             // Scope the state table mutex lock because DestroyState also modifies the state table and will attempt to
             // lock the mutex.
@@ -226,7 +227,7 @@ class VulkanStateTracker
     {
         if (command_buffer != VK_NULL_HANDLE)
         {
-            auto wrapper = reinterpret_cast<CommandBufferWrapper*>(command_buffer);
+            auto wrapper = getWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
 
             TrackCommandExecution(wrapper, call_id, parameter_buffer);
         }
@@ -241,7 +242,7 @@ class VulkanStateTracker
     {
         if (command_buffer != VK_NULL_HANDLE)
         {
-            auto wrapper = reinterpret_cast<CommandBufferWrapper*>(command_buffer);
+            auto wrapper = getWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
 
             TrackCommandExecution(wrapper, call_id, parameter_buffer);
             func(wrapper, args...);
@@ -395,7 +396,7 @@ class VulkanStateTracker
         {
             if (new_handles[i] != VK_NULL_HANDLE)
             {
-                auto wrapper = reinterpret_cast<Wrapper*>(new_handles[i]);
+                auto wrapper = getWrapperPointerFromHandle<Wrapper*>(new_handles[i]);
 
                 // Adds the handle wrapper to the object state table, filtering for duplicate handle retrieval.
                 if (state_table_.InsertWrapper(wrapper->handle_id, wrapper))

--- a/framework/encode/vulkan_state_tracker.h
+++ b/framework/encode/vulkan_state_tracker.h
@@ -74,7 +74,7 @@ class VulkanStateTracker
 
         if (*new_handle != VK_NULL_HANDLE)
         {
-            auto wrapper = getWrapperPointerFromHandle<Wrapper*>(*new_handle);
+            auto wrapper = GetWrapperPointerFromHandle<Wrapper*>(*new_handle);
 
             // Adds the handle wrapper to the object state table, filtering for duplicate handle retrieval.
             std::unique_lock<std::mutex> lock(state_table_mutex_);
@@ -110,7 +110,7 @@ class VulkanStateTracker
         {
             if (new_handles[i] != VK_NULL_HANDLE)
             {
-                auto wrapper = getWrapperPointerFromHandle<Wrapper*>(new_handles[i]);
+                auto wrapper = GetWrapperPointerFromHandle<Wrapper*>(new_handles[i]);
 
                 // Adds the handle wrapper to the object state table, filtering for duplicate handle retrieval.
                 if (state_table_.InsertWrapper(wrapper->handle_id, wrapper))
@@ -204,7 +204,7 @@ class VulkanStateTracker
     {
         if (handle != VK_NULL_HANDLE)
         {
-            auto wrapper = getWrapperPointerFromHandle<Wrapper*>(handle);
+            auto wrapper = GetWrapperPointerFromHandle<Wrapper*>(handle);
 
             // Scope the state table mutex lock because DestroyState also modifies the state table and will attempt to
             // lock the mutex.
@@ -227,7 +227,7 @@ class VulkanStateTracker
     {
         if (command_buffer != VK_NULL_HANDLE)
         {
-            auto wrapper = getWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
+            auto wrapper = GetWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
 
             TrackCommandExecution(wrapper, call_id, parameter_buffer);
         }
@@ -242,7 +242,7 @@ class VulkanStateTracker
     {
         if (command_buffer != VK_NULL_HANDLE)
         {
-            auto wrapper = getWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
+            auto wrapper = GetWrapperPointerFromHandle<CommandBufferWrapper*>(command_buffer);
 
             TrackCommandExecution(wrapper, call_id, parameter_buffer);
             func(wrapper, args...);
@@ -396,7 +396,7 @@ class VulkanStateTracker
         {
             if (new_handles[i] != VK_NULL_HANDLE)
             {
-                auto wrapper = getWrapperPointerFromHandle<Wrapper*>(new_handles[i]);
+                auto wrapper = GetWrapperPointerFromHandle<Wrapper*>(new_handles[i]);
 
                 // Adds the handle wrapper to the object state table, filtering for duplicate handle retrieval.
                 if (state_table_.InsertWrapper(wrapper->handle_id, wrapper))

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -1,5 +1,6 @@
 /*
 ** Copyright (c) 2019-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -108,7 +109,7 @@ inline void InitializeState<VkPhysicalDevice, DeviceWrapper, VkDeviceCreateInfo>
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->physical_device = reinterpret_cast<PhysicalDeviceWrapper*>(parent_handle);
+    wrapper->physical_device = getWrapperPointerFromHandle<PhysicalDeviceWrapper*>(parent_handle);
 }
 
 template <>
@@ -134,7 +135,7 @@ inline void InitializeState<VkDevice, PipelineLayoutWrapper, VkPipelineLayoutCre
     {
         assert(create_info->pSetLayouts[i] != VK_NULL_HANDLE);
 
-        auto layout_wrapper = reinterpret_cast<DescriptorSetLayoutWrapper*>(create_info->pSetLayouts[i]);
+        auto layout_wrapper = getWrapperPointerFromHandle<DescriptorSetLayoutWrapper*>(create_info->pSetLayouts[i]);
         CreateDependencyInfo info;
         info.handle_id         = layout_wrapper->handle_id;
         info.create_call_id    = layout_wrapper->create_call_id;
@@ -180,7 +181,7 @@ inline void InitializeState<VkDevice, QueryPoolWrapper, VkQueryPoolCreateInfo>(V
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device      = reinterpret_cast<DeviceWrapper*>(parent_handle);
+    wrapper->device      = getWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
     wrapper->query_type  = create_info->queryType;
     wrapper->query_count = create_info->queryCount;
     wrapper->pending_queries.resize(create_info->queryCount);
@@ -203,7 +204,7 @@ inline void InitializeState<VkDevice, FenceWrapper, VkFenceCreateInfo>(VkDevice 
     wrapper->create_parameters = std::move(create_parameters);
 
     wrapper->created_signaled = ((create_info->flags & VK_FENCE_CREATE_SIGNALED_BIT) == VK_FENCE_CREATE_SIGNALED_BIT);
-    wrapper->device           = reinterpret_cast<DeviceWrapper*>(parent_handle);
+    wrapper->device           = getWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
 }
 
 template <>
@@ -222,7 +223,7 @@ inline void InitializeState<VkDevice, EventWrapper, VkEventCreateInfo>(VkDevice 
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device = reinterpret_cast<DeviceWrapper*>(parent_handle);
+    wrapper->device = getWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
 }
 
 template <>
@@ -241,7 +242,7 @@ inline void InitializeState<VkDevice, SemaphoreWrapper, VkSemaphoreCreateInfo>(V
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device = reinterpret_cast<DeviceWrapper*>(parent_handle);
+    wrapper->device = getWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
 
     auto next = reinterpret_cast<const VkBaseInStructure*>(create_info->pNext);
     while (next)
@@ -272,7 +273,7 @@ InitializeState<VkDevice, FramebufferWrapper, VkFramebufferCreateInfo>(VkDevice 
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto render_pass_wrapper = reinterpret_cast<RenderPassWrapper*>(create_info->renderPass);
+    auto render_pass_wrapper = getWrapperPointerFromHandle<RenderPassWrapper*>(create_info->renderPass);
     assert(render_pass_wrapper != nullptr);
     wrapper->render_pass_id                = render_pass_wrapper->handle_id;
     wrapper->render_pass_create_call_id    = render_pass_wrapper->create_call_id;
@@ -282,7 +283,7 @@ InitializeState<VkDevice, FramebufferWrapper, VkFramebufferCreateInfo>(VkDevice 
     {
         for (uint32_t i = 0; i < create_info->attachmentCount; ++i)
         {
-            auto image_view_wrapper = reinterpret_cast<ImageViewWrapper*>(create_info->pAttachments[i]);
+            auto image_view_wrapper = getWrapperPointerFromHandle<ImageViewWrapper*>(create_info->pAttachments[i]);
             assert(image_view_wrapper != nullptr);
 
             wrapper->image_view_ids.push_back(image_view_wrapper->handle_id);
@@ -366,7 +367,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
 
     for (uint32_t i = 0; i < create_info->stageCount; ++i)
     {
-        auto shader_wrapper = reinterpret_cast<ShaderModuleWrapper*>(create_info->pStages[i].module);
+        auto shader_wrapper = getWrapperPointerFromHandle<ShaderModuleWrapper*>(create_info->pStages[i].module);
         assert(shader_wrapper != nullptr);
 
         CreateDependencyInfo info;
@@ -377,7 +378,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
         wrapper->shader_module_dependencies.emplace_back(std::move(info));
     }
 
-    auto render_pass_wrapper = reinterpret_cast<RenderPassWrapper*>(create_info->renderPass);
+    auto render_pass_wrapper = getWrapperPointerFromHandle<RenderPassWrapper*>(create_info->renderPass);
     if (render_pass_wrapper)
     {
         wrapper->render_pass_dependency.handle_id         = render_pass_wrapper->handle_id;
@@ -385,7 +386,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
         wrapper->render_pass_dependency.create_parameters = render_pass_wrapper->create_parameters;
     }
 
-    auto layout_wrapper = reinterpret_cast<PipelineLayoutWrapper*>(create_info->layout);
+    auto layout_wrapper = getWrapperPointerFromHandle<PipelineLayoutWrapper*>(create_info->layout);
     assert(layout_wrapper != nullptr);
 
     wrapper->layout_dependency.handle_id         = layout_wrapper->handle_id;
@@ -415,7 +416,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto shader_wrapper = reinterpret_cast<ShaderModuleWrapper*>(create_info->stage.module);
+    auto shader_wrapper = getWrapperPointerFromHandle<ShaderModuleWrapper*>(create_info->stage.module);
     assert(shader_wrapper != nullptr);
 
     CreateDependencyInfo info;
@@ -425,7 +426,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
 
     wrapper->shader_module_dependencies.emplace_back(std::move(info));
 
-    auto layout_wrapper = reinterpret_cast<PipelineLayoutWrapper*>(create_info->layout);
+    auto layout_wrapper = getWrapperPointerFromHandle<PipelineLayoutWrapper*>(create_info->layout);
     assert(layout_wrapper != nullptr);
 
     wrapper->layout_dependency.handle_id         = layout_wrapper->handle_id;
@@ -457,7 +458,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
 
     for (uint32_t i = 0; i < create_info->stageCount; ++i)
     {
-        auto shader_wrapper = reinterpret_cast<ShaderModuleWrapper*>(create_info->pStages[i].module);
+        auto shader_wrapper = getWrapperPointerFromHandle<ShaderModuleWrapper*>(create_info->pStages[i].module);
         assert(shader_wrapper != nullptr);
 
         CreateDependencyInfo info;
@@ -468,7 +469,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
         wrapper->shader_module_dependencies.emplace_back(std::move(info));
     }
 
-    auto layout_wrapper = reinterpret_cast<PipelineLayoutWrapper*>(create_info->layout);
+    auto layout_wrapper = getWrapperPointerFromHandle<PipelineLayoutWrapper*>(create_info->layout);
     assert(layout_wrapper != nullptr);
 
     wrapper->layout_dependency.handle_id         = layout_wrapper->handle_id;
@@ -501,7 +502,7 @@ InitializeGroupObjectState<VkDevice, VkDeferredOperationKHR, PipelineWrapper, Vk
 
     for (uint32_t i = 0; i < create_info->stageCount; ++i)
     {
-        auto shader_wrapper = reinterpret_cast<ShaderModuleWrapper*>(create_info->pStages[i].module);
+        auto shader_wrapper = getWrapperPointerFromHandle<ShaderModuleWrapper*>(create_info->pStages[i].module);
         assert(shader_wrapper != nullptr);
 
         CreateDependencyInfo info;
@@ -512,7 +513,7 @@ InitializeGroupObjectState<VkDevice, VkDeferredOperationKHR, PipelineWrapper, Vk
         wrapper->shader_module_dependencies.emplace_back(std::move(info));
     }
 
-    auto layout_wrapper = reinterpret_cast<PipelineLayoutWrapper*>(create_info->layout);
+    auto layout_wrapper = getWrapperPointerFromHandle<PipelineLayoutWrapper*>(create_info->layout);
     assert(layout_wrapper != nullptr);
 
     wrapper->layout_dependency.handle_id         = layout_wrapper->handle_id;
@@ -615,8 +616,8 @@ InitializeState<VkDevice, SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(VkDevic
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device        = reinterpret_cast<DeviceWrapper*>(parent_handle);
-    wrapper->surface       = reinterpret_cast<SurfaceKHRWrapper*>(create_info->surface);
+    wrapper->device        = getWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
+    wrapper->surface       = getWrapperPointerFromHandle<SurfaceKHRWrapper*>(create_info->surface);
     wrapper->format        = create_info->imageFormat;
     wrapper->extent        = { create_info->imageExtent.width, create_info->imageExtent.height, 0 };
     wrapper->pre_transform = create_info->preTransform;
@@ -646,7 +647,7 @@ inline void InitializeGroupObjectState<VkDevice, VkSwapchainKHR, ImageWrapper, v
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto swapchain_wrapper = reinterpret_cast<SwapchainKHRWrapper*>(swapchain_handle);
+    auto swapchain_wrapper = getWrapperPointerFromHandle<SwapchainKHRWrapper*>(swapchain_handle);
     assert(swapchain_wrapper != nullptr);
 
     wrapper->image_type         = VK_IMAGE_TYPE_2D;
@@ -678,7 +679,7 @@ InitializeState<VkDevice, BufferViewWrapper, VkBufferViewCreateInfo>(VkDevice   
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto buffer        = reinterpret_cast<BufferWrapper*>(create_info->buffer);
+    auto buffer        = getWrapperPointerFromHandle<BufferWrapper*>(create_info->buffer);
     wrapper->buffer_id = buffer->handle_id;
 }
 
@@ -698,7 +699,7 @@ inline void InitializeState<VkDevice, ImageViewWrapper, VkImageViewCreateInfo>(V
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto image        = reinterpret_cast<ImageWrapper*>(create_info->image);
+    auto image        = getWrapperPointerFromHandle<ImageWrapper*>(create_info->image);
     wrapper->image_id = image->handle_id;
     wrapper->image    = image;
 }
@@ -776,9 +777,10 @@ inline void InitializePoolObjectState(VkDevice                           parent_
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device = reinterpret_cast<DeviceWrapper*>(parent_handle);
+    wrapper->device = getWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
 
-    auto layout_wrapper = reinterpret_cast<DescriptorSetLayoutWrapper*>(alloc_info->pSetLayouts[alloc_index]);
+    auto layout_wrapper =
+        getWrapperPointerFromHandle<DescriptorSetLayoutWrapper*>(alloc_info->pSetLayouts[alloc_index]);
     assert(layout_wrapper != nullptr);
 
     // Add a binding entry for each binding described by the descriptor set layout.

--- a/framework/encode/vulkan_state_tracker_initializers.h
+++ b/framework/encode/vulkan_state_tracker_initializers.h
@@ -109,7 +109,7 @@ inline void InitializeState<VkPhysicalDevice, DeviceWrapper, VkDeviceCreateInfo>
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->physical_device = getWrapperPointerFromHandle<PhysicalDeviceWrapper*>(parent_handle);
+    wrapper->physical_device = GetWrapperPointerFromHandle<PhysicalDeviceWrapper*>(parent_handle);
 }
 
 template <>
@@ -135,7 +135,7 @@ inline void InitializeState<VkDevice, PipelineLayoutWrapper, VkPipelineLayoutCre
     {
         assert(create_info->pSetLayouts[i] != VK_NULL_HANDLE);
 
-        auto layout_wrapper = getWrapperPointerFromHandle<DescriptorSetLayoutWrapper*>(create_info->pSetLayouts[i]);
+        auto layout_wrapper = GetWrapperPointerFromHandle<DescriptorSetLayoutWrapper*>(create_info->pSetLayouts[i]);
         CreateDependencyInfo info;
         info.handle_id         = layout_wrapper->handle_id;
         info.create_call_id    = layout_wrapper->create_call_id;
@@ -181,7 +181,7 @@ inline void InitializeState<VkDevice, QueryPoolWrapper, VkQueryPoolCreateInfo>(V
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device      = getWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
+    wrapper->device      = GetWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
     wrapper->query_type  = create_info->queryType;
     wrapper->query_count = create_info->queryCount;
     wrapper->pending_queries.resize(create_info->queryCount);
@@ -204,7 +204,7 @@ inline void InitializeState<VkDevice, FenceWrapper, VkFenceCreateInfo>(VkDevice 
     wrapper->create_parameters = std::move(create_parameters);
 
     wrapper->created_signaled = ((create_info->flags & VK_FENCE_CREATE_SIGNALED_BIT) == VK_FENCE_CREATE_SIGNALED_BIT);
-    wrapper->device           = getWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
+    wrapper->device           = GetWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
 }
 
 template <>
@@ -223,7 +223,7 @@ inline void InitializeState<VkDevice, EventWrapper, VkEventCreateInfo>(VkDevice 
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device = getWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
+    wrapper->device = GetWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
 }
 
 template <>
@@ -242,7 +242,7 @@ inline void InitializeState<VkDevice, SemaphoreWrapper, VkSemaphoreCreateInfo>(V
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device = getWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
+    wrapper->device = GetWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
 
     auto next = reinterpret_cast<const VkBaseInStructure*>(create_info->pNext);
     while (next)
@@ -273,7 +273,7 @@ InitializeState<VkDevice, FramebufferWrapper, VkFramebufferCreateInfo>(VkDevice 
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto render_pass_wrapper = getWrapperPointerFromHandle<RenderPassWrapper*>(create_info->renderPass);
+    auto render_pass_wrapper = GetWrapperPointerFromHandle<RenderPassWrapper*>(create_info->renderPass);
     assert(render_pass_wrapper != nullptr);
     wrapper->render_pass_id                = render_pass_wrapper->handle_id;
     wrapper->render_pass_create_call_id    = render_pass_wrapper->create_call_id;
@@ -283,7 +283,7 @@ InitializeState<VkDevice, FramebufferWrapper, VkFramebufferCreateInfo>(VkDevice 
     {
         for (uint32_t i = 0; i < create_info->attachmentCount; ++i)
         {
-            auto image_view_wrapper = getWrapperPointerFromHandle<ImageViewWrapper*>(create_info->pAttachments[i]);
+            auto image_view_wrapper = GetWrapperPointerFromHandle<ImageViewWrapper*>(create_info->pAttachments[i]);
             assert(image_view_wrapper != nullptr);
 
             wrapper->image_view_ids.push_back(image_view_wrapper->handle_id);
@@ -367,7 +367,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
 
     for (uint32_t i = 0; i < create_info->stageCount; ++i)
     {
-        auto shader_wrapper = getWrapperPointerFromHandle<ShaderModuleWrapper*>(create_info->pStages[i].module);
+        auto shader_wrapper = GetWrapperPointerFromHandle<ShaderModuleWrapper*>(create_info->pStages[i].module);
         assert(shader_wrapper != nullptr);
 
         CreateDependencyInfo info;
@@ -378,7 +378,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
         wrapper->shader_module_dependencies.emplace_back(std::move(info));
     }
 
-    auto render_pass_wrapper = getWrapperPointerFromHandle<RenderPassWrapper*>(create_info->renderPass);
+    auto render_pass_wrapper = GetWrapperPointerFromHandle<RenderPassWrapper*>(create_info->renderPass);
     if (render_pass_wrapper)
     {
         wrapper->render_pass_dependency.handle_id         = render_pass_wrapper->handle_id;
@@ -386,7 +386,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
         wrapper->render_pass_dependency.create_parameters = render_pass_wrapper->create_parameters;
     }
 
-    auto layout_wrapper = getWrapperPointerFromHandle<PipelineLayoutWrapper*>(create_info->layout);
+    auto layout_wrapper = GetWrapperPointerFromHandle<PipelineLayoutWrapper*>(create_info->layout);
     assert(layout_wrapper != nullptr);
 
     wrapper->layout_dependency.handle_id         = layout_wrapper->handle_id;
@@ -416,7 +416,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto shader_wrapper = getWrapperPointerFromHandle<ShaderModuleWrapper*>(create_info->stage.module);
+    auto shader_wrapper = GetWrapperPointerFromHandle<ShaderModuleWrapper*>(create_info->stage.module);
     assert(shader_wrapper != nullptr);
 
     CreateDependencyInfo info;
@@ -426,7 +426,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
 
     wrapper->shader_module_dependencies.emplace_back(std::move(info));
 
-    auto layout_wrapper = getWrapperPointerFromHandle<PipelineLayoutWrapper*>(create_info->layout);
+    auto layout_wrapper = GetWrapperPointerFromHandle<PipelineLayoutWrapper*>(create_info->layout);
     assert(layout_wrapper != nullptr);
 
     wrapper->layout_dependency.handle_id         = layout_wrapper->handle_id;
@@ -458,7 +458,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
 
     for (uint32_t i = 0; i < create_info->stageCount; ++i)
     {
-        auto shader_wrapper = getWrapperPointerFromHandle<ShaderModuleWrapper*>(create_info->pStages[i].module);
+        auto shader_wrapper = GetWrapperPointerFromHandle<ShaderModuleWrapper*>(create_info->pStages[i].module);
         assert(shader_wrapper != nullptr);
 
         CreateDependencyInfo info;
@@ -469,7 +469,7 @@ inline void InitializeGroupObjectState<VkDevice, VkPipelineCache, PipelineWrappe
         wrapper->shader_module_dependencies.emplace_back(std::move(info));
     }
 
-    auto layout_wrapper = getWrapperPointerFromHandle<PipelineLayoutWrapper*>(create_info->layout);
+    auto layout_wrapper = GetWrapperPointerFromHandle<PipelineLayoutWrapper*>(create_info->layout);
     assert(layout_wrapper != nullptr);
 
     wrapper->layout_dependency.handle_id         = layout_wrapper->handle_id;
@@ -502,7 +502,7 @@ InitializeGroupObjectState<VkDevice, VkDeferredOperationKHR, PipelineWrapper, Vk
 
     for (uint32_t i = 0; i < create_info->stageCount; ++i)
     {
-        auto shader_wrapper = getWrapperPointerFromHandle<ShaderModuleWrapper*>(create_info->pStages[i].module);
+        auto shader_wrapper = GetWrapperPointerFromHandle<ShaderModuleWrapper*>(create_info->pStages[i].module);
         assert(shader_wrapper != nullptr);
 
         CreateDependencyInfo info;
@@ -513,7 +513,7 @@ InitializeGroupObjectState<VkDevice, VkDeferredOperationKHR, PipelineWrapper, Vk
         wrapper->shader_module_dependencies.emplace_back(std::move(info));
     }
 
-    auto layout_wrapper = getWrapperPointerFromHandle<PipelineLayoutWrapper*>(create_info->layout);
+    auto layout_wrapper = GetWrapperPointerFromHandle<PipelineLayoutWrapper*>(create_info->layout);
     assert(layout_wrapper != nullptr);
 
     wrapper->layout_dependency.handle_id         = layout_wrapper->handle_id;
@@ -616,8 +616,8 @@ InitializeState<VkDevice, SwapchainKHRWrapper, VkSwapchainCreateInfoKHR>(VkDevic
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device        = getWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
-    wrapper->surface       = getWrapperPointerFromHandle<SurfaceKHRWrapper*>(create_info->surface);
+    wrapper->device        = GetWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
+    wrapper->surface       = GetWrapperPointerFromHandle<SurfaceKHRWrapper*>(create_info->surface);
     wrapper->format        = create_info->imageFormat;
     wrapper->extent        = { create_info->imageExtent.width, create_info->imageExtent.height, 0 };
     wrapper->pre_transform = create_info->preTransform;
@@ -647,7 +647,7 @@ inline void InitializeGroupObjectState<VkDevice, VkSwapchainKHR, ImageWrapper, v
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto swapchain_wrapper = getWrapperPointerFromHandle<SwapchainKHRWrapper*>(swapchain_handle);
+    auto swapchain_wrapper = GetWrapperPointerFromHandle<SwapchainKHRWrapper*>(swapchain_handle);
     assert(swapchain_wrapper != nullptr);
 
     wrapper->image_type         = VK_IMAGE_TYPE_2D;
@@ -679,7 +679,7 @@ InitializeState<VkDevice, BufferViewWrapper, VkBufferViewCreateInfo>(VkDevice   
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto buffer        = getWrapperPointerFromHandle<BufferWrapper*>(create_info->buffer);
+    auto buffer        = GetWrapperPointerFromHandle<BufferWrapper*>(create_info->buffer);
     wrapper->buffer_id = buffer->handle_id;
 }
 
@@ -699,7 +699,7 @@ inline void InitializeState<VkDevice, ImageViewWrapper, VkImageViewCreateInfo>(V
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    auto image        = getWrapperPointerFromHandle<ImageWrapper*>(create_info->image);
+    auto image        = GetWrapperPointerFromHandle<ImageWrapper*>(create_info->image);
     wrapper->image_id = image->handle_id;
     wrapper->image    = image;
 }
@@ -777,10 +777,10 @@ inline void InitializePoolObjectState(VkDevice                           parent_
     wrapper->create_call_id    = create_call_id;
     wrapper->create_parameters = std::move(create_parameters);
 
-    wrapper->device = getWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
+    wrapper->device = GetWrapperPointerFromHandle<DeviceWrapper*>(parent_handle);
 
     auto layout_wrapper =
-        getWrapperPointerFromHandle<DescriptorSetLayoutWrapper*>(alloc_info->pSetLayouts[alloc_index]);
+        GetWrapperPointerFromHandle<DescriptorSetLayoutWrapper*>(alloc_info->pSetLayouts[alloc_index]);
     assert(layout_wrapper != nullptr);
 
     // Add a binding entry for each binding described by the descriptor set layout.

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -1953,7 +1953,7 @@ void VulkanStateWriter::WriteSwapchainImageState(const VulkanStateTable& state_t
 
             if (wrapper->image_acquired_info[i].last_presented_queue != VK_NULL_HANDLE)
             {
-                auto queue_wrapper = getWrapperPointerFromHandle<const QueueWrapper*>(
+                auto queue_wrapper = GetWrapperPointerFromHandle<const QueueWrapper*>(
                     wrapper->image_acquired_info[i].last_presented_queue);
                 info.last_presented_queue_id = queue_wrapper->handle_id;
             }

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2266,7 +2266,7 @@ void VulkanStateWriter::WriteCommandProcessingCreateCommands(format::HandleId de
     // struct members to be wrapped handles.
     CommandPoolWrapper encode_wrapper;
     encode_wrapper.handle_id = command_pool_id;
-    WrapperManager::getInstance()->add(encode_wrapper.handle_id, reinterpret_cast<void*>(&encode_wrapper));
+    WrapperManager::GetInstance()->Add(encode_wrapper.handle_id, reinterpret_cast<void*>(&encode_wrapper));
 
     VkCommandBufferAllocateInfo alloc_info = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO };
     alloc_info.pNext                       = nullptr;
@@ -2280,7 +2280,7 @@ void VulkanStateWriter::WriteCommandProcessingCreateCommands(format::HandleId de
     encoder_.EncodeEnumValue(result);
 
     WriteFunctionCall(format::ApiCallId::ApiCall_vkAllocateCommandBuffers, &parameter_stream_);
-    WrapperManager::getInstance()->remove(encode_wrapper.handle_id);
+    WrapperManager::GetInstance()->Remove(encode_wrapper.handle_id);
     parameter_stream_.Reset();
 }
 

--- a/framework/generated/generated_decode_pnext_struct.cpp
+++ b/framework/generated/generated_decode_pnext_struct.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_encode_pnext_struct.cpp
+++ b/framework/generated/generated_encode_pnext_struct.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_layer_func_table.h
+++ b/framework/generated/generated_layer_func_table.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -6803,7 +6803,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPropertiesKHR(
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayPropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPropertiesKHR* handle_struct)->DisplayKHRWrapper* { return getWrapperPointerFromHandle<DisplayKHRWrapper*>(handle_struct->display); });
+        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayPropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPropertiesKHR* handle_struct)->DisplayKHRWrapper* { return GetWrapperPointerFromHandle<DisplayKHRWrapper*>(handle_struct->display); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPropertiesKHR>::Dispatch(VulkanCaptureManager::Get(), result, physicalDevice, pPropertyCount, pProperties);
@@ -6842,7 +6842,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlanePropertiesKHR(
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayPlanePropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPlanePropertiesKHR* handle_struct)->DisplayKHRWrapper* { return getWrapperPointerFromHandle<DisplayKHRWrapper*>(handle_struct->currentDisplay); });
+        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayPlanePropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPlanePropertiesKHR* handle_struct)->DisplayKHRWrapper* { return GetWrapperPointerFromHandle<DisplayKHRWrapper*>(handle_struct->currentDisplay); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPlanePropertiesKHR>::Dispatch(VulkanCaptureManager::Get(), result, physicalDevice, pPropertyCount, pProperties);
@@ -6925,7 +6925,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModePropertiesKHR(
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayModeKHRWrapper, VkDisplayModePropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayModePropertiesKHR* handle_struct)->DisplayModeKHRWrapper* { return getWrapperPointerFromHandle<DisplayModeKHRWrapper*>(handle_struct->displayMode); });
+        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayModeKHRWrapper, VkDisplayModePropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayModePropertiesKHR* handle_struct)->DisplayModeKHRWrapper* { return GetWrapperPointerFromHandle<DisplayModeKHRWrapper*>(handle_struct->displayMode); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDisplayModePropertiesKHR>::Dispatch(VulkanCaptureManager::Get(), result, physicalDevice, display, pPropertyCount, pProperties);
@@ -8735,7 +8735,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayProperties2KHR(
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayProperties2KHR* handle_struct)->DisplayKHRWrapper* { return getWrapperPointerFromHandle<DisplayKHRWrapper*>(handle_struct->displayProperties.display); });
+        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayProperties2KHR* handle_struct)->DisplayKHRWrapper* { return GetWrapperPointerFromHandle<DisplayKHRWrapper*>(handle_struct->displayProperties.display); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayProperties2KHR>::Dispatch(VulkanCaptureManager::Get(), result, physicalDevice, pPropertyCount, pProperties);
@@ -8774,7 +8774,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlaneProperties2KHR(
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayPlaneProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPlaneProperties2KHR* handle_struct)->DisplayKHRWrapper* { return getWrapperPointerFromHandle<DisplayKHRWrapper*>(handle_struct->displayPlaneProperties.currentDisplay); });
+        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayPlaneProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPlaneProperties2KHR* handle_struct)->DisplayKHRWrapper* { return GetWrapperPointerFromHandle<DisplayKHRWrapper*>(handle_struct->displayPlaneProperties.currentDisplay); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPlaneProperties2KHR>::Dispatch(VulkanCaptureManager::Get(), result, physicalDevice, pPropertyCount, pProperties);
@@ -8816,7 +8816,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModeProperties2KHR(
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayModeKHRWrapper, VkDisplayModeProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayModeProperties2KHR* handle_struct)->DisplayModeKHRWrapper* { return getWrapperPointerFromHandle<DisplayModeKHRWrapper*>(handle_struct->displayModeProperties.displayMode); });
+        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayModeKHRWrapper, VkDisplayModeProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayModeProperties2KHR* handle_struct)->DisplayModeKHRWrapper* { return GetWrapperPointerFromHandle<DisplayModeKHRWrapper*>(handle_struct->displayModeProperties.displayMode); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDisplayModeProperties2KHR>::Dispatch(VulkanCaptureManager::Get(), result, physicalDevice, display, pPropertyCount, pProperties);

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),
@@ -6802,7 +6803,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPropertiesKHR(
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayPropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPropertiesKHR* handle_struct)->DisplayKHRWrapper* { return reinterpret_cast<DisplayKHRWrapper*>(handle_struct->display); });
+        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayPropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPropertiesKHR* handle_struct)->DisplayKHRWrapper* { return getWrapperPointerFromHandle<DisplayKHRWrapper*>(handle_struct->display); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPropertiesKHR>::Dispatch(VulkanCaptureManager::Get(), result, physicalDevice, pPropertyCount, pProperties);
@@ -6841,7 +6842,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlanePropertiesKHR(
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayPlanePropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPlanePropertiesKHR* handle_struct)->DisplayKHRWrapper* { return reinterpret_cast<DisplayKHRWrapper*>(handle_struct->currentDisplay); });
+        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayPlanePropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPlanePropertiesKHR* handle_struct)->DisplayKHRWrapper* { return getWrapperPointerFromHandle<DisplayKHRWrapper*>(handle_struct->currentDisplay); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPlanePropertiesKHR>::Dispatch(VulkanCaptureManager::Get(), result, physicalDevice, pPropertyCount, pProperties);
@@ -6924,7 +6925,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModePropertiesKHR(
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayModeKHRWrapper, VkDisplayModePropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayModePropertiesKHR* handle_struct)->DisplayModeKHRWrapper* { return reinterpret_cast<DisplayModeKHRWrapper*>(handle_struct->displayMode); });
+        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayModeKHRWrapper, VkDisplayModePropertiesKHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayModePropertiesKHR* handle_struct)->DisplayModeKHRWrapper* { return getWrapperPointerFromHandle<DisplayModeKHRWrapper*>(handle_struct->displayMode); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDisplayModePropertiesKHR>::Dispatch(VulkanCaptureManager::Get(), result, physicalDevice, display, pPropertyCount, pProperties);
@@ -8734,7 +8735,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayProperties2KHR(
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayProperties2KHR* handle_struct)->DisplayKHRWrapper* { return reinterpret_cast<DisplayKHRWrapper*>(handle_struct->displayProperties.display); });
+        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayProperties2KHR* handle_struct)->DisplayKHRWrapper* { return getWrapperPointerFromHandle<DisplayKHRWrapper*>(handle_struct->displayProperties.display); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayProperties2KHR>::Dispatch(VulkanCaptureManager::Get(), result, physicalDevice, pPropertyCount, pProperties);
@@ -8773,7 +8774,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceDisplayPlaneProperties2KHR(
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayPlaneProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPlaneProperties2KHR* handle_struct)->DisplayKHRWrapper* { return reinterpret_cast<DisplayKHRWrapper*>(handle_struct->displayPlaneProperties.currentDisplay); });
+        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayKHRWrapper, VkDisplayPlaneProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayPlaneProperties2KHR* handle_struct)->DisplayKHRWrapper* { return getWrapperPointerFromHandle<DisplayKHRWrapper*>(handle_struct->displayPlaneProperties.currentDisplay); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetPhysicalDeviceDisplayPlaneProperties2KHR>::Dispatch(VulkanCaptureManager::Get(), result, physicalDevice, pPropertyCount, pProperties);
@@ -8815,7 +8816,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetDisplayModeProperties2KHR(
         encoder->EncodeUInt32Ptr(pPropertyCount, omit_output_data);
         EncodeStructArray(encoder, pProperties, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, omit_output_data);
         encoder->EncodeEnumValue(result);
-        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayModeKHRWrapper, VkDisplayModeProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayModeProperties2KHR* handle_struct)->DisplayModeKHRWrapper* { return reinterpret_cast<DisplayModeKHRWrapper*>(handle_struct->displayModeProperties.displayMode); });
+        VulkanCaptureManager::Get()->EndStructGroupCreateApiCallCapture<VkPhysicalDevice, DisplayModeKHRWrapper, VkDisplayModeProperties2KHR>(result, physicalDevice, (pPropertyCount != nullptr) ? (*pPropertyCount) : 0, pProperties, [](VkDisplayModeProperties2KHR* handle_struct)->DisplayModeKHRWrapper* { return getWrapperPointerFromHandle<DisplayModeKHRWrapper*>(handle_struct->displayModeProperties.displayMode); });
     }
 
     CustomEncoderPostCall<format::ApiCallId::ApiCall_vkGetDisplayModeProperties2KHR>::Dispatch(VulkanCaptureManager::Get(), result, physicalDevice, display, pPropertyCount, pProperties);

--- a/framework/generated/generated_vulkan_api_call_encoders.h
+++ b/framework/generated/generated_vulkan_api_call_encoders.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_ascii_consumer.cpp
+++ b/framework/generated/generated_vulkan_ascii_consumer.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_ascii_consumer.h
+++ b/framework/generated/generated_vulkan_ascii_consumer.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_command_buffer_util.cpp
+++ b/framework/generated/generated_vulkan_command_buffer_util.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_command_buffer_util.h
+++ b/framework/generated/generated_vulkan_command_buffer_util.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_consumer.h
+++ b/framework/generated/generated_vulkan_consumer.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_decoder.cpp
+++ b/framework/generated/generated_vulkan_decoder.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_decoder.h
+++ b/framework/generated/generated_vulkan_decoder.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_dispatch_table.h
+++ b/framework/generated/generated_vulkan_dispatch_table.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_enum_to_string.cpp
+++ b/framework/generated/generated_vulkan_enum_to_string.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_enum_to_string.h
+++ b/framework/generated/generated_vulkan_enum_to_string.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_feature_util.cpp
+++ b/framework/generated/generated_vulkan_feature_util.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_object_info_table_base2.h
+++ b/framework/generated/generated_vulkan_object_info_table_base2.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_pnext_to_string.cpp
+++ b/framework/generated/generated_vulkan_pnext_to_string.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_referenced_resource_consumer.h
+++ b/framework/generated/generated_vulkan_referenced_resource_consumer.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_replay_consumer.h
+++ b/framework/generated/generated_vulkan_replay_consumer.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_state_table.h
+++ b/framework/generated/generated_vulkan_state_table.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_decoders.cpp
+++ b/framework/generated/generated_vulkan_struct_decoders.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_decoders.h
+++ b/framework/generated/generated_vulkan_struct_decoders.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_decoders_forward.h
+++ b/framework/generated/generated_vulkan_struct_decoders_forward.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_encoders.cpp
+++ b/framework/generated/generated_vulkan_struct_encoders.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_encoders.h
+++ b/framework/generated/generated_vulkan_struct_encoders.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_handle_mappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_handle_mappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_mappers.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_handle_wrappers.cpp
+++ b/framework/generated/generated_vulkan_struct_handle_wrappers.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_handle_wrappers.h
+++ b/framework/generated/generated_vulkan_struct_handle_wrappers.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_to_string.cpp
+++ b/framework/generated/generated_vulkan_struct_to_string.cpp
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/generated_vulkan_struct_to_string.h
+++ b/framework/generated/generated_vulkan_struct_to_string.h
@@ -1,6 +1,7 @@
 /*
 ** Copyright (c) 2018-2021 Valve Corporation
 ** Copyright (c) 2018-2021 LunarG, Inc.
+** Copyright (c) 2022 Advanced Micro Devices, Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and associated documentation files (the "Software"),

--- a/framework/generated/vulkan_generators/gencode.py
+++ b/framework/generated/vulkan_generators/gencode.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2018-2021 Valve Corporation
 # Copyright (c) 2018-2021 LunarG, Inc.
+# Copyright (c) 2022 Advanced Micro Devices, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
@@ -164,7 +165,8 @@ def make_gen_opts(args):
     # Copyright text prefixing all headers (list of strings).
     prefix_strings = [
         '/*', '** Copyright (c) 2018-2021 Valve Corporation',
-        '** Copyright (c) 2018-2021 LunarG, Inc.', '**',
+        '** Copyright (c) 2018-2021 LunarG, Inc.',
+        '** Copyright (c) 2022 Advanced Micro Devices, Inc.', '**',
         '** Permission is hereby granted, free of charge, to any person obtaining a',
         '** copy of this software and associated documentation files (the "Software"),',
         '** to deal in the Software without restriction, including without limitation',

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2018-2019 Valve Corporation
 # Copyright (c) 2018-2019 LunarG, Inc.
+# Copyright (c) 2022 Advanced Micro Devices, Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
@@ -452,7 +453,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                         )
 
                         if not member_array_length:
-                            unwrap_handle_def = '[]({}* handle_struct)->{wrapper}Wrapper* {{ return reinterpret_cast<{wrapper}Wrapper*>(handle_struct->{}); }}'.format(
+                            unwrap_handle_def = '[]({}* handle_struct)->{wrapper}Wrapper* {{ return getWrapperPointerFromHandle<{wrapper}Wrapper*>(handle_struct->{}); }}'.format(
                                 handle.base_type,
                                 member_handle_name,
                                 wrapper=member_handle_type[2:]

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -453,7 +453,7 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
                         )
 
                         if not member_array_length:
-                            unwrap_handle_def = '[]({}* handle_struct)->{wrapper}Wrapper* {{ return getWrapperPointerFromHandle<{wrapper}Wrapper*>(handle_struct->{}); }}'.format(
+                            unwrap_handle_def = '[]({}* handle_struct)->{wrapper}Wrapper* {{ return GetWrapperPointerFromHandle<{wrapper}Wrapper*>(handle_struct->{}); }}'.format(
                                 handle.base_type,
                                 member_handle_name,
                                 wrapper=member_handle_type[2:]


### PR DESCRIPTION
Currently, when target app call creates any non-dispatchable Vulkan handle , GFXR will replace the real handle with the wrapper pointer and return a fake handle to the target app. So within target app, the wrapper pointer is used as Vulkan non-dispatch handle. When target app calls some API function that uses such handle, GFXR will convert the fake handle to real Vulkan handle and pass it to driver.

Some title shows texture missing issues when running with GFXR capture layer, however the title has no issue when running with validation + capture layer. Further investigation verified that the issue is caused by the target title behaves differently when the fake handle using wrapper pointer. By changing the fake handle to global ID, the texture missing issue is resolved. It’s also the same case for validation layer which use global Id as Vulkan handle, if it's changed to this which make validation layer use pointer as fake handle, same issue will occur. So for the title, the fake handle needs to be the global ID instead of handle wrapper pointer.

The commit changes the fake handle from using wrapper pointer to global ID to fix the texture missing issue for the title, the change also fixes the issue descripted in https://github.com/LunarG/gfxreconstruct/issues/677 .

The change in the commit composite of the following 2 parts:

1. Utility functions used to handle wrapper pointer to global ID conversion. 

        These functions are all in the files vulkan_handle_wrapper_util.h/.cpp, they provide the conversion between wrapper 
    pointer, global ID and Vulkan real non-dispatch handle.
        A class WrapperManager is used for these conversions which manage a map from global ID to handle wrapper pointer.
    For any global ID, the class can get its wrapper pointer and further get its real Vulkan handle through wrapper pointer. 
    Before the commit, handle wrapper handling already provide the mechanism for similar conversion, the commit extend
     the conversion following the existing mechanism and current unified interface.


2. Change all conversion from wrapper pointer to Global Id. 

    All these changes happen in capture side, the commit doesn’t change replay side because replay already use global ID. 
When GFXR write recorded data to trace file, the handle is already changed to global ID. For capture side including capture
and trim handling, the commit switch all wrapper pointer to global ID if the wrapper pointer is used as a  faked Vulkan
non-dispatchable handle.

The commit already test all Sascha welliem samples on Win64 and Win32, also tested Wolf2 and Doom ET, Linux side tested vkcube and all passed. For Doom ET testing, because the title needs deferred operation pull request, so GFXR binary come from merging result from deferred operation fix pull request + this pull request.

The pull-request includes changes of vulkan_api_call_encoders_body_generator.py and gencode.py. Please note that the change in gencode.py is only for adding additional copyright info to auto generated files.