### PR TITLE
Clean up for clang build.

### DIFF
--- a/external/VulkanMemoryAllocator/include/vk_mem_alloc.h
+++ b/external/VulkanMemoryAllocator/include/vk_mem_alloc.h
@@ -12068,7 +12068,6 @@ VkResult VmaBlockVector::AllocatePage(
     const bool mapped = (createInfo.flags & VMA_ALLOCATION_CREATE_MAPPED_BIT) != 0;
     const bool isUserDataString = (createInfo.flags & VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT) != 0;
     
-    const bool withinBudget = (createInfo.flags & VMA_ALLOCATION_CREATE_WITHIN_BUDGET_BIT) != 0;
     VkDeviceSize freeMemory;
     {
         const uint32_t heapIndex = m_hAllocator->MemoryTypeIndexToHeapIndex(m_MemoryTypeIndex);

--- a/framework/application/application.cpp
+++ b/framework/application/application.cpp
@@ -61,8 +61,8 @@ Application::Application(const std::string&     name,
                          const std::string&     cli_wsi_extension,
                          decode::FileProcessor* file_processor) :
     name_(name),
-    file_processor_(file_processor), cli_wsi_extension_(cli_wsi_extension), running_(false), paused_(false),
-    pause_frame_(0)
+    file_processor_(file_processor), running_(false), paused_(false),
+    pause_frame_(0), cli_wsi_extension_(cli_wsi_extension)
 {
     if (!cli_wsi_extension_.empty())
     {

--- a/framework/application/application.cpp
+++ b/framework/application/application.cpp
@@ -61,8 +61,8 @@ Application::Application(const std::string&     name,
                          const std::string&     cli_wsi_extension,
                          decode::FileProcessor* file_processor) :
     name_(name),
-    file_processor_(file_processor), running_(false), paused_(false),
-    pause_frame_(0), cli_wsi_extension_(cli_wsi_extension)
+    file_processor_(file_processor), running_(false), paused_(false), pause_frame_(0),
+    cli_wsi_extension_(cli_wsi_extension)
 {
     if (!cli_wsi_extension_.empty())
     {

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -36,7 +36,7 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 FileProcessor::FileProcessor() :
-    file_header_{}, file_descriptor_(nullptr), current_frame_number_(0), bytes_read_(0),
+    file_descriptor_(nullptr), file_header_{}, current_frame_number_(0), bytes_read_(0),
     error_state_(kErrorInvalidFileDescriptor), annotation_handler_(nullptr), compressor_(nullptr), api_call_index_(0)
 {}
 
@@ -241,7 +241,6 @@ bool FileProcessor::ProcessBlocks()
             else if (block_header.type == format::BlockType::kStateMarkerBlock)
             {
                 format::MarkerType marker_type  = format::MarkerType::kUnknownMarker;
-                uint64_t           frame_number = 0;
 
                 success = ReadBytes(&marker_type, sizeof(marker_type));
 

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -240,7 +240,7 @@ bool FileProcessor::ProcessBlocks()
             }
             else if (block_header.type == format::BlockType::kStateMarkerBlock)
             {
-                format::MarkerType marker_type  = format::MarkerType::kUnknownMarker;
+                format::MarkerType marker_type = format::MarkerType::kUnknownMarker;
 
                 success = ReadBytes(&marker_type, sizeof(marker_type));
 

--- a/framework/decode/file_transformer.cpp
+++ b/framework/decode/file_transformer.cpp
@@ -32,7 +32,7 @@ GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
 FileTransformer::FileTransformer() :
-    file_header_{}, input_file_(nullptr), output_file_(nullptr), bytes_read_(0), bytes_written_(0),
+    input_file_(nullptr), output_file_(nullptr), file_header_{}, bytes_read_(0), bytes_written_(0),
     error_state_(kErrorInvalidFileDescriptor), loading_state_(false)
 {}
 
@@ -225,7 +225,6 @@ bool FileTransformer::ProcessNextBlock()
         else if (block_header.type == format::BlockType::kStateMarkerBlock)
         {
             format::MarkerType marker_type  = format::MarkerType::kUnknownMarker;
-            uint64_t           frame_number = 0;
 
             success = ReadBytes(&marker_type, sizeof(marker_type));
 

--- a/framework/decode/file_transformer.cpp
+++ b/framework/decode/file_transformer.cpp
@@ -224,7 +224,7 @@ bool FileTransformer::ProcessNextBlock()
         }
         else if (block_header.type == format::BlockType::kStateMarkerBlock)
         {
-            format::MarkerType marker_type  = format::MarkerType::kUnknownMarker;
+            format::MarkerType marker_type = format::MarkerType::kUnknownMarker;
 
             success = ReadBytes(&marker_type, sizeof(marker_type));
 

--- a/framework/decode/vulkan_enum_util.h
+++ b/framework/decode/vulkan_enum_util.h
@@ -41,7 +41,7 @@ GFXRECON_BEGIN_NAMESPACE(enumutil)
  * @param value VkResult code to process.
  * @return String describing the specified VkResult code.
  */
-static const char* GetResultDescription(VkResult result)
+inline static const char* GetResultDescription(VkResult result)
 {
     // clang-format off
     switch (result)

--- a/framework/decode/vulkan_realign_allocator.cpp
+++ b/framework/decode/vulkan_realign_allocator.cpp
@@ -263,8 +263,8 @@ VkResult VulkanRealignAllocator::WriteMappedMemoryRange(MemoryData     allocator
                                                         uint64_t       size,
                                                         const uint8_t* data)
 {
-    VkResult     result         = VK_ERROR_MEMORY_MAP_FAILED;
-    auto         memory_info    = GetMemoryAllocInfo(allocator_data);
+    VkResult result      = VK_ERROR_MEMORY_MAP_FAILED;
+    auto     memory_info = GetMemoryAllocInfo(allocator_data);
 
     if (memory_info != nullptr)
     {

--- a/framework/decode/vulkan_realign_allocator.cpp
+++ b/framework/decode/vulkan_realign_allocator.cpp
@@ -264,7 +264,6 @@ VkResult VulkanRealignAllocator::WriteMappedMemoryRange(MemoryData     allocator
                                                         const uint8_t* data)
 {
     VkResult     result         = VK_ERROR_MEMORY_MAP_FAILED;
-    VkDeviceSize realign_offset = offset;
     auto         memory_info    = GetMemoryAllocInfo(allocator_data);
 
     if (memory_info != nullptr)

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1275,7 +1275,7 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
     {
         assert(device_info->handle != VK_NULL_HANDLE);
 
-        VkDevice       device = device_info->handle;
+        VkDevice device = device_info->handle;
 
         auto allocator = device_info->allocator.get();
         assert(allocator != nullptr);
@@ -1627,7 +1627,7 @@ void* VulkanReplayConsumerBase::PreProcessExternalObject(uint64_t          objec
         else
         {
             GFXRECON_LOG_WARNING_ONCE("Failed to find a valid AHardwareBuffer handle for a call to "
-                                 "vkGetAndroidHardwareBufferPropertiesANDROID")
+                                      "vkGetAndroidHardwareBufferPropertiesANDROID")
         }
     }
 #endif

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -1275,10 +1275,7 @@ void VulkanReplayConsumerBase::ProcessBeginResourceInitCommand(format::HandleId 
     {
         assert(device_info->handle != VK_NULL_HANDLE);
 
-        VkResult       result = VK_SUCCESS;
         VkDevice       device = device_info->handle;
-        VkBuffer       buffer = VK_NULL_HANDLE;
-        VkDeviceMemory memory = VK_NULL_HANDLE;
 
         auto allocator = device_info->allocator.get();
         assert(allocator != nullptr);
@@ -1831,9 +1828,6 @@ void VulkanReplayConsumerBase::SelectPhysicalDevice(PhysicalDeviceInfo* physical
 
     if (instance_info != nullptr)
     {
-        const auto&      replay_devices = instance_info->replay_devices;
-        VkPhysicalDevice current_device = physical_device_info->handle;
-
         bool have_override = false;
 
         if (options_.override_gpu_index >= 0)
@@ -4607,8 +4601,6 @@ VkResult VulkanReplayConsumerBase::OverrideCreateShaderModule(
 
     // Replace shader in 'override_info'
     std::unique_ptr<char[]> file_code;
-    const uint32_t*         orig_code = original_info->pCode;
-    size_t                  orig_size = original_info->codeSize;
     uint64_t                handle_id = *pShaderModule->GetPointer();
     std::string             file_name = "sh" + std::to_string(handle_id);
     std::string             file_path = util::filepath::Join(options_.replace_dir, file_name);

--- a/framework/decode/vulkan_resource_tracking_consumer.cpp
+++ b/framework/decode/vulkan_resource_tracking_consumer.cpp
@@ -39,8 +39,8 @@ const std::vector<std::string> kLoaderLibNames = {
 
 VulkanResourceTrackingConsumer::VulkanResourceTrackingConsumer(
     const VulkanReplayOptions& options, VulkanTrackedObjectInfoTable* tracked_object_info_table) :
-    loader_handle_(nullptr), create_instance_function_(nullptr),
-    get_instance_proc_addr_(nullptr), options_(options),
+    loader_handle_(nullptr),
+    create_instance_function_(nullptr), get_instance_proc_addr_(nullptr), options_(options),
     tracked_object_info_table_(tracked_object_info_table)
 {
     assert(tracked_object_info_table != nullptr);

--- a/framework/decode/vulkan_resource_tracking_consumer.cpp
+++ b/framework/decode/vulkan_resource_tracking_consumer.cpp
@@ -39,8 +39,8 @@ const std::vector<std::string> kLoaderLibNames = {
 
 VulkanResourceTrackingConsumer::VulkanResourceTrackingConsumer(
     const VulkanReplayOptions& options, VulkanTrackedObjectInfoTable* tracked_object_info_table) :
-    options_(options),
-    loader_handle_(nullptr), get_instance_proc_addr_(nullptr), create_instance_function_(nullptr),
+    loader_handle_(nullptr), create_instance_function_(nullptr),
+    get_instance_proc_addr_(nullptr), options_(options),
     tracked_object_info_table_(tracked_object_info_table)
 {
     assert(tracked_object_info_table != nullptr);

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -85,14 +85,13 @@ format::ThreadId CaptureManager::ThreadData::GetThreadId()
 }
 
 CaptureManager::CaptureManager(format::ApiFamilyId api_family) :
-    screenshot_prefix_(""), global_frame_count_(0),
-    api_family_(api_family), timestamp_filename_(true), force_file_flush_(false),
-    memory_tracking_mode_(CaptureSettings::MemoryTrackingMode::kPageGuard), page_guard_align_buffer_sizes_(false),
-    page_guard_track_ahb_memory_(false), page_guard_memory_mode_(kMemoryModeShadowInternal), trim_enabled_(false),
-    trim_current_range_(0), current_frame_(kFirstFrame), capture_mode_(kModeWrite), previous_hotkey_state_(false),
-    debug_layer_(false), debug_device_lost_(false), screenshots_enabled_(false)
-{
-}
+    screenshot_prefix_(""), global_frame_count_(0), api_family_(api_family), timestamp_filename_(true),
+    force_file_flush_(false), memory_tracking_mode_(CaptureSettings::MemoryTrackingMode::kPageGuard),
+    page_guard_align_buffer_sizes_(false), page_guard_track_ahb_memory_(false),
+    page_guard_memory_mode_(kMemoryModeShadowInternal), trim_enabled_(false), trim_current_range_(0),
+    current_frame_(kFirstFrame), capture_mode_(kModeWrite), previous_hotkey_state_(false), debug_layer_(false),
+    debug_device_lost_(false), screenshots_enabled_(false)
+{}
 
 CaptureManager::~CaptureManager()
 {
@@ -312,13 +311,13 @@ bool CaptureManager::Initialize(std::string base_filename, const CaptureSettings
         // Check if trim is enabled by hot-key trigger at the first frame
         else if (!trace_settings.trim_key.empty())
         {
-            trim_key_ = trace_settings.trim_key;
+            trim_key_        = trace_settings.trim_key;
             trim_key_frames_ = trace_settings.trim_key_frames;
 
             // Enable state tracking when hotkey pressed
             if (IsTrimHotkeyPressed())
             {
-                capture_mode_ = kModeWriteAndTrack;
+                capture_mode_         = kModeWriteAndTrack;
                 trim_key_first_frame_ = current_frame_;
 
                 success = CreateCaptureFile(util::filepath::InsertFilenamePostfix(base_filename_, "_trim_trigger"));

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -57,7 +57,7 @@ util::SharedMutex                                        CaptureManager::state_m
 std::atomic<format::HandleId> CaptureManager::unique_id_counter_{ format::kNullHandleId };
 
 CaptureManager::ThreadData::ThreadData() :
-    thread_id_(GetThreadId()), object_id_(format::kNullHandleId), call_id_(format::ApiCallId::ApiCall_Unknown)
+    thread_id_(GetThreadId()), call_id_(format::ApiCallId::ApiCall_Unknown), object_id_(format::kNullHandleId)
 {
     parameter_buffer_  = std::make_unique<encode::ParameterBuffer>();
     parameter_encoder_ = std::make_unique<ParameterEncoder>(parameter_buffer_.get());
@@ -85,13 +85,14 @@ format::ThreadId CaptureManager::ThreadData::GetThreadId()
 }
 
 CaptureManager::CaptureManager(format::ApiFamilyId api_family) :
-    api_family_(api_family), force_file_flush_(false), timestamp_filename_(true),
+    screenshot_prefix_(""), global_frame_count_(0),
+    api_family_(api_family), timestamp_filename_(true), force_file_flush_(false),
     memory_tracking_mode_(CaptureSettings::MemoryTrackingMode::kPageGuard), page_guard_align_buffer_sizes_(false),
     page_guard_track_ahb_memory_(false), page_guard_memory_mode_(kMemoryModeShadowInternal), trim_enabled_(false),
     trim_current_range_(0), current_frame_(kFirstFrame), capture_mode_(kModeWrite), previous_hotkey_state_(false),
-    debug_layer_(false), debug_device_lost_(false), screenshot_prefix_(""), screenshots_enabled_(false),
-    global_frame_count_(0)
-{}
+    debug_layer_(false), debug_device_lost_(false), screenshots_enabled_(false)
+{
+}
 
 CaptureManager::~CaptureManager()
 {

--- a/framework/encode/custom_vulkan_struct_handle_wrappers.cpp
+++ b/framework/encode/custom_vulkan_struct_handle_wrappers.cpp
@@ -39,9 +39,6 @@ static const VkDescriptorImageInfo* UnwrapDescriptorImageInfoStructArrayHandles(
 
     if ((values != nullptr) && (len > 0))
     {
-        const uint8_t* bytes     = reinterpret_cast<const uint8_t*>(values);
-        size_t         num_bytes = len * sizeof(values[0]);
-
         // Copy and transform handles.
         VkDescriptorImageInfo* unwrapped_structs = MakeUnwrapStructs(values, len, unwrap_memory);
 

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -634,7 +634,7 @@ VkResult VulkanCaptureManager::OverrideCreateDevice(VkPhysicalDevice            
 
     for (size_t i = 0; i < extension_count; ++i)
     {
-        auto entry = pCreateInfo_unwrapped->ppEnabledExtensionNames[i];
+        auto entry = extensions[i];
 
         modified_extensions.push_back(entry);
 
@@ -1175,7 +1175,6 @@ void VulkanCaptureManager::ProcessEnumeratePhysicalDevices(VkResult          res
                 auto             physical_device_wrapper = reinterpret_cast<PhysicalDeviceWrapper*>(physical_device);
                 format::HandleId physical_device_id      = physical_device_wrapper->handle_id;
                 VkPhysicalDevice physical_device_handle  = physical_device_wrapper->handle;
-                uint32_t         count                   = 0;
 
                 VkPhysicalDeviceProperties       properties;
                 VkPhysicalDeviceMemoryProperties memory_properties;

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2009,7 +2009,6 @@ void VulkanStateWriter::WritePhysicalDevicePropertiesMetaData(const PhysicalDevi
 
     format::HandleId           physical_device_id     = physical_device_wrapper->handle_id;
     VkPhysicalDevice           physical_device_handle = physical_device_wrapper->handle;
-    uint32_t                   count                  = 0;
     VkPhysicalDeviceProperties properties;
 
     instance_table->GetPhysicalDeviceProperties(physical_device_handle, &properties);

--- a/framework/format/platform_types.h
+++ b/framework/format/platform_types.h
@@ -190,9 +190,9 @@ extern "C"
         VkDevice device, const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo, struct AHardwareBuffer** pBuffer);
 
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateAndroidSurfaceKHR(VkInstance,
-                                                                    const VkAndroidSurfaceCreateInfoKHR*,
-                                                                    const VkAllocationCallbacks*,
-                                                                    VkSurfaceKHR*)
+                                                                           const VkAndroidSurfaceCreateInfoKHR*,
+                                                                           const VkAllocationCallbacks*,
+                                                                           VkSurfaceKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkCreateAndroidSurfaceKHR");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -292,10 +292,8 @@ typedef VkResult(VKAPI_PTR* PFN_vkGetSemaphoreZirconHandleFUCHSIA)(
 
 extern "C"
 {
-    inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateImagePipeSurfaceFUCHSIA(VkInstance,
-                                                                          const VkImagePipeSurfaceCreateInfoFUCHSIA*,
-                                                                          const VkAllocationCallbacks*,
-                                                                          VkSurfaceKHR*)
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateImagePipeSurfaceFUCHSIA(
+        VkInstance, const VkImagePipeSurfaceCreateInfoFUCHSIA*, const VkAllocationCallbacks*, VkSurfaceKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkCreateImagePipeSurfaceFUCHSIA");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -355,9 +353,9 @@ extern "C"
                                                            VkSurfaceKHR*                    pSurface);
 
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateIOSSurfaceMVK(VkInstance,
-                                                                const VkIOSSurfaceCreateInfoMVK*,
-                                                                const VkAllocationCallbacks*,
-                                                                VkSurfaceKHR*)
+                                                                       const VkIOSSurfaceCreateInfoMVK*,
+                                                                       const VkAllocationCallbacks*,
+                                                                       VkSurfaceKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkCreateIOSSurfaceMVK");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -386,9 +384,9 @@ extern "C"
                                                              VkSurfaceKHR*                      pSurface);
 
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateMacOSSurfaceMVK(VkInstance,
-                                                                  const VkMacOSSurfaceCreateInfoMVK*,
-                                                                  const VkAllocationCallbacks*,
-                                                                  VkSurfaceKHR*)
+                                                                         const VkMacOSSurfaceCreateInfoMVK*,
+                                                                         const VkAllocationCallbacks*,
+                                                                         VkSurfaceKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkCreateMacOSSurfaceMVK");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -419,9 +417,9 @@ extern "C"
                                                              VkSurfaceKHR*                      pSurface);
 
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateMetalSurfaceEXT(VkInstance,
-                                                                  const VkMetalSurfaceCreateInfoEXT*,
-                                                                  const VkAllocationCallbacks*,
-                                                                  VkSurfaceKHR*)
+                                                                         const VkMetalSurfaceCreateInfoEXT*,
+                                                                         const VkAllocationCallbacks*,
+                                                                         VkSurfaceKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkCreateMetalSurfaceEXT");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -457,17 +455,17 @@ extern "C"
                                                                                   MirConnection*   connection);
 
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateMirSurfaceKHR(VkInstance,
-                                                                const VkMirSurfaceCreateInfoKHR*,
-                                                                const VkAllocationCallbacks*,
-                                                                VkSurfaceKHR*)
+                                                                       const VkMirSurfaceCreateInfoKHR*,
+                                                                       const VkAllocationCallbacks*,
+                                                                       VkSurfaceKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkCreateMirSurfaceKHR");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
     inline static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceMirPresentationSupportKHR(VkPhysicalDevice,
-                                                                                       uint32_t,
-                                                                                       MirConnection*)
+                                                                                              uint32_t,
+                                                                                              MirConnection*)
     {
         GFXRECON_LOG_ERROR(
             "Calling unsupported platform extension function vkGetPhysicalDeviceMirPresentationSupportKHR");
@@ -497,9 +495,9 @@ extern "C"
                                                          VkSurfaceKHR*                  pSurface);
 
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateViSurfaceNN(VkInstance,
-                                                              const VkViSurfaceCreateInfoNN*,
-                                                              const VkAllocationCallbacks*,
-                                                              VkSurfaceKHR*)
+                                                                     const VkViSurfaceCreateInfoNN*,
+                                                                     const VkAllocationCallbacks*,
+                                                                     VkSurfaceKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkCreateViSurfaceNN");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -534,17 +532,17 @@ extern "C"
                                                                                       uint32_t         queueFamilyIndex,
                                                                                       struct wl_display* display);
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateWaylandSurfaceKHR(VkInstance,
-                                                                    const VkWaylandSurfaceCreateInfoKHR*,
-                                                                    const VkAllocationCallbacks*,
-                                                                    VkSurfaceKHR*)
+                                                                           const VkWaylandSurfaceCreateInfoKHR*,
+                                                                           const VkAllocationCallbacks*,
+                                                                           VkSurfaceKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkCreateWaylandSurfaceKHR");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
     inline static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceWaylandPresentationSupportKHR(VkPhysicalDevice,
-                                                                                           uint32_t,
-                                                                                           struct wl_display*)
+                                                                                                  uint32_t,
+                                                                                                  struct wl_display*)
     {
         GFXRECON_LOG_ERROR(
             "Calling unsupported platform extension function vkGetPhysicalDeviceWaylandPresentationSupportKHR");
@@ -782,15 +780,16 @@ extern "C"
                                                               HANDLE*                           pHandle);
 
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateWin32SurfaceKHR(VkInstance,
-                                                                  const VkWin32SurfaceCreateInfoKHR*,
-                                                                  const VkAllocationCallbacks*,
-                                                                  VkSurfaceKHR*)
+                                                                         const VkWin32SurfaceCreateInfoKHR*,
+                                                                         const VkAllocationCallbacks*,
+                                                                         VkSurfaceKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkCreateWin32SurfaceKHR");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    inline static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceWin32PresentationSupportKHR(VkPhysicalDevice, uint32_t)
+    inline static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceWin32PresentationSupportKHR(VkPhysicalDevice,
+                                                                                                uint32_t)
     {
         GFXRECON_LOG_ERROR(
             "Calling unsupported platform extension function vkGetPhysicalDeviceWin32PresentationSupportKHR");
@@ -827,55 +826,56 @@ extern "C"
     }
 
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetMemoryWin32HandleKHR(VkDevice,
-                                                                    const VkMemoryGetWin32HandleInfoKHR*,
-                                                                    HANDLE*)
+                                                                           const VkMemoryGetWin32HandleInfoKHR*,
+                                                                           HANDLE*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkGetMemoryWin32HandleKHR");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetMemoryWin32HandlePropertiesKHR(VkDevice,
-                                                                              VkExternalMemoryHandleTypeFlagBits,
-                                                                              HANDLE,
-                                                                              VkMemoryWin32HandlePropertiesKHR*)
+                                                                                     VkExternalMemoryHandleTypeFlagBits,
+                                                                                     HANDLE,
+                                                                                     VkMemoryWin32HandlePropertiesKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkGetMemoryWin32HandlePropertiesKHR");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    inline static VKAPI_ATTR VkResult VKAPI_CALL vkImportSemaphoreWin32HandleKHR(VkDevice,
-                                                                          const VkImportSemaphoreWin32HandleInfoKHR*)
+    inline static VKAPI_ATTR VkResult VKAPI_CALL
+    vkImportSemaphoreWin32HandleKHR(VkDevice, const VkImportSemaphoreWin32HandleInfoKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkImportSemaphoreWin32HandleKHR");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetSemaphoreWin32HandleKHR(VkDevice,
-                                                                       const VkSemaphoreGetWin32HandleInfoKHR*,
-                                                                       HANDLE*)
+                                                                              const VkSemaphoreGetWin32HandleInfoKHR*,
+                                                                              HANDLE*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkGetSemaphoreWin32HandleKHR");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    inline static VKAPI_ATTR VkResult VKAPI_CALL vkImportFenceWin32HandleKHR(VkDevice, const VkImportFenceWin32HandleInfoKHR*)
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkImportFenceWin32HandleKHR(VkDevice,
+                                                                             const VkImportFenceWin32HandleInfoKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkImportFenceWin32HandleKHR");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetFenceWin32HandleKHR(VkDevice,
-                                                                   const VkFenceGetWin32HandleInfoKHR*,
-                                                                   HANDLE*)
+                                                                          const VkFenceGetWin32HandleInfoKHR*,
+                                                                          HANDLE*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkGetFenceWin32HandleKHR");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetMemoryWin32HandleNV(VkDevice,
-                                                                   VkDeviceMemory,
-                                                                   VkExternalMemoryHandleTypeFlagsNV,
-                                                                   HANDLE*)
+                                                                          VkDeviceMemory,
+                                                                          VkExternalMemoryHandleTypeFlagsNV,
+                                                                          HANDLE*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkGetMemoryWin32HandleNV");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -914,18 +914,18 @@ extern "C"
                                                                                   xcb_visualid_t    visual_id);
 
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateXcbSurfaceKHR(VkInstance,
-                                                                const VkXcbSurfaceCreateInfoKHR*,
-                                                                const VkAllocationCallbacks*,
-                                                                VkSurfaceKHR*)
+                                                                       const VkXcbSurfaceCreateInfoKHR*,
+                                                                       const VkAllocationCallbacks*,
+                                                                       VkSurfaceKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkCreateXcbSurfaceKHR");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
     inline static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceXcbPresentationSupportKHR(VkPhysicalDevice,
-                                                                                       uint32_t,
-                                                                                       xcb_connection_t*,
-                                                                                       xcb_visualid_t)
+                                                                                              uint32_t,
+                                                                                              xcb_connection_t*,
+                                                                                              xcb_visualid_t)
     {
         GFXRECON_LOG_ERROR(
             "Calling unsupported platform extension function vkGetPhysicalDeviceXcbPresentationSupportKHR");
@@ -969,18 +969,18 @@ extern "C"
                                                                                    VisualID         visualID);
 
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateXlibSurfaceKHR(VkInstance,
-                                                                 const VkXlibSurfaceCreateInfoKHR*,
-                                                                 const VkAllocationCallbacks*,
-                                                                 VkSurfaceKHR*)
+                                                                        const VkXlibSurfaceCreateInfoKHR*,
+                                                                        const VkAllocationCallbacks*,
+                                                                        VkSurfaceKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkCreateXlibSurfaceKHR");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
     inline static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceXlibPresentationSupportKHR(VkPhysicalDevice,
-                                                                                        uint32_t,
-                                                                                        Display*,
-                                                                                        VisualID)
+                                                                                               uint32_t,
+                                                                                               Display*,
+                                                                                               VisualID)
     {
         GFXRECON_LOG_ERROR(
             "Calling unsupported platform extension function vkGetPhysicalDeviceXlibPresentationSupportKHR");
@@ -1009,9 +1009,9 @@ extern "C"
     }
 
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetRandROutputDisplayEXT(VkPhysicalDevice,
-                                                                     Display*,
-                                                                     RROutput,
-                                                                     VkDisplayKHR*)
+                                                                            Display*,
+                                                                            RROutput,
+                                                                            VkDisplayKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkGetRandROutputDisplayEXT");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -1093,17 +1093,17 @@ typedef VkBool32(VKAPI_PTR* PFN_vkGetPhysicalDeviceDirectFBPresentationSupportEX
 extern "C"
 {
     inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateDirectFBSurfaceEXT(VkInstance,
-                                                                     const VkDirectFBSurfaceCreateInfoEXT*,
-                                                                     const VkAllocationCallbacks*,
-                                                                     VkSurfaceKHR*)
+                                                                            const VkDirectFBSurfaceCreateInfoEXT*,
+                                                                            const VkAllocationCallbacks*,
+                                                                            VkSurfaceKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkCreateDirectFBSurfaceEXT");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
     inline static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceDirectFBPresentationSupportEXT(VkPhysicalDevice,
-                                                                                            uint32_t,
-                                                                                            IDirectFB*)
+                                                                                                   uint32_t,
+                                                                                                   IDirectFB*)
     {
         GFXRECON_LOG_ERROR(
             "Calling unsupported platform extension function vkGetPhysicalDeviceDirectFBPresentationSupportEXT");
@@ -1139,10 +1139,11 @@ typedef VkBool32(VKAPI_PTR* PFN_vkGetPhysicalDeviceScreenPresentationSupportQNX)
 
 extern "C"
 {
-    inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateScreenSurfaceQNX(VkInstance                          instance,
-                                                                   const VkScreenSurfaceCreateInfoQNX* pCreateInfo,
-                                                                   const VkAllocationCallbacks*        pAllocator,
-                                                                   VkSurfaceKHR*                       pSurface)
+    inline static VKAPI_ATTR VkResult VKAPI_CALL
+    vkCreateScreenSurfaceQNX(VkInstance                          instance,
+                             const VkScreenSurfaceCreateInfoQNX* pCreateInfo,
+                             const VkAllocationCallbacks*        pAllocator,
+                             VkSurfaceKHR*                       pSurface)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkCreateScreenSurfaceQNX");
         return VK_ERROR_EXTENSION_NOT_PRESENT;

--- a/framework/format/platform_types.h
+++ b/framework/format/platform_types.h
@@ -189,7 +189,7 @@ extern "C"
     typedef VkResult(VKAPI_PTR* PFN_vkGetMemoryAndroidHardwareBufferANDROID)(
         VkDevice device, const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo, struct AHardwareBuffer** pBuffer);
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkCreateAndroidSurfaceKHR(VkInstance,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateAndroidSurfaceKHR(VkInstance,
                                                                     const VkAndroidSurfaceCreateInfoKHR*,
                                                                     const VkAllocationCallbacks*,
                                                                     VkSurfaceKHR*)
@@ -198,7 +198,7 @@ extern "C"
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkGetAndroidHardwareBufferPropertiesANDROID(
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetAndroidHardwareBufferPropertiesANDROID(
         VkDevice, const struct AHardwareBuffer*, VkAndroidHardwareBufferPropertiesANDROID*)
     {
         GFXRECON_LOG_ERROR(
@@ -206,7 +206,7 @@ extern "C"
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkGetMemoryAndroidHardwareBufferANDROID(
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetMemoryAndroidHardwareBufferANDROID(
         VkDevice, const VkMemoryGetAndroidHardwareBufferInfoANDROID*, struct AHardwareBuffer**)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkGetMemoryAndroidHardwareBufferANDROID");
@@ -292,7 +292,7 @@ typedef VkResult(VKAPI_PTR* PFN_vkGetSemaphoreZirconHandleFUCHSIA)(
 
 extern "C"
 {
-    static VKAPI_ATTR VkResult VKAPI_CALL vkCreateImagePipeSurfaceFUCHSIA(VkInstance,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateImagePipeSurfaceFUCHSIA(VkInstance,
                                                                           const VkImagePipeSurfaceCreateInfoFUCHSIA*,
                                                                           const VkAllocationCallbacks*,
                                                                           VkSurfaceKHR*)
@@ -301,14 +301,14 @@ extern "C"
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkGetMemoryZirconHandleFUCHSIA(
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetMemoryZirconHandleFUCHSIA(
         VkDevice device, const VkMemoryGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo, zx_handle_t* pZirconHandle)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkGetMemoryZirconHandleFUCHSIA");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL
+    inline static VKAPI_ATTR VkResult VKAPI_CALL
     vkGetMemoryZirconHandlePropertiesFUCHSIA(VkDevice                               device,
                                              VkExternalMemoryHandleTypeFlagBits     handleType,
                                              zx_handle_t                            zirconHandle,
@@ -318,14 +318,14 @@ extern "C"
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkImportSemaphoreZirconHandleFUCHSIA(
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkImportSemaphoreZirconHandleFUCHSIA(
         VkDevice device, const VkImportSemaphoreZirconHandleInfoFUCHSIA* pImportSemaphoreZirconHandleInfo)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkImportSemaphoreZirconHandleFUCHSIA");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkGetSemaphoreZirconHandleFUCHSIA(
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetSemaphoreZirconHandleFUCHSIA(
         VkDevice device, const VkSemaphoreGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo, zx_handle_t* pZirconHandle)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkGetSemaphoreZirconHandleFUCHSIA");
@@ -354,7 +354,7 @@ extern "C"
                                                            const VkAllocationCallbacks*     pAllocator,
                                                            VkSurfaceKHR*                    pSurface);
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkCreateIOSSurfaceMVK(VkInstance,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateIOSSurfaceMVK(VkInstance,
                                                                 const VkIOSSurfaceCreateInfoMVK*,
                                                                 const VkAllocationCallbacks*,
                                                                 VkSurfaceKHR*)
@@ -385,7 +385,7 @@ extern "C"
                                                              const VkAllocationCallbacks*       pAllocator,
                                                              VkSurfaceKHR*                      pSurface);
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkCreateMacOSSurfaceMVK(VkInstance,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateMacOSSurfaceMVK(VkInstance,
                                                                   const VkMacOSSurfaceCreateInfoMVK*,
                                                                   const VkAllocationCallbacks*,
                                                                   VkSurfaceKHR*)
@@ -418,7 +418,7 @@ extern "C"
                                                              const VkAllocationCallbacks*       pAllocator,
                                                              VkSurfaceKHR*                      pSurface);
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkCreateMetalSurfaceEXT(VkInstance,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateMetalSurfaceEXT(VkInstance,
                                                                   const VkMetalSurfaceCreateInfoEXT*,
                                                                   const VkAllocationCallbacks*,
                                                                   VkSurfaceKHR*)
@@ -456,7 +456,7 @@ extern "C"
                                                                                   uint32_t         queueFamilyIndex,
                                                                                   MirConnection*   connection);
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkCreateMirSurfaceKHR(VkInstance,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateMirSurfaceKHR(VkInstance,
                                                                 const VkMirSurfaceCreateInfoKHR*,
                                                                 const VkAllocationCallbacks*,
                                                                 VkSurfaceKHR*)
@@ -465,7 +465,7 @@ extern "C"
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceMirPresentationSupportKHR(VkPhysicalDevice,
+    inline static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceMirPresentationSupportKHR(VkPhysicalDevice,
                                                                                        uint32_t,
                                                                                        MirConnection*)
     {
@@ -496,7 +496,7 @@ extern "C"
                                                          const VkAllocationCallbacks*   pAllocator,
                                                          VkSurfaceKHR*                  pSurface);
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkCreateViSurfaceNN(VkInstance,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateViSurfaceNN(VkInstance,
                                                               const VkViSurfaceCreateInfoNN*,
                                                               const VkAllocationCallbacks*,
                                                               VkSurfaceKHR*)
@@ -533,7 +533,7 @@ extern "C"
     typedef VkBool32(VKAPI_PTR* PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR)(VkPhysicalDevice physicalDevice,
                                                                                       uint32_t         queueFamilyIndex,
                                                                                       struct wl_display* display);
-    static VKAPI_ATTR VkResult VKAPI_CALL vkCreateWaylandSurfaceKHR(VkInstance,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateWaylandSurfaceKHR(VkInstance,
                                                                     const VkWaylandSurfaceCreateInfoKHR*,
                                                                     const VkAllocationCallbacks*,
                                                                     VkSurfaceKHR*)
@@ -542,7 +542,7 @@ extern "C"
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceWaylandPresentationSupportKHR(VkPhysicalDevice,
+    inline static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceWaylandPresentationSupportKHR(VkPhysicalDevice,
                                                                                            uint32_t,
                                                                                            struct wl_display*)
     {
@@ -781,7 +781,7 @@ extern "C"
                                                               VkExternalMemoryHandleTypeFlagsNV handleType,
                                                               HANDLE*                           pHandle);
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkCreateWin32SurfaceKHR(VkInstance,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateWin32SurfaceKHR(VkInstance,
                                                                   const VkWin32SurfaceCreateInfoKHR*,
                                                                   const VkAllocationCallbacks*,
                                                                   VkSurfaceKHR*)
@@ -790,14 +790,14 @@ extern "C"
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceWin32PresentationSupportKHR(VkPhysicalDevice, uint32_t)
+    inline static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceWin32PresentationSupportKHR(VkPhysicalDevice, uint32_t)
     {
         GFXRECON_LOG_ERROR(
             "Calling unsupported platform extension function vkGetPhysicalDeviceWin32PresentationSupportKHR");
         return VK_FALSE;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfacePresentModes2EXT(
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfacePresentModes2EXT(
         VkPhysicalDevice, const VkPhysicalDeviceSurfaceInfo2KHR*, uint32_t*, VkPresentModeKHR*)
     {
         GFXRECON_LOG_ERROR(
@@ -805,28 +805,28 @@ extern "C"
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkAcquireFullScreenExclusiveModeEXT(VkDevice, VkSwapchainKHR)
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkAcquireFullScreenExclusiveModeEXT(VkDevice, VkSwapchainKHR)
     {
         // Convert full screen exclusive calls to no-op functions that report success on non-WIN32 platforms.
         GFXRECON_LOG_INFO("Ignoring WIN32 platform-specific extension function vkAcquireFullScreenExclusiveModeEXT");
         return VK_SUCCESS;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkReleaseFullScreenExclusiveModeEXT(VkDevice, VkSwapchainKHR)
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkReleaseFullScreenExclusiveModeEXT(VkDevice, VkSwapchainKHR)
     {
         // Convert full screen exclusive calls to no-op functions that report success on non-WIN32 platforms.
         GFXRECON_LOG_INFO("Ignoring WIN32 platform-specific extension function vkReleaseFullScreenExclusiveModeEXT");
         return VK_SUCCESS;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkGetDeviceGroupSurfacePresentModes2EXT(
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetDeviceGroupSurfacePresentModes2EXT(
         VkDevice, const VkPhysicalDeviceSurfaceInfo2KHR*, VkDeviceGroupPresentModeFlagsKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkGetDeviceGroupSurfacePresentModes2EXT");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkGetMemoryWin32HandleKHR(VkDevice,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetMemoryWin32HandleKHR(VkDevice,
                                                                     const VkMemoryGetWin32HandleInfoKHR*,
                                                                     HANDLE*)
     {
@@ -834,7 +834,7 @@ extern "C"
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkGetMemoryWin32HandlePropertiesKHR(VkDevice,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetMemoryWin32HandlePropertiesKHR(VkDevice,
                                                                               VkExternalMemoryHandleTypeFlagBits,
                                                                               HANDLE,
                                                                               VkMemoryWin32HandlePropertiesKHR*)
@@ -843,14 +843,14 @@ extern "C"
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkImportSemaphoreWin32HandleKHR(VkDevice,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkImportSemaphoreWin32HandleKHR(VkDevice,
                                                                           const VkImportSemaphoreWin32HandleInfoKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkImportSemaphoreWin32HandleKHR");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkGetSemaphoreWin32HandleKHR(VkDevice,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetSemaphoreWin32HandleKHR(VkDevice,
                                                                        const VkSemaphoreGetWin32HandleInfoKHR*,
                                                                        HANDLE*)
     {
@@ -858,13 +858,13 @@ extern "C"
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkImportFenceWin32HandleKHR(VkDevice, const VkImportFenceWin32HandleInfoKHR*)
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkImportFenceWin32HandleKHR(VkDevice, const VkImportFenceWin32HandleInfoKHR*)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkImportFenceWin32HandleKHR");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkGetFenceWin32HandleKHR(VkDevice,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetFenceWin32HandleKHR(VkDevice,
                                                                    const VkFenceGetWin32HandleInfoKHR*,
                                                                    HANDLE*)
     {
@@ -872,7 +872,7 @@ extern "C"
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkGetMemoryWin32HandleNV(VkDevice,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetMemoryWin32HandleNV(VkDevice,
                                                                    VkDeviceMemory,
                                                                    VkExternalMemoryHandleTypeFlagsNV,
                                                                    HANDLE*)
@@ -913,7 +913,7 @@ extern "C"
                                                                                   xcb_connection_t* connection,
                                                                                   xcb_visualid_t    visual_id);
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkCreateXcbSurfaceKHR(VkInstance,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateXcbSurfaceKHR(VkInstance,
                                                                 const VkXcbSurfaceCreateInfoKHR*,
                                                                 const VkAllocationCallbacks*,
                                                                 VkSurfaceKHR*)
@@ -922,7 +922,7 @@ extern "C"
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceXcbPresentationSupportKHR(VkPhysicalDevice,
+    inline static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceXcbPresentationSupportKHR(VkPhysicalDevice,
                                                                                        uint32_t,
                                                                                        xcb_connection_t*,
                                                                                        xcb_visualid_t)
@@ -968,7 +968,7 @@ extern "C"
                                                                                    Display*         dpy,
                                                                                    VisualID         visualID);
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkCreateXlibSurfaceKHR(VkInstance,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateXlibSurfaceKHR(VkInstance,
                                                                  const VkXlibSurfaceCreateInfoKHR*,
                                                                  const VkAllocationCallbacks*,
                                                                  VkSurfaceKHR*)
@@ -977,7 +977,7 @@ extern "C"
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceXlibPresentationSupportKHR(VkPhysicalDevice,
+    inline static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceXlibPresentationSupportKHR(VkPhysicalDevice,
                                                                                         uint32_t,
                                                                                         Display*,
                                                                                         VisualID)
@@ -1002,13 +1002,13 @@ typedef VkResult(VKAPI_PTR* PFN_vkGetRandROutputDisplayEXT)(VkPhysicalDevice phy
 
 extern "C"
 {
-    static VKAPI_ATTR VkResult VKAPI_CALL vkAcquireXlibDisplayEXT(VkPhysicalDevice, Display*, VkDisplayKHR)
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkAcquireXlibDisplayEXT(VkPhysicalDevice, Display*, VkDisplayKHR)
     {
         GFXRECON_LOG_ERROR("Calling unsupported platform extension function vkAcquireXlibDisplayEXT");
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkResult VKAPI_CALL vkGetRandROutputDisplayEXT(VkPhysicalDevice,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkGetRandROutputDisplayEXT(VkPhysicalDevice,
                                                                      Display*,
                                                                      RROutput,
                                                                      VkDisplayKHR*)
@@ -1051,7 +1051,7 @@ typedef VkResult(VKAPI_PTR* PFN_vkCreateStreamDescriptorSurfaceGGP)(
 
 extern "C"
 {
-    static VKAPI_ATTR VkResult VKAPI_CALL
+    inline static VKAPI_ATTR VkResult VKAPI_CALL
     vkCreateStreamDescriptorSurfaceGGP(VkInstance                                    instance,
                                        const VkStreamDescriptorSurfaceCreateInfoGGP* pCreateInfo,
                                        const VkAllocationCallbacks*                  pAllocator,
@@ -1092,7 +1092,7 @@ typedef VkBool32(VKAPI_PTR* PFN_vkGetPhysicalDeviceDirectFBPresentationSupportEX
 
 extern "C"
 {
-    static VKAPI_ATTR VkResult VKAPI_CALL vkCreateDirectFBSurfaceEXT(VkInstance,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateDirectFBSurfaceEXT(VkInstance,
                                                                      const VkDirectFBSurfaceCreateInfoEXT*,
                                                                      const VkAllocationCallbacks*,
                                                                      VkSurfaceKHR*)
@@ -1101,7 +1101,7 @@ extern "C"
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceDirectFBPresentationSupportEXT(VkPhysicalDevice,
+    inline static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceDirectFBPresentationSupportEXT(VkPhysicalDevice,
                                                                                             uint32_t,
                                                                                             IDirectFB*)
     {
@@ -1139,7 +1139,7 @@ typedef VkBool32(VKAPI_PTR* PFN_vkGetPhysicalDeviceScreenPresentationSupportQNX)
 
 extern "C"
 {
-    static VKAPI_ATTR VkResult VKAPI_CALL vkCreateScreenSurfaceQNX(VkInstance                          instance,
+    inline static VKAPI_ATTR VkResult VKAPI_CALL vkCreateScreenSurfaceQNX(VkInstance                          instance,
                                                                    const VkScreenSurfaceCreateInfoQNX* pCreateInfo,
                                                                    const VkAllocationCallbacks*        pAllocator,
                                                                    VkSurfaceKHR*                       pSurface)
@@ -1148,7 +1148,7 @@ extern "C"
         return VK_ERROR_EXTENSION_NOT_PRESENT;
     }
 
-    static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceScreenPresentationSupportQNX(
+    inline static VKAPI_ATTR VkBool32 VKAPI_CALL vkGetPhysicalDeviceScreenPresentationSupportQNX(
         VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex, struct _screen_window* window)
     {
         GFXRECON_LOG_ERROR(

--- a/framework/generated/generated_vulkan_dispatch_table.h
+++ b/framework/generated/generated_vulkan_dispatch_table.h
@@ -51,7 +51,7 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 typedef const void* DispatchKey;
 
 // Retrieve a dispatch key from a dispatchable handle
-static DispatchKey GetDispatchKey(const void* handle)
+inline static DispatchKey GetDispatchKey(const void* handle)
 {
     const DispatchKey* dispatch_key = reinterpret_cast<const DispatchKey*>(handle);
     return (*dispatch_key);
@@ -1118,7 +1118,7 @@ static void LoadFunction(GetProcAddr gpa, Handle handle, const char* name, FuncP
     }
 }
 
-static void LoadInstanceTable(PFN_vkGetInstanceProcAddr gpa, VkInstance instance, InstanceTable* table)
+inline static void LoadInstanceTable(PFN_vkGetInstanceProcAddr gpa, VkInstance instance, InstanceTable* table)
 {
     assert(table != nullptr);
 
@@ -1222,7 +1222,7 @@ static void LoadInstanceTable(PFN_vkGetInstanceProcAddr gpa, VkInstance instance
     LoadFunction(gpa, instance, "vkGetPhysicalDeviceScreenPresentationSupportQNX", &table->GetPhysicalDeviceScreenPresentationSupportQNX);
 }
 
-static void LoadDeviceTable(PFN_vkGetDeviceProcAddr gpa, VkDevice device, DeviceTable* table)
+inline static void LoadDeviceTable(PFN_vkGetDeviceProcAddr gpa, VkDevice device, DeviceTable* table)
 {
     assert(table != nullptr);
 

--- a/framework/graphics/fps_info.cpp
+++ b/framework/graphics/fps_info.cpp
@@ -61,8 +61,8 @@ FpsInfo::FpsInfo(uint64_t measurement_start_frame,
                  bool     flush_measurement_range) :
     measurement_start_frame_(measurement_start_frame),
     measurement_end_frame_(measurement_end_frame), measurement_start_time_(0), measurement_end_time_(0),
-    quit_after_range_(quit_after_range), flush_measurement_range_(flush_measurement_range),
-    has_measurement_range_(has_measurement_range), started_measurement_(false), ended_measurement_(false)
+    has_measurement_range_(has_measurement_range), quit_after_range_(quit_after_range),
+    flush_measurement_range_(flush_measurement_range), started_measurement_(false), ended_measurement_(false)
 {}
 
 void FpsInfo::BeginFile()

--- a/framework/util/defines.h
+++ b/framework/util/defines.h
@@ -46,7 +46,7 @@
 #define GFXRECON_MAYBE_UNUSED [[maybe_unused]]
 #elif defined(__GNUC__)
 #define GFXRECON_MAYBE_UNUSED [[gnu::maybe_unused]]
-#elif
+#else
 #define GFXRECON_MAYBE_UNUSED
 #endif
 

--- a/framework/util/defines.h
+++ b/framework/util/defines.h
@@ -45,7 +45,7 @@
 #if defined(__clang__)
 #define GFXRECON_MAYBE_UNUSED [[maybe_unused]]
 #elif defined(__GNUC__)
-#define GFXRECON_MAYBE_UNUSED [[gnu::maybe_unused]]
+#define GFXRECON_MAYBE_UNUSED __attribute__((unused))
 #else
 #define GFXRECON_MAYBE_UNUSED
 #endif

--- a/framework/util/defines.h
+++ b/framework/util/defines.h
@@ -39,6 +39,17 @@
 
 #define GFXRECON_UNREFERENCED_PARAMETER(x) ((void)x)
 
+// C++17 introduced "[[maybe_unused]]".  While we still use a prior
+// C++ version, define some helpful macros.
+
+#if defined(__clang__)
+#define GFXRECON_MAYBE_UNUSED [[maybe_unused]]
+#elif defined(__GNUC__)
+#define GFXRECON_MAYBE_UNUSED [[gnu::maybe_unused]]
+#elif
+#define GFXRECON_MAYBE_UNUSED 
+#endif
+
 // Use two macros for the x is a macro case, to ensure macro expansion is applied to x prior to string conversion.
 #define GFXRECON_STR_EXPAND(x) #x
 #define GFXRECON_STR(x) GFXRECON_STR_EXPAND(x)

--- a/framework/util/defines.h
+++ b/framework/util/defines.h
@@ -47,7 +47,7 @@
 #elif defined(__GNUC__)
 #define GFXRECON_MAYBE_UNUSED [[gnu::maybe_unused]]
 #elif
-#define GFXRECON_MAYBE_UNUSED 
+#define GFXRECON_MAYBE_UNUSED
 #endif
 
 // Use two macros for the x is a macro case, to ensure macro expansion is applied to x prior to string conversion.

--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -144,7 +144,6 @@ VKAPI_ATTR VkResult VKAPI_CALL dispatch_CreateInstance(const VkInstanceCreateInf
             if (fpCreateInstance)
             {
                 // Advance the link info for the next element on the chain
-                auto pLayerInfo          = chain_info->u.pLayerInfo;
                 chain_info->u.pLayerInfo = chain_info->u.pLayerInfo->pNext;
 
                 result = fpCreateInstance(pCreateInfo, pAllocator, pInstance);

--- a/tools/compress/main.cpp
+++ b/tools/compress/main.cpp
@@ -163,6 +163,8 @@ int main(int argc, const char** argv)
         {
             _set_abort_behavior(0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
         }
+#else
+        GFXRECON_UNREFERENCED_PARAMETER(kNoDebugPopup);
 #endif
     }
 

--- a/tools/extract/main.cpp
+++ b/tools/extract/main.cpp
@@ -40,7 +40,7 @@ const char kHelpShortOption[]   = "-h";
 const char kHelpLongOption[]    = "--help";
 const char kVersionOption[]     = "--version";
 const char kDirectoryArgument[] = "--dir";
-const char kNoDebugPopup[]      = "--no-debug-popup";
+GFXRECON_MAYBE_UNUSED const char kNoDebugPopup[]    = "--no-debug-popup";
 
 const char kOptions[]   = "-h|--help,--version,--no-debug-popup";
 const char kArguments[] = "--dir";

--- a/tools/extract/main.cpp
+++ b/tools/extract/main.cpp
@@ -36,11 +36,11 @@
 #include <cstdlib>
 #include <string>
 
-const char kHelpShortOption[]   = "-h";
-const char kHelpLongOption[]    = "--help";
-const char kVersionOption[]     = "--version";
-const char kDirectoryArgument[] = "--dir";
-GFXRECON_MAYBE_UNUSED const char kNoDebugPopup[]    = "--no-debug-popup";
+const char                       kHelpShortOption[]   = "-h";
+const char                       kHelpLongOption[]    = "--help";
+const char                       kVersionOption[]     = "--version";
+const char                       kDirectoryArgument[] = "--dir";
+GFXRECON_MAYBE_UNUSED const char kNoDebugPopup[]      = "--no-debug-popup";
 
 const char kOptions[]   = "-h|--help,--version,--no-debug-popup";
 const char kArguments[] = "--dir";

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -39,9 +39,9 @@
 #include <string>
 #include <unordered_map>
 
-const char kHelpShortOption[] = "-h";
-const char kHelpLongOption[]  = "--help";
-const char kVersionOption[]   = "--version";
+const char                       kHelpShortOption[] = "-h";
+const char                       kHelpLongOption[]  = "--help";
+const char                       kVersionOption[]   = "--version";
 GFXRECON_MAYBE_UNUSED const char kNoDebugPopup[]    = "--no-debug-popup";
 
 const char kOptions[] = "-h|--help,--version,--no-debug-popup";

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -42,7 +42,7 @@
 const char kHelpShortOption[] = "-h";
 const char kHelpLongOption[]  = "--help";
 const char kVersionOption[]   = "--version";
-const char kNoDebugPopup[]    = "--no-debug-popup";
+GFXRECON_MAYBE_UNUSED const char kNoDebugPopup[]    = "--no-debug-popup";
 
 const char kOptions[] = "-h|--help,--version,--no-debug-popup";
 

--- a/tools/optimize/main.cpp
+++ b/tools/optimize/main.cpp
@@ -42,7 +42,7 @@
 const char kHelpShortOption[] = "-h";
 const char kHelpLongOption[]  = "--help";
 const char kVersionOption[]   = "--version";
-const char kNoDebugPopup[]    = "--no-debug-popup";
+GFXRECON_MAYBE_UNUSED const char kNoDebugPopup[]    = "--no-debug-popup";
 
 const char kOptions[] = "-h|--help,--version,--no-debug-popup";
 
@@ -107,7 +107,7 @@ static bool CheckOptionPrintVersion(const char* exe_name, const gfxrecon::util::
     return false;
 }
 
-static std::string GetVersionString(uint32_t api_version)
+GFXRECON_MAYBE_UNUSED static std::string GetVersionString(uint32_t api_version)
 {
     uint32_t major = api_version >> 22;
     uint32_t minor = (api_version >> 12) & 0x3ff;

--- a/tools/optimize/main.cpp
+++ b/tools/optimize/main.cpp
@@ -39,9 +39,9 @@
 #include <unordered_set>
 #include <vector>
 
-const char kHelpShortOption[] = "-h";
-const char kHelpLongOption[]  = "--help";
-const char kVersionOption[]   = "--version";
+const char                       kHelpShortOption[] = "-h";
+const char                       kHelpLongOption[]  = "--help";
+const char                       kVersionOption[]   = "--version";
 GFXRECON_MAYBE_UNUSED const char kNoDebugPopup[]    = "--no-debug-popup";
 
 const char kOptions[] = "-h|--help,--version,--no-debug-popup";

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -131,7 +131,7 @@ const char kDefaultScreenshotDir[] = "/sdcard";
 const char kDefaultScreenshotDir[] = "";
 #endif
 
-static void ProcessDisableDebugPopup(const gfxrecon::util::ArgumentParser& arg_parser)
+GFXRECON_MAYBE_UNUSED static void ProcessDisableDebugPopup(const gfxrecon::util::ArgumentParser& arg_parser)
 {
 #if defined(WIN32) && defined(_DEBUG)
     if (arg_parser.IsOptionSet(kNoDebugPopup))
@@ -141,7 +141,7 @@ static void ProcessDisableDebugPopup(const gfxrecon::util::ArgumentParser& arg_p
 #endif
 }
 
-static void CheckActiveLayers(const std::string& list)
+GFXRECON_MAYBE_UNUSED static void CheckActiveLayers(const std::string& list)
 {
     if (!list.empty())
     {
@@ -231,7 +231,7 @@ InitRealignAllocatorCreateFunc(const std::string&                              f
     };
 }
 
-static uint32_t GetPauseFrame(const gfxrecon::util::ArgumentParser& arg_parser)
+GFXRECON_MAYBE_UNUSED static uint32_t GetPauseFrame(const gfxrecon::util::ArgumentParser& arg_parser)
 {
     uint32_t    pause_frame = 0;
     const auto& value       = arg_parser.GetArgumentValue(kPauseFrameArgument);
@@ -248,7 +248,7 @@ static uint32_t GetPauseFrame(const gfxrecon::util::ArgumentParser& arg_parser)
     return pause_frame;
 }
 
-static WsiPlatform GetWsiPlatform(const gfxrecon::util::ArgumentParser& arg_parser)
+GFXRECON_MAYBE_UNUSED static WsiPlatform GetWsiPlatform(const gfxrecon::util::ArgumentParser& arg_parser)
 {
     WsiPlatform wsi_platform = WsiPlatform::kAuto;
     const auto& value        = arg_parser.GetArgumentValue(kWsiArgument);
@@ -316,7 +316,7 @@ static WsiPlatform GetWsiPlatform(const gfxrecon::util::ArgumentParser& arg_pars
     return wsi_platform;
 }
 
-static std::string GetWsiExtensionName(WsiPlatform wsi_platform)
+GFXRECON_MAYBE_UNUSED static std::string GetWsiExtensionName(WsiPlatform wsi_platform)
 {
     switch (wsi_platform)
     {
@@ -357,7 +357,7 @@ static std::string GetWsiExtensionName(WsiPlatform wsi_platform)
     }
 }
 
-static std::string GetWsiArgString()
+GFXRECON_MAYBE_UNUSED static std::string GetWsiArgString()
 {
     std::string wsi_args = kWsiPlatformAuto;
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
@@ -388,7 +388,7 @@ static std::string GetWsiArgString()
 }
 
 // Modifies settings parameter with values set via command line
-static void GetLogSettings(const gfxrecon::util::ArgumentParser& arg_parser,
+GFXRECON_MAYBE_UNUSED static void GetLogSettings(const gfxrecon::util::ArgumentParser& arg_parser,
                            gfxrecon::util::Log::Settings&        log_settings)
 {
     // Parse log level
@@ -474,7 +474,7 @@ GetScreenshotRanges(const gfxrecon::util::ArgumentParser& arg_parser)
     return ranges;
 }
 
-static bool
+GFXRECON_MAYBE_UNUSED static bool
 GetMeasurementFrameRange(const gfxrecon::util::ArgumentParser& arg_parser, uint32_t& start_frame, uint32_t& end_frame)
 {
     start_frame = 1;
@@ -621,7 +621,7 @@ static bool IsApiFamilyIdEnabled(const gfxrecon::util::ArgumentParser& arg_parse
 }
 #endif
 
-static std::vector<int32_t> GetFilteredMsgs(const gfxrecon::util::ArgumentParser& arg_parser,
+GFXRECON_MAYBE_UNUSED static std::vector<int32_t> GetFilteredMsgs(const gfxrecon::util::ArgumentParser& arg_parser,
                                             const char*                           filter_messages)
 {
     const auto&          value = arg_parser.GetArgumentValue(filter_messages);
@@ -689,7 +689,7 @@ static void GetReplayOptions(gfxrecon::decode::ReplayOptions& options, const gfx
     }
 }
 
-static gfxrecon::decode::VulkanReplayOptions
+GFXRECON_MAYBE_UNUSED static gfxrecon::decode::VulkanReplayOptions
 GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parser,
                        const std::string&                              filename,
                        gfxrecon::decode::VulkanTrackedObjectInfoTable* tracked_object_info_table)

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -389,7 +389,7 @@ GFXRECON_MAYBE_UNUSED static std::string GetWsiArgString()
 
 // Modifies settings parameter with values set via command line
 GFXRECON_MAYBE_UNUSED static void GetLogSettings(const gfxrecon::util::ArgumentParser& arg_parser,
-                           gfxrecon::util::Log::Settings&        log_settings)
+                                                 gfxrecon::util::Log::Settings&        log_settings)
 {
     // Parse log level
     gfxrecon::util::Log::Severity log_level;
@@ -622,7 +622,7 @@ static bool IsApiFamilyIdEnabled(const gfxrecon::util::ArgumentParser& arg_parse
 #endif
 
 GFXRECON_MAYBE_UNUSED static std::vector<int32_t> GetFilteredMsgs(const gfxrecon::util::ArgumentParser& arg_parser,
-                                            const char*                           filter_messages)
+                                                                  const char*                           filter_messages)
 {
     const auto&          value = arg_parser.GetArgumentValue(filter_messages);
     std::vector<int32_t> msgs;


### PR DESCRIPTION
Clean up for clang.
Mark a bunch of functions `inline` so they aren't compiled multiple times in one unit.
Mark a bunch of variables and functions maybe unused.
Delete some unused variables.