### PR TITLE
Store architecture type used when capturing

### DIFF
--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -683,6 +683,12 @@ void CaptureManager::BuildOptionList(const format::EnabledOptions&        enable
     assert(option_list != nullptr);
 
     option_list->push_back({ format::FileOption::kCompressionType, enabled_options.compression_type });
+
+#ifdef GFXRECON_ARCH64
+    option_list->push_back({ format::FileOption::kCaptureArch, format::CaptureArchType::k64bit });
+#else
+    option_list->push_back({ format::FileOption::kCaptureArch, format::CaptureArchType::k32bit });
+#endif
 }
 
 void CaptureManager::WriteDisplayMessageCmd(const char* message)

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -142,11 +142,19 @@ enum CompressionType : uint32_t
     kZstd = 3
 };
 
+enum CaptureArchType : uint32_t
+{
+    kUnknownArch  = 0,
+    k32bit        = 1,
+    k64bit        = 2
+};
+
 enum FileOption : uint32_t
 {
     kUnknownFileOption = 0,
     kCompressionType   = 1, // One of the CompressionType values defining the compression algorithm used with parameter
                             // encoding. Default = CompressionType::kNone.
+    kCaptureArch       = 2
 };
 
 enum PointerAttributes : uint32_t

--- a/tools/info/main.cpp
+++ b/tools/info/main.cpp
@@ -543,6 +543,7 @@ int main(int argc, const char** argv)
 
             // File options.
             gfxrecon::format::CompressionType compression_type = gfxrecon::format::CompressionType::kNone;
+            gfxrecon::format::CaptureArchType arch_type        = gfxrecon::format::CaptureArchType::kUnknownArch;
 
             auto file_options = file_processor.GetFileOptions();
             for (const auto& option : file_options)
@@ -550,6 +551,10 @@ int main(int argc, const char** argv)
                 if (option.key == gfxrecon::format::FileOption::kCompressionType)
                 {
                     compression_type = static_cast<gfxrecon::format::CompressionType>(option.value);
+                }
+                else if (option.key == gfxrecon::format::FileOption::kCaptureArch)
+                {
+                    arch_type = static_cast<gfxrecon::format::CaptureArchType>(option.value);
                 }
             }
 
@@ -562,6 +567,12 @@ int main(int argc, const char** argv)
             else
             {
                 GFXRECON_WRITE_CONSOLE("\tCompression format: %s", kUnrecognizedFormatString);
+            }
+
+            if (arch_type != gfxrecon::format::CaptureArchType::kUnknownArch)
+            {
+                GFXRECON_WRITE_CONSOLE("\tArchitecture: %s",
+                                       arch_type == gfxrecon::format::CaptureArchType::k32bit ? "32bit" : "64bit");
             }
 
             // Frame counts.


### PR DESCRIPTION
Store architecture type when capturing a trace in the file's header.
gfxrecon-info prints that information