### PR TITLE
Make SetRayTracingShaderGroupHandlesCommandHeader`s size constant

### DIFF
--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -885,7 +885,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
         success = success && ReadBytes(&header.data_size, sizeof(header.data_size));
 
         // Read variable size shader group handle data into parameter_buffer_.
-        success = success && ReadParameterBuffer(header.data_size);
+        success = success && ReadParameterBuffer(static_cast<size_t>(header.data_size));
 
         if (success)
         {
@@ -896,7 +896,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                     decoder->DispatchSetRayTracingShaderGroupHandlesCommand(header.thread_id,
                                                                             header.device_id,
                                                                             header.pipeline_id,
-                                                                            header.data_size,
+                                                                            static_cast<size_t>(header.data_size),
                                                                             parameter_buffer_.data());
                 }
             }

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -456,7 +456,7 @@ struct SetRayTracingShaderGroupHandlesCommandHeader
     format::ThreadId thread_id;
     format::HandleId device_id;
     format::HandleId pipeline_id;
-    size_t           data_size;
+    uint64_t         data_size;
 };
 
 struct CreateHeapAllocationCommand


### PR DESCRIPTION
One of the members of SetRayTracingShaderGroupHandlesCommandHeader was
of size_t type. This would cause trouble when replaying captures
captured in 32bit with a 64bit gfxrecon-replay or vice versa

This commit converts that member variable to uint64_t in order to have a
fixed size