### PR TITLE
Fix for race condition - deadlock

### DIFF
--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -617,8 +617,6 @@ std::string CaptureManager::CreateTrimFilename(const std::string&               
 
 bool CaptureManager::CreateCaptureFile(const std::string& base_filename)
 {
-    auto state_lock = AcquireUniqueStateLock();
-
     bool        success          = true;
     std::string capture_filename = base_filename;
 
@@ -645,8 +643,6 @@ bool CaptureManager::CreateCaptureFile(const std::string& base_filename)
 
 void CaptureManager::ActivateTrimming()
 {
-    auto state_lock = AcquireUniqueStateLock();
-
     capture_mode_ |= kModeWrite;
 
     auto thread_data = GetThreadData();
@@ -657,8 +653,6 @@ void CaptureManager::ActivateTrimming()
 
 void CaptureManager::DeactivateTrimming()
 {
-    auto state_lock = AcquireUniqueStateLock();
-
     capture_mode_ &= ~kModeWrite;
     file_stream_ = nullptr;
 }

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -50,7 +50,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(
     const VkAllocationCallbacks*                pAllocator,
     VkInstance*                                 pInstance)
 {
-    auto state_lock = VulkanCaptureManager::Get()->AcquireSharedStateLock();
+    auto state_lock = VulkanCaptureManager::Get()->AcquireUniqueStateLock();
 
     bool omit_output_data = false;
 
@@ -6607,7 +6607,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(
     VkQueue                                     queue,
     const VkPresentInfoKHR*                     pPresentInfo)
 {
-    auto state_lock = VulkanCaptureManager::Get()->AcquireSharedStateLock();
+    auto state_lock = VulkanCaptureManager::Get()->AcquireUniqueStateLock();
 
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueuePresentKHR>::Dispatch(VulkanCaptureManager::Get(), queue, pPresentInfo);
 

--- a/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_api_call_encoders_body_generator.py
@@ -217,7 +217,11 @@ class VulkanApiCallEncodersBodyGenerator(BaseGenerator):
 
         body = ''
 
-        body += indent + 'auto state_lock = VulkanCaptureManager::Get()->AcquireSharedStateLock();\n'
+        if name == "vkCreateInstance" or name == "vkQueuePresentKHR":
+            body += indent + 'auto state_lock = VulkanCaptureManager::Get()->AcquireUniqueStateLock();\n'
+        else:
+            body += indent + 'auto state_lock = VulkanCaptureManager::Get()->AcquireSharedStateLock();\n'
+
         body += '\n'
 
         if has_outputs or (return_type and return_type != 'void'):


### PR DESCRIPTION
A race condition - bad combination of mutexes existed in the the
codepath of vkCreateInstance which caused a hang when two threads called
the function at the same time. This commit addresses the issue.

Also the internal implementation of shared_mutex is removed in favor of
std::shared_timed_mutex.