### PR TITLE
Add timestamp metadata and use it to replay at same speed

### DIFF
--- a/USAGE_android.md
+++ b/USAGE_android.md
@@ -305,7 +305,7 @@ usage: gfxrecon.py replay [-h] [-p LOCAL_FILE] [--version] [--pause-frame N]
                           [--screenshot-format FORMAT] [--screenshot-dir DIR]
                           [--screenshot-prefix PREFIX] [--sfa] [--opcd]
                           [--surface-index N] [--sync] [--remove-unsupported]
-                          [-m MODE]
+                          [--timestamp-sync] [-m MODE]
                           [file]
 
 Launch the replay tool.
@@ -370,6 +370,8 @@ optional arguments:
   --onhb, --omit-null-hardware-buffers
                         Omit Vulkan API calls which would pass a NULL
                         AHardwareBuffer*.  (forwarded to replay tool)
+  --timestamp-sync      Adjust playback speed to match speed of recorded
+                        application (forwarded to replay tool)
 ```
 
 The command will force-stop an active replay process before starting the replay

--- a/USAGE_desktop.md
+++ b/USAGE_desktop.md
@@ -353,7 +353,7 @@ gfxrecon-replay         [-h | --help] [--version] [--gpu <index>]
                         [--screenshot-dir <dir>] [--screenshot-prefix <file-prefix>]
                         [--sfa | --skip-failed-allocations] [--replace-shaders <dir>]
                         [--opcd | --omit-pipeline-cache-data] [--wsi <platform>]
-                        [--surface-index <N>] [--remove-unsupported]
+                        [--surface-index <N>] [--remove-unsupported] [--timestamp-sync]
                         [-m <mode> | --memory-translation <mode>]
                         [--log-level <level>] [--log-file <file>] [--log-debugview]
                         <file>
@@ -437,6 +437,7 @@ Optional arguments:
                                         to different allocations with different
                                         offsets.  Uses VMA to manage allocations
                                         and suballocations.
+  --timestamp-sync      Adjust playback speed to match speed of recorded application.
 ```
 
 ### Keyboard Controls

--- a/android/scripts/gfxrecon.py
+++ b/android/scripts/gfxrecon.py
@@ -79,6 +79,7 @@ def CreateReplayParser():
     parser.add_argument('--sync', action='store_true', default=False, help='Synchronize after each queue submission with vkQueueWaitIdle (forwarded to replay tool)')
     parser.add_argument('--remove-unsupported', action='store_true', default=False, help='Remove unsupported extensions and features from instance and device creation parameters (forwarded to replay tool)')
     parser.add_argument('--onhb', '--omit-null-hardware-buffers', action='store_true', default=False, help='Omit Vulkan calls that would pass a NULL AHardwareBuffer* (forwarded to replay tool)')
+    parser.add_argument('--timestamp-sync', action='store_true', default=False, help='Adjust playback speed to match speed of recorded application (forwarded to replay tool)')
 
     parser.add_argument('-m', '--memory-translation', metavar='MODE', choices=['none', 'remap', 'realign', 'rebind'], help='Enable memory translation for replay on GPUs with memory types that are not compatible with the capture GPU\'s memory types.  Available modes are: none, remap, realign, rebind (forwarded to replay tool)')
     parser.add_argument('file', nargs='?', help='File on device to play (forwarded to replay tool)')
@@ -137,6 +138,9 @@ def MakeExtrasString(args):
     if args.memory_translation:
         arg_list.append('-m')
         arg_list.append('{}'.format(args.memory_translation))
+    
+    if args.timestamp_sync:
+        arg_list.append('--timestamp-sync')
 
     if args.file:
         arg_list.append(args.file)

--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -31,6 +31,7 @@
 #include "vulkan/vulkan.h"
 
 #include <string>
+#include <chrono>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -62,6 +63,9 @@ class ApiDecoder
     virtual void DispatchStateEndMarker(uint64_t frame_number) = 0;
 
     virtual void DispatchDisplayMessageCommand(format::ThreadId thread_id, const std::string& message) = 0;
+
+    virtual void DispatchTimestampCommand(format::ThreadId                                    thread_id,
+                                          decltype(std::chrono::high_resolution_clock::now()) time) = 0;
 
     virtual void DispatchFillMemoryCommand(
         format::ThreadId thread_id, uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data) = 0;

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -55,6 +55,8 @@ class VulkanConsumerBase
 
     virtual void ProcessDisplayMessageCommand(const std::string& message) {}
 
+    virtual void ProcessTimestampCommand(decltype(std::chrono::high_resolution_clock::now()) time) {}
+
     virtual void ProcessFillMemoryCommand(uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data) {}
 
     virtual void ProcessResizeWindowCommand(format::HandleId surface_id, uint32_t width, uint32_t height) {}

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -75,6 +75,17 @@ void VulkanDecoderBase::DispatchFillMemoryCommand(
     }
 }
 
+void VulkanDecoderBase::DispatchTimestampCommand(format::ThreadId                                    thread_id,
+                                                 decltype(std::chrono::high_resolution_clock::now()) time)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(thread_id);
+
+    for (auto consumer : consumers_)
+    {
+        consumer->ProcessTimestampCommand(time);
+    }
+}
+
 void VulkanDecoderBase::DispatchResizeWindowCommand(format::ThreadId thread_id,
                                                     format::HandleId surface_id,
                                                     uint32_t         width,

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -76,6 +76,9 @@ class VulkanDecoderBase : public ApiDecoder
 
     virtual void DispatchStateEndMarker(uint64_t frame_number) override;
 
+    virtual void DispatchTimestampCommand(format::ThreadId                                    thread_id,
+                                          decltype(std::chrono::high_resolution_clock::now()) time) override;
+
     virtual void DispatchDisplayMessageCommand(format::ThreadId thread_id, const std::string& message) override;
 
     virtual void DispatchFillMemoryCommand(

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -247,19 +247,22 @@ void VulkanReplayConsumerBase::ProcessDisplayMessageCommand(const std::string& m
 
 void VulkanReplayConsumerBase::ProcessTimestampCommand(decltype(std::chrono::high_resolution_clock::now()) time)
 {
-    if (last_timestamp_capture_ != std::chrono::time_point<std::chrono::high_resolution_clock>{})
+    if (options_.sync_to_timestamps)
     {
-        auto duration_capture = time - last_timestamp_capture_;
-        auto duration_replay  = std::chrono::high_resolution_clock::now() - last_timestamp_replay_;
-        if (duration_replay < duration_capture)
+        if (last_timestamp_capture_ != std::chrono::time_point<std::chrono::high_resolution_clock>{})
         {
-            auto to_sleep = duration_capture - duration_replay;
-            GFXRECON_LOG_DEBUG("Sleeping %f ms to sync", std::chrono::duration<double, std::milli>(to_sleep).count());
-            std::this_thread::sleep_for(to_sleep);
+            auto duration_capture = time - last_timestamp_capture_;
+            auto duration_replay  = std::chrono::high_resolution_clock::now() - last_timestamp_replay_;
+            if (duration_replay < duration_capture)
+            {
+                auto to_sleep = duration_capture - duration_replay;
+                GFXRECON_LOG_DEBUG("Sleeping %f ms to sync", std::chrono::duration<double, std::milli>(to_sleep).count());
+                std::this_thread::sleep_for(to_sleep);
+            }
         }
+        last_timestamp_capture_ = time;
+        last_timestamp_replay_  = std::chrono::high_resolution_clock::now();
     }
-    last_timestamp_capture_ = time;
-    last_timestamp_replay_  = std::chrono::high_resolution_clock::now();
 }
 
 void VulkanReplayConsumerBase::ProcessFillMemoryCommand(uint64_t       memory_id,

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -84,6 +84,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
 
     virtual void ProcessDisplayMessageCommand(const std::string& message) override;
 
+    virtual void ProcessTimestampCommand(decltype(std::chrono::high_resolution_clock::now()) time) override;
+
     virtual void
     ProcessFillMemoryCommand(uint64_t memory_id, uint64_t offset, uint64_t size, const uint8_t* data) override;
 
@@ -1039,6 +1041,8 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     std::string                                                      screenshot_file_prefix_;
     int32_t                                                          create_surface_count_;
     graphics::FpsInfo*                                               fps_info_;
+    std::chrono::time_point<std::chrono::high_resolution_clock>      last_timestamp_capture_;
+    std::chrono::time_point<std::chrono::high_resolution_clock>      last_timestamp_replay_;
 
     // Used to track if any shadow sync objects are active to avoid checking if not needed
     std::unordered_set<VkSemaphore> shadow_semaphores_;

--- a/framework/decode/vulkan_replay_options.h
+++ b/framework/decode/vulkan_replay_options.h
@@ -55,6 +55,7 @@ struct VulkanReplayOptions : public ReplayOptions
     std::string                  screenshot_dir;
     std::string                  screenshot_file_prefix{ kDefaultScreenshotFilePrefix };
     std::string                  replace_dir;
+    bool                         sync_to_timestamps{ false };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -681,6 +681,23 @@ void CaptureManager::BuildOptionList(const format::EnabledOptions&        enable
     option_list->push_back({ format::FileOption::kCompressionType, enabled_options.compression_type });
 }
 
+void CaptureManager::WriteTimestamp(decltype(std::chrono::high_resolution_clock::now()) time)
+{
+    if ((capture_mode_ & kModeWrite) == kModeWrite)
+    {
+        format::TimestampCommand timestamp_cmd;
+        timestamp_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
+        timestamp_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(timestamp_cmd);
+        timestamp_cmd.meta_header.meta_data_id =
+            format::MakeMetaDataId(api_family_, format::MetaDataType::kTimestampCommand);
+        timestamp_cmd.thread_id = GetThreadData()->thread_id_;
+
+        timestamp_cmd.time_nanos = std::chrono::nanoseconds(time.time_since_epoch()).count();
+
+        WriteToFile(&timestamp_cmd, sizeof(timestamp_cmd));
+    }
+}
+
 void CaptureManager::WriteDisplayMessageCmd(const char* message)
 {
     if ((capture_mode_ & kModeWrite) == kModeWrite)

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -227,6 +227,9 @@ class CaptureManager
 
     ParameterEncoder* InitMethodCallCapture(format::ApiCallId call_id, format::HandleId object_id);
 
+    void WriteTimestamp(
+        decltype(std::chrono::high_resolution_clock::now()) time = std::chrono::high_resolution_clock::now());
+
     void WriteResizeWindowCmd(format::HandleId surface_id, uint32_t width, uint32_t height);
 
     void WriteFillMemoryCmd(format::HandleId memory_id, uint64_t offset, uint64_t size, const void* data);

--- a/framework/encode/custom_vulkan_encoder_commands.h
+++ b/framework/encode/custom_vulkan_encoder_commands.h
@@ -900,6 +900,16 @@ struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetAndroidHardwareBuffe
     }
 };
 
+template <>
+struct CustomEncoderPreCall<format::ApiCallId::ApiCall_vkQueuePresentKHR>
+{
+    template <typename... Args>
+    static void Dispatch(VulkanCaptureManager* manager, Args... args)
+    {
+        manager->PreProcess_vkQueuePresentKHR(args...);
+    }
+};
+
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)
 

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -2151,6 +2151,13 @@ void VulkanCaptureManager::PreProcess_vkGetAndroidHardwareBufferPropertiesANDROI
 #endif
 }
 
+void VulkanCaptureManager::PreProcess_vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo)
+{
+    GFXRECON_UNREFERENCED_PARAMETER(queue);
+    GFXRECON_UNREFERENCED_PARAMETER(pPresentInfo);
+    WriteTimestamp();
+}
+
 #if defined(__ANDROID__)
 void VulkanCaptureManager::OverrideGetPhysicalDeviceSurfacePresentModesKHR(uint32_t*         pPresentModeCount,
                                                                            VkPresentModeKHR* pPresentModes)

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -938,6 +938,8 @@ class VulkanCaptureManager : public CaptureManager
                                                                 const struct AHardwareBuffer*             buffer,
                                                                 VkAndroidHardwareBufferPropertiesANDROID* pProperties);
 
+    void PreProcess_vkQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo);
+
 #if defined(__ANDROID__)
     void OverrideGetPhysicalDeviceSurfacePresentModesKHR(uint32_t* pPresentModeCount, VkPresentModeKHR* pPresentModes);
 #endif

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -112,7 +112,8 @@ enum class MetaDataType : uint16_t
     kSetOpaqueAddressCommand                = 14,
     kSetRayTracingShaderGroupHandlesCommand = 15,
     kCreateHeapAllocationCommand            = 16,
-    kInitSubresourceCommand                 = 17
+    kInitSubresourceCommand                 = 17,
+    kTimestampCommand                       = 18
 };
 
 // MetaDataId is stored in the capture file and its type must be uint32_t to avoid breaking capture file compatibility.
@@ -268,6 +269,15 @@ struct FillMemoryCommandHeader
     HandleId memory_id;
     uint64_t memory_offset; // Offset from the start of the mapped pointer, not the start of the memory object.
     uint64_t memory_size;   // Uncompressed size of the data encoded after the header.
+};
+
+// Not a header because this command does not include a variable length data payload.
+// All of the command data is present in the struct.
+struct TimestampCommand
+{
+    MetaDataHeader   meta_header;
+    format::ThreadId thread_id;
+    uint64_t         time_nanos;
 };
 
 struct DisplayMessageCommandHeader

--- a/tools/replay/replay_settings.h
+++ b/tools/replay/replay_settings.h
@@ -29,7 +29,7 @@ const char kOptions[] =
     "-h|--help,--version,--log-debugview,--no-debug-popup,--paused,--sync,--sfa|--skip-failed-allocations,--"
     "opcd|--omit-pipeline-cache-data,--remove-unsupported,--validate,--debug-device-lost,--create-dummy-allocations,--"
     "screenshot-all,--dcp,--discard-cached-psos,--onhb|--omit-null-hardware-buffers,--qamr|--quit-after-measurement-"
-    "range,--fmr|--flush-measurement-range";
+    "range,--fmr|--flush-measurement-range,--timestamp-sync";
 const char kArguments[] = "--log-level,--log-file,--gpu,--pause-frame,--wsi,--surface-index,-m|--memory-translation,--"
                           "replace-shaders,--screenshots,--denied-messages,--allowed-messages,--screenshot-format,--"
                           "screenshot-dir,--screenshot-prefix,--mfr|--measurement-frame-range";
@@ -53,7 +53,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("\t\t\t[--sfa | --skip-failed-allocations] [--replace-shaders <dir>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--opcd | --omit-pipeline-cache-data] [--wsi <platform>]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--dcp | --discard-cached-psos] [--surface-index <N>]");
-    GFXRECON_WRITE_CONSOLE("\t\t\t[--remove-unsupported] [--validate]");
+    GFXRECON_WRITE_CONSOLE("\t\t\t[--remove-unsupported] [--validate] [--timestamp-sync]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[--onhb | --omit-null-hardware-buffers]");
     GFXRECON_WRITE_CONSOLE("\t\t\t[-m <mode> | --memory-translation <mode>]");
 #if defined(WIN32)
@@ -164,6 +164,7 @@ static void PrintUsage(const char* exe_name)
     GFXRECON_WRITE_CONSOLE("          \t\t         \tto different allocations with different");
     GFXRECON_WRITE_CONSOLE("          \t\t         \toffsets.  Uses VMA to manage allocations");
     GFXRECON_WRITE_CONSOLE("          \t\t         \tand suballocations.");
+    GFXRECON_WRITE_CONSOLE("  --timestamp-sync\tAdjust playback speed to match speed of recorded application.");
 #if defined(WIN32)
     GFXRECON_WRITE_CONSOLE("  --api <api>\t\tUse the specified API for replay (Windows only).");
     GFXRECON_WRITE_CONSOLE("          \t\tAvailable values are:");

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -90,6 +90,7 @@ const char kOutput[]                             = "--output";
 const char kMeasurementRangeArgument[]           = "--measurement-frame-range";
 const char kQuitAfterMeasurementRangeOption[]    = "--quit-after-measurement-range";
 const char kFlushMeasurementRangeOption[]        = "--flush-measurement-range";
+const char kSyncToTimestamps[]                   = "--timestamp-sync";
 #if defined(WIN32)
 const char kApiFamilyOption[] = "--api";
 #endif
@@ -748,6 +749,11 @@ GetVulkanReplayOptions(const gfxrecon::util::ArgumentParser&           arg_parse
     if (!surface_index.empty())
     {
         replay_options.surface_index = std::stoi(surface_index);
+    }
+
+    if (arg_parser.IsOptionSet(kSyncToTimestamps))
+    {
+        replay_options.sync_to_timestamps = true;
     }
 
     return replay_options;


### PR DESCRIPTION
This adds a timestamp command before every VkQueuePresent and syncs the relative delay between timestamp commands in replay.

Therefore, the replay will be around the same speed as the original program and e.g. animations do not look too fast.

This is just something I needed and found useful for myself. I would probably make this optional for replay and maybe for capture as well. The changes required for that will be added later on.

I would appreciate any kind of feedback on this, but it would of course also be fine if this kind of feature is not desired for GFXreconstruct.