### PR TITLE
Deferred operation for CreateRayTracingPipelinesKHR

### DIFF
--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -199,7 +199,6 @@ typedef VulkanObjectInfo<VkDebugUtilsMessengerEXT>        DebugUtilsMessengerEXT
 typedef VulkanObjectInfo<VkAccelerationStructureKHR>      AccelerationStructureKHRInfo;
 typedef VulkanObjectInfo<VkAccelerationStructureNV>       AccelerationStructureNVInfo;
 typedef VulkanObjectInfo<VkPerformanceConfigurationINTEL> PerformanceConfigurationINTELInfo;
-typedef VulkanObjectInfo<VkDeferredOperationKHR>          DeferredOperationKHRInfo;
 typedef VulkanObjectInfo<VkPrivateDataSlotEXT>            PrivateDataSlotEXTInfo;
 
 //
@@ -422,6 +421,56 @@ struct ValidationCacheEXTInfo : public VulkanObjectInfo<VkValidationCacheEXT>
 struct FramebufferInfo : public VulkanObjectInfo<VkFramebuffer>
 {
     std::unordered_map<uint32_t, size_t> array_counts;
+};
+
+struct SpecializationInfoData
+{
+    std::vector<VkSpecializationMapEntry> map_entries;
+    std::vector<uint32_t>                 data;
+};
+
+struct PipelineShaderStageCreateInfoData
+{
+    std::string            name;
+    VkSpecializationInfo   specialization_info;
+    SpecializationInfoData specialization_info_data;
+};
+
+struct PipelineLibraryCreateInfoKHRData
+{
+    std::vector<VkPipeline> libraries;
+};
+
+struct PipelineDynamicStateCreateInfoData
+{
+    std::vector<VkDynamicState> dynamic_states;
+};
+
+struct RayTracingPipelineCreateInfoData
+{
+    std::vector<VkPipelineShaderStageCreateInfo>      stages;
+    std::vector<PipelineShaderStageCreateInfoData>    stages_data;
+    std::vector<VkRayTracingShaderGroupCreateInfoKHR> groups;
+    VkPipelineLibraryCreateInfoKHR                    library_info;
+    PipelineLibraryCreateInfoKHRData                  library_info_data;
+    VkRayTracingPipelineInterfaceCreateInfoKHR        library_interface;
+    VkPipelineDynamicStateCreateInfo                  dynamic_state;
+    PipelineDynamicStateCreateInfoData                dynamic_state_data;
+};
+
+struct DeferredOperationKHRInfo : public VulkanObjectInfo<VkDeferredOperationKHR>
+{
+    // Record CreateRayTracingPipelinesKHR parameters for safety.
+    VkResult                                       join_state{ VK_NOT_READY };
+    VkDevice                                       record_device{ VK_NULL_HANDLE };
+    VkDeferredOperationKHR                         record_deferred_operation{ VK_NULL_HANDLE };
+    VkPipelineCache                                record_pipeline_cache{ VK_NULL_HANDLE };
+    uint32_t                                       record_create_info_count{ 0 };
+    std::vector<VkRayTracingPipelineCreateInfoKHR> record_create_infos;
+    std::vector<RayTracingPipelineCreateInfoData>  record_create_infos_data;
+    VkAllocationCallbacks                          record_allocator{};
+    VkAllocationCallbacks*                         record_p_allocator{ nullptr };
+    std::vector<VkPipeline>                        record_pipelines;
 };
 
 //

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -871,12 +871,17 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         PFN_vkCreateRayTracingPipelinesKHR                                     func,
         VkResult                                                               original_result,
         const DeviceInfo*                                                      device_info,
-        const DeferredOperationKHRInfo*                                        deferred_operation_info,
+        DeferredOperationKHRInfo*                                              deferred_operation_info,
         const PipelineCacheInfo*                                               pipeline_cache_info,
         uint32_t                                                               createInfoCount,
         const StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>* pCreateInfos,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>*             pAllocator,
         HandlePointerDecoder<VkPipeline>*                                      pPipelines);
+
+    VkResult OverrideDeferredOperationJoinKHR(PFN_vkDeferredOperationJoinKHR func,
+                                              VkResult                       original_result,
+                                              const DeviceInfo*              device_info,
+                                              DeferredOperationKHRInfo*      deferred_operation_info);
 
     VkDeviceAddress
     OverrideGetBufferDeviceAddress(PFN_vkGetBufferDeviceAddress                                   func,
@@ -1001,6 +1006,11 @@ class VulkanReplayConsumerBase : public VulkanConsumer
     void InitializeScreenshotHandler();
 
     void WriteScreenshots(const Decoded_VkPresentInfoKHR* meta_info) const;
+
+    void CopyCreateRayTracingPipelines(uint32_t                                 create_info_count,
+                                       const VkRayTracingPipelineCreateInfoKHR* create_infos,
+                                       const std::vector<std::vector<VkRayTracingShaderGroupCreateInfoKHR>>* groups,
+                                       DeferredOperationKHRInfo& deferred_operation_info);
 
   private:
     typedef std::unordered_set<Window*> ActiveWindows;

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1191,12 +1191,18 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
         CreateWrappedHandles<DeviceWrapper, DeferredOperationKHRWrapper, PipelineWrapper>(
             device, deferredOperation, pPipelines, createInfoCount, GetUniqueId);
 
-        if (device_wrapper->property_feature_info.feature_rayTracingPipelineShaderGroupHandleCaptureReplay)
+        for (uint32_t i = 0; i < createInfoCount; ++i)
         {
-            for (uint32_t i = 0; i < createInfoCount; ++i)
-            {
-                PipelineWrapper* pipeline_wrapper = reinterpret_cast<PipelineWrapper*>(pPipelines[i]);
+            PipelineWrapper* pipeline_wrapper = reinterpret_cast<PipelineWrapper*>(pPipelines[i]);
 
+            if (deferred_operation_wrapper)
+            {
+                pipeline_wrapper->deferred_operation.handle_id         = deferred_operation_wrapper->handle_id;
+                pipeline_wrapper->deferred_operation.create_call_id    = deferred_operation_wrapper->create_call_id;
+                pipeline_wrapper->deferred_operation.create_parameters = deferred_operation_wrapper->create_parameters;
+            }
+            if (device_wrapper->property_feature_info.feature_rayTracingPipelineShaderGroupHandleCaptureReplay)
+            {
                 uint32_t data_size = device_wrapper->property_feature_info.property_shaderGroupHandleCaptureReplaySize *
                                      pCreateInfos[i].groupCount;
                 std::vector<uint8_t> data(data_size);

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -135,7 +135,9 @@ class VulkanCaptureManager : public CaptureManager
                                       typename Wrapper::HandleType* handles,
                                       const CreateInfo*             create_infos)
     {
-        if (((GetCaptureMode() & kModeTrack) == kModeTrack) && ((result == VK_SUCCESS) || (result == VK_INCOMPLETE)) &&
+        if (((GetCaptureMode() & kModeTrack) == kModeTrack) &&
+            ((result == VK_SUCCESS) || (result == VK_OPERATION_DEFERRED_KHR) ||
+             (result == VK_OPERATION_NOT_DEFERRED_KHR) || (result == VK_INCOMPLETE)) &&
             (handles != nullptr))
         {
             assert(state_tracker_ != nullptr);

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -311,6 +311,7 @@ struct PipelineWrapper : public HandleWrapper<VkPipeline>
     // Ray tracing pipeline's shader group handle data
     format::HandleId     device_id{ format::kNullHandleId };
     std::vector<uint8_t> shader_group_handle_data;
+    CreateDependencyInfo deferred_operation;
 
     // TODO: Base pipeline
     // TODO: Pipeline cache

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -78,7 +78,6 @@ struct DebugUtilsMessengerEXTWrapper        : public HandleWrapper<VkDebugUtilsM
 struct ValidationCacheEXTWrapper            : public HandleWrapper<VkValidationCacheEXT> {};
 struct IndirectCommandsLayoutNVWrapper      : public HandleWrapper<VkIndirectCommandsLayoutNV> {};
 struct PerformanceConfigurationINTELWrapper : public HandleWrapper<VkPerformanceConfigurationINTEL> {};
-struct DeferredOperationKHRWrapper          : public HandleWrapper<VkDeferredOperationKHR> {};
 struct PrivateDataSlotEXTWrapper            : public HandleWrapper<VkPrivateDataSlotEXT> {};
 
 // This handle type has a create function, but no destroy function. The handle wrapper will be owned by its parent VkDisplayKHR
@@ -315,6 +314,20 @@ struct PipelineWrapper : public HandleWrapper<VkPipeline>
 
     // TODO: Base pipeline
     // TODO: Pipeline cache
+};
+
+struct DeferredOperationKHRWrapper : public HandleWrapper<VkDeferredOperationKHR>
+{
+    // Record CreateRayTracingPipelinesKHR parameters for safety.
+    HandleUnwrapMemory                             record_handle_unwrap_memory;
+    VkDevice                                       record_device_unwrapped{ VK_NULL_HANDLE };
+    VkDeferredOperationKHR                         record_deferred_operation_unwrapped{ VK_NULL_HANDLE };
+    VkPipelineCache                                record_pipeline_cache_unwrapped{ VK_NULL_HANDLE };
+    uint32_t                                       record_create_info_count{ 0 };
+    std::vector<VkRayTracingPipelineCreateInfoKHR> record_create_infos;
+    VkAllocationCallbacks                          record_allocator{};
+    VkAllocationCallbacks*                         record_p_allocator{ nullptr };
+    std::vector<VkPipeline>                        record_pipelines;
 };
 
 struct DescriptorUpdateTemplateWrapper : public HandleWrapper<VkDescriptorUpdateTemplate>

--- a/framework/encode/vulkan_state_info.h
+++ b/framework/encode/vulkan_state_info.h
@@ -68,6 +68,7 @@ struct DescriptorInfo
     VkDescriptorType                              type;
     const void*                                   write_pnext{ nullptr };
     HandleUnwrapMemory                            write_pnext_memory;
+    std::vector<VkAccelerationStructureKHR>       record_write_set_accel_structs;
     uint32_t                                      count{ 0 };
     bool                                          immutable_samplers{ 0 };
     std::unique_ptr<bool[]>                       written;

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -505,6 +505,7 @@ void VulkanStateWriter::WritePipelineState(const VulkanStateTable& state_table)
     std::unordered_map<format::HandleId, const util::MemoryOutputStream*> temp_render_passes;
     std::unordered_map<format::HandleId, const util::MemoryOutputStream*> temp_layouts;
     std::unordered_map<format::HandleId, const util::MemoryOutputStream*> temp_ds_layouts;
+    std::unordered_map<format::HandleId, const util::MemoryOutputStream*> temp_deferred_operations;
 
     // First pass over pipeline table to sort pipelines by type and determine which dependencies need to be created
     // temporarily.
@@ -554,6 +555,13 @@ void VulkanStateWriter::WritePipelineState(const VulkanStateTable& state_table)
             {
                 ray_tracing_pipelines_nv.push_back(wrapper->create_parameters.get());
                 processed_ray_tracing_pipelines_nv.insert(wrapper->create_parameters.get());
+            }
+
+            if (wrapper->deferred_operation.handle_id != format::kNullHandleId)
+            {
+                auto        create_parameters = wrapper->deferred_operation.create_parameters.get();
+                const auto& inserted          = temp_deferred_operations.insert(
+                    std::make_pair(wrapper->deferred_operation.handle_id, create_parameters));
             }
         }
         else if (wrapper->create_call_id == format::ApiCall_vkCreateRayTracingPipelinesKHR)
@@ -668,6 +676,17 @@ void VulkanStateWriter::WritePipelineState(const VulkanStateTable& state_table)
     for (const auto& entry : temp_layouts)
     {
         DestroyTemporaryDeviceObject(format::ApiCall_vkDestroyPipelineLayout, entry.first, entry.second);
+    }
+
+    for (const auto& entry : temp_deferred_operations)
+    {
+        format::HandleId device_id = *reinterpret_cast<const format::HandleId*>(entry.second->GetData());
+
+        encoder_.EncodeHandleIdValue(device_id);
+        encoder_.EncodeHandleIdValue(entry.first);
+        encoder_.EncodeEnumValue(VK_SUCCESS);
+        WriteFunctionCall(format::ApiCall_vkGetDeferredOperationResultKHR, &parameter_stream_);
+        parameter_stream_.Reset();
     }
 }
 

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -4688,10 +4688,10 @@ void VulkanReplayConsumer::Process_vkDeferredOperationJoinKHR(
     format::HandleId                            device,
     format::HandleId                            operation)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkDeferredOperationKHR in_operation = MapHandle<DeferredOperationKHRInfo>(operation, &VulkanObjectInfoTable::GetDeferredOperationKHRInfo);
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
+    auto in_operation = GetObjectInfoTable().GetDeferredOperationKHRInfo(operation);
 
-    VkResult replay_result = GetDeviceTable(in_device)->DeferredOperationJoinKHR(in_device, in_operation);
+    VkResult replay_result = OverrideDeferredOperationJoinKHR(GetDeviceTable(in_device->handle)->DeferredOperationJoinKHR, returnValue, in_device, in_operation);
     CheckResult("vkDeferredOperationJoinKHR", returnValue, replay_result);
 }
 

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -84,6 +84,7 @@
     "vkGetBufferDeviceAddressKHR": "OverrideGetBufferDeviceAddress",
     "vkGetAccelerationStructureDeviceAddressKHR": "OverrideGetAccelerationStructureDeviceAddressKHR",
     "vkGetRayTracingShaderGroupHandlesKHR": "OverrideGetRayTracingShaderGroupHandlesKHR",
-    "vkGetAndroidHardwareBufferPropertiesANDROID": "OverrideGetAndroidHardwareBufferPropertiesANDROID"
+    "vkGetAndroidHardwareBufferPropertiesANDROID": "OverrideGetAndroidHardwareBufferPropertiesANDROID",
+    "vkDeferredOperationJoinKHR": "OverrideDeferredOperationJoinKHR"
   }
 }

--- a/framework/graphics/vulkan_device_util.cpp
+++ b/framework/graphics/vulkan_device_util.cpp
@@ -192,23 +192,22 @@ VulkanDeviceUtil::EnableRequiredPhysicalDeviceFeatures(uint32_t                 
                     GetPhysicalDeviceFeatures(
                         instance_api_version, instance_table, physical_device, supported_features);
 
-                    if (supported_features.rayTracingPipelineShaderGroupHandleCaptureReplay)
-                    {
-                        rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay = VK_TRUE;
-
-                        VkPhysicalDeviceRayTracingPipelinePropertiesKHR rt_properties{
-                            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR, nullptr
-                        };
-                        GetPhysicalDeviceProperties(
-                            instance_api_version, instance_table, physical_device, rt_properties);
-
-                        result.property_shaderGroupHandleCaptureReplaySize =
-                            rt_properties.shaderGroupHandleCaptureReplaySize;
-                    }
+                    rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay =
+                        supported_features.rayTracingPipelineShaderGroupHandleCaptureReplay;
                 }
 
                 result.feature_rayTracingPipelineShaderGroupHandleCaptureReplay =
                     rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay;
+                if (result.feature_rayTracingPipelineShaderGroupHandleCaptureReplay)
+                {
+                    VkPhysicalDeviceRayTracingPipelinePropertiesKHR rt_properties{
+                        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR, nullptr
+                    };
+                    GetPhysicalDeviceProperties(instance_api_version, instance_table, physical_device, rt_properties);
+
+                    result.property_shaderGroupHandleCaptureReplaySize =
+                        rt_properties.shaderGroupHandleCaptureReplaySize;
+                }
             }
             break;
             default:


### PR DESCRIPTION
The old PR https://github.com/LunarG/gfxreconstruct/pull/653 changes order of both capture and replay. It runs `DeferredOperationJoinKHR` immediately after `CreateRayTracingPipelinesKHR`.

This PR keeps the original order, so it needs to record parameters and their pointer's data of CreateRayTracingPipelinesKHR to avoid those parameters be modified or invalid. Replay is more complicated than capture.  Now, it has a problem for replay. It's hard to deep copy pNext and pNext's pointer data. So if the application uses pNext, the replay would fail.

The second solution is to record decode data, like `StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR> pCreateInfos`, example: https://github.com/locke-lunarg/gfxreconstruct/commits/deferred3. But the problem is that it uses `DecodeAllocator::Allocate` to allocate memory and save data. The memory could be overwrite in the following function call, so the data might be overwrite before `DeferredOperationJoinKHR`. It can't guarantee safety. We have two ways to fix it. Firstly, we could add a option to save data in another container, instead of `DecodeAllocator::Allocate`. But it might take a week. Secondly, we could add a switch in `DecodeAllocator::End()` to avoid it to clear memory before `DeferredOperationJoinKHR`.

The third solution is the most safety and easy that is to run `DeferredOperationJoinKHR` immediately after `CreateRayTracingPipelinesKHR`. It's just like the old PR, but only for replay. But it changes the order.