### PR TITLE
Deferred operation for CreateRayTracingPipelinesKHR

### DIFF
--- a/framework/decode/decode_allocator.cpp
+++ b/framework/decode/decode_allocator.cpp
@@ -42,7 +42,9 @@ void DecodeAllocator::End()
 {
     assert((instance_ != nullptr) && instance_->can_allocate_);
     if (instance_->end_can_clear_)
+    {
         instance_->allocator_.Clear(false);
+    }
     instance_->can_allocate_ = false;
 }
 

--- a/framework/decode/decode_allocator.cpp
+++ b/framework/decode/decode_allocator.cpp
@@ -41,8 +41,19 @@ void DecodeAllocator::Begin()
 void DecodeAllocator::End()
 {
     assert((instance_ != nullptr) && instance_->can_allocate_);
-    instance_->allocator_.Clear(false);
+    if (instance_->end_can_clear_)
+        instance_->allocator_.Clear(false);
     instance_->can_allocate_ = false;
+}
+
+void DecodeAllocator::TurnOnEndCanClear()
+{
+    instance_->end_can_clear_ = true;
+}
+
+void DecodeAllocator::TurnOffEndCanClear()
+{
+    instance_->end_can_clear_ = false;
 }
 
 void DecodeAllocator::FreeSystemMemory()

--- a/framework/decode/decode_allocator.h
+++ b/framework/decode/decode_allocator.h
@@ -48,6 +48,10 @@ class DecodeAllocator
     // is re-used for future allocations.
     static void End();
 
+    static void TurnOnEndCanClear();
+
+    static void TurnOffEndCanClear();
+
     // Free system memory blocks. Must not be called between Begin and End
     static void FreeSystemMemory();
 
@@ -55,7 +59,7 @@ class DecodeAllocator
     static void DestroyInstance();
 
   private:
-    DecodeAllocator() : allocator_(kAllocatorBlockSize), can_allocate_(false) {}
+    DecodeAllocator() : allocator_(kAllocatorBlockSize), can_allocate_(false), end_can_clear_(true) {}
 
   private:
     static const size_t     kAllocatorBlockSize{ 64 * 1024 };
@@ -63,6 +67,7 @@ class DecodeAllocator
 
     util::MonotonicAllocator allocator_;
     bool                     can_allocate_;
+    bool                     end_can_clear_;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -351,6 +351,51 @@ size_t VulkanDecoderBase::Decode_vkUpdateDescriptorSetWithTemplateKHR(const ApiC
     return bytes_read;
 }
 
+size_t VulkanDecoderBase::Decode_vkCreateRayTracingPipelinesKHR(const ApiCallInfo& call_info,
+                                                                const uint8_t*     parameter_buffer,
+                                                                size_t             buffer_size)
+{
+    size_t bytes_read = 0;
+
+    format::HandleId                                                device;
+    format::HandleId                                                deferredOperation;
+    format::HandleId                                                pipelineCache;
+    uint32_t                                                        createInfoCount;
+    StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR> pCreateInfos;
+    StructPointerDecoder<Decoded_VkAllocationCallbacks>             pAllocator;
+    HandlePointerDecoder<VkPipeline>                                pPipelines;
+    VkResult                                                        return_value;
+
+    bytes_read +=
+        ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &device);
+    bytes_read += ValueDecoder::DecodeHandleIdValue(
+        (parameter_buffer + bytes_read), (buffer_size - bytes_read), &deferredOperation);
+    bytes_read +=
+        ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &pipelineCache);
+    bytes_read +=
+        ValueDecoder::DecodeUInt32Value((parameter_buffer + bytes_read), (buffer_size - bytes_read), &createInfoCount);
+    bytes_read += pCreateInfos.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));
+    bytes_read += pAllocator.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));
+    bytes_read += pPipelines.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));
+    bytes_read +=
+        ValueDecoder::DecodeEnumValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &return_value);
+
+    for (auto consumer : GetConsumers())
+    {
+        consumer->Process_vkCreateRayTracingPipelinesKHR(call_info,
+                                                         return_value,
+                                                         device,
+                                                         deferredOperation,
+                                                         pipelineCache,
+                                                         createInfoCount,
+                                                         &pCreateInfos,
+                                                         &pAllocator,
+                                                         &pPipelines);
+    }
+
+    return bytes_read;
+}
+
 void VulkanDecoderBase::DecodeFunctionCall(format::ApiCallId  call_id,
                                            const ApiCallInfo& call_info,
                                            const uint8_t*     parameter_buffer,
@@ -368,6 +413,9 @@ void VulkanDecoderBase::DecodeFunctionCall(format::ApiCallId  call_id,
             break;
         case format::ApiCallId::ApiCall_vkUpdateDescriptorSetWithTemplateKHR:
             Decode_vkUpdateDescriptorSetWithTemplateKHR(call_info, parameter_buffer, buffer_size);
+            break;
+        case format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesKHR:
+            Decode_vkCreateRayTracingPipelinesKHR(call_info, parameter_buffer, buffer_size);
             break;
         default:
             break;

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -178,6 +178,10 @@ class VulkanDecoderBase : public ApiDecoder
                                                        const uint8_t*     parameter_buffer,
                                                        size_t             buffer_size);
 
+    size_t Decode_vkCreateRayTracingPipelinesKHR(const ApiCallInfo& call_info,
+                                                 const uint8_t*     parameter_buffer,
+                                                 size_t             buffer_size);
+
   private:
     std::vector<VulkanConsumer*> consumers_;
 };

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -35,6 +35,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <unordered_map>
 
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
@@ -182,8 +183,20 @@ class VulkanDecoderBase : public ApiDecoder
                                                  const uint8_t*     parameter_buffer,
                                                  size_t             buffer_size);
 
+    size_t Decode_vkDeferredOperationJoinKHR(const ApiCallInfo& call_info,
+                                             const uint8_t*     parameter_buffer,
+                                             size_t             buffer_size);
+
   private:
     std::vector<VulkanConsumer*> consumers_;
+
+    struct DeferredOperationFunctionCallData
+    {
+        StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR> pCreateInfos;
+        StructPointerDecoder<Decoded_VkAllocationCallbacks>             pAllocator;
+        HandlePointerDecoder<VkPipeline>                                pPipelines;
+    };
+    std::unordered_map<format::HandleId, DeferredOperationFunctionCallData> record_deferred_operation_function_call;
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -199,7 +199,6 @@ typedef VulkanObjectInfo<VkDebugUtilsMessengerEXT>        DebugUtilsMessengerEXT
 typedef VulkanObjectInfo<VkAccelerationStructureKHR>      AccelerationStructureKHRInfo;
 typedef VulkanObjectInfo<VkAccelerationStructureNV>       AccelerationStructureNVInfo;
 typedef VulkanObjectInfo<VkPerformanceConfigurationINTEL> PerformanceConfigurationINTELInfo;
-typedef VulkanObjectInfo<VkDeferredOperationKHR>          DeferredOperationKHRInfo;
 
 //
 // Declarations for Vulkan objects with additional replay state info.
@@ -421,6 +420,15 @@ struct ValidationCacheEXTInfo : public VulkanObjectInfo<VkValidationCacheEXT>
 struct FramebufferInfo : public VulkanObjectInfo<VkFramebuffer>
 {
     std::unordered_map<uint32_t, size_t> array_counts;
+};
+
+struct DeferredOperationKHRInfo : public VulkanObjectInfo<VkDeferredOperationKHR>
+{
+    VkResult join_state{ VK_NOT_READY };
+
+    // Record CreateRayTracingPipelinesKHR parameters for safety.
+    std::vector<VkRayTracingPipelineCreateInfoKHR>                 record_modified_create_infos;
+    std::vector<std::vector<VkRayTracingShaderGroupCreateInfoKHR>> record_modified_pgroups;
 };
 
 //

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -871,12 +871,17 @@ class VulkanReplayConsumerBase : public VulkanConsumer
         PFN_vkCreateRayTracingPipelinesKHR                                     func,
         VkResult                                                               original_result,
         const DeviceInfo*                                                      device_info,
-        const DeferredOperationKHRInfo*                                        deferred_operation_info,
+        DeferredOperationKHRInfo*                                              deferred_operation_info,
         const PipelineCacheInfo*                                               pipeline_cache_info,
         uint32_t                                                               createInfoCount,
         const StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR>* pCreateInfos,
         const StructPointerDecoder<Decoded_VkAllocationCallbacks>*             pAllocator,
         HandlePointerDecoder<VkPipeline>*                                      pPipelines);
+
+    VkResult OverrideDeferredOperationJoinKHR(PFN_vkDeferredOperationJoinKHR func,
+                                              VkResult                       original_result,
+                                              const DeviceInfo*              device_info,
+                                              DeferredOperationKHRInfo*      deferred_operation_info);
 
     VkDeviceAddress
     OverrideGetBufferDeviceAddress(PFN_vkGetBufferDeviceAddress                                   func,

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1183,12 +1183,18 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
         CreateWrappedHandles<DeviceWrapper, DeferredOperationKHRWrapper, PipelineWrapper>(
             device, deferredOperation, pPipelines, createInfoCount, GetUniqueId);
 
-        if (device_wrapper->property_feature_info.feature_rayTracingPipelineShaderGroupHandleCaptureReplay)
+        for (uint32_t i = 0; i < createInfoCount; ++i)
         {
-            for (uint32_t i = 0; i < createInfoCount; ++i)
-            {
-                PipelineWrapper* pipeline_wrapper = reinterpret_cast<PipelineWrapper*>(pPipelines[i]);
+            PipelineWrapper* pipeline_wrapper = reinterpret_cast<PipelineWrapper*>(pPipelines[i]);
 
+            if (deferred_operation_wrapper)
+            {
+                pipeline_wrapper->deferred_operation.handle_id         = deferred_operation_wrapper->handle_id;
+                pipeline_wrapper->deferred_operation.create_call_id    = deferred_operation_wrapper->create_call_id;
+                pipeline_wrapper->deferred_operation.create_parameters = deferred_operation_wrapper->create_parameters;
+            }
+            if (device_wrapper->property_feature_info.feature_rayTracingPipelineShaderGroupHandleCaptureReplay)
+            {
                 uint32_t data_size = device_wrapper->property_feature_info.property_shaderGroupHandleCaptureReplaySize *
                                      pCreateInfos[i].groupCount;
                 std::vector<uint8_t> data(data_size);

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -1078,9 +1078,33 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
     auto                   device_wrapper              = reinterpret_cast<DeviceWrapper*>(device);
     VkDevice               device_unwrapped            = device_wrapper->handle;
     const DeviceTable*     device_table                = GetDeviceTable(device);
-    auto                   handle_unwrap_memory        = VulkanCaptureManager::Get()->GetHandleUnwrapMemory();
     VkDeferredOperationKHR deferredOperation_unwrapped = GetWrappedHandle<VkDeferredOperationKHR>(deferredOperation);
-    VkPipelineCache        pipelineCache_unwrapped     = GetWrappedHandle<VkPipelineCache>(pipelineCache);
+    DeferredOperationKHRWrapper* deferred_operation_wrapper =
+        reinterpret_cast<DeferredOperationKHRWrapper*>(deferredOperation);
+
+    VkPipelineCache     pipelineCache_unwrapped = GetWrappedHandle<VkPipelineCache>(pipelineCache);
+    HandleUnwrapMemory* handle_unwrap_memory    = nullptr;
+
+    if (deferred_operation_wrapper)
+    {
+        handle_unwrap_memory = &deferred_operation_wrapper->handle_unwrap_memory;
+        if (pAllocator)
+        {
+            deferred_operation_wrapper->allocator   = *pAllocator;
+            deferred_operation_wrapper->p_allocator = &deferred_operation_wrapper->allocator;
+        }
+        else
+        {
+            deferred_operation_wrapper->allocator   = {};
+            deferred_operation_wrapper->p_allocator = nullptr;
+        }
+        deferred_operation_wrapper->create_infos.resize(createInfoCount);
+        deferred_operation_wrapper->pipelines.resize(createInfoCount);
+    }
+    else
+    {
+        handle_unwrap_memory = VulkanCaptureManager::Get()->GetHandleUnwrapMemory();
+    }
     const VkRayTracingPipelineCreateInfoKHR* pCreateInfos_unwrapped =
         UnwrapStructArrayHandles(pCreateInfos, createInfoCount, handle_unwrap_memory);
 
@@ -1093,26 +1117,68 @@ VulkanCaptureManager::OverrideCreateRayTracingPipelinesKHR(VkDevice             
             modified_create_infos[i] = pCreateInfos_unwrapped[i];
             modified_create_infos[i].flags |= VK_PIPELINE_CREATE_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR;
         }
-        result = device_table->CreateRayTracingPipelinesKHR(device_unwrapped,
-                                                            deferredOperation_unwrapped,
-                                                            pipelineCache_unwrapped,
-                                                            createInfoCount,
-                                                            modified_create_infos.get(),
-                                                            pAllocator,
-                                                            pPipelines);
+        if (deferred_operation_wrapper)
+        {
+            std::memcpy(deferred_operation_wrapper->create_infos.data(),
+                        modified_create_infos.get(),
+                        sizeof(VkRayTracingPipelineCreateInfoKHR) * createInfoCount);
+            result = device_table->CreateRayTracingPipelinesKHR(device_unwrapped,
+                                                                deferredOperation_unwrapped,
+                                                                pipelineCache_unwrapped,
+                                                                createInfoCount,
+                                                                deferred_operation_wrapper->create_infos.data(),
+                                                                deferred_operation_wrapper->p_allocator,
+                                                                deferred_operation_wrapper->pipelines.data());
+
+            std::memcpy(pPipelines, deferred_operation_wrapper->pipelines.data(), sizeof(VkPipeline) * createInfoCount);
+        }
+        else
+        {
+            result = device_table->CreateRayTracingPipelinesKHR(device_unwrapped,
+                                                                deferredOperation_unwrapped,
+                                                                pipelineCache_unwrapped,
+                                                                createInfoCount,
+                                                                modified_create_infos.get(),
+                                                                pAllocator,
+                                                                pPipelines);
+        }
     }
     else
     {
-        result = device_table->CreateRayTracingPipelinesKHR(device_unwrapped,
-                                                            deferredOperation_unwrapped,
-                                                            pipelineCache_unwrapped,
-                                                            createInfoCount,
-                                                            pCreateInfos_unwrapped,
-                                                            pAllocator,
-                                                            pPipelines);
-    }
+        GFXRECON_LOG_ERROR_ONCE(
+            "The capturing application used vkCreateRayTracingPipelinesKHR, which may require the "
+            "rayTracingPipelineShaderGroupHandleCaptureReplay feature for accurate capture and replay. The capturing "
+            "device does not support this feature, so replay may fail.");
 
-    if ((result == VK_SUCCESS) && (pPipelines != nullptr))
+        if (deferred_operation_wrapper)
+        {
+            std::memcpy(deferred_operation_wrapper->create_infos.data(),
+                        pCreateInfos_unwrapped,
+                        sizeof(VkRayTracingPipelineCreateInfoKHR) * createInfoCount);
+            result = device_table->CreateRayTracingPipelinesKHR(device_unwrapped,
+                                                                deferredOperation_unwrapped,
+                                                                pipelineCache_unwrapped,
+                                                                createInfoCount,
+                                                                deferred_operation_wrapper->create_infos.data(),
+                                                                deferred_operation_wrapper->p_allocator,
+                                                                deferred_operation_wrapper->pipelines.data());
+
+            std::memcpy(pPipelines, deferred_operation_wrapper->pipelines.data(), sizeof(VkPipeline) * createInfoCount);
+        }
+        else
+        {
+            result = device_table->CreateRayTracingPipelinesKHR(device_unwrapped,
+                                                                deferredOperation_unwrapped,
+                                                                pipelineCache_unwrapped,
+                                                                createInfoCount,
+                                                                pCreateInfos_unwrapped,
+                                                                pAllocator,
+                                                                pPipelines);
+        }
+    }
+    if (((result == VK_SUCCESS) || (result == VK_OPERATION_DEFERRED_KHR) ||
+         (result == VK_OPERATION_NOT_DEFERRED_KHR)) &&
+        (pPipelines != nullptr))
     {
         CreateWrappedHandles<DeviceWrapper, DeferredOperationKHRWrapper, PipelineWrapper>(
             device, deferredOperation, pPipelines, createInfoCount, GetUniqueId);

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -135,7 +135,9 @@ class VulkanCaptureManager : public CaptureManager
                                       typename Wrapper::HandleType* handles,
                                       const CreateInfo*             create_infos)
     {
-        if (((GetCaptureMode() & kModeTrack) == kModeTrack) && ((result == VK_SUCCESS) || (result == VK_INCOMPLETE)) &&
+        if (((GetCaptureMode() & kModeTrack) == kModeTrack) &&
+            ((result == VK_SUCCESS) || (result == VK_OPERATION_DEFERRED_KHR) ||
+             (result == VK_OPERATION_NOT_DEFERRED_KHR) || (result == VK_INCOMPLETE)) &&
             (handles != nullptr))
         {
             assert(state_tracker_ != nullptr);

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -308,6 +308,7 @@ struct PipelineWrapper : public HandleWrapper<VkPipeline>
     // Ray tracing pipeline's shader group handle data
     format::HandleId     device_id{ format::kNullHandleId };
     std::vector<uint8_t> shader_group_handle_data;
+    CreateDependencyInfo deferred_operation;
 
     // TODO: Base pipeline
     // TODO: Pipeline cache

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -78,7 +78,6 @@ struct DebugUtilsMessengerEXTWrapper        : public HandleWrapper<VkDebugUtilsM
 struct ValidationCacheEXTWrapper            : public HandleWrapper<VkValidationCacheEXT> {};
 struct IndirectCommandsLayoutNVWrapper      : public HandleWrapper<VkIndirectCommandsLayoutNV> {};
 struct PerformanceConfigurationINTELWrapper : public HandleWrapper<VkPerformanceConfigurationINTEL> {};
-struct DeferredOperationKHRWrapper          : public HandleWrapper<VkDeferredOperationKHR> {};
 struct PrivateDataSlotWrapper               : public HandleWrapper<VkPrivateDataSlot> {};
 
 // This handle type has a create function, but no destroy function. The handle wrapper will be owned by its parent VkDisplayKHR
@@ -312,6 +311,16 @@ struct PipelineWrapper : public HandleWrapper<VkPipeline>
 
     // TODO: Base pipeline
     // TODO: Pipeline cache
+};
+
+struct DeferredOperationKHRWrapper : public HandleWrapper<VkDeferredOperationKHR>
+{
+    // Record CreateRayTracingPipelinesKHR parameters for safety.
+    HandleUnwrapMemory                             handle_unwrap_memory;
+    std::vector<VkRayTracingPipelineCreateInfoKHR> create_infos;
+    VkAllocationCallbacks                          allocator{};
+    VkAllocationCallbacks*                         p_allocator{ nullptr };
+    std::vector<VkPipeline>                        pipelines;
 };
 
 struct DescriptorUpdateTemplateWrapper : public HandleWrapper<VkDescriptorUpdateTemplate>

--- a/framework/encode/vulkan_state_info.h
+++ b/framework/encode/vulkan_state_info.h
@@ -68,6 +68,7 @@ struct DescriptorInfo
     VkDescriptorType                              type;
     const void*                                   write_pnext{ nullptr };
     HandleUnwrapMemory                            write_pnext_memory;
+    std::vector<VkAccelerationStructureKHR>       record_write_set_accel_structs;
     uint32_t                                      count{ 0 };
     bool                                          immutable_samplers{ 0 };
     std::unique_ptr<bool[]>                       written;

--- a/framework/encode/vulkan_state_tracker.cpp
+++ b/framework/encode/vulkan_state_tracker.cpp
@@ -597,6 +597,23 @@ void VulkanStateTracker::TrackUpdateDescriptorSets(uint32_t                    w
                 if (write->pNext != nullptr)
                 {
                     binding.write_pnext = TrackPNextStruct(write->pNext, &binding.write_pnext_memory);
+                    auto* pnext         = reinterpret_cast<const VkBaseInStructure*>(binding.write_pnext);
+                    switch (pnext->sType)
+                    {
+                        case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_KHR:
+                        {
+                            auto* acc_struct = reinterpret_cast<VkWriteDescriptorSetAccelerationStructureKHR*>(
+                                const_cast<void*>(binding.write_pnext));
+                            binding.record_write_set_accel_structs.resize(acc_struct->accelerationStructureCount);
+                            std::copy(acc_struct->pAccelerationStructures,
+                                      acc_struct->pAccelerationStructures + acc_struct->accelerationStructureCount,
+                                      std::back_inserter(binding.record_write_set_accel_structs));
+                            acc_struct->pAccelerationStructures = binding.record_write_set_accel_structs.data();
+                            break;
+                        }
+                        default:
+                            break;
+                    }
                 }
 
                 // Update current and write counts for binding's descriptor count. If current count is

--- a/framework/generated/generated_vulkan_decoder.cpp
+++ b/framework/generated/generated_vulkan_decoder.cpp
@@ -11148,36 +11148,6 @@ size_t VulkanDecoder::Decode_vkCmdTraceRaysKHR(const ApiCallInfo& call_info, con
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkCreateRayTracingPipelinesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
-{
-    size_t bytes_read = 0;
-
-    format::HandleId device;
-    format::HandleId deferredOperation;
-    format::HandleId pipelineCache;
-    uint32_t createInfoCount;
-    StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR> pCreateInfos;
-    StructPointerDecoder<Decoded_VkAllocationCallbacks> pAllocator;
-    HandlePointerDecoder<VkPipeline> pPipelines;
-    VkResult return_value;
-
-    bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &device);
-    bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &deferredOperation);
-    bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &pipelineCache);
-    bytes_read += ValueDecoder::DecodeUInt32Value((parameter_buffer + bytes_read), (buffer_size - bytes_read), &createInfoCount);
-    bytes_read += pCreateInfos.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));
-    bytes_read += pAllocator.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));
-    bytes_read += pPipelines.Decode((parameter_buffer + bytes_read), (buffer_size - bytes_read));
-    bytes_read += ValueDecoder::DecodeEnumValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &return_value);
-
-    for (auto consumer : GetConsumers())
-    {
-        consumer->Process_vkCreateRayTracingPipelinesKHR(call_info, return_value, device, deferredOperation, pipelineCache, createInfoCount, &pCreateInfos, &pAllocator, &pPipelines);
-    }
-
-    return bytes_read;
-}
-
 size_t VulkanDecoder::Decode_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
@@ -12807,9 +12777,6 @@ void VulkanDecoder::DecodeFunctionCall(format::ApiCallId             call_id,
         break;
     case format::ApiCallId::ApiCall_vkCmdTraceRaysKHR:
         Decode_vkCmdTraceRaysKHR(call_info, parameter_buffer, buffer_size);
-        break;
-    case format::ApiCallId::ApiCall_vkCreateRayTracingPipelinesKHR:
-        Decode_vkCreateRayTracingPipelinesKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR:
         Decode_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(call_info, parameter_buffer, buffer_size);

--- a/framework/generated/generated_vulkan_decoder.cpp
+++ b/framework/generated/generated_vulkan_decoder.cpp
@@ -6770,26 +6770,6 @@ size_t VulkanDecoder::Decode_vkGetDeferredOperationResultKHR(const ApiCallInfo& 
     return bytes_read;
 }
 
-size_t VulkanDecoder::Decode_vkDeferredOperationJoinKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
-{
-    size_t bytes_read = 0;
-
-    format::HandleId device;
-    format::HandleId operation;
-    VkResult return_value;
-
-    bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &device);
-    bytes_read += ValueDecoder::DecodeHandleIdValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &operation);
-    bytes_read += ValueDecoder::DecodeEnumValue((parameter_buffer + bytes_read), (buffer_size - bytes_read), &return_value);
-
-    for (auto consumer : GetConsumers())
-    {
-        consumer->Process_vkDeferredOperationJoinKHR(call_info, return_value, device, operation);
-    }
-
-    return bytes_read;
-}
-
 size_t VulkanDecoder::Decode_vkGetPipelineExecutablePropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size)
 {
     size_t bytes_read = 0;
@@ -12177,9 +12157,6 @@ void VulkanDecoder::DecodeFunctionCall(format::ApiCallId             call_id,
         break;
     case format::ApiCallId::ApiCall_vkGetDeferredOperationResultKHR:
         Decode_vkGetDeferredOperationResultKHR(call_info, parameter_buffer, buffer_size);
-        break;
-    case format::ApiCallId::ApiCall_vkDeferredOperationJoinKHR:
-        Decode_vkDeferredOperationJoinKHR(call_info, parameter_buffer, buffer_size);
         break;
     case format::ApiCallId::ApiCall_vkGetPipelineExecutablePropertiesKHR:
         Decode_vkGetPipelineExecutablePropertiesKHR(call_info, parameter_buffer, buffer_size);

--- a/framework/generated/generated_vulkan_decoder.h
+++ b/framework/generated/generated_vulkan_decoder.h
@@ -1066,8 +1066,6 @@ class VulkanDecoder : public VulkanDecoderBase
 
     size_t Decode_vkCmdTraceRaysKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkCreateRayTracingPipelinesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
-
     size_t Decode_vkGetRayTracingCaptureReplayShaderGroupHandlesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
     size_t Decode_vkCmdTraceRaysIndirectKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);

--- a/framework/generated/generated_vulkan_decoder.h
+++ b/framework/generated/generated_vulkan_decoder.h
@@ -666,8 +666,6 @@ class VulkanDecoder : public VulkanDecoderBase
 
     size_t Decode_vkGetDeferredOperationResultKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
-    size_t Decode_vkDeferredOperationJoinKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
-
     size_t Decode_vkGetPipelineExecutablePropertiesKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);
 
     size_t Decode_vkGetPipelineExecutableStatisticsKHR(const ApiCallInfo& call_info, const uint8_t* parameter_buffer, size_t buffer_size);

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -4690,10 +4690,10 @@ void VulkanReplayConsumer::Process_vkDeferredOperationJoinKHR(
     format::HandleId                            device,
     format::HandleId                            operation)
 {
-    VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
-    VkDeferredOperationKHR in_operation = MapHandle<DeferredOperationKHRInfo>(operation, &VulkanObjectInfoTable::GetDeferredOperationKHRInfo);
+    auto in_device = GetObjectInfoTable().GetDeviceInfo(device);
+    auto in_operation = GetObjectInfoTable().GetDeferredOperationKHRInfo(operation);
 
-    VkResult replay_result = GetDeviceTable(in_device)->DeferredOperationJoinKHR(in_device, in_operation);
+    VkResult replay_result = OverrideDeferredOperationJoinKHR(GetDeviceTable(in_device->handle)->DeferredOperationJoinKHR, returnValue, in_device, in_operation);
     CheckResult("vkDeferredOperationJoinKHR", returnValue, replay_result);
 }
 

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -233,6 +233,8 @@ class BaseGenerator(OutputGenerator):
     # These API calls should not be processed by the code generator.  They require special implementations.
     APICALL_BLACKLIST = []
 
+    APICALL_DECODER_BLACKLIST = []
+
     # These method calls should not be processed by the code generator.  They require special implementations.
     METHODCALL_BLACKLIST = []
 
@@ -745,6 +747,8 @@ class BaseGenerator(OutputGenerator):
     def is_cmd_black_listed(self, name):
         """Determines if a function with the specified typename is blacklisted."""
         if name in self.APICALL_BLACKLIST:
+            return True
+        if 'Decoder' in self.__class__.__name__ and name in self.APICALL_DECODER_BLACKLIST:
             return True
         return False
 
@@ -1340,6 +1344,7 @@ class BaseGenerator(OutputGenerator):
     def __load_blacklists(self, filename):
         lists = json.loads(open(filename, 'r').read())
         self.APICALL_BLACKLIST += lists['functions']
+        self.APICALL_DECODER_BLACKLIST += lists['functions-decoder']
         self.STRUCT_BLACKLIST += lists['structures']
         if 'classmethods' in lists:
             for class_name, method_list in lists['classmethods'].items():

--- a/framework/generated/vulkan_generators/blacklists.json
+++ b/framework/generated/vulkan_generators/blacklists.json
@@ -14,7 +14,8 @@
     "vkCopyAccelerationStructureKHR"
   ],
   "functions-decoder": [
-    "vkCreateRayTracingPipelinesKHR"
+    "vkCreateRayTracingPipelinesKHR",
+    "vkDeferredOperationJoinKHR"
   ],
   "structures": [
     "VkBaseOutStructure",

--- a/framework/generated/vulkan_generators/blacklists.json
+++ b/framework/generated/vulkan_generators/blacklists.json
@@ -13,6 +13,9 @@
     "vkBuildAccelerationStructuresKHR",
     "vkCopyAccelerationStructureKHR"
   ],
+  "functions-decoder": [
+    "vkCreateRayTracingPipelinesKHR"
+  ],
   "structures": [
     "VkBaseOutStructure",
     "VkBaseInStructure",

--- a/framework/generated/vulkan_generators/replay_overrides.json
+++ b/framework/generated/vulkan_generators/replay_overrides.json
@@ -84,6 +84,7 @@
     "vkGetBufferDeviceAddressKHR": "OverrideGetBufferDeviceAddress",
     "vkGetAccelerationStructureDeviceAddressKHR": "OverrideGetAccelerationStructureDeviceAddressKHR",
     "vkGetRayTracingShaderGroupHandlesKHR": "OverrideGetRayTracingShaderGroupHandlesKHR",
-    "vkGetAndroidHardwareBufferPropertiesANDROID": "OverrideGetAndroidHardwareBufferPropertiesANDROID"
+    "vkGetAndroidHardwareBufferPropertiesANDROID": "OverrideGetAndroidHardwareBufferPropertiesANDROID",
+    "vkDeferredOperationJoinKHR": "OverrideDeferredOperationJoinKHR"
   }
 }

--- a/framework/graphics/vulkan_device_util.cpp
+++ b/framework/graphics/vulkan_device_util.cpp
@@ -192,23 +192,22 @@ VulkanDeviceUtil::EnableRequiredPhysicalDeviceFeatures(uint32_t                 
                     GetPhysicalDeviceFeatures(
                         instance_api_version, instance_table, physical_device, supported_features);
 
-                    if (supported_features.rayTracingPipelineShaderGroupHandleCaptureReplay)
-                    {
-                        rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay = VK_TRUE;
-
-                        VkPhysicalDeviceRayTracingPipelinePropertiesKHR rt_properties{
-                            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR, nullptr
-                        };
-                        GetPhysicalDeviceProperties(
-                            instance_api_version, instance_table, physical_device, rt_properties);
-
-                        result.property_shaderGroupHandleCaptureReplaySize =
-                            rt_properties.shaderGroupHandleCaptureReplaySize;
-                    }
+                    rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay =
+                        supported_features.rayTracingPipelineShaderGroupHandleCaptureReplay;
                 }
 
                 result.feature_rayTracingPipelineShaderGroupHandleCaptureReplay =
                     rt_pipeline_features->rayTracingPipelineShaderGroupHandleCaptureReplay;
+                if (result.feature_rayTracingPipelineShaderGroupHandleCaptureReplay)
+                {
+                    VkPhysicalDeviceRayTracingPipelinePropertiesKHR rt_properties{
+                        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR, nullptr
+                    };
+                    GetPhysicalDeviceProperties(instance_api_version, instance_table, physical_device, rt_properties);
+
+                    result.property_shaderGroupHandleCaptureReplaySize =
+                        rt_properties.shaderGroupHandleCaptureReplaySize;
+                }
             }
             break;
             default:

--- a/layer/trace_layer.cpp
+++ b/layer/trace_layer.cpp
@@ -58,6 +58,7 @@ const std::vector<VkExtensionProperties> kDeviceExtensionProps = { VkExtensionPr
 const char* const kUnsupportedDeviceExtensions[] = {
     // Supporting the CPU moving around descriptor set data directly has too many
     // perf/robustness tradeoffs to be worth it.
+    VK_NVX_BINARY_IMPORT_EXTENSION_NAME,
     VK_VALVE_DESCRIPTOR_SET_HOST_MAPPING_EXTENSION_NAME,
 };
 


### PR DESCRIPTION
The old PRs: https://github.com/LunarG/gfxreconstruct/pull/653, https://github.com/LunarG/gfxreconstruct/pull/773

This PR keeps the original order, so it needs to record parameters and their pointer's data of `CreateRayTracingPipelinesKHR` to avoid those parameters be modified or invalid.

Replay is more complicated than capture. It is to record decode data, like `StructPointerDecoder<Decoded_VkRayTracingPipelineCreateInfoKHR> pCreateInfos`. It added a switch in `DecodeAllocator::End()` to avoid it to clear memory before `DeferredOperationJoinKHR`. It might replay a lot of functions between CreateRayTracingPipelinesKHR and GetDeferredOperationResultKHR. Those functions' data will not be released until `DeferredOperationJoinKHR`. But I think the data size should be not big. A potential problem is if an application uses deferred operation on `CreateRayTracingPipelinesKHR`, but it doesn't run `DeferredOperationJoinKHR` for some unknown reasons, it will keep the whole data until end.

It's normal if it prints a lot of `[gfxrecon] WARNING - API call vkDeferredOperationJoinKHR returned value VK_SUCCESS that does not match return value from capture file: VK_THREAD_IDLE_KHR.` During capture, it might run tens or hundreds times `DeferredOperationJoinKHR` until it gets VK_SUCCESS. The whole `DeferredOperationJoinKHR` are written into files. During replay, it runs loop in first `DeferredOperationJoinKHR` until it gets VK_SUCCESS. Since the first `DeferredOperationJoinKHR` has gotten VK_SUCCESS, the rest will get VK_SUCCESS, too. So the replay results are different to the capture results. 