### PR TITLE
toascii - Changed Pointers to Functions to Output in hex

### DIFF
--- a/framework/generated/generated_vulkan_struct_decoders_to_string.cpp
+++ b/framework/generated/generated_vulkan_struct_decoders_to_string.cpp
@@ -298,11 +298,11 @@ template <> std::string ToString<decode::Decoded_VkAllocationCallbacks>(const de
         [&](std::stringstream& strStrm)
         {
             FieldToString(strStrm, true, "pUserData", toStringFlags, tabCount, tabSize, decode::DataPointerDecoderToString(&decoded_obj.pUserData));
-            FieldToString(strStrm, false, "pfnAllocation", toStringFlags, tabCount, tabSize, "\"" + ToString(decoded_obj.pfnAllocation) + "\"");
-            FieldToString(strStrm, false, "pfnReallocation", toStringFlags, tabCount, tabSize, "\"" + ToString(decoded_obj.pfnReallocation) + "\"");
-            FieldToString(strStrm, false, "pfnFree", toStringFlags, tabCount, tabSize, "\"" + ToString(decoded_obj.pfnFree) + "\"");
-            FieldToString(strStrm, false, "pfnInternalAllocation", toStringFlags, tabCount, tabSize, "\"" + ToString(decoded_obj.pfnInternalAllocation) + "\"");
-            FieldToString(strStrm, false, "pfnInternalFree", toStringFlags, tabCount, tabSize, "\"" + ToString(decoded_obj.pfnInternalFree) + "\"");
+            FieldToString(strStrm, false, "pfnAllocation", toStringFlags, tabCount, tabSize, decode::DataPointerDecoderToString(decoded_obj.pfnAllocation));
+            FieldToString(strStrm, false, "pfnReallocation", toStringFlags, tabCount, tabSize, decode::DataPointerDecoderToString(decoded_obj.pfnReallocation));
+            FieldToString(strStrm, false, "pfnFree", toStringFlags, tabCount, tabSize, decode::DataPointerDecoderToString(decoded_obj.pfnFree));
+            FieldToString(strStrm, false, "pfnInternalAllocation", toStringFlags, tabCount, tabSize, decode::DataPointerDecoderToString(decoded_obj.pfnInternalAllocation));
+            FieldToString(strStrm, false, "pfnInternalFree", toStringFlags, tabCount, tabSize, decode::DataPointerDecoderToString(decoded_obj.pfnInternalFree));
         }
     );
 }
@@ -7810,7 +7810,7 @@ template <> std::string ToString<decode::Decoded_VkDebugReportCallbackCreateInfo
             FieldToString(strStrm, true, "sType", toStringFlags, tabCount, tabSize, '"' + ToString(obj.sType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "pNext", toStringFlags, tabCount, tabSize, PNextDecodedToString(decoded_obj.pNext, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(obj.flags, toStringFlags, tabCount, tabSize));
-            FieldToString(strStrm, false, "pfnCallback", toStringFlags, tabCount, tabSize, "\"" + ToString(decoded_obj.pfnCallback) + "\"");
+            FieldToString(strStrm, false, "pfnCallback", toStringFlags, tabCount, tabSize, decode::DataPointerDecoderToString(decoded_obj.pfnCallback));
             FieldToString(strStrm, false, "pUserData", toStringFlags, tabCount, tabSize, decode::DataPointerDecoderToString(&decoded_obj.pUserData));
         }
     );
@@ -9009,7 +9009,7 @@ template <> std::string ToString<decode::Decoded_VkDebugUtilsMessengerCreateInfo
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(obj.flags, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "messageSeverity", toStringFlags, tabCount, tabSize, ToString(obj.messageSeverity, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "messageType", toStringFlags, tabCount, tabSize, ToString(obj.messageType, toStringFlags, tabCount, tabSize));
-            FieldToString(strStrm, false, "pfnUserCallback", toStringFlags, tabCount, tabSize, "\"" + ToString(decoded_obj.pfnUserCallback) + "\"");
+            FieldToString(strStrm, false, "pfnUserCallback", toStringFlags, tabCount, tabSize, decode::DataPointerDecoderToString(decoded_obj.pfnUserCallback));
             FieldToString(strStrm, false, "pUserData", toStringFlags, tabCount, tabSize, decode::DataPointerDecoderToString(&decoded_obj.pUserData));
         }
     );
@@ -11911,7 +11911,7 @@ template <> std::string ToString<decode::Decoded_VkDeviceDeviceMemoryReportCreat
             FieldToString(strStrm, true, "sType", toStringFlags, tabCount, tabSize, '"' + ToString(obj.sType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "pNext", toStringFlags, tabCount, tabSize, PNextDecodedToString(decoded_obj.pNext, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(obj.flags, toStringFlags, tabCount, tabSize));
-            FieldToString(strStrm, false, "pfnUserCallback", toStringFlags, tabCount, tabSize, "\"" + ToString(decoded_obj.pfnUserCallback) + "\"");
+            FieldToString(strStrm, false, "pfnUserCallback", toStringFlags, tabCount, tabSize, decode::DataPointerDecoderToString(decoded_obj.pfnUserCallback));
             FieldToString(strStrm, false, "pUserData", toStringFlags, tabCount, tabSize, decode::DataPointerDecoderToString(&decoded_obj.pUserData));
         }
     );

--- a/framework/generated/vulkan_generators/vulkan_struct_decoders_to_string_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_struct_decoders_to_string_body_generator.py
@@ -167,8 +167,10 @@ class VulkanStructDecodersToStringBodyGenerator(BaseGenerator):
 
             # Function pointers and void data pointers simply write the address
             elif 'pfn' in value.name:
-                # In decoded types these are uint64_ts so use the non-pointer path:
-                toString = '"\\"" + ToString(decoded_obj.{0}) + "\\""'
+                # In decoded types these are uint64_ts so use the data pointer decoder path for
+                # that type which still outputs hex:
+                toString = 'decode::DataPointerDecoderToString(decoded_obj.{0})'
+
             elif 'void' in value.full_type:
                 # Pointers to windows, surfaces, non-Vulkan handles etc. encoded as a uint64_t:
                 if value.platform_base_type != None:


### PR DESCRIPTION
Fixes #790

Most traces don't have function pointers in them so shown to have no ill effects on lots of those locally, and shown to be correct on three traces which do use them, for example a Windows one:

```
      "pCreateInfo": {                                 |      "pCreateInfo": {
          "sType": "VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSE|          "sType": "VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT",
          "pNext": null,                               |          "pNext": null,
          "flags": 0,                                  |          "flags": 0,
          "messageSeverity": 4352,                     |          "messageSeverity": 4352,
          "messageType": 3,                            |          "messageType": 3,
          "pfnUserCallback": "140698248157248",        |          "pfnUserCallback": "0x7ff6dd1a1840",
          "pUserData": "0x0"                           |          "pUserData": "0x0"
      },                                               |      },
      "pAllocator": null,                              |      "pAllocator": null,
      "[out]pMessenger": "0x2"                         |      "[out]pMessenger": "0x2"
  },                                                   |  },
```

An Android one:

```
   "sharingMode": "VK_SHARING_MODE_EXCLUSIVE|          "sharingMode": "VK_SHARING_MODE_EXCLUSIVE",
          "queueFamilyIndexCount": 0,              |          "queueFamilyIndexCount": 0,
          "pQueueFamilyIndices": []                |          "pQueueFamilyIndices": []
      },                                           |      },
      "pAllocator": {                              |      "pAllocator": {
          "pUserData": "0x0",                      |          "pUserData": "0x0",
          "pfnAllocation": "465834563476",         |          "pfnAllocation": "0x6c75e75794",
          "pfnReallocation": "465834563788",       |          "pfnReallocation": "0x6c75e758cc",
          "pfnFree": "465834564548",               |          "pfnFree": "0x6c75e75bc4",
          "pfnInternalAllocation": "465834565512", |          "pfnInternalAllocation": "0x6c75e75f88",
          "pfnInternalFree": "465834565548"        |          "pfnInternalFree": "0x6c75e75fac"
      },                                           |      },
      "[out]pBuffer": "0x6d"                       |      "[out]pBuffer": "0x6d"
  },                                               |  },
  "[595]vkGetBufferMemoryRequirements": {          |  "[595]vkGetBufferMemoryRequirements": {
      "device": "0x40",                            |      "device": "0x40",
      "buffer": "0x6d",                            |      "buffer": "0x6d",
+ +-- 65 lines: "[out]pMemoryRequirements": {------|+ +-- 65 lines: "[out]pMemoryRequirements": {--------------
          "queueFamilyIndexCount": 0,              |          "queueFamilyIndexCount": 0,
          "pQueueFamilyIndices": [],               |          "pQueueFamilyIndices": [],
          "initialLayout": "VK_IMAGE_LAYOUT_UNDEFIN|          "initialLayout": "VK_IMAGE_LAYOUT_UNDEFINED"
      },                                           |      },
      "pAllocator": {                              |      "pAllocator": {
          "pUserData": "0x0",                      |          "pUserData": "0x0",
          "pfnAllocation": "465834563476",         |          "pfnAllocation": "0x6c75e75794",
          "pfnReallocation": "465834563788",       |          "pfnReallocation": "0x6c75e758cc",
          "pfnFree": "465834564548",               |          "pfnFree": "0x6c75e75bc4",
          "pfnInternalAllocation": "465834565512", |          "pfnInternalAllocation": "0x6c75e75f88",
          "pfnInternalFree": "465834565548"        |          "pfnInternalFree": "0x6c75e75fac"
      },                                           |      },
      "[out]pImage": "0x6e"                        |      "[out]pImage": "0x6e"
  },                                               |  },
  "[600]vkGetImageMemoryRequirements": {           |  "[600]vkGetImageMemoryRequirements": {
      "device": "0x40",                            |      "device": "0x40",
      "image": "0x6e",                             |      "image": "0x6e",
+ +-- 92 lines: "[out]pMemoryRequirements": {------|+ +-- 92 lines: "[out]pMemoryRequirements": {--------------
              "baseArrayLayer": 0,                 |              "baseArrayLayer": 0,
              "layerCount": 1                      |              "layerCount": 1
          }                                        |          }
      },                                           |      },
      "pAllocator": {                              |      "pAllocator": {
          "pUserData": "0x0",                      |          "pUserData": "0x0",
          "pfnAllocation": "465834563476",         |          "pfnAllocation": "0x6c75e75794",
          "pfnReallocation": "465834563788",       |          "pfnReallocation": "0x6c75e758cc",
          "pfnFree": "465834564548",               |          "pfnFree": "0x6c75e75bc4",
          "pfnInternalAllocation": "465834565512", |          "pfnInternalAllocation": "0x6c75e75f88",
          "pfnInternalFree": "465834565548"        |          "pfnInternalFree": "0x6c75e75fac"
      },                                           |      },
      "[out]pView": "0x6f"                         |      "[out]pView": "0x6f"
  },                                               |  },
  "[608]vkCreateBuffer": {                         |  "[608]vkCreateBuffer": {
      "return": "VK_SUCCESS",                      |      "return": "VK_SUCCESS",
      "device": "0x40",                            |      "device": "0x40",
+ +--  6 lines: "pCreateInfo": {-------------------|+ +--  6 lines: "pCreateInfo": {---------------------------
          "sharingMode": "VK_SHARING_MODE_EXCLUSIVE|          "sharingMode": "VK_SHARING_MODE_EXCLUSIVE",
          "queueFamilyIndexCount": 0,              |          "queueFamilyIndexCount": 0,
          "pQueueFamilyIndices": []                |          "pQueueFamilyIndices": []
      },                                           |      },
      "pAllocator": {                              |      "pAllocator": {
          "pUserData": "0x0",                      |          "pUserData": "0x0",
          "pfnAllocation": "465834563476",         |          "pfnAllocation": "0x6c75e75794",
          "pfnReallocation": "465834563788",       |          "pfnReallocation": "0x6c75e758cc",
          "pfnFree": "465834564548",               |          "pfnFree": "0x6c75e75bc4",
          "pfnInternalAllocation": "465834565512", |          "pfnInternalAllocation": "0x6c75e75f88",
          "pfnInternalFree": "465834565548"        |          "pfnInternalFree": "0x6c75e75fac"
      },                                           |      },
      "[out]pBuffer": "0x70"                       |      "[out]pBuffer": "0x70"
  },                                               |  },
  "[609]vkGetBufferMemoryRequirements": {          |  "[609]vkGetBufferMemoryRequirements": {
      "device": "0x40",                            |      "device": "0x40",
      "buffer": "0x70",                            |      "buffer": "0x70",
+ +--150 lines: "[out]pMemoryRequirements": {------|+ +--150 lines: "[out]pMemoryRequirements": {--------------
          "queueFamilyIndexCount": 0,              |          "queueFamilyIndexCount": 0,
          "pQueueFamilyIndices": [],               |          "pQueueFamilyIndices": [],
          "initialLayout": "VK_IMAGE_LAYOUT_UNDEFIN|          "initialLayout": "VK_IMAGE_LAYOUT_UNDEFINED"
      },                                           |      },
      "pAllocator": {                              |      "pAllocator": {
          "pUserData": "0x0",                      |          "pUserData": "0x0",
          "pfnAllocation": "465834563476",         |          "pfnAllocation": "0x6c75e75794",
          "pfnReallocation": "465834563788",       |          "pfnReallocation": "0x6c75e758cc",
          "pfnFree": "465834564548",               |          "pfnFree": "0x6c75e75bc4",
          "pfnInternalAllocation": "465834565512", |          "pfnInternalAllocation": "0x6c75e75f88",
          "pfnInternalFree": "465834565548"        |          "pfnInternalFree": "0x6c75e75fac"
      },                                           |      },
      "[out]pImage": "0x71"                        |      "[out]pImage": "0x71"
  },                                               |  },
  "[617]vkGetImageMemoryRequirements": {           |  "[617]vkGetImageMemoryRequirements": {
      "device": "0x40",                            |      "device": "0x40",
      "image": "0x71",                             |      "image": "0x71",
+ +-- 92 lines: "[out]pMemoryRequirements": {------|+ +-- 92 lines: "[out]pMemoryRequirements": {--------------
              "baseArrayLayer": 0,                 |              "baseArrayLayer": 0,
              "layerCount": 1                      |              "layerCount": 1
          }                                        |          }
      },                                           |      },
```

