### PR TITLE
create and use CreateHardwareBufferCommandHeader2

### DIFF
--- a/framework/decode/api_decoder.h
+++ b/framework/decode/api_decoder.h
@@ -85,7 +85,7 @@ class ApiDecoder
                                         uint32_t                                            width,
                                         uint32_t                                            height,
                                         uint32_t                                            stride,
-                                        uint32_t                                            usage,
+                                        uint64_t                                            usage,
                                         uint32_t                                            layers,
                                         const std::vector<format::HardwareBufferPlaneInfo>& plane_info) = 0;
 

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -628,7 +628,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
             HandleBlockReadError(kErrorReadingBlockHeader, "Failed to read display message meta-data block header");
         }
     }
-    else if (meta_data_type == format::MetaDataType::kCreateHardwareBufferCommand)
+    else if (meta_data_type == format::MetaDataType::kCreateHardwareBufferCommand_deprecated)
     {
         format::CreateHardwareBufferCommandHeader_deprecated header;
 
@@ -699,7 +699,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                                  "Failed to read create hardware buffer meta-data block header");
         }
     }
-    else if (meta_data_type == format::MetaDataType::kCreateHardwareBufferCommand2)
+    else if (meta_data_type == format::MetaDataType::kCreateHardwareBufferCommand)
     {
         format::CreateHardwareBufferCommandHeader header;
 

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -630,7 +630,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
     }
     else if (meta_data_type == format::MetaDataType::kCreateHardwareBufferCommand)
     {
-        format::CreateHardwareBufferCommandHeader header;
+        format::CreateHardwareBufferCommandHeader_deprecated header;
 
         success = ReadBytes(&header.thread_id, sizeof(header.thread_id));
         success = success && ReadBytes(&header.memory_id, sizeof(header.memory_id));
@@ -701,7 +701,7 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
     }
     else if (meta_data_type == format::MetaDataType::kCreateHardwareBufferCommand2)
     {
-        format::CreateHardwareBufferCommandHeader2 header;
+        format::CreateHardwareBufferCommandHeader header;
 
         success = ReadBytes(&header.thread_id, sizeof(header.thread_id));
         success = success && ReadBytes(&header.memory_id, sizeof(header.memory_id));

--- a/framework/decode/file_processor.cpp
+++ b/framework/decode/file_processor.cpp
@@ -699,6 +699,77 @@ bool FileProcessor::ProcessMetaData(const format::BlockHeader& block_header, for
                                  "Failed to read create hardware buffer meta-data block header");
         }
     }
+    else if (meta_data_type == format::MetaDataType::kCreateHardwareBufferCommand2)
+    {
+        format::CreateHardwareBufferCommandHeader2 header;
+
+        success = ReadBytes(&header.thread_id, sizeof(header.thread_id));
+        success = success && ReadBytes(&header.memory_id, sizeof(header.memory_id));
+        success = success && ReadBytes(&header.buffer_id, sizeof(header.buffer_id));
+        success = success && ReadBytes(&header.format, sizeof(header.format));
+        success = success && ReadBytes(&header.width, sizeof(header.width));
+        success = success && ReadBytes(&header.height, sizeof(header.height));
+        success = success && ReadBytes(&header.stride, sizeof(header.stride));
+        success = success && ReadBytes(&header.usage, sizeof(header.usage));
+        success = success && ReadBytes(&header.layers, sizeof(header.layers));
+        success = success && ReadBytes(&header.planes, sizeof(header.planes));
+
+        if (success)
+        {
+            std::vector<format::HardwareBufferPlaneInfo> entries;
+
+            for (uint64_t i = 0; i < header.planes; ++i)
+            {
+                format::HardwareBufferPlaneInfo entry;
+
+                if (!ReadBytes(&entry, sizeof(entry)))
+                {
+                    success = false;
+                    break;
+                }
+
+                entries.emplace_back(std::move(entry));
+            }
+
+            if (success)
+            {
+                for (auto decoder : decoders_)
+                {
+                    if (decoder->SupportsMetaDataId(meta_data_id))
+                    {
+                        decoder->DispatchCreateHardwareBufferCommand(header.thread_id,
+                                                                     header.memory_id,
+                                                                     header.buffer_id,
+                                                                     header.format,
+                                                                     header.width,
+                                                                     header.height,
+                                                                     header.stride,
+                                                                     header.usage,
+                                                                     header.layers,
+                                                                     entries);
+                    }
+                }
+            }
+            else
+            {
+                if (format::IsBlockCompressed(block_header.type))
+                {
+                    HandleBlockReadError(kErrorReadingCompressedBlockData,
+                                         "Failed to read create hardware buffer meta-data block");
+                }
+                else
+                {
+                    HandleBlockReadError(kErrorReadingBlockData,
+                                         "Failed to read create hardware buffer meta-data block");
+                }
+            }
+        }
+        else
+        {
+            HandleBlockReadError(kErrorReadingBlockHeader,
+                                 "Failed to read create hardware buffer meta-data block header");
+        }
+    }
     else if (meta_data_type == format::MetaDataType::kDestroyHardwareBufferCommand)
     {
         format::DestroyHardwareBufferCommand command;

--- a/framework/decode/vulkan_consumer_base.h
+++ b/framework/decode/vulkan_consumer_base.h
@@ -69,7 +69,7 @@ class VulkanConsumerBase
                                                     uint32_t                                            width,
                                                     uint32_t                                            height,
                                                     uint32_t                                            stride,
-                                                    uint32_t                                            usage,
+                                                    uint64_t                                            usage,
                                                     uint32_t                                            layers,
                                                     const std::vector<format::HardwareBufferPlaneInfo>& plane_info)
     {}

--- a/framework/decode/vulkan_decoder_base.cpp
+++ b/framework/decode/vulkan_decoder_base.cpp
@@ -107,7 +107,7 @@ void VulkanDecoderBase::DispatchCreateHardwareBufferCommand(
     uint32_t                                            width,
     uint32_t                                            height,
     uint32_t                                            stride,
-    uint32_t                                            usage,
+    uint64_t                                            usage,
     uint32_t                                            layers,
     const std::vector<format::HardwareBufferPlaneInfo>& plane_info)
 {

--- a/framework/decode/vulkan_decoder_base.h
+++ b/framework/decode/vulkan_decoder_base.h
@@ -100,7 +100,7 @@ class VulkanDecoderBase : public ApiDecoder
                                         uint32_t                                            width,
                                         uint32_t                                            height,
                                         uint32_t                                            stride,
-                                        uint32_t                                            usage,
+                                        uint64_t                                            usage,
                                         uint32_t                                            layers,
                                         const std::vector<format::HardwareBufferPlaneInfo>& plane_info) override;
 

--- a/framework/decode/vulkan_replay_consumer_base.cpp
+++ b/framework/decode/vulkan_replay_consumer_base.cpp
@@ -420,7 +420,7 @@ void VulkanReplayConsumerBase::ProcessCreateHardwareBufferCommand(
     uint32_t                                            width,
     uint32_t                                            height,
     uint32_t                                            stride,
-    uint32_t                                            usage,
+    uint64_t                                            usage,
     uint32_t                                            layers,
     const std::vector<format::HardwareBufferPlaneInfo>& plane_info)
 {

--- a/framework/decode/vulkan_replay_consumer_base.h
+++ b/framework/decode/vulkan_replay_consumer_base.h
@@ -102,7 +102,7 @@ class VulkanReplayConsumerBase : public VulkanConsumer
                                        uint32_t                                            width,
                                        uint32_t                                            height,
                                        uint32_t                                            stride,
-                                       uint32_t                                            usage,
+                                       uint64_t                                            usage,
                                        uint32_t                                            layers,
                                        const std::vector<format::HardwareBufferPlaneInfo>& plane_info) override;
 

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -185,7 +185,7 @@ void VulkanCaptureManager::WriteCreateHardwareBufferCmd(format::HandleId        
         create_buffer_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
         create_buffer_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(create_buffer_cmd);
         create_buffer_cmd.meta_header.meta_data_id      = format::MakeMetaDataId(
-            format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kCreateHardwareBufferCommand2);
+            format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kCreateHardwareBufferCommand);
         create_buffer_cmd.thread_id = thread_data->thread_id_;
         create_buffer_cmd.memory_id = memory_id;
         create_buffer_cmd.buffer_id = reinterpret_cast<uint64_t>(buffer);
@@ -552,7 +552,7 @@ VkResult VulkanCaptureManager::OverrideCreateInstance(const VkInstanceCreateInfo
             const char* const*       extensions      = create_info_copy.ppEnabledExtensionNames;
             std::vector<const char*> modified_extensions;
 
-            bool has_dev_prop2 = false;
+            bool has_dev_prop2    = false;
             bool has_ext_mem_caps = false;
 
             for (size_t i = 0; i < extension_count; ++i)

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -177,7 +177,7 @@ void VulkanCaptureManager::WriteCreateHardwareBufferCmd(format::HandleId        
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
         assert(buffer != nullptr);
 
-        format::CreateHardwareBufferCommandHeader create_buffer_cmd;
+        format::CreateHardwareBufferCommandHeader2 create_buffer_cmd;
 
         auto thread_data = GetThreadData();
         assert(thread_data != nullptr);

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -177,7 +177,7 @@ void VulkanCaptureManager::WriteCreateHardwareBufferCmd(format::HandleId        
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
         assert(buffer != nullptr);
 
-        format::CreateHardwareBufferCommandHeader2 create_buffer_cmd;
+        format::CreateHardwareBufferCommandHeader create_buffer_cmd;
 
         auto thread_data = GetThreadData();
         assert(thread_data != nullptr);

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -185,7 +185,7 @@ void VulkanCaptureManager::WriteCreateHardwareBufferCmd(format::HandleId        
         create_buffer_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
         create_buffer_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(create_buffer_cmd);
         create_buffer_cmd.meta_header.meta_data_id      = format::MakeMetaDataId(
-            format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kCreateHardwareBufferCommand);
+            format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kCreateHardwareBufferCommand2);
         create_buffer_cmd.thread_id = thread_data->thread_id_;
         create_buffer_cmd.memory_id = memory_id;
         create_buffer_cmd.buffer_id = reinterpret_cast<uint64_t>(buffer);

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2811,7 +2811,7 @@ void VulkanStateWriter::WriteCreateHardwareBufferCmd(format::HandleId memory_id,
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
     assert(hardware_buffer != nullptr);
 
-    format::CreateHardwareBufferCommandHeader create_buffer_cmd;
+    format::CreateHardwareBufferCommandHeader2 create_buffer_cmd;
 
     create_buffer_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
     create_buffer_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(create_buffer_cmd);

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2811,7 +2811,7 @@ void VulkanStateWriter::WriteCreateHardwareBufferCmd(format::HandleId memory_id,
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
     assert(hardware_buffer != nullptr);
 
-    format::CreateHardwareBufferCommandHeader2 create_buffer_cmd;
+    format::CreateHardwareBufferCommandHeader create_buffer_cmd;
 
     create_buffer_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
     create_buffer_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(create_buffer_cmd);

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2816,7 +2816,7 @@ void VulkanStateWriter::WriteCreateHardwareBufferCmd(format::HandleId memory_id,
     create_buffer_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
     create_buffer_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(create_buffer_cmd);
     create_buffer_cmd.meta_header.meta_data_id      = format::MakeMetaDataId(
-        format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kCreateHardwareBufferCommand);
+        format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kCreateHardwareBufferCommand2);
     create_buffer_cmd.thread_id = thread_id_;
     create_buffer_cmd.memory_id = memory_id;
     create_buffer_cmd.buffer_id = reinterpret_cast<uint64_t>(hardware_buffer);

--- a/framework/encode/vulkan_state_writer.cpp
+++ b/framework/encode/vulkan_state_writer.cpp
@@ -2816,7 +2816,7 @@ void VulkanStateWriter::WriteCreateHardwareBufferCmd(format::HandleId memory_id,
     create_buffer_cmd.meta_header.block_header.type = format::BlockType::kMetaDataBlock;
     create_buffer_cmd.meta_header.block_header.size = format::GetMetaDataBlockBaseSize(create_buffer_cmd);
     create_buffer_cmd.meta_header.meta_data_id      = format::MakeMetaDataId(
-        format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kCreateHardwareBufferCommand2);
+        format::ApiFamilyId::ApiFamily_Vulkan, format::MetaDataType::kCreateHardwareBufferCommand);
     create_buffer_cmd.thread_id = thread_id_;
     create_buffer_cmd.memory_id = memory_id;
     create_buffer_cmd.buffer_id = reinterpret_cast<uint64_t>(hardware_buffer);

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -313,6 +313,8 @@ struct ResizeWindowCommand2
     uint32_t         pre_transform;
 };
 
+// This command header's "usage" member is sized incorrectly.  Existing decoding must remain in place in order to
+// process captures that already exist.  Do not use this command header in any new code.
 struct CreateHardwareBufferCommandHeader
 {
     MetaDataHeader meta_header;

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -119,6 +119,7 @@ enum class MetaDataType : uint16_t
     kReserved21                             = 21,
     kReserved22                             = 22,
     kReserved23                             = 23,
+    kCreateHardwareBufferCommand2           = 24,
 };
 
 // MetaDataId is stored in the capture file and its type must be uint32_t to avoid breaking capture file compatibility.
@@ -323,6 +324,22 @@ struct CreateHardwareBufferCommandHeader
     uint32_t       height;
     uint32_t       stride; // Size of a row in pixels.
     uint32_t       usage;
+    uint32_t       layers;
+    uint32_t       planes; // When additional multi-plane data is available, header is followed by 'planes' count
+                           // HardwareBufferLayerInfo records.  When unavailable, 'planes' is zero.
+};
+
+struct CreateHardwareBufferCommandHeader2
+{
+    MetaDataHeader meta_header;
+    ThreadId       thread_id;
+    HandleId       memory_id; // Globally unique ID assigned to the buffer for tracking memory modifications.
+    uint64_t       buffer_id; // Address of the buffer object.
+    uint32_t       format;
+    uint32_t       width;
+    uint32_t       height;
+    uint32_t       stride; // Size of a row in pixels.
+    uint64_t       usage;
     uint32_t       layers;
     uint32_t       planes; // When additional multi-plane data is available, header is followed by 'planes' count
                            // HardwareBufferLayerInfo records.  When unavailable, 'planes' is zero.

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -104,7 +104,7 @@ enum class MetaDataType : uint16_t
     kEndResourceInitCommand                 = 6,
     kInitBufferCommand                      = 7,
     kInitImageCommand                       = 8,
-    kCreateHardwareBufferCommand            = 9,
+    kCreateHardwareBufferCommand_deprecated = 9,
     kDestroyHardwareBufferCommand           = 10,
     kSetDevicePropertiesCommand             = 11,
     kSetDeviceMemoryPropertiesCommand       = 12,
@@ -119,7 +119,7 @@ enum class MetaDataType : uint16_t
     kReserved21                             = 21,
     kReserved22                             = 22,
     kReserved23                             = 23,
-    kCreateHardwareBufferCommand2           = 24,
+    kCreateHardwareBufferCommand            = 24,
 };
 
 // MetaDataId is stored in the capture file and its type must be uint32_t to avoid breaking capture file compatibility.

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -315,7 +315,7 @@ struct ResizeWindowCommand2
 
 // This command header's "usage" member is sized incorrectly.  Existing decoding must remain in place in order to
 // process captures that already exist.  Do not use this command header in any new code.
-struct CreateHardwareBufferCommandHeader
+struct CreateHardwareBufferCommandHeader_deprecated
 {
     MetaDataHeader meta_header;
     ThreadId       thread_id;
@@ -331,7 +331,7 @@ struct CreateHardwareBufferCommandHeader
                            // HardwareBufferLayerInfo records.  When unavailable, 'planes' is zero.
 };
 
-struct CreateHardwareBufferCommandHeader2
+struct CreateHardwareBufferCommandHeader
 {
     MetaDataHeader meta_header;
     ThreadId       thread_id;


### PR DESCRIPTION
Make a `CreateHardwareBufferCommandHeader2` with uint64_t, transition all encoding to the 2 version, and update `DispatchCreateHardwareBufferCommand` and `ProcessCreateHardwareBufferCommand` to take uint64_t usage, add an additional `FileProcessor` clause for the new `CreateHardwareBufferCommandHeader2`.

Fixes #745.