### PR TITLE
[Docs] Add Clang to Fedora dependencies

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -233,7 +233,7 @@ command:
 
 ```bash
 sudo dnf install git cmake libxcb-devel libX11-devel xcb-util-keysyms-devel \
-        libXrandr-devel wayland-devel zlib-devel lz4-devel libzstd-devel
+        libXrandr-devel wayland-devel zlib-devel lz4-devel libzstd-devel clang
 ```
 
 For arm64 builds (cross compilation):


### PR DESCRIPTION
At least on my Fedora 36 machine I needed clang to be installed, without it I would get `No CMAKE_CXX_COMPILER could be found`