### PR TITLE
toascii - Minimal Change to Enable JSON Lines Output - Explicit Type

### DIFF
--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -136,6 +136,7 @@ target_sources(gfxrecon_decode
 
 if (MSVC)
     # These files may fail to compile with VS2017 and older, requiring the default section limit of 2^16 to be increased.
+    set_source_files_properties(${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_ascii_consumer.cpp PROPERTIES COMPILE_FLAGS /bigobj)
     set_source_files_properties(${CMAKE_SOURCE_DIR}/framework/generated/generated_vulkan_struct_decoders_to_string.cpp PROPERTIES COMPILE_FLAGS /bigobj)
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/test/main.cpp PROPERTIES COMPILE_FLAGS /bigobj)
     if (MSVC_VERSION LESS 1920)

--- a/framework/decode/vulkan_ascii_consumer_base.cpp
+++ b/framework/decode/vulkan_ascii_consumer_base.cpp
@@ -39,14 +39,13 @@ void VulkanAsciiConsumerBase::Initialize(FILE* file)
 {
     assert(file);
     file_ = file;
-    fprintf(file_, "{");
 }
 
 void VulkanAsciiConsumerBase::Destroy()
 {
     if (file_ != nullptr)
     {
-        fprintf(file_, "\n}\n");
+        fprintf(file_, "\n");
         file_ = nullptr;
     }
 }
@@ -82,7 +81,7 @@ void VulkanAsciiConsumerBase::Process_vkAllocateCommandBuffers(
         FieldToString(strStrm, false, "[out]pCommandBuffers", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(commandBufferCount, pCommandBuffers, toStringFlags, tabCount, tabSize));
     };
 
-    WriteApiCallToFile(call_info, "vkAllocateCommandBuffers", toStringFlags, tabCount, tabSize, createString);
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize, createString);
 }
 
 void VulkanAsciiConsumerBase::Process_vkAllocateDescriptorSets(
@@ -110,7 +109,7 @@ void VulkanAsciiConsumerBase::Process_vkAllocateDescriptorSets(
         FieldToString(strStrm, false, "[out]pDescriptorSets", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(descriptorSetCount, pDescriptorSets, toStringFlags, tabCount, tabSize));
     };
 
-    WriteApiCallToFile(call_info, "vkAllocateDescriptorSets", toStringFlags, tabCount, tabSize, createString);
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize, createString);
 }
 
 void VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresIndirectKHR(
@@ -152,7 +151,7 @@ void VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresIndirectKH
         FieldToString(strStrm, false, "ppMaxPrimitiveCounts", toStringFlags, tabCount, tabSize, arrayString);
     };
 
-    WriteApiCallToFile(call_info, "vkCmdBuildAccelerationStructuresIndirectKHR", toStringFlags, tabCount, tabSize, createString);
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize, createString);
 }
 
 void VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresKHR(
@@ -191,7 +190,7 @@ void VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresKHR(
         FieldToString(strStrm, false, "ppBuildRangeInfos", toStringFlags, tabCount, tabSize, arrayString);
     };
 
-    WriteApiCallToFile(call_info, "vkCmdBuildAccelerationStructuresKHR", toStringFlags, tabCount, tabSize, createString);
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize, createString);
 }
 
 void VulkanAsciiConsumerBase::Process_vkGetAccelerationStructureBuildSizesKHR(
@@ -222,7 +221,7 @@ void VulkanAsciiConsumerBase::Process_vkGetAccelerationStructureBuildSizesKHR(
         FieldToString(strStrm, false, "[out]pSizeInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSizeInfo, toStringFlags, tabCount, tabSize));
     };
 
-    WriteApiCallToFile(call_info, "vkGetAccelerationStructureBuildSizesKHR", toStringFlags, tabCount, tabSize, createString);
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize, createString);
 }
 
 void VulkanAsciiConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(
@@ -247,7 +246,7 @@ void VulkanAsciiConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(
         FieldToString(strStrm, false, "pData", toStringFlags, tabCount, tabSize, DescriptorUpdateTemplateDecoderToString(pData));
     };
 
-    WriteApiCallToFile(call_info, "vkCmdPushDescriptorSetWithTemplateKHR", toStringFlags, tabCount, tabSize, createString);
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize, createString);
 }
 
 void VulkanAsciiConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(
@@ -271,7 +270,7 @@ void VulkanAsciiConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(
         FieldToString(strStrm, false, "pData", toStringFlags, tabCount, tabSize, DescriptorUpdateTemplateDecoderToString(pData));
     };
 
-    WriteApiCallToFile(call_info, "vkUpdateDescriptorSetWithTemplate", toStringFlags, tabCount, tabSize, createString);
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize, createString);
 }
 
 void VulkanAsciiConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(
@@ -295,7 +294,7 @@ void VulkanAsciiConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(
         FieldToString(strStrm, false, "pData", toStringFlags, tabCount, tabSize, DescriptorUpdateTemplateDecoderToString(pData));
     };
 
-    WriteApiCallToFile(call_info, "vkUpdateDescriptorSetWithTemplateKHR", toStringFlags, tabCount, tabSize, createString);
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize, createString);
 }
 
 // clang-format on

--- a/framework/decode/vulkan_ascii_consumer_base.cpp
+++ b/framework/decode/vulkan_ascii_consumer_base.cpp
@@ -71,14 +71,26 @@ void VulkanAsciiConsumerBase::Process_vkAllocateCommandBuffers(
     uint32_t tabSize            = 4;
 
     auto createString = [&](std::stringstream& strStrm) {
-        FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-        FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+        FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+        FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+        FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAllocateCommandBuffers\"");
+        FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+        FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+        strStrm << GetNewlineString(toStringFlags);
+        tabCount += 1;
+
+        FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
         FieldToString(strStrm, false, "pAllocateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocateInfo, toStringFlags, tabCount, tabSize));
 
         auto pDecodedAllocateInfo = pAllocateInfo ? pAllocateInfo->GetPointer() : nullptr;
         auto commandBufferCount   = pDecodedAllocateInfo ? pDecodedAllocateInfo->commandBufferCount : 0;
 
         FieldToString(strStrm, false, "[out]pCommandBuffers", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(commandBufferCount, pCommandBuffers, toStringFlags, tabCount, tabSize));
+
+        tabCount -= 1;
+        strStrm << GetNewlineString(toStringFlags);
+        strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+        strStrm << "}";
     };
 
     WriteApiCallToFile(toStringFlags, tabCount, tabSize, createString);
@@ -99,14 +111,26 @@ void VulkanAsciiConsumerBase::Process_vkAllocateDescriptorSets(
     uint32_t tabSize            = 4;
 
     auto createString = [&](std::stringstream& strStrm) {
-        FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-        FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+        FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+        FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+        FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAllocateDescriptorSets\"");
+        FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+        FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+        strStrm << GetNewlineString(toStringFlags);
+        tabCount += 1;
+
+        FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
         FieldToString(strStrm, false, "pAllocateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocateInfo, toStringFlags, tabCount, tabSize));
 
         auto pDecodedAllocateInfo = pAllocateInfo ? pAllocateInfo->GetPointer() : nullptr;
         auto descriptorSetCount   = pDecodedAllocateInfo ? pDecodedAllocateInfo->descriptorSetCount : 0;
 
         FieldToString(strStrm, false, "[out]pDescriptorSets", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(descriptorSetCount, pDescriptorSets, toStringFlags, tabCount, tabSize));
+
+        tabCount -= 1;
+        strStrm << GetNewlineString(toStringFlags);
+        strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+        strStrm << "}";
     };
 
     WriteApiCallToFile(toStringFlags, tabCount, tabSize, createString);
@@ -129,6 +153,12 @@ void VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresIndirectKH
     uint32_t tabSize            = 4;
 
     auto createString = [&](std::stringstream& strStrm) {
+        FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+        FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+        FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBuildAccelerationStructuresIndirectKHR\"");
+        FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+        strStrm << GetNewlineString(toStringFlags);
+        tabCount += 1;
         FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
         FieldToString(strStrm, false, "infoCount", toStringFlags, tabCount, tabSize, ToString(infoCount, toStringFlags, tabCount, tabSize));
         FieldToString(strStrm, false, "pInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(infoCount, pInfos, toStringFlags, tabCount, tabSize));
@@ -149,6 +179,11 @@ void VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresIndirectKH
         auto arrayString = ArrayToString(infoCount, pInfos, toStringFlags, tabCount + 1, tabSize, validateArray, createArrayString);
 
         FieldToString(strStrm, false, "ppMaxPrimitiveCounts", toStringFlags, tabCount, tabSize, arrayString);
+
+        tabCount -= 1;
+        strStrm << GetNewlineString(toStringFlags);
+        strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+        strStrm << "}";
     };
 
     WriteApiCallToFile(toStringFlags, tabCount, tabSize, createString);
@@ -169,6 +204,13 @@ void VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresKHR(
     uint32_t      tabSize       = 4;
 
     auto createString = [&](std::stringstream& strStrm) {
+        FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+        FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+        FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBuildAccelerationStructuresKHR\"");
+        FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+        strStrm << GetNewlineString(toStringFlags);
+        tabCount += 1;
+
         FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
         FieldToString(strStrm, false, "infoCount", toStringFlags, tabCount, tabSize, ToString(infoCount, toStringFlags, tabCount, tabSize));
         FieldToString(strStrm, false, "pInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(infoCount, pInfos, toStringFlags, tabCount, tabSize));
@@ -188,6 +230,11 @@ void VulkanAsciiConsumerBase::Process_vkCmdBuildAccelerationStructuresKHR(
         auto arrayString = ArrayToString(infoCount, pInfos, toStringFlags, tabCount, tabSize, validateArray, createArrayString);
 
         FieldToString(strStrm, false, "ppBuildRangeInfos", toStringFlags, tabCount, tabSize, arrayString);
+
+        tabCount -= 1;
+        strStrm << GetNewlineString(toStringFlags);
+        strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+        strStrm << "}";
     };
 
     WriteApiCallToFile(toStringFlags, tabCount, tabSize, createString);
@@ -209,6 +256,13 @@ void VulkanAsciiConsumerBase::Process_vkGetAccelerationStructureBuildSizesKHR(
     uint32_t      tabSize       = 4;
 
     auto createString = [&](std::stringstream& strStrm) {
+        FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+        FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+        FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetAccelerationStructureBuildSizesKHR\"");
+        FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+        strStrm << GetNewlineString(toStringFlags);
+        tabCount += 1;
+
         FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
         FieldToString(strStrm, false, "buildType", toStringFlags, tabCount, tabSize, '"' + ToString(buildType, toStringFlags, tabCount, tabSize) + '"');
         FieldToString(strStrm, false, "pBuildInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pBuildInfo, toStringFlags, tabCount, tabSize));
@@ -219,6 +273,11 @@ void VulkanAsciiConsumerBase::Process_vkGetAccelerationStructureBuildSizesKHR(
 
         FieldToString(strStrm, false, "pMaxPrimitiveCounts", toStringFlags, tabCount, tabSize, ArrayToString(geometryCount, pDecodedMaxPrimitiveCounts, toStringFlags, tabCount, tabSize));
         FieldToString(strStrm, false, "[out]pSizeInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSizeInfo, toStringFlags, tabCount, tabSize));
+
+        tabCount -= 1;
+        strStrm << GetNewlineString(toStringFlags);
+        strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+        strStrm << "}";
     };
 
     WriteApiCallToFile(toStringFlags, tabCount, tabSize, createString);
@@ -240,10 +299,22 @@ void VulkanAsciiConsumerBase::Process_vkCmdPushDescriptorSetWithTemplateKHR(
     uint32_t tabSize            = 4;
 
     auto createString = [&](std::stringstream& strStrm) {
+        FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+        FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+        FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdPushDescriptorSetWithTemplateKHR\"");
+        FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+        strStrm << GetNewlineString(toStringFlags);
+        tabCount += 1;
+
         FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
         FieldToString(strStrm, false, "descriptorUpdateTemplate", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorUpdateTemplate));
         FieldToString(strStrm, false, "layout", toStringFlags, tabCount, tabSize, HandleIdToString(layout));
         FieldToString(strStrm, false, "pData", toStringFlags, tabCount, tabSize, DescriptorUpdateTemplateDecoderToString(pData));
+
+        tabCount -= 1;
+        strStrm << GetNewlineString(toStringFlags);
+        strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+        strStrm << "}";
     };
 
     WriteApiCallToFile(toStringFlags, tabCount, tabSize, createString);
@@ -264,10 +335,22 @@ void VulkanAsciiConsumerBase::Process_vkUpdateDescriptorSetWithTemplate(
     uint32_t      tabSize       = 4;
 
     auto createString = [&](std::stringstream& strStrm) {
+        FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+        FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+        FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkUpdateDescriptorSetWithTemplate\"");
+        FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+        strStrm << GetNewlineString(toStringFlags);
+        tabCount += 1;
+
         FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
         FieldToString(strStrm, false, "descriptorSet", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorSet));
         FieldToString(strStrm, false, "descriptorUpdateTemplate", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorUpdateTemplate));
         FieldToString(strStrm, false, "pData", toStringFlags, tabCount, tabSize, DescriptorUpdateTemplateDecoderToString(pData));
+
+        tabCount -= 1;
+        strStrm << GetNewlineString(toStringFlags);
+        strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+        strStrm << "}";
     };
 
     WriteApiCallToFile(toStringFlags, tabCount, tabSize, createString);
@@ -288,10 +371,22 @@ void VulkanAsciiConsumerBase::Process_vkUpdateDescriptorSetWithTemplateKHR(
     uint32_t tabSize            = 4;
 
     auto createString = [&](std::stringstream& strStrm) {
+        FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+        FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+        FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkUpdateDescriptorSetWithTemplateKHR\"");
+        FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+        strStrm << GetNewlineString(toStringFlags);
+        tabCount += 1;
+
         FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
         FieldToString(strStrm, false, "descriptorSet", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorSet));
         FieldToString(strStrm, false, "descriptorUpdateTemplate", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorUpdateTemplate));
         FieldToString(strStrm, false, "pData", toStringFlags, tabCount, tabSize, DescriptorUpdateTemplateDecoderToString(pData));
+
+        tabCount -= 1;
+        strStrm << GetNewlineString(toStringFlags);
+        strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+        strStrm << "}";
     };
 
     WriteApiCallToFile(toStringFlags, tabCount, tabSize, createString);

--- a/framework/decode/vulkan_ascii_consumer_base.h
+++ b/framework/decode/vulkan_ascii_consumer_base.h
@@ -109,18 +109,13 @@ class VulkanAsciiConsumerBase : public VulkanConsumer
 
   protected:
     template <typename ToStringFunctionType>
-    inline void WriteApiCallToFile(const ApiCallInfo&   call_info,
-                                   const std::string&   functionName,
-                                   util::ToStringFlags  toStringFlags,
+    inline void WriteApiCallToFile(util::ToStringFlags  toStringFlags,
                                    uint32_t&            tabCount,
                                    uint32_t             tabSize,
                                    ToStringFunctionType toStringFunction)
     {
         using namespace util;
-        fprintf(file_, "%s\n", (call_info.index ? "," : ""));
-        fprintf(file_, "\"[%s]%s\":", std::to_string(call_info.index).c_str(), functionName.c_str());
-        fprintf(file_, "%s", GetWhitespaceString(toStringFlags).c_str());
-        fprintf(file_, "%s", ObjectToString(toStringFlags, tabCount, tabSize, toStringFunction).c_str());
+        fprintf(file_, "%s\n", ObjectToString(toStringFlags, tabCount, tabSize, toStringFunction).c_str());
     }
 
   private:

--- a/framework/generated/generated_vulkan_ascii_consumer.cpp
+++ b/framework/generated/generated_vulkan_ascii_consumer.cpp
@@ -54,7 +54,8 @@ void VulkanAsciiConsumer::Process_vkCreateInstance(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateInstance\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
@@ -83,7 +84,8 @@ void VulkanAsciiConsumer::Process_vkDestroyInstance(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyInstance\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
@@ -114,7 +116,8 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDevices(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkEnumeratePhysicalDevices\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPhysicalDeviceCount, toStringFlags, tabCount, tabSize));
@@ -143,7 +146,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFeatures(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceFeatures\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pFeatures", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFeatures, toStringFlags, tabCount, tabSize));
@@ -172,7 +176,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceFormatProperties\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "format", toStringFlags, tabCount, tabSize, '"' + ToString(format, toStringFlags, tabCount, tabSize) + '"');
@@ -208,7 +213,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceImageFormatProperties\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "format", toStringFlags, tabCount, tabSize, '"' + ToString(format, toStringFlags, tabCount, tabSize) + '"');
@@ -241,7 +247,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceProperties(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceProperties\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
@@ -270,7 +277,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceQueueFamilyProperties\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pQueueFamilyPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pQueueFamilyPropertyCount, toStringFlags, tabCount, tabSize));
@@ -299,7 +307,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceMemoryProperties\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pMemoryProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryProperties, toStringFlags, tabCount, tabSize));
@@ -331,7 +340,8 @@ void VulkanAsciiConsumer::Process_vkCreateDevice(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDevice\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -361,7 +371,8 @@ void VulkanAsciiConsumer::Process_vkDestroyDevice(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyDevice\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
@@ -391,7 +402,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceQueue(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceQueue\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
@@ -425,7 +437,8 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueSubmit\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "submitCount", toStringFlags, tabCount, tabSize, ToString(submitCount, toStringFlags, tabCount, tabSize));
@@ -456,7 +469,8 @@ void VulkanAsciiConsumer::Process_vkQueueWaitIdle(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueWaitIdle\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             tabCount -= 1;
@@ -484,7 +498,8 @@ void VulkanAsciiConsumer::Process_vkDeviceWaitIdle(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDeviceWaitIdle\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             tabCount -= 1;
@@ -515,7 +530,8 @@ void VulkanAsciiConsumer::Process_vkAllocateMemory(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAllocateMemory\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAllocateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocateInfo, toStringFlags, tabCount, tabSize));
@@ -546,7 +562,8 @@ void VulkanAsciiConsumer::Process_vkFreeMemory(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkFreeMemory\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
@@ -581,7 +598,8 @@ void VulkanAsciiConsumer::Process_vkMapMemory(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkMapMemory\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
@@ -613,7 +631,8 @@ void VulkanAsciiConsumer::Process_vkUnmapMemory(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkUnmapMemory\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
@@ -644,7 +663,8 @@ void VulkanAsciiConsumer::Process_vkFlushMappedMemoryRanges(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkFlushMappedMemoryRanges\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memoryRangeCount", toStringFlags, tabCount, tabSize, ToString(memoryRangeCount, toStringFlags, tabCount, tabSize));
@@ -676,7 +696,8 @@ void VulkanAsciiConsumer::Process_vkInvalidateMappedMemoryRanges(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkInvalidateMappedMemoryRanges\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memoryRangeCount", toStringFlags, tabCount, tabSize, ToString(memoryRangeCount, toStringFlags, tabCount, tabSize));
@@ -706,7 +727,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryCommitment(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceMemoryCommitment\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
@@ -739,7 +761,8 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkBindBufferMemory\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
@@ -773,7 +796,8 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkBindImageMemory\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
@@ -804,7 +828,8 @@ void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetBufferMemoryRequirements\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
@@ -834,7 +859,8 @@ void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageMemoryRequirements\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
@@ -865,7 +891,8 @@ void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageSparseMemoryRequirements\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
@@ -901,7 +928,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSparseImageFormatProperties\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "format", toStringFlags, tabCount, tabSize, '"' + ToString(format, toStringFlags, tabCount, tabSize) + '"');
@@ -939,7 +967,8 @@ void VulkanAsciiConsumer::Process_vkQueueBindSparse(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueBindSparse\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
@@ -973,7 +1002,8 @@ void VulkanAsciiConsumer::Process_vkCreateFence(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateFence\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -1004,7 +1034,8 @@ void VulkanAsciiConsumer::Process_vkDestroyFence(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyFence\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
@@ -1036,7 +1067,8 @@ void VulkanAsciiConsumer::Process_vkResetFences(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkResetFences\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "fenceCount", toStringFlags, tabCount, tabSize, ToString(fenceCount, toStringFlags, tabCount, tabSize));
@@ -1067,7 +1099,8 @@ void VulkanAsciiConsumer::Process_vkGetFenceStatus(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetFenceStatus\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
@@ -1100,7 +1133,8 @@ void VulkanAsciiConsumer::Process_vkWaitForFences(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkWaitForFences\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "fenceCount", toStringFlags, tabCount, tabSize, ToString(fenceCount, toStringFlags, tabCount, tabSize));
@@ -1135,7 +1169,8 @@ void VulkanAsciiConsumer::Process_vkCreateSemaphore(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateSemaphore\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -1166,7 +1201,8 @@ void VulkanAsciiConsumer::Process_vkDestroySemaphore(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroySemaphore\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "semaphore", toStringFlags, tabCount, tabSize, HandleIdToString(semaphore));
@@ -1199,7 +1235,8 @@ void VulkanAsciiConsumer::Process_vkCreateEvent(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateEvent\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -1230,7 +1267,8 @@ void VulkanAsciiConsumer::Process_vkDestroyEvent(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyEvent\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
@@ -1261,7 +1299,8 @@ void VulkanAsciiConsumer::Process_vkGetEventStatus(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetEventStatus\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
@@ -1291,7 +1330,8 @@ void VulkanAsciiConsumer::Process_vkSetEvent(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSetEvent\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
@@ -1321,7 +1361,8 @@ void VulkanAsciiConsumer::Process_vkResetEvent(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkResetEvent\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
@@ -1353,7 +1394,8 @@ void VulkanAsciiConsumer::Process_vkCreateQueryPool(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateQueryPool\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -1384,7 +1426,8 @@ void VulkanAsciiConsumer::Process_vkDestroyQueryPool(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyQueryPool\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
@@ -1421,7 +1464,8 @@ void VulkanAsciiConsumer::Process_vkGetQueryPoolResults(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetQueryPoolResults\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
@@ -1459,7 +1503,8 @@ void VulkanAsciiConsumer::Process_vkCreateBuffer(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateBuffer\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -1490,7 +1535,8 @@ void VulkanAsciiConsumer::Process_vkDestroyBuffer(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyBuffer\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
@@ -1523,7 +1569,8 @@ void VulkanAsciiConsumer::Process_vkCreateBufferView(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateBufferView\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -1554,7 +1601,8 @@ void VulkanAsciiConsumer::Process_vkDestroyBufferView(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyBufferView\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bufferView", toStringFlags, tabCount, tabSize, HandleIdToString(bufferView));
@@ -1587,7 +1635,8 @@ void VulkanAsciiConsumer::Process_vkCreateImage(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateImage\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -1618,7 +1667,8 @@ void VulkanAsciiConsumer::Process_vkDestroyImage(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyImage\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
@@ -1649,7 +1699,8 @@ void VulkanAsciiConsumer::Process_vkGetImageSubresourceLayout(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageSubresourceLayout\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
@@ -1683,7 +1734,8 @@ void VulkanAsciiConsumer::Process_vkCreateImageView(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateImageView\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -1714,7 +1766,8 @@ void VulkanAsciiConsumer::Process_vkDestroyImageView(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyImageView\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "imageView", toStringFlags, tabCount, tabSize, HandleIdToString(imageView));
@@ -1747,7 +1800,8 @@ void VulkanAsciiConsumer::Process_vkCreateShaderModule(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateShaderModule\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -1778,7 +1832,8 @@ void VulkanAsciiConsumer::Process_vkDestroyShaderModule(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyShaderModule\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "shaderModule", toStringFlags, tabCount, tabSize, HandleIdToString(shaderModule));
@@ -1811,7 +1866,8 @@ void VulkanAsciiConsumer::Process_vkCreatePipelineCache(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreatePipelineCache\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -1842,7 +1898,8 @@ void VulkanAsciiConsumer::Process_vkDestroyPipelineCache(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyPipelineCache\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
@@ -1875,7 +1932,8 @@ void VulkanAsciiConsumer::Process_vkGetPipelineCacheData(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPipelineCacheData\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
@@ -1909,7 +1967,8 @@ void VulkanAsciiConsumer::Process_vkMergePipelineCaches(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkMergePipelineCaches\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "dstCache", toStringFlags, tabCount, tabSize, HandleIdToString(dstCache));
@@ -1945,7 +2004,8 @@ void VulkanAsciiConsumer::Process_vkCreateGraphicsPipelines(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateGraphicsPipelines\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
@@ -1983,7 +2043,8 @@ void VulkanAsciiConsumer::Process_vkCreateComputePipelines(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateComputePipelines\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
@@ -2016,7 +2077,8 @@ void VulkanAsciiConsumer::Process_vkDestroyPipeline(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyPipeline\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
@@ -2049,7 +2111,8 @@ void VulkanAsciiConsumer::Process_vkCreatePipelineLayout(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreatePipelineLayout\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -2080,7 +2143,8 @@ void VulkanAsciiConsumer::Process_vkDestroyPipelineLayout(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyPipelineLayout\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipelineLayout", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineLayout));
@@ -2113,7 +2177,8 @@ void VulkanAsciiConsumer::Process_vkCreateSampler(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateSampler\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -2144,7 +2209,8 @@ void VulkanAsciiConsumer::Process_vkDestroySampler(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroySampler\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "sampler", toStringFlags, tabCount, tabSize, HandleIdToString(sampler));
@@ -2177,7 +2243,8 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorSetLayout(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDescriptorSetLayout\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -2208,7 +2275,8 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorSetLayout(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyDescriptorSetLayout\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorSetLayout", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorSetLayout));
@@ -2241,7 +2309,8 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorPool(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDescriptorPool\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -2272,7 +2341,8 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorPool(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyDescriptorPool\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorPool", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorPool));
@@ -2304,7 +2374,8 @@ void VulkanAsciiConsumer::Process_vkResetDescriptorPool(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkResetDescriptorPool\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorPool", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorPool));
@@ -2337,7 +2408,8 @@ void VulkanAsciiConsumer::Process_vkFreeDescriptorSets(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkFreeDescriptorSets\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorPool", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorPool));
@@ -2370,7 +2442,8 @@ void VulkanAsciiConsumer::Process_vkUpdateDescriptorSets(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkUpdateDescriptorSets\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorWriteCount", toStringFlags, tabCount, tabSize, ToString(descriptorWriteCount, toStringFlags, tabCount, tabSize));
@@ -2405,7 +2478,8 @@ void VulkanAsciiConsumer::Process_vkCreateFramebuffer(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateFramebuffer\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -2436,7 +2510,8 @@ void VulkanAsciiConsumer::Process_vkDestroyFramebuffer(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyFramebuffer\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "framebuffer", toStringFlags, tabCount, tabSize, HandleIdToString(framebuffer));
@@ -2469,7 +2544,8 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateRenderPass\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -2500,7 +2576,8 @@ void VulkanAsciiConsumer::Process_vkDestroyRenderPass(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyRenderPass\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "renderPass", toStringFlags, tabCount, tabSize, HandleIdToString(renderPass));
@@ -2530,7 +2607,8 @@ void VulkanAsciiConsumer::Process_vkGetRenderAreaGranularity(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetRenderAreaGranularity\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "renderPass", toStringFlags, tabCount, tabSize, HandleIdToString(renderPass));
@@ -2563,7 +2641,8 @@ void VulkanAsciiConsumer::Process_vkCreateCommandPool(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateCommandPool\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -2594,7 +2673,8 @@ void VulkanAsciiConsumer::Process_vkDestroyCommandPool(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyCommandPool\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "commandPool", toStringFlags, tabCount, tabSize, HandleIdToString(commandPool));
@@ -2626,7 +2706,8 @@ void VulkanAsciiConsumer::Process_vkResetCommandPool(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkResetCommandPool\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "commandPool", toStringFlags, tabCount, tabSize, HandleIdToString(commandPool));
@@ -2657,7 +2738,8 @@ void VulkanAsciiConsumer::Process_vkFreeCommandBuffers(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkFreeCommandBuffers\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "commandPool", toStringFlags, tabCount, tabSize, HandleIdToString(commandPool));
@@ -2689,7 +2771,8 @@ void VulkanAsciiConsumer::Process_vkBeginCommandBuffer(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkBeginCommandBuffer\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pBeginInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pBeginInfo, toStringFlags, tabCount, tabSize));
@@ -2718,7 +2801,8 @@ void VulkanAsciiConsumer::Process_vkEndCommandBuffer(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkEndCommandBuffer\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             tabCount -= 1;
@@ -2747,7 +2831,8 @@ void VulkanAsciiConsumer::Process_vkResetCommandBuffer(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkResetCommandBuffer\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
@@ -2776,7 +2861,8 @@ void VulkanAsciiConsumer::Process_vkCmdBindPipeline(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindPipeline\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pipelineBindPoint", toStringFlags, tabCount, tabSize, '"' + ToString(pipelineBindPoint, toStringFlags, tabCount, tabSize) + '"');
@@ -2807,7 +2893,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewport(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetViewport\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstViewport", toStringFlags, tabCount, tabSize, ToString(firstViewport, toStringFlags, tabCount, tabSize));
@@ -2839,7 +2926,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetScissor(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetScissor\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstScissor", toStringFlags, tabCount, tabSize, ToString(firstScissor, toStringFlags, tabCount, tabSize));
@@ -2869,7 +2957,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetLineWidth(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetLineWidth\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "lineWidth", toStringFlags, tabCount, tabSize, ToString(lineWidth, toStringFlags, tabCount, tabSize));
@@ -2899,7 +2988,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBias(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthBias\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthBiasConstantFactor", toStringFlags, tabCount, tabSize, ToString(depthBiasConstantFactor, toStringFlags, tabCount, tabSize));
@@ -2929,7 +3019,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetBlendConstants(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetBlendConstants\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "blendConstants", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(4, blendConstants, toStringFlags, tabCount, tabSize));
@@ -2958,7 +3049,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBounds(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthBounds\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "minDepthBounds", toStringFlags, tabCount, tabSize, ToString(minDepthBounds, toStringFlags, tabCount, tabSize));
@@ -2988,7 +3080,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilCompareMask(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetStencilCompareMask\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "faceMask", toStringFlags, tabCount, tabSize, ToString(faceMask, toStringFlags, tabCount, tabSize));
@@ -3018,7 +3111,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilWriteMask(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetStencilWriteMask\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "faceMask", toStringFlags, tabCount, tabSize, ToString(faceMask, toStringFlags, tabCount, tabSize));
@@ -3048,7 +3142,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilReference(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetStencilReference\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "faceMask", toStringFlags, tabCount, tabSize, ToString(faceMask, toStringFlags, tabCount, tabSize));
@@ -3083,7 +3178,8 @@ void VulkanAsciiConsumer::Process_vkCmdBindDescriptorSets(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindDescriptorSets\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pipelineBindPoint", toStringFlags, tabCount, tabSize, '"' + ToString(pipelineBindPoint, toStringFlags, tabCount, tabSize) + '"');
@@ -3119,7 +3215,8 @@ void VulkanAsciiConsumer::Process_vkCmdBindIndexBuffer(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindIndexBuffer\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
@@ -3152,7 +3249,8 @@ void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindVertexBuffers\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstBinding", toStringFlags, tabCount, tabSize, ToString(firstBinding, toStringFlags, tabCount, tabSize));
@@ -3186,7 +3284,8 @@ void VulkanAsciiConsumer::Process_vkCmdDraw(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDraw\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "vertexCount", toStringFlags, tabCount, tabSize, ToString(vertexCount, toStringFlags, tabCount, tabSize));
@@ -3221,7 +3320,8 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexed(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndexed\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "indexCount", toStringFlags, tabCount, tabSize, ToString(indexCount, toStringFlags, tabCount, tabSize));
@@ -3256,7 +3356,8 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirect(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndirect\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
@@ -3290,7 +3391,8 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirect(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndexedIndirect\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
@@ -3323,7 +3425,8 @@ void VulkanAsciiConsumer::Process_vkCmdDispatch(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDispatch\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "groupCountX", toStringFlags, tabCount, tabSize, ToString(groupCountX, toStringFlags, tabCount, tabSize));
@@ -3354,7 +3457,8 @@ void VulkanAsciiConsumer::Process_vkCmdDispatchIndirect(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDispatchIndirect\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
@@ -3386,7 +3490,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBuffer(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyBuffer\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "srcBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(srcBuffer));
@@ -3422,7 +3527,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImage(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyImage\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "srcImage", toStringFlags, tabCount, tabSize, HandleIdToString(srcImage));
@@ -3461,7 +3567,8 @@ void VulkanAsciiConsumer::Process_vkCmdBlitImage(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBlitImage\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "srcImage", toStringFlags, tabCount, tabSize, HandleIdToString(srcImage));
@@ -3499,7 +3606,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBufferToImage(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyBufferToImage\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "srcBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(srcBuffer));
@@ -3535,7 +3643,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImageToBuffer(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyImageToBuffer\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "srcImage", toStringFlags, tabCount, tabSize, HandleIdToString(srcImage));
@@ -3570,7 +3679,8 @@ void VulkanAsciiConsumer::Process_vkCmdUpdateBuffer(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdUpdateBuffer\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "dstBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(dstBuffer));
@@ -3604,7 +3714,8 @@ void VulkanAsciiConsumer::Process_vkCmdFillBuffer(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdFillBuffer\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "dstBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(dstBuffer));
@@ -3639,7 +3750,8 @@ void VulkanAsciiConsumer::Process_vkCmdClearColorImage(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdClearColorImage\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
@@ -3675,7 +3787,8 @@ void VulkanAsciiConsumer::Process_vkCmdClearDepthStencilImage(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdClearDepthStencilImage\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
@@ -3710,7 +3823,8 @@ void VulkanAsciiConsumer::Process_vkCmdClearAttachments(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdClearAttachments\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "attachmentCount", toStringFlags, tabCount, tabSize, ToString(attachmentCount, toStringFlags, tabCount, tabSize));
@@ -3746,7 +3860,8 @@ void VulkanAsciiConsumer::Process_vkCmdResolveImage(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdResolveImage\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "srcImage", toStringFlags, tabCount, tabSize, HandleIdToString(srcImage));
@@ -3780,7 +3895,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetEvent(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetEvent\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
@@ -3810,7 +3926,8 @@ void VulkanAsciiConsumer::Process_vkCmdResetEvent(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdResetEvent\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
@@ -3848,7 +3965,8 @@ void VulkanAsciiConsumer::Process_vkCmdWaitEvents(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWaitEvents\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "eventCount", toStringFlags, tabCount, tabSize, ToString(eventCount, toStringFlags, tabCount, tabSize));
@@ -3893,7 +4011,8 @@ void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdPipelineBarrier\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "srcStageMask", toStringFlags, tabCount, tabSize, ToString(srcStageMask, toStringFlags, tabCount, tabSize));
@@ -3931,7 +4050,8 @@ void VulkanAsciiConsumer::Process_vkCmdBeginQuery(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginQuery\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
@@ -3962,7 +4082,8 @@ void VulkanAsciiConsumer::Process_vkCmdEndQuery(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndQuery\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
@@ -3993,7 +4114,8 @@ void VulkanAsciiConsumer::Process_vkCmdResetQueryPool(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdResetQueryPool\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
@@ -4025,7 +4147,8 @@ void VulkanAsciiConsumer::Process_vkCmdWriteTimestamp(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWriteTimestamp\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pipelineStage", toStringFlags, tabCount, tabSize, '"' + ToString(pipelineStage, toStringFlags, tabCount, tabSize) + '"');
@@ -4061,7 +4184,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyQueryPoolResults(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyQueryPoolResults\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
@@ -4099,7 +4223,8 @@ void VulkanAsciiConsumer::Process_vkCmdPushConstants(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdPushConstants\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "layout", toStringFlags, tabCount, tabSize, HandleIdToString(layout));
@@ -4132,7 +4257,8 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginRenderPass\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pRenderPassBegin", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRenderPassBegin, toStringFlags, tabCount, tabSize));
@@ -4161,7 +4287,8 @@ void VulkanAsciiConsumer::Process_vkCmdNextSubpass(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdNextSubpass\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "contents", toStringFlags, tabCount, tabSize, '"' + ToString(contents, toStringFlags, tabCount, tabSize) + '"');
@@ -4188,7 +4315,8 @@ void VulkanAsciiConsumer::Process_vkCmdEndRenderPass(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndRenderPass\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             tabCount -= 1;
@@ -4216,7 +4344,8 @@ void VulkanAsciiConsumer::Process_vkCmdExecuteCommands(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdExecuteCommands\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "commandBufferCount", toStringFlags, tabCount, tabSize, ToString(commandBufferCount, toStringFlags, tabCount, tabSize));
@@ -4248,7 +4377,8 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory2(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkBindBufferMemory2\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
@@ -4280,7 +4410,8 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory2(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkBindImageMemory2\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
@@ -4312,7 +4443,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupPeerMemoryFeatures(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceGroupPeerMemoryFeatures\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "heapIndex", toStringFlags, tabCount, tabSize, ToString(heapIndex, toStringFlags, tabCount, tabSize));
@@ -4343,7 +4475,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetDeviceMask(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDeviceMask\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "deviceMask", toStringFlags, tabCount, tabSize, ToString(deviceMask, toStringFlags, tabCount, tabSize));
@@ -4376,7 +4509,8 @@ void VulkanAsciiConsumer::Process_vkCmdDispatchBase(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDispatchBase\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "baseGroupX", toStringFlags, tabCount, tabSize, ToString(baseGroupX, toStringFlags, tabCount, tabSize));
@@ -4412,7 +4546,8 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroups(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkEnumeratePhysicalDeviceGroups\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPhysicalDeviceGroupCount, toStringFlags, tabCount, tabSize));
@@ -4442,7 +4577,8 @@ void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageMemoryRequirements2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -4472,7 +4608,8 @@ void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetBufferMemoryRequirements2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -4503,7 +4640,8 @@ void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageSparseMemoryRequirements2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -4533,7 +4671,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFeatures2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceFeatures2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pFeatures", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFeatures, toStringFlags, tabCount, tabSize));
@@ -4561,7 +4700,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceProperties2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceProperties2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
@@ -4590,7 +4730,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceFormatProperties2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "format", toStringFlags, tabCount, tabSize, '"' + ToString(format, toStringFlags, tabCount, tabSize) + '"');
@@ -4622,7 +4763,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceImageFormatProperties2\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pImageFormatInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatInfo, toStringFlags, tabCount, tabSize));
@@ -4652,7 +4794,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceQueueFamilyProperties2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pQueueFamilyPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pQueueFamilyPropertyCount, toStringFlags, tabCount, tabSize));
@@ -4681,7 +4824,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceMemoryProperties2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pMemoryProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryProperties, toStringFlags, tabCount, tabSize));
@@ -4711,7 +4855,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSparseImageFormatProperties2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pFormatInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFormatInfo, toStringFlags, tabCount, tabSize));
@@ -4742,7 +4887,8 @@ void VulkanAsciiConsumer::Process_vkTrimCommandPool(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkTrimCommandPool\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "commandPool", toStringFlags, tabCount, tabSize, HandleIdToString(commandPool));
@@ -4772,7 +4918,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceQueue2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceQueue2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pQueueInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pQueueInfo, toStringFlags, tabCount, tabSize));
@@ -4805,7 +4952,8 @@ void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversion(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateSamplerYcbcrConversion\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -4836,7 +4984,8 @@ void VulkanAsciiConsumer::Process_vkDestroySamplerYcbcrConversion(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroySamplerYcbcrConversion\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "ycbcrConversion", toStringFlags, tabCount, tabSize, HandleIdToString(ycbcrConversion));
@@ -4869,7 +5018,8 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplate(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDescriptorUpdateTemplate\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -4900,7 +5050,8 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorUpdateTemplate(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyDescriptorUpdateTemplate\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorUpdateTemplate", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorUpdateTemplate));
@@ -4930,7 +5081,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalBufferProperties(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceExternalBufferProperties\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pExternalBufferInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalBufferInfo, toStringFlags, tabCount, tabSize));
@@ -4960,7 +5112,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalFenceProperties(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceExternalFenceProperties\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pExternalFenceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalFenceInfo, toStringFlags, tabCount, tabSize));
@@ -4990,7 +5143,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalSemaphoreProperties
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceExternalSemaphoreProperties\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pExternalSemaphoreInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalSemaphoreInfo, toStringFlags, tabCount, tabSize));
@@ -5020,7 +5174,8 @@ void VulkanAsciiConsumer::Process_vkGetDescriptorSetLayoutSupport(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDescriptorSetLayoutSupport\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -5054,7 +5209,8 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCount(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndirectCount\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
@@ -5092,7 +5248,8 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCount(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndexedIndirectCount\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
@@ -5129,7 +5286,8 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass2(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateRenderPass2\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -5160,7 +5318,8 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginRenderPass2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pRenderPassBegin", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRenderPassBegin, toStringFlags, tabCount, tabSize));
@@ -5190,7 +5349,8 @@ void VulkanAsciiConsumer::Process_vkCmdNextSubpass2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdNextSubpass2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pSubpassBeginInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSubpassBeginInfo, toStringFlags, tabCount, tabSize));
@@ -5219,7 +5379,8 @@ void VulkanAsciiConsumer::Process_vkCmdEndRenderPass2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndRenderPass2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pSubpassEndInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSubpassEndInfo, toStringFlags, tabCount, tabSize));
@@ -5249,7 +5410,8 @@ void VulkanAsciiConsumer::Process_vkResetQueryPool(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkResetQueryPool\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
@@ -5282,7 +5444,8 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValue(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetSemaphoreCounterValue\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "semaphore", toStringFlags, tabCount, tabSize, HandleIdToString(semaphore));
@@ -5314,7 +5477,8 @@ void VulkanAsciiConsumer::Process_vkWaitSemaphores(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkWaitSemaphores\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pWaitInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pWaitInfo, toStringFlags, tabCount, tabSize));
@@ -5345,7 +5509,8 @@ void VulkanAsciiConsumer::Process_vkSignalSemaphore(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSignalSemaphore\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pSignalInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSignalInfo, toStringFlags, tabCount, tabSize));
@@ -5375,7 +5540,8 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddress(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetBufferDeviceAddress\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -5405,7 +5571,8 @@ void VulkanAsciiConsumer::Process_vkGetBufferOpaqueCaptureAddress(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetBufferOpaqueCaptureAddress\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -5435,7 +5602,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddress(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceMemoryOpaqueCaptureAddress\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -5466,7 +5634,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceToolProperties(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceToolProperties\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pToolCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pToolCount, toStringFlags, tabCount, tabSize));
@@ -5499,7 +5668,8 @@ void VulkanAsciiConsumer::Process_vkCreatePrivateDataSlot(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreatePrivateDataSlot\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -5530,7 +5700,8 @@ void VulkanAsciiConsumer::Process_vkDestroyPrivateDataSlot(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyPrivateDataSlot\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "privateDataSlot", toStringFlags, tabCount, tabSize, HandleIdToString(privateDataSlot));
@@ -5564,7 +5735,8 @@ void VulkanAsciiConsumer::Process_vkSetPrivateData(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSetPrivateData\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "objectType", toStringFlags, tabCount, tabSize, '"' + ToString(objectType, toStringFlags, tabCount, tabSize) + '"');
@@ -5598,7 +5770,8 @@ void VulkanAsciiConsumer::Process_vkGetPrivateData(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPrivateData\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "objectType", toStringFlags, tabCount, tabSize, '"' + ToString(objectType, toStringFlags, tabCount, tabSize) + '"');
@@ -5630,7 +5803,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetEvent2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetEvent2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
@@ -5660,7 +5834,8 @@ void VulkanAsciiConsumer::Process_vkCmdResetEvent2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdResetEvent2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
@@ -5691,7 +5866,8 @@ void VulkanAsciiConsumer::Process_vkCmdWaitEvents2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWaitEvents2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "eventCount", toStringFlags, tabCount, tabSize, ToString(eventCount, toStringFlags, tabCount, tabSize));
@@ -5721,7 +5897,8 @@ void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdPipelineBarrier2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pDependencyInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDependencyInfo, toStringFlags, tabCount, tabSize));
@@ -5751,7 +5928,8 @@ void VulkanAsciiConsumer::Process_vkCmdWriteTimestamp2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWriteTimestamp2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "stage", toStringFlags, tabCount, tabSize, ToString(stage, toStringFlags, tabCount, tabSize));
@@ -5785,7 +5963,8 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit2(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueSubmit2\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "submitCount", toStringFlags, tabCount, tabSize, ToString(submitCount, toStringFlags, tabCount, tabSize));
@@ -5815,7 +5994,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBuffer2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyBuffer2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCopyBufferInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCopyBufferInfo, toStringFlags, tabCount, tabSize));
@@ -5843,7 +6023,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImage2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyImage2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCopyImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCopyImageInfo, toStringFlags, tabCount, tabSize));
@@ -5871,7 +6052,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBufferToImage2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyBufferToImage2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCopyBufferToImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCopyBufferToImageInfo, toStringFlags, tabCount, tabSize));
@@ -5899,7 +6081,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImageToBuffer2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyImageToBuffer2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCopyImageToBufferInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCopyImageToBufferInfo, toStringFlags, tabCount, tabSize));
@@ -5927,7 +6110,8 @@ void VulkanAsciiConsumer::Process_vkCmdBlitImage2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBlitImage2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pBlitImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pBlitImageInfo, toStringFlags, tabCount, tabSize));
@@ -5955,7 +6139,8 @@ void VulkanAsciiConsumer::Process_vkCmdResolveImage2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdResolveImage2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pResolveImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pResolveImageInfo, toStringFlags, tabCount, tabSize));
@@ -5983,7 +6168,8 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRendering(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginRendering\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pRenderingInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRenderingInfo, toStringFlags, tabCount, tabSize));
@@ -6010,7 +6196,8 @@ void VulkanAsciiConsumer::Process_vkCmdEndRendering(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndRendering\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             tabCount -= 1;
@@ -6037,7 +6224,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetCullMode(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetCullMode\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "cullMode", toStringFlags, tabCount, tabSize, ToString(cullMode, toStringFlags, tabCount, tabSize));
@@ -6065,7 +6253,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetFrontFace(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetFrontFace\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "frontFace", toStringFlags, tabCount, tabSize, '"' + ToString(frontFace, toStringFlags, tabCount, tabSize) + '"');
@@ -6093,7 +6282,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveTopology(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetPrimitiveTopology\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "primitiveTopology", toStringFlags, tabCount, tabSize, '"' + ToString(primitiveTopology, toStringFlags, tabCount, tabSize) + '"');
@@ -6122,7 +6312,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportWithCount(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetViewportWithCount\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "viewportCount", toStringFlags, tabCount, tabSize, ToString(viewportCount, toStringFlags, tabCount, tabSize));
@@ -6152,7 +6343,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetScissorWithCount(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetScissorWithCount\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "scissorCount", toStringFlags, tabCount, tabSize, ToString(scissorCount, toStringFlags, tabCount, tabSize));
@@ -6186,7 +6378,8 @@ void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers2(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindVertexBuffers2\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstBinding", toStringFlags, tabCount, tabSize, ToString(firstBinding, toStringFlags, tabCount, tabSize));
@@ -6219,7 +6412,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthTestEnable(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthTestEnable\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthTestEnable", toStringFlags, tabCount, tabSize, ToString(depthTestEnable, toStringFlags, tabCount, tabSize));
@@ -6247,7 +6441,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthWriteEnable(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthWriteEnable\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthWriteEnable", toStringFlags, tabCount, tabSize, ToString(depthWriteEnable, toStringFlags, tabCount, tabSize));
@@ -6275,7 +6470,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthCompareOp(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthCompareOp\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthCompareOp", toStringFlags, tabCount, tabSize, '"' + ToString(depthCompareOp, toStringFlags, tabCount, tabSize) + '"');
@@ -6303,7 +6499,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBoundsTestEnable(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthBoundsTestEnable\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthBoundsTestEnable", toStringFlags, tabCount, tabSize, ToString(depthBoundsTestEnable, toStringFlags, tabCount, tabSize));
@@ -6331,7 +6528,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilTestEnable(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetStencilTestEnable\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "stencilTestEnable", toStringFlags, tabCount, tabSize, ToString(stencilTestEnable, toStringFlags, tabCount, tabSize));
@@ -6363,7 +6561,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilOp(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetStencilOp\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "faceMask", toStringFlags, tabCount, tabSize, ToString(faceMask, toStringFlags, tabCount, tabSize));
@@ -6395,7 +6594,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetRasterizerDiscardEnable(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetRasterizerDiscardEnable\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "rasterizerDiscardEnable", toStringFlags, tabCount, tabSize, ToString(rasterizerDiscardEnable, toStringFlags, tabCount, tabSize));
@@ -6423,7 +6623,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBiasEnable(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthBiasEnable\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthBiasEnable", toStringFlags, tabCount, tabSize, ToString(depthBiasEnable, toStringFlags, tabCount, tabSize));
@@ -6451,7 +6652,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveRestartEnable(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetPrimitiveRestartEnable\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "primitiveRestartEnable", toStringFlags, tabCount, tabSize, ToString(primitiveRestartEnable, toStringFlags, tabCount, tabSize));
@@ -6480,7 +6682,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceBufferMemoryRequirements(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceBufferMemoryRequirements\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -6510,7 +6713,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceImageMemoryRequirements(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceImageMemoryRequirements\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -6541,7 +6745,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceImageSparseMemoryRequirements(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceImageSparseMemoryRequirements\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -6572,7 +6777,8 @@ void VulkanAsciiConsumer::Process_vkDestroySurfaceKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroySurfaceKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
@@ -6605,7 +6811,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceSupportKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSurfaceSupportKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
@@ -6638,7 +6845,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSurfaceCapabilitiesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
@@ -6671,7 +6879,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSurfaceFormatsKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
@@ -6705,7 +6914,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSurfacePresentModesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
@@ -6739,7 +6949,8 @@ void VulkanAsciiConsumer::Process_vkCreateSwapchainKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateSwapchainKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -6770,7 +6981,8 @@ void VulkanAsciiConsumer::Process_vkDestroySwapchainKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroySwapchainKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
@@ -6803,7 +7015,8 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainImagesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetSwapchainImagesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
@@ -6839,7 +7052,8 @@ void VulkanAsciiConsumer::Process_vkAcquireNextImageKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAcquireNextImageKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
@@ -6873,7 +7087,8 @@ void VulkanAsciiConsumer::Process_vkQueuePresentKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueuePresentKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "pPresentInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentInfo, toStringFlags, tabCount, tabSize));
@@ -6903,7 +7118,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupPresentCapabilitiesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceGroupPresentCapabilitiesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "[out]pDeviceGroupPresentCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDeviceGroupPresentCapabilities, toStringFlags, tabCount, tabSize));
@@ -6934,7 +7150,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceGroupSurfacePresentModesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
@@ -6967,7 +7184,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDevicePresentRectanglesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
@@ -7000,7 +7218,8 @@ void VulkanAsciiConsumer::Process_vkAcquireNextImage2KHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAcquireNextImage2KHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAcquireInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAcquireInfo, toStringFlags, tabCount, tabSize));
@@ -7032,7 +7251,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceDisplayPropertiesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
@@ -7064,7 +7284,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceDisplayPlanePropertiesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
@@ -7097,7 +7318,8 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDisplayPlaneSupportedDisplaysKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "planeIndex", toStringFlags, tabCount, tabSize, ToString(planeIndex, toStringFlags, tabCount, tabSize));
@@ -7131,7 +7353,8 @@ void VulkanAsciiConsumer::Process_vkGetDisplayModePropertiesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDisplayModePropertiesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
@@ -7166,7 +7389,8 @@ void VulkanAsciiConsumer::Process_vkCreateDisplayModeKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDisplayModeKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
@@ -7201,7 +7425,8 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilitiesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDisplayPlaneCapabilitiesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "mode", toStringFlags, tabCount, tabSize, HandleIdToString(mode));
@@ -7235,7 +7460,8 @@ void VulkanAsciiConsumer::Process_vkCreateDisplayPlaneSurfaceKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDisplayPlaneSurfaceKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -7270,7 +7496,8 @@ void VulkanAsciiConsumer::Process_vkCreateSharedSwapchainsKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateSharedSwapchainsKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchainCount", toStringFlags, tabCount, tabSize, ToString(swapchainCount, toStringFlags, tabCount, tabSize));
@@ -7305,7 +7532,8 @@ void VulkanAsciiConsumer::Process_vkCreateXlibSurfaceKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateXlibSurfaceKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -7339,7 +7567,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceXlibPresentationSupportKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
@@ -7373,7 +7602,8 @@ void VulkanAsciiConsumer::Process_vkCreateXcbSurfaceKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateXcbSurfaceKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -7407,7 +7637,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceXcbPresentationSupportKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
@@ -7441,7 +7672,8 @@ void VulkanAsciiConsumer::Process_vkCreateWaylandSurfaceKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateWaylandSurfaceKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -7474,7 +7706,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWaylandPresentationSupportK
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceWaylandPresentationSupportKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
@@ -7507,7 +7740,8 @@ void VulkanAsciiConsumer::Process_vkCreateAndroidSurfaceKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateAndroidSurfaceKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -7541,7 +7775,8 @@ void VulkanAsciiConsumer::Process_vkCreateWin32SurfaceKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateWin32SurfaceKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -7573,7 +7808,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWin32PresentationSupportKHR
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceWin32PresentationSupportKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
@@ -7601,7 +7837,8 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRenderingKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginRenderingKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pRenderingInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRenderingInfo, toStringFlags, tabCount, tabSize));
@@ -7628,7 +7865,8 @@ void VulkanAsciiConsumer::Process_vkCmdEndRenderingKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndRenderingKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             tabCount -= 1;
@@ -7655,7 +7893,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFeatures2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceFeatures2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pFeatures", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFeatures, toStringFlags, tabCount, tabSize));
@@ -7683,7 +7922,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceProperties2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceProperties2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
@@ -7712,7 +7952,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceFormatProperties2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "format", toStringFlags, tabCount, tabSize, '"' + ToString(format, toStringFlags, tabCount, tabSize) + '"');
@@ -7744,7 +7985,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceImageFormatProperties2KHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pImageFormatInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatInfo, toStringFlags, tabCount, tabSize));
@@ -7774,7 +8016,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceQueueFamilyProperties2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pQueueFamilyPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pQueueFamilyPropertyCount, toStringFlags, tabCount, tabSize));
@@ -7803,7 +8046,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceMemoryProperties2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pMemoryProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryProperties, toStringFlags, tabCount, tabSize));
@@ -7833,7 +8077,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSparseImageFormatProperties2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pFormatInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFormatInfo, toStringFlags, tabCount, tabSize));
@@ -7866,7 +8111,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceGroupPeerMemoryFeaturesKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "heapIndex", toStringFlags, tabCount, tabSize, ToString(heapIndex, toStringFlags, tabCount, tabSize));
@@ -7897,7 +8143,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetDeviceMaskKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDeviceMaskKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "deviceMask", toStringFlags, tabCount, tabSize, ToString(deviceMask, toStringFlags, tabCount, tabSize));
@@ -7930,7 +8177,8 @@ void VulkanAsciiConsumer::Process_vkCmdDispatchBaseKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDispatchBaseKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "baseGroupX", toStringFlags, tabCount, tabSize, ToString(baseGroupX, toStringFlags, tabCount, tabSize));
@@ -7964,7 +8212,8 @@ void VulkanAsciiConsumer::Process_vkTrimCommandPoolKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkTrimCommandPoolKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "commandPool", toStringFlags, tabCount, tabSize, HandleIdToString(commandPool));
@@ -7996,7 +8245,8 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkEnumeratePhysicalDeviceGroupsKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPhysicalDeviceGroupCount, toStringFlags, tabCount, tabSize));
@@ -8026,7 +8276,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceExternalBufferPropertiesKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pExternalBufferInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalBufferInfo, toStringFlags, tabCount, tabSize));
@@ -8058,7 +8309,8 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryWin32HandleKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetWin32HandleInfo, toStringFlags, tabCount, tabSize));
@@ -8091,7 +8343,8 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandlePropertiesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryWin32HandlePropertiesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
@@ -8124,7 +8377,8 @@ void VulkanAsciiConsumer::Process_vkGetMemoryFdKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryFdKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetFdInfo, toStringFlags, tabCount, tabSize));
@@ -8157,7 +8411,8 @@ void VulkanAsciiConsumer::Process_vkGetMemoryFdPropertiesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryFdPropertiesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
@@ -8188,7 +8443,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalSemaphoreProperties
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceExternalSemaphorePropertiesKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pExternalSemaphoreInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalSemaphoreInfo, toStringFlags, tabCount, tabSize));
@@ -8219,7 +8475,8 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreWin32HandleKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkImportSemaphoreWin32HandleKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportSemaphoreWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportSemaphoreWin32HandleInfo, toStringFlags, tabCount, tabSize));
@@ -8250,7 +8507,8 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreWin32HandleKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetSemaphoreWin32HandleKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetWin32HandleInfo, toStringFlags, tabCount, tabSize));
@@ -8281,7 +8539,8 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreFdKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkImportSemaphoreFdKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportSemaphoreFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportSemaphoreFdInfo, toStringFlags, tabCount, tabSize));
@@ -8312,7 +8571,8 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreFdKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetSemaphoreFdKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetFdInfo, toStringFlags, tabCount, tabSize));
@@ -8345,7 +8605,8 @@ void VulkanAsciiConsumer::Process_vkCmdPushDescriptorSetKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdPushDescriptorSetKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pipelineBindPoint", toStringFlags, tabCount, tabSize, '"' + ToString(pipelineBindPoint, toStringFlags, tabCount, tabSize) + '"');
@@ -8381,7 +8642,8 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplateKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDescriptorUpdateTemplateKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -8412,7 +8674,8 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorUpdateTemplateKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyDescriptorUpdateTemplateKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorUpdateTemplate", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorUpdateTemplate));
@@ -8445,7 +8708,8 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass2KHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateRenderPass2KHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -8476,7 +8740,8 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginRenderPass2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pRenderPassBegin", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRenderPassBegin, toStringFlags, tabCount, tabSize));
@@ -8506,7 +8771,8 @@ void VulkanAsciiConsumer::Process_vkCmdNextSubpass2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdNextSubpass2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pSubpassBeginInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSubpassBeginInfo, toStringFlags, tabCount, tabSize));
@@ -8535,7 +8801,8 @@ void VulkanAsciiConsumer::Process_vkCmdEndRenderPass2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndRenderPass2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pSubpassEndInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSubpassEndInfo, toStringFlags, tabCount, tabSize));
@@ -8565,7 +8832,8 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainStatusKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetSwapchainStatusKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
@@ -8594,7 +8862,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceExternalFencePropertiesKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pExternalFenceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalFenceInfo, toStringFlags, tabCount, tabSize));
@@ -8625,7 +8894,8 @@ void VulkanAsciiConsumer::Process_vkImportFenceWin32HandleKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkImportFenceWin32HandleKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportFenceWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportFenceWin32HandleInfo, toStringFlags, tabCount, tabSize));
@@ -8656,7 +8926,8 @@ void VulkanAsciiConsumer::Process_vkGetFenceWin32HandleKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetFenceWin32HandleKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetWin32HandleInfo, toStringFlags, tabCount, tabSize));
@@ -8687,7 +8958,8 @@ void VulkanAsciiConsumer::Process_vkImportFenceFdKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkImportFenceFdKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportFenceFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportFenceFdInfo, toStringFlags, tabCount, tabSize));
@@ -8718,7 +8990,8 @@ void VulkanAsciiConsumer::Process_vkGetFenceFdKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetFenceFdKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetFdInfo, toStringFlags, tabCount, tabSize));
@@ -8752,7 +9025,8 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceQueueFamilyPerformanc
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
@@ -8784,7 +9058,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyPerformanceQuery
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pPerformanceQueryCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPerformanceQueryCreateInfo, toStringFlags, tabCount, tabSize));
@@ -8815,7 +9090,8 @@ void VulkanAsciiConsumer::Process_vkAcquireProfilingLockKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAcquireProfilingLockKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -8842,7 +9118,8 @@ void VulkanAsciiConsumer::Process_vkReleaseProfilingLockKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkReleaseProfilingLockKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             tabCount -= 1;
@@ -8872,7 +9149,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSurfaceCapabilities2KHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
@@ -8905,7 +9183,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSurfaceFormats2KHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
@@ -8938,7 +9217,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceDisplayProperties2KHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
@@ -8970,7 +9250,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceDisplayPlaneProperties2KHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
@@ -9003,7 +9284,8 @@ void VulkanAsciiConsumer::Process_vkGetDisplayModeProperties2KHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDisplayModeProperties2KHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
@@ -9036,7 +9318,8 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDisplayPlaneCapabilities2KHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pDisplayPlaneInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayPlaneInfo, toStringFlags, tabCount, tabSize));
@@ -9066,7 +9349,8 @@ void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageMemoryRequirements2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -9096,7 +9380,8 @@ void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetBufferMemoryRequirements2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -9127,7 +9412,8 @@ void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageSparseMemoryRequirements2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -9161,7 +9447,8 @@ void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateSamplerYcbcrConversionKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -9192,7 +9479,8 @@ void VulkanAsciiConsumer::Process_vkDestroySamplerYcbcrConversionKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroySamplerYcbcrConversionKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "ycbcrConversion", toStringFlags, tabCount, tabSize, HandleIdToString(ycbcrConversion));
@@ -9224,7 +9512,8 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory2KHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkBindBufferMemory2KHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
@@ -9256,7 +9545,8 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory2KHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkBindImageMemory2KHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
@@ -9286,7 +9576,8 @@ void VulkanAsciiConsumer::Process_vkGetDescriptorSetLayoutSupportKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDescriptorSetLayoutSupportKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -9320,7 +9611,8 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCountKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndirectCountKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
@@ -9358,7 +9650,8 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCountKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndexedIndirectCountKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
@@ -9394,7 +9687,8 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValueKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetSemaphoreCounterValueKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "semaphore", toStringFlags, tabCount, tabSize, HandleIdToString(semaphore));
@@ -9426,7 +9720,8 @@ void VulkanAsciiConsumer::Process_vkWaitSemaphoresKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkWaitSemaphoresKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pWaitInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pWaitInfo, toStringFlags, tabCount, tabSize));
@@ -9457,7 +9752,8 @@ void VulkanAsciiConsumer::Process_vkSignalSemaphoreKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSignalSemaphoreKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pSignalInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSignalInfo, toStringFlags, tabCount, tabSize));
@@ -9488,7 +9784,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceFragmentShadingRatesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pFragmentShadingRateCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFragmentShadingRateCount, toStringFlags, tabCount, tabSize));
@@ -9518,7 +9815,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetFragmentShadingRateKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetFragmentShadingRateKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pFragmentSize", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFragmentSize, toStringFlags, tabCount, tabSize));
@@ -9551,7 +9849,8 @@ void VulkanAsciiConsumer::Process_vkWaitForPresentKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkWaitForPresentKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
@@ -9583,7 +9882,8 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetBufferDeviceAddressKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -9613,7 +9913,8 @@ void VulkanAsciiConsumer::Process_vkGetBufferOpaqueCaptureAddressKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetBufferOpaqueCaptureAddressKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -9643,7 +9944,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddressKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceMemoryOpaqueCaptureAddressKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -9674,7 +9976,8 @@ void VulkanAsciiConsumer::Process_vkCreateDeferredOperationKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDeferredOperationKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
@@ -9704,7 +10007,8 @@ void VulkanAsciiConsumer::Process_vkDestroyDeferredOperationKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyDeferredOperationKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
@@ -9735,7 +10039,8 @@ void VulkanAsciiConsumer::Process_vkGetDeferredOperationMaxConcurrencyKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeferredOperationMaxConcurrencyKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
@@ -9765,7 +10070,8 @@ void VulkanAsciiConsumer::Process_vkGetDeferredOperationResultKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeferredOperationResultKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
@@ -9795,7 +10101,8 @@ void VulkanAsciiConsumer::Process_vkDeferredOperationJoinKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDeferredOperationJoinKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
@@ -9827,7 +10134,8 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPipelineExecutablePropertiesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pPipelineInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPipelineInfo, toStringFlags, tabCount, tabSize));
@@ -9861,7 +10169,8 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPipelineExecutableStatisticsKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pExecutableInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExecutableInfo, toStringFlags, tabCount, tabSize));
@@ -9895,7 +10204,8 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutableInternalRepresentations
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPipelineExecutableInternalRepresentationsKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pExecutableInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExecutableInfo, toStringFlags, tabCount, tabSize));
@@ -9926,7 +10236,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetEvent2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetEvent2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
@@ -9956,7 +10267,8 @@ void VulkanAsciiConsumer::Process_vkCmdResetEvent2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdResetEvent2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
@@ -9987,7 +10299,8 @@ void VulkanAsciiConsumer::Process_vkCmdWaitEvents2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWaitEvents2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "eventCount", toStringFlags, tabCount, tabSize, ToString(eventCount, toStringFlags, tabCount, tabSize));
@@ -10017,7 +10330,8 @@ void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdPipelineBarrier2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pDependencyInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDependencyInfo, toStringFlags, tabCount, tabSize));
@@ -10047,7 +10361,8 @@ void VulkanAsciiConsumer::Process_vkCmdWriteTimestamp2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWriteTimestamp2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "stage", toStringFlags, tabCount, tabSize, ToString(stage, toStringFlags, tabCount, tabSize));
@@ -10081,7 +10396,8 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit2KHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueSubmit2KHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "submitCount", toStringFlags, tabCount, tabSize, ToString(submitCount, toStringFlags, tabCount, tabSize));
@@ -10114,7 +10430,8 @@ void VulkanAsciiConsumer::Process_vkCmdWriteBufferMarker2AMD(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWriteBufferMarker2AMD\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "stage", toStringFlags, tabCount, tabSize, ToString(stage, toStringFlags, tabCount, tabSize));
@@ -10146,7 +10463,8 @@ void VulkanAsciiConsumer::Process_vkGetQueueCheckpointData2NV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetQueueCheckpointData2NV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "[out]pCheckpointDataCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCheckpointDataCount, toStringFlags, tabCount, tabSize));
@@ -10175,7 +10493,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBuffer2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyBuffer2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCopyBufferInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCopyBufferInfo, toStringFlags, tabCount, tabSize));
@@ -10203,7 +10522,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImage2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyImage2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCopyImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCopyImageInfo, toStringFlags, tabCount, tabSize));
@@ -10231,7 +10551,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBufferToImage2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyBufferToImage2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCopyBufferToImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCopyBufferToImageInfo, toStringFlags, tabCount, tabSize));
@@ -10259,7 +10580,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImageToBuffer2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyImageToBuffer2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCopyImageToBufferInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCopyImageToBufferInfo, toStringFlags, tabCount, tabSize));
@@ -10287,7 +10609,8 @@ void VulkanAsciiConsumer::Process_vkCmdBlitImage2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBlitImage2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pBlitImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pBlitImageInfo, toStringFlags, tabCount, tabSize));
@@ -10315,7 +10638,8 @@ void VulkanAsciiConsumer::Process_vkCmdResolveImage2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdResolveImage2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pResolveImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pResolveImageInfo, toStringFlags, tabCount, tabSize));
@@ -10343,7 +10667,8 @@ void VulkanAsciiConsumer::Process_vkCmdTraceRaysIndirect2KHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdTraceRaysIndirect2KHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "indirectDeviceAddress", toStringFlags, tabCount, tabSize, ToString(indirectDeviceAddress, toStringFlags, tabCount, tabSize));
@@ -10372,7 +10697,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceBufferMemoryRequirementsKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceBufferMemoryRequirementsKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -10402,7 +10728,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceImageMemoryRequirementsKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceImageMemoryRequirementsKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -10433,7 +10760,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceImageSparseMemoryRequirementsKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceImageSparseMemoryRequirementsKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -10467,7 +10795,8 @@ void VulkanAsciiConsumer::Process_vkCreateDebugReportCallbackEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDebugReportCallbackEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -10498,7 +10827,8 @@ void VulkanAsciiConsumer::Process_vkDestroyDebugReportCallbackEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyDebugReportCallbackEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "callback", toStringFlags, tabCount, tabSize, HandleIdToString(callback));
@@ -10533,7 +10863,8 @@ void VulkanAsciiConsumer::Process_vkDebugReportMessageEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDebugReportMessageEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
@@ -10569,7 +10900,8 @@ void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectTagEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDebugMarkerSetObjectTagEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pTagInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pTagInfo, toStringFlags, tabCount, tabSize));
@@ -10599,7 +10931,8 @@ void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectNameEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDebugMarkerSetObjectNameEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pNameInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pNameInfo, toStringFlags, tabCount, tabSize));
@@ -10627,7 +10960,8 @@ void VulkanAsciiConsumer::Process_vkCmdDebugMarkerBeginEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDebugMarkerBeginEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pMarkerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMarkerInfo, toStringFlags, tabCount, tabSize));
@@ -10654,7 +10988,8 @@ void VulkanAsciiConsumer::Process_vkCmdDebugMarkerEndEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDebugMarkerEndEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             tabCount -= 1;
@@ -10681,7 +11016,8 @@ void VulkanAsciiConsumer::Process_vkCmdDebugMarkerInsertEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDebugMarkerInsertEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pMarkerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMarkerInfo, toStringFlags, tabCount, tabSize));
@@ -10713,7 +11049,8 @@ void VulkanAsciiConsumer::Process_vkCmdBindTransformFeedbackBuffersEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindTransformFeedbackBuffersEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstBinding", toStringFlags, tabCount, tabSize, ToString(firstBinding, toStringFlags, tabCount, tabSize));
@@ -10748,7 +11085,8 @@ void VulkanAsciiConsumer::Process_vkCmdBeginTransformFeedbackEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginTransformFeedbackEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstCounterBuffer", toStringFlags, tabCount, tabSize, ToString(firstCounterBuffer, toStringFlags, tabCount, tabSize));
@@ -10782,7 +11120,8 @@ void VulkanAsciiConsumer::Process_vkCmdEndTransformFeedbackEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndTransformFeedbackEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstCounterBuffer", toStringFlags, tabCount, tabSize, ToString(firstCounterBuffer, toStringFlags, tabCount, tabSize));
@@ -10816,7 +11155,8 @@ void VulkanAsciiConsumer::Process_vkCmdBeginQueryIndexedEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginQueryIndexedEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
@@ -10849,7 +11189,8 @@ void VulkanAsciiConsumer::Process_vkCmdEndQueryIndexedEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndQueryIndexedEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
@@ -10884,7 +11225,8 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectByteCountEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndirectByteCountEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "instanceCount", toStringFlags, tabCount, tabSize, ToString(instanceCount, toStringFlags, tabCount, tabSize));
@@ -10919,7 +11261,8 @@ void VulkanAsciiConsumer::Process_vkGetImageViewHandleNVX(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageViewHandleNVX\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -10950,7 +11293,8 @@ void VulkanAsciiConsumer::Process_vkGetImageViewAddressNVX(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageViewAddressNVX\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "imageView", toStringFlags, tabCount, tabSize, HandleIdToString(imageView));
@@ -10984,7 +11328,8 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCountAMD(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndirectCountAMD\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
@@ -11022,7 +11367,8 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCountAMD(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndexedIndirectCountAMD\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
@@ -11061,7 +11407,8 @@ void VulkanAsciiConsumer::Process_vkGetShaderInfoAMD(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetShaderInfoAMD\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
@@ -11097,7 +11444,8 @@ void VulkanAsciiConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateStreamDescriptorSurfaceGGP\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -11135,7 +11483,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalImageFormatProperti
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceExternalImageFormatPropertiesNV\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "format", toStringFlags, tabCount, tabSize, '"' + ToString(format, toStringFlags, tabCount, tabSize) + '"');
@@ -11173,7 +11522,8 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleNV(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryWin32HandleNV\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
@@ -11207,7 +11557,8 @@ void VulkanAsciiConsumer::Process_vkCreateViSurfaceNN(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateViSurfaceNN\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -11237,7 +11588,8 @@ void VulkanAsciiConsumer::Process_vkCmdBeginConditionalRenderingEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginConditionalRenderingEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pConditionalRenderingBegin", toStringFlags, tabCount, tabSize, PointerDecoderToString(pConditionalRenderingBegin, toStringFlags, tabCount, tabSize));
@@ -11264,7 +11616,8 @@ void VulkanAsciiConsumer::Process_vkCmdEndConditionalRenderingEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndConditionalRenderingEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             tabCount -= 1;
@@ -11293,7 +11646,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportWScalingNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetViewportWScalingNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstViewport", toStringFlags, tabCount, tabSize, ToString(firstViewport, toStringFlags, tabCount, tabSize));
@@ -11325,7 +11679,8 @@ void VulkanAsciiConsumer::Process_vkReleaseDisplayEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkReleaseDisplayEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
@@ -11356,7 +11711,8 @@ void VulkanAsciiConsumer::Process_vkAcquireXlibDisplayEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAcquireXlibDisplayEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "dpy", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dpy));
@@ -11389,7 +11745,8 @@ void VulkanAsciiConsumer::Process_vkGetRandROutputDisplayEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetRandROutputDisplayEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "dpy", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dpy));
@@ -11422,7 +11779,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSurfaceCapabilities2EXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
@@ -11454,7 +11812,8 @@ void VulkanAsciiConsumer::Process_vkDisplayPowerControlEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDisplayPowerControlEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
@@ -11487,7 +11846,8 @@ void VulkanAsciiConsumer::Process_vkRegisterDeviceEventEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkRegisterDeviceEventEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pDeviceEventInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDeviceEventInfo, toStringFlags, tabCount, tabSize));
@@ -11522,7 +11882,8 @@ void VulkanAsciiConsumer::Process_vkRegisterDisplayEventEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkRegisterDisplayEventEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
@@ -11557,7 +11918,8 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainCounterEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetSwapchainCounterEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
@@ -11590,7 +11952,8 @@ void VulkanAsciiConsumer::Process_vkGetRefreshCycleDurationGOOGLE(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetRefreshCycleDurationGOOGLE\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
@@ -11623,7 +11986,8 @@ void VulkanAsciiConsumer::Process_vkGetPastPresentationTimingGOOGLE(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPastPresentationTimingGOOGLE\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
@@ -11655,7 +12019,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetDiscardRectangleEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDiscardRectangleEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstDiscardRectangle", toStringFlags, tabCount, tabSize, ToString(firstDiscardRectangle, toStringFlags, tabCount, tabSize));
@@ -11687,7 +12052,8 @@ void VulkanAsciiConsumer::Process_vkSetHdrMetadataEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSetHdrMetadataEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchainCount", toStringFlags, tabCount, tabSize, ToString(swapchainCount, toStringFlags, tabCount, tabSize));
@@ -11721,7 +12087,8 @@ void VulkanAsciiConsumer::Process_vkCreateIOSSurfaceMVK(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateIOSSurfaceMVK\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -11755,7 +12122,8 @@ void VulkanAsciiConsumer::Process_vkCreateMacOSSurfaceMVK(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateMacOSSurfaceMVK\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -11787,7 +12155,8 @@ void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectNameEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSetDebugUtilsObjectNameEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pNameInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pNameInfo, toStringFlags, tabCount, tabSize));
@@ -11817,7 +12186,8 @@ void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectTagEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSetDebugUtilsObjectTagEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pTagInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pTagInfo, toStringFlags, tabCount, tabSize));
@@ -11845,7 +12215,8 @@ void VulkanAsciiConsumer::Process_vkQueueBeginDebugUtilsLabelEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueBeginDebugUtilsLabelEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "pLabelInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pLabelInfo, toStringFlags, tabCount, tabSize));
@@ -11872,7 +12243,8 @@ void VulkanAsciiConsumer::Process_vkQueueEndDebugUtilsLabelEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueEndDebugUtilsLabelEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             tabCount -= 1;
@@ -11899,7 +12271,8 @@ void VulkanAsciiConsumer::Process_vkQueueInsertDebugUtilsLabelEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueInsertDebugUtilsLabelEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "pLabelInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pLabelInfo, toStringFlags, tabCount, tabSize));
@@ -11927,7 +12300,8 @@ void VulkanAsciiConsumer::Process_vkCmdBeginDebugUtilsLabelEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginDebugUtilsLabelEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pLabelInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pLabelInfo, toStringFlags, tabCount, tabSize));
@@ -11954,7 +12328,8 @@ void VulkanAsciiConsumer::Process_vkCmdEndDebugUtilsLabelEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndDebugUtilsLabelEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             tabCount -= 1;
@@ -11981,7 +12356,8 @@ void VulkanAsciiConsumer::Process_vkCmdInsertDebugUtilsLabelEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdInsertDebugUtilsLabelEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pLabelInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pLabelInfo, toStringFlags, tabCount, tabSize));
@@ -12013,7 +12389,8 @@ void VulkanAsciiConsumer::Process_vkCreateDebugUtilsMessengerEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDebugUtilsMessengerEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -12044,7 +12421,8 @@ void VulkanAsciiConsumer::Process_vkDestroyDebugUtilsMessengerEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyDebugUtilsMessengerEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "messenger", toStringFlags, tabCount, tabSize, HandleIdToString(messenger));
@@ -12075,7 +12453,8 @@ void VulkanAsciiConsumer::Process_vkSubmitDebugUtilsMessageEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSubmitDebugUtilsMessageEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "messageSeverity", toStringFlags, tabCount, tabSize, '"' + ToString(messageSeverity, toStringFlags, tabCount, tabSize) + '"');
@@ -12108,7 +12487,8 @@ void VulkanAsciiConsumer::Process_vkGetAndroidHardwareBufferPropertiesANDROID(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetAndroidHardwareBufferPropertiesANDROID\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(buffer));
@@ -12140,7 +12520,8 @@ void VulkanAsciiConsumer::Process_vkGetMemoryAndroidHardwareBufferANDROID(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryAndroidHardwareBufferANDROID\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -12169,7 +12550,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetSampleLocationsEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetSampleLocationsEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pSampleLocationsInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSampleLocationsInfo, toStringFlags, tabCount, tabSize));
@@ -12198,7 +12580,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceMultisamplePropertiesEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "samples", toStringFlags, tabCount, tabSize, '"' + ToString(samples, toStringFlags, tabCount, tabSize) + '"');
@@ -12230,7 +12613,8 @@ void VulkanAsciiConsumer::Process_vkGetImageDrmFormatModifierPropertiesEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageDrmFormatModifierPropertiesEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
@@ -12263,7 +12647,8 @@ void VulkanAsciiConsumer::Process_vkCreateValidationCacheEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateValidationCacheEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -12294,7 +12679,8 @@ void VulkanAsciiConsumer::Process_vkDestroyValidationCacheEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyValidationCacheEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "validationCache", toStringFlags, tabCount, tabSize, HandleIdToString(validationCache));
@@ -12327,7 +12713,8 @@ void VulkanAsciiConsumer::Process_vkMergeValidationCachesEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkMergeValidationCachesEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "dstCache", toStringFlags, tabCount, tabSize, HandleIdToString(dstCache));
@@ -12361,7 +12748,8 @@ void VulkanAsciiConsumer::Process_vkGetValidationCacheDataEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetValidationCacheDataEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "validationCache", toStringFlags, tabCount, tabSize, HandleIdToString(validationCache));
@@ -12392,7 +12780,8 @@ void VulkanAsciiConsumer::Process_vkCmdBindShadingRateImageNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindShadingRateImageNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "imageView", toStringFlags, tabCount, tabSize, HandleIdToString(imageView));
@@ -12423,7 +12812,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportShadingRatePaletteNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetViewportShadingRatePaletteNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstViewport", toStringFlags, tabCount, tabSize, ToString(firstViewport, toStringFlags, tabCount, tabSize));
@@ -12455,7 +12845,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetCoarseSampleOrderNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetCoarseSampleOrderNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "sampleOrderType", toStringFlags, tabCount, tabSize, '"' + ToString(sampleOrderType, toStringFlags, tabCount, tabSize) + '"');
@@ -12489,7 +12880,8 @@ void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureNV(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateAccelerationStructureNV\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -12520,7 +12912,8 @@ void VulkanAsciiConsumer::Process_vkDestroyAccelerationStructureNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyAccelerationStructureNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "accelerationStructure", toStringFlags, tabCount, tabSize, HandleIdToString(accelerationStructure));
@@ -12550,7 +12943,8 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureMemoryRequirementsNV
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetAccelerationStructureMemoryRequirementsNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -12582,7 +12976,8 @@ void VulkanAsciiConsumer::Process_vkBindAccelerationStructureMemoryNV(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkBindAccelerationStructureMemoryNV\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
@@ -12618,7 +13013,8 @@ void VulkanAsciiConsumer::Process_vkCmdBuildAccelerationStructureNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBuildAccelerationStructureNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -12655,7 +13051,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyAccelerationStructureNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyAccelerationStructureNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "dst", toStringFlags, tabCount, tabSize, HandleIdToString(dst));
@@ -12698,7 +13095,8 @@ void VulkanAsciiConsumer::Process_vkCmdTraceRaysNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdTraceRaysNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "raygenShaderBindingTableBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(raygenShaderBindingTableBuffer));
@@ -12745,7 +13143,8 @@ void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesNV(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateRayTracingPipelinesNV\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
@@ -12783,7 +13182,8 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupHandlesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetRayTracingShaderGroupHandlesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
@@ -12821,7 +13221,8 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupHandlesNV(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetRayTracingShaderGroupHandlesNV\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
@@ -12857,7 +13258,8 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureHandleNV(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetAccelerationStructureHandleNV\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "accelerationStructure", toStringFlags, tabCount, tabSize, HandleIdToString(accelerationStructure));
@@ -12891,7 +13293,8 @@ void VulkanAsciiConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWriteAccelerationStructuresPropertiesNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "accelerationStructureCount", toStringFlags, tabCount, tabSize, ToString(accelerationStructureCount, toStringFlags, tabCount, tabSize));
@@ -12926,7 +13329,8 @@ void VulkanAsciiConsumer::Process_vkCompileDeferredNV(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCompileDeferredNV\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
@@ -12959,7 +13363,8 @@ void VulkanAsciiConsumer::Process_vkGetMemoryHostPointerPropertiesEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryHostPointerPropertiesEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
@@ -12992,7 +13397,8 @@ void VulkanAsciiConsumer::Process_vkCmdWriteBufferMarkerAMD(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWriteBufferMarkerAMD\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pipelineStage", toStringFlags, tabCount, tabSize, '"' + ToString(pipelineStage, toStringFlags, tabCount, tabSize) + '"');
@@ -13026,7 +13432,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceCalibrateableTimeDomainsEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pTimeDomainCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pTimeDomainCount, toStringFlags, tabCount, tabSize));
@@ -13060,7 +13467,8 @@ void VulkanAsciiConsumer::Process_vkGetCalibratedTimestampsEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetCalibratedTimestampsEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "timestampCount", toStringFlags, tabCount, tabSize, ToString(timestampCount, toStringFlags, tabCount, tabSize));
@@ -13092,7 +13500,8 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMeshTasksNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawMeshTasksNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "taskCount", toStringFlags, tabCount, tabSize, ToString(taskCount, toStringFlags, tabCount, tabSize));
@@ -13124,7 +13533,8 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMeshTasksIndirectNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawMeshTasksIndirectNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
@@ -13160,7 +13570,8 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMeshTasksIndirectCountNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawMeshTasksIndirectCountNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
@@ -13195,7 +13606,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetExclusiveScissorNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetExclusiveScissorNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstExclusiveScissor", toStringFlags, tabCount, tabSize, ToString(firstExclusiveScissor, toStringFlags, tabCount, tabSize));
@@ -13225,7 +13637,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetCheckpointNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetCheckpointNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCheckpointMarker", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pCheckpointMarker));
@@ -13254,7 +13667,8 @@ void VulkanAsciiConsumer::Process_vkGetQueueCheckpointDataNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetQueueCheckpointDataNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "[out]pCheckpointDataCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCheckpointDataCount, toStringFlags, tabCount, tabSize));
@@ -13285,7 +13699,8 @@ void VulkanAsciiConsumer::Process_vkInitializePerformanceApiINTEL(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkInitializePerformanceApiINTEL\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInitializeInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInitializeInfo, toStringFlags, tabCount, tabSize));
@@ -13312,7 +13727,8 @@ void VulkanAsciiConsumer::Process_vkUninitializePerformanceApiINTEL(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkUninitializePerformanceApiINTEL\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             tabCount -= 1;
@@ -13341,7 +13757,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceMarkerINTEL(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetPerformanceMarkerINTEL\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pMarkerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMarkerInfo, toStringFlags, tabCount, tabSize));
@@ -13371,7 +13788,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetPerformanceStreamMarkerINTEL\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pMarkerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMarkerInfo, toStringFlags, tabCount, tabSize));
@@ -13401,7 +13819,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetPerformanceOverrideINTEL\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pOverrideInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pOverrideInfo, toStringFlags, tabCount, tabSize));
@@ -13432,7 +13851,8 @@ void VulkanAsciiConsumer::Process_vkAcquirePerformanceConfigurationINTEL(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAcquirePerformanceConfigurationINTEL\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAcquireInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAcquireInfo, toStringFlags, tabCount, tabSize));
@@ -13463,7 +13883,8 @@ void VulkanAsciiConsumer::Process_vkReleasePerformanceConfigurationINTEL(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkReleasePerformanceConfigurationINTEL\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "configuration", toStringFlags, tabCount, tabSize, HandleIdToString(configuration));
@@ -13493,7 +13914,8 @@ void VulkanAsciiConsumer::Process_vkQueueSetPerformanceConfigurationINTEL(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueSetPerformanceConfigurationINTEL\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "configuration", toStringFlags, tabCount, tabSize, HandleIdToString(configuration));
@@ -13524,7 +13946,8 @@ void VulkanAsciiConsumer::Process_vkGetPerformanceParameterINTEL(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPerformanceParameterINTEL\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "parameter", toStringFlags, tabCount, tabSize, '"' + ToString(parameter, toStringFlags, tabCount, tabSize) + '"');
@@ -13554,7 +13977,8 @@ void VulkanAsciiConsumer::Process_vkSetLocalDimmingAMD(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSetLocalDimmingAMD\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapChain", toStringFlags, tabCount, tabSize, HandleIdToString(swapChain));
@@ -13587,7 +14011,8 @@ void VulkanAsciiConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateImagePipeSurfaceFUCHSIA\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -13621,7 +14046,8 @@ void VulkanAsciiConsumer::Process_vkCreateMetalSurfaceEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateMetalSurfaceEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -13653,7 +14079,8 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetBufferDeviceAddressEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -13684,7 +14111,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceToolPropertiesEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceToolPropertiesEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pToolCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pToolCount, toStringFlags, tabCount, tabSize));
@@ -13716,7 +14144,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixProperties
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceCooperativeMatrixPropertiesNV\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
@@ -13748,7 +14177,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedSa
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pCombinationCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCombinationCount, toStringFlags, tabCount, tabSize));
@@ -13781,7 +14211,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSurfacePresentModes2EXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
@@ -13813,7 +14244,8 @@ void VulkanAsciiConsumer::Process_vkAcquireFullScreenExclusiveModeEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAcquireFullScreenExclusiveModeEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
@@ -13843,7 +14275,8 @@ void VulkanAsciiConsumer::Process_vkReleaseFullScreenExclusiveModeEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkReleaseFullScreenExclusiveModeEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
@@ -13874,7 +14307,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModes2EXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceGroupSurfacePresentModes2EXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
@@ -13907,7 +14341,8 @@ void VulkanAsciiConsumer::Process_vkCreateHeadlessSurfaceEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateHeadlessSurfaceEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -13938,7 +14373,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetLineStippleEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetLineStippleEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "lineStippleFactor", toStringFlags, tabCount, tabSize, ToString(lineStippleFactor, toStringFlags, tabCount, tabSize));
@@ -13969,7 +14405,8 @@ void VulkanAsciiConsumer::Process_vkResetQueryPoolEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkResetQueryPoolEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
@@ -13999,7 +14436,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetCullModeEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetCullModeEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "cullMode", toStringFlags, tabCount, tabSize, ToString(cullMode, toStringFlags, tabCount, tabSize));
@@ -14027,7 +14465,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetFrontFaceEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetFrontFaceEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "frontFace", toStringFlags, tabCount, tabSize, '"' + ToString(frontFace, toStringFlags, tabCount, tabSize) + '"');
@@ -14055,7 +14494,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveTopologyEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetPrimitiveTopologyEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "primitiveTopology", toStringFlags, tabCount, tabSize, '"' + ToString(primitiveTopology, toStringFlags, tabCount, tabSize) + '"');
@@ -14084,7 +14524,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportWithCountEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetViewportWithCountEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "viewportCount", toStringFlags, tabCount, tabSize, ToString(viewportCount, toStringFlags, tabCount, tabSize));
@@ -14114,7 +14555,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetScissorWithCountEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetScissorWithCountEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "scissorCount", toStringFlags, tabCount, tabSize, ToString(scissorCount, toStringFlags, tabCount, tabSize));
@@ -14148,7 +14590,8 @@ void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers2EXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindVertexBuffers2EXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstBinding", toStringFlags, tabCount, tabSize, ToString(firstBinding, toStringFlags, tabCount, tabSize));
@@ -14181,7 +14624,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthTestEnableEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthTestEnableEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthTestEnable", toStringFlags, tabCount, tabSize, ToString(depthTestEnable, toStringFlags, tabCount, tabSize));
@@ -14209,7 +14653,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthWriteEnableEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthWriteEnableEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthWriteEnable", toStringFlags, tabCount, tabSize, ToString(depthWriteEnable, toStringFlags, tabCount, tabSize));
@@ -14237,7 +14682,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthCompareOpEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthCompareOpEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthCompareOp", toStringFlags, tabCount, tabSize, '"' + ToString(depthCompareOp, toStringFlags, tabCount, tabSize) + '"');
@@ -14265,7 +14711,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBoundsTestEnableEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthBoundsTestEnableEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthBoundsTestEnable", toStringFlags, tabCount, tabSize, ToString(depthBoundsTestEnable, toStringFlags, tabCount, tabSize));
@@ -14293,7 +14740,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilTestEnableEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetStencilTestEnableEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "stencilTestEnable", toStringFlags, tabCount, tabSize, ToString(stencilTestEnable, toStringFlags, tabCount, tabSize));
@@ -14325,7 +14773,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilOpEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetStencilOpEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "faceMask", toStringFlags, tabCount, tabSize, ToString(faceMask, toStringFlags, tabCount, tabSize));
@@ -14358,7 +14807,8 @@ void VulkanAsciiConsumer::Process_vkGetGeneratedCommandsMemoryRequirementsNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetGeneratedCommandsMemoryRequirementsNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -14387,7 +14837,8 @@ void VulkanAsciiConsumer::Process_vkCmdPreprocessGeneratedCommandsNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdPreprocessGeneratedCommandsNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pGeneratedCommandsInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGeneratedCommandsInfo, toStringFlags, tabCount, tabSize));
@@ -14416,7 +14867,8 @@ void VulkanAsciiConsumer::Process_vkCmdExecuteGeneratedCommandsNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdExecuteGeneratedCommandsNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "isPreprocessed", toStringFlags, tabCount, tabSize, ToString(isPreprocessed, toStringFlags, tabCount, tabSize));
@@ -14447,7 +14899,8 @@ void VulkanAsciiConsumer::Process_vkCmdBindPipelineShaderGroupNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindPipelineShaderGroupNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pipelineBindPoint", toStringFlags, tabCount, tabSize, '"' + ToString(pipelineBindPoint, toStringFlags, tabCount, tabSize) + '"');
@@ -14481,7 +14934,8 @@ void VulkanAsciiConsumer::Process_vkCreateIndirectCommandsLayoutNV(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateIndirectCommandsLayoutNV\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -14512,7 +14966,8 @@ void VulkanAsciiConsumer::Process_vkDestroyIndirectCommandsLayoutNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyIndirectCommandsLayoutNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "indirectCommandsLayout", toStringFlags, tabCount, tabSize, HandleIdToString(indirectCommandsLayout));
@@ -14544,7 +14999,8 @@ void VulkanAsciiConsumer::Process_vkAcquireDrmDisplayEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAcquireDrmDisplayEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "drmFd", toStringFlags, tabCount, tabSize, ToString(drmFd, toStringFlags, tabCount, tabSize));
@@ -14577,7 +15033,8 @@ void VulkanAsciiConsumer::Process_vkGetDrmDisplayEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDrmDisplayEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "drmFd", toStringFlags, tabCount, tabSize, ToString(drmFd, toStringFlags, tabCount, tabSize));
@@ -14611,7 +15068,8 @@ void VulkanAsciiConsumer::Process_vkCreatePrivateDataSlotEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreatePrivateDataSlotEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -14642,7 +15100,8 @@ void VulkanAsciiConsumer::Process_vkDestroyPrivateDataSlotEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyPrivateDataSlotEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "privateDataSlot", toStringFlags, tabCount, tabSize, HandleIdToString(privateDataSlot));
@@ -14676,7 +15135,8 @@ void VulkanAsciiConsumer::Process_vkSetPrivateDataEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSetPrivateDataEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "objectType", toStringFlags, tabCount, tabSize, '"' + ToString(objectType, toStringFlags, tabCount, tabSize) + '"');
@@ -14710,7 +15170,8 @@ void VulkanAsciiConsumer::Process_vkGetPrivateDataEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPrivateDataEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "objectType", toStringFlags, tabCount, tabSize, '"' + ToString(objectType, toStringFlags, tabCount, tabSize) + '"');
@@ -14742,7 +15203,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetFragmentShadingRateEnumNV(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetFragmentShadingRateEnumNV\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "shadingRate", toStringFlags, tabCount, tabSize, '"' + ToString(shadingRate, toStringFlags, tabCount, tabSize) + '"');
@@ -14773,7 +15235,8 @@ void VulkanAsciiConsumer::Process_vkGetImageSubresourceLayout2EXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageSubresourceLayout2EXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
@@ -14805,7 +15268,8 @@ void VulkanAsciiConsumer::Process_vkAcquireWinrtDisplayNV(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAcquireWinrtDisplayNV\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
@@ -14836,7 +15300,8 @@ void VulkanAsciiConsumer::Process_vkGetWinrtDisplayNV(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetWinrtDisplayNV\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "deviceRelativeId", toStringFlags, tabCount, tabSize, ToString(deviceRelativeId, toStringFlags, tabCount, tabSize));
@@ -14869,7 +15334,8 @@ void VulkanAsciiConsumer::Process_vkCreateDirectFBSurfaceEXT(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDirectFBSurfaceEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -14902,7 +15368,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDirectFBPresentationSupport
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceDirectFBPresentationSupportEXT\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
@@ -14934,7 +15401,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetVertexInputEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetVertexInputEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "vertexBindingDescriptionCount", toStringFlags, tabCount, tabSize, ToString(vertexBindingDescriptionCount, toStringFlags, tabCount, tabSize));
@@ -14968,7 +15436,8 @@ void VulkanAsciiConsumer::Process_vkGetMemoryZirconHandleFUCHSIA(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryZirconHandleFUCHSIA\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetZirconHandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetZirconHandleInfo, toStringFlags, tabCount, tabSize));
@@ -15001,7 +15470,8 @@ void VulkanAsciiConsumer::Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryZirconHandlePropertiesFUCHSIA\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
@@ -15033,7 +15503,8 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreZirconHandleFUCHSIA(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkImportSemaphoreZirconHandleFUCHSIA\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportSemaphoreZirconHandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportSemaphoreZirconHandleInfo, toStringFlags, tabCount, tabSize));
@@ -15064,7 +15535,8 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreZirconHandleFUCHSIA(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetSemaphoreZirconHandleFUCHSIA\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetZirconHandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetZirconHandleInfo, toStringFlags, tabCount, tabSize));
@@ -15094,7 +15566,8 @@ void VulkanAsciiConsumer::Process_vkCmdBindInvocationMaskHUAWEI(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindInvocationMaskHUAWEI\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "imageView", toStringFlags, tabCount, tabSize, HandleIdToString(imageView));
@@ -15126,7 +15599,8 @@ void VulkanAsciiConsumer::Process_vkGetMemoryRemoteAddressNV(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryRemoteAddressNV\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pMemoryGetRemoteAddressInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryGetRemoteAddressInfo, toStringFlags, tabCount, tabSize));
@@ -15155,7 +15629,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetPatchControlPointsEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetPatchControlPointsEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "patchControlPoints", toStringFlags, tabCount, tabSize, ToString(patchControlPoints, toStringFlags, tabCount, tabSize));
@@ -15183,7 +15658,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetRasterizerDiscardEnableEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetRasterizerDiscardEnableEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "rasterizerDiscardEnable", toStringFlags, tabCount, tabSize, ToString(rasterizerDiscardEnable, toStringFlags, tabCount, tabSize));
@@ -15211,7 +15687,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBiasEnableEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthBiasEnableEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthBiasEnable", toStringFlags, tabCount, tabSize, ToString(depthBiasEnable, toStringFlags, tabCount, tabSize));
@@ -15239,7 +15716,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetLogicOpEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetLogicOpEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "logicOp", toStringFlags, tabCount, tabSize, '"' + ToString(logicOp, toStringFlags, tabCount, tabSize) + '"');
@@ -15267,7 +15745,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveRestartEnableEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetPrimitiveRestartEnableEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "primitiveRestartEnable", toStringFlags, tabCount, tabSize, ToString(primitiveRestartEnable, toStringFlags, tabCount, tabSize));
@@ -15299,7 +15778,8 @@ void VulkanAsciiConsumer::Process_vkCreateScreenSurfaceQNX(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateScreenSurfaceQNX\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -15332,7 +15812,8 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceScreenPresentationSupportQN
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceScreenPresentationSupportQNX\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
@@ -15362,7 +15843,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetColorWriteEnableEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetColorWriteEnableEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "attachmentCount", toStringFlags, tabCount, tabSize, ToString(attachmentCount, toStringFlags, tabCount, tabSize));
@@ -15395,7 +15877,8 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMultiEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawMultiEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "drawCount", toStringFlags, tabCount, tabSize, ToString(drawCount, toStringFlags, tabCount, tabSize));
@@ -15432,7 +15915,8 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMultiIndexedEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawMultiIndexedEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "drawCount", toStringFlags, tabCount, tabSize, ToString(drawCount, toStringFlags, tabCount, tabSize));
@@ -15466,7 +15950,8 @@ void VulkanAsciiConsumer::Process_vkSetDeviceMemoryPriorityEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSetDeviceMemoryPriorityEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
@@ -15496,7 +15981,8 @@ void VulkanAsciiConsumer::Process_vkGetDescriptorSetLayoutHostMappingInfoVALVE(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDescriptorSetLayoutHostMappingInfoVALVE\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pBindingReference", toStringFlags, tabCount, tabSize, PointerDecoderToString(pBindingReference, toStringFlags, tabCount, tabSize));
@@ -15526,7 +16012,8 @@ void VulkanAsciiConsumer::Process_vkGetDescriptorSetHostMappingVALVE(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDescriptorSetHostMappingVALVE\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorSet", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorSet));
@@ -15556,7 +16043,8 @@ void VulkanAsciiConsumer::Process_vkGetShaderModuleIdentifierEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetShaderModuleIdentifierEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "shaderModule", toStringFlags, tabCount, tabSize, HandleIdToString(shaderModule));
@@ -15586,7 +16074,8 @@ void VulkanAsciiConsumer::Process_vkGetShaderModuleCreateInfoIdentifierEXT(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetShaderModuleCreateInfoIdentifierEXT\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -15619,7 +16108,8 @@ void VulkanAsciiConsumer::Process_vkGetFramebufferTilePropertiesQCOM(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetFramebufferTilePropertiesQCOM\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "framebuffer", toStringFlags, tabCount, tabSize, HandleIdToString(framebuffer));
@@ -15652,7 +16142,8 @@ void VulkanAsciiConsumer::Process_vkGetDynamicRenderingTilePropertiesQCOM(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDynamicRenderingTilePropertiesQCOM\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pRenderingInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRenderingInfo, toStringFlags, tabCount, tabSize));
@@ -15685,7 +16176,8 @@ void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateAccelerationStructureKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
@@ -15716,7 +16208,8 @@ void VulkanAsciiConsumer::Process_vkDestroyAccelerationStructureKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyAccelerationStructureKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "accelerationStructure", toStringFlags, tabCount, tabSize, HandleIdToString(accelerationStructure));
@@ -15748,7 +16241,8 @@ void VulkanAsciiConsumer::Process_vkCopyAccelerationStructureToMemoryKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCopyAccelerationStructureToMemoryKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "deferredOperation", toStringFlags, tabCount, tabSize, HandleIdToString(deferredOperation));
@@ -15780,7 +16274,8 @@ void VulkanAsciiConsumer::Process_vkCopyMemoryToAccelerationStructureKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCopyMemoryToAccelerationStructureKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "deferredOperation", toStringFlags, tabCount, tabSize, HandleIdToString(deferredOperation));
@@ -15816,7 +16311,8 @@ void VulkanAsciiConsumer::Process_vkWriteAccelerationStructuresPropertiesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkWriteAccelerationStructuresPropertiesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "accelerationStructureCount", toStringFlags, tabCount, tabSize, ToString(accelerationStructureCount, toStringFlags, tabCount, tabSize));
@@ -15849,7 +16345,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyAccelerationStructureKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyAccelerationStructureKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -15877,7 +16374,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyAccelerationStructureToMemoryKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyAccelerationStructureToMemoryKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -15905,7 +16403,8 @@ void VulkanAsciiConsumer::Process_vkCmdCopyMemoryToAccelerationStructureKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyMemoryToAccelerationStructureKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -15935,7 +16434,8 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureDeviceAddressKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetAccelerationStructureDeviceAddressKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
@@ -15967,7 +16467,8 @@ void VulkanAsciiConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWriteAccelerationStructuresPropertiesKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "accelerationStructureCount", toStringFlags, tabCount, tabSize, ToString(accelerationStructureCount, toStringFlags, tabCount, tabSize));
@@ -16000,7 +16501,8 @@ void VulkanAsciiConsumer::Process_vkGetDeviceAccelerationStructureCompatibilityK
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceAccelerationStructureCompatibilityKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pVersionInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pVersionInfo, toStringFlags, tabCount, tabSize));
@@ -16035,7 +16537,8 @@ void VulkanAsciiConsumer::Process_vkCmdTraceRaysKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdTraceRaysKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pRaygenShaderBindingTable", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRaygenShaderBindingTable, toStringFlags, tabCount, tabSize));
@@ -16076,7 +16579,8 @@ void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateRayTracingPipelinesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "deferredOperation", toStringFlags, tabCount, tabSize, HandleIdToString(deferredOperation));
@@ -16115,7 +16619,8 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingCaptureReplayShaderGroupHandles
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetRayTracingCaptureReplayShaderGroupHandlesKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
@@ -16151,7 +16656,8 @@ void VulkanAsciiConsumer::Process_vkCmdTraceRaysIndirectKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdTraceRaysIndirectKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pRaygenShaderBindingTable", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRaygenShaderBindingTable, toStringFlags, tabCount, tabSize));
@@ -16187,7 +16693,8 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupStackSizeKHR(
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetRayTracingShaderGroupStackSizeKHR\"");
             FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
@@ -16217,7 +16724,8 @@ void VulkanAsciiConsumer::Process_vkCmdSetRayTracingPipelineStackSizeKHR(
             FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
             FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetRayTracingPipelineStackSizeKHR\"");
-            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");
+            strStrm << GetNewlineString(toStringFlags);
             tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pipelineStackSize", toStringFlags, tabCount, tabSize, ToString(pipelineStackSize, toStringFlags, tabCount, tabSize));

--- a/framework/generated/generated_vulkan_ascii_consumer.cpp
+++ b/framework/generated/generated_vulkan_ascii_consumer.cpp
@@ -47,13 +47,23 @@ void VulkanAsciiConsumer::Process_vkCreateInstance(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateInstance", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateInstance\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pInstance", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pInstance));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -67,11 +77,21 @@ void VulkanAsciiConsumer::Process_vkDestroyInstance(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyInstance", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyInstance\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -87,13 +107,23 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDevices(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkEnumeratePhysicalDevices", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkEnumeratePhysicalDevices\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPhysicalDeviceCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPhysicalDevices", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(pPhysicalDeviceCount, pPhysicalDevices, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -107,11 +137,21 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFeatures(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceFeatures", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceFeatures\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pFeatures", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFeatures, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -126,12 +166,22 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceFormatProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceFormatProperties\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "format", toStringFlags, tabCount, tabSize, '"' + ToString(format, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFormatProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -151,17 +201,27 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceImageFormatProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceImageFormatProperties\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "format", toStringFlags, tabCount, tabSize, '"' + ToString(format, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "type", toStringFlags, tabCount, tabSize, '"' + ToString(type, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "tiling", toStringFlags, tabCount, tabSize, '"' + ToString(tiling, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "usage", toStringFlags, tabCount, tabSize, ToString(usage, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImageFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -175,11 +235,21 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceProperties(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceProperties\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -194,12 +264,22 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceQueueFamilyProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceQueueFamilyProperties\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pQueueFamilyPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pQueueFamilyPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pQueueFamilyProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pQueueFamilyProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -213,11 +293,21 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceMemoryProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceMemoryProperties\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pMemoryProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -234,14 +324,24 @@ void VulkanAsciiConsumer::Process_vkCreateDevice(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateDevice", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDevice\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDevice", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDevice));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -255,11 +355,21 @@ void VulkanAsciiConsumer::Process_vkDestroyDevice(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyDevice", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyDevice\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -275,13 +385,23 @@ void VulkanAsciiConsumer::Process_vkGetDeviceQueue(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceQueue", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceQueue\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "queueIndex", toStringFlags, tabCount, tabSize, ToString(queueIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pQueue", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pQueue));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -298,14 +418,24 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkQueueSubmit", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueSubmit\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "submitCount", toStringFlags, tabCount, tabSize, ToString(submitCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSubmits", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSubmits, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -319,11 +449,21 @@ void VulkanAsciiConsumer::Process_vkQueueWaitIdle(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkQueueWaitIdle", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueWaitIdle\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -337,11 +477,21 @@ void VulkanAsciiConsumer::Process_vkDeviceWaitIdle(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDeviceWaitIdle", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDeviceWaitIdle\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -358,14 +508,24 @@ void VulkanAsciiConsumer::Process_vkAllocateMemory(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkAllocateMemory", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAllocateMemory\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAllocateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemory", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pMemory));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -380,12 +540,22 @@ void VulkanAsciiConsumer::Process_vkFreeMemory(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkFreeMemory", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkFreeMemory\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -404,16 +574,26 @@ void VulkanAsciiConsumer::Process_vkMapMemory(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkMapMemory", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkMapMemory\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "offset", toStringFlags, tabCount, tabSize, ToString(offset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "size", toStringFlags, tabCount, tabSize, ToString(size, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]ppData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(ppData));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -427,11 +607,21 @@ void VulkanAsciiConsumer::Process_vkUnmapMemory(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkUnmapMemory", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkUnmapMemory\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -447,13 +637,23 @@ void VulkanAsciiConsumer::Process_vkFlushMappedMemoryRanges(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkFlushMappedMemoryRanges", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkFlushMappedMemoryRanges\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memoryRangeCount", toStringFlags, tabCount, tabSize, ToString(memoryRangeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pMemoryRanges", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pMemoryRanges, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -469,13 +669,23 @@ void VulkanAsciiConsumer::Process_vkInvalidateMappedMemoryRanges(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkInvalidateMappedMemoryRanges", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkInvalidateMappedMemoryRanges\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memoryRangeCount", toStringFlags, tabCount, tabSize, ToString(memoryRangeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pMemoryRanges", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pMemoryRanges, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -490,12 +700,22 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryCommitment(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceMemoryCommitment", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceMemoryCommitment\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "[out]pCommittedMemoryInBytes", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCommittedMemoryInBytes, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -512,14 +732,24 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkBindBufferMemory", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkBindBufferMemory\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "memoryOffset", toStringFlags, tabCount, tabSize, ToString(memoryOffset, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -536,14 +766,24 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkBindImageMemory", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkBindImageMemory\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "memoryOffset", toStringFlags, tabCount, tabSize, ToString(memoryOffset, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -558,12 +798,22 @@ void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetBufferMemoryRequirements", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetBufferMemoryRequirements\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "[out]pMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -578,12 +828,22 @@ void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetImageMemoryRequirements", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageMemoryRequirements\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
             FieldToString(strStrm, false, "[out]pMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -599,13 +859,23 @@ void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetImageSparseMemoryRequirements", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageSparseMemoryRequirements\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
             FieldToString(strStrm, false, "[out]pSparseMemoryRequirementCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSparseMemoryRequirementCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSparseMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSparseMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -625,9 +895,14 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSparseImageFormatProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSparseImageFormatProperties\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "format", toStringFlags, tabCount, tabSize, '"' + ToString(format, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "type", toStringFlags, tabCount, tabSize, '"' + ToString(type, toStringFlags, tabCount, tabSize) + '"');
@@ -636,6 +911,11 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties
             FieldToString(strStrm, false, "tiling", toStringFlags, tabCount, tabSize, '"' + ToString(tiling, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -652,14 +932,24 @@ void VulkanAsciiConsumer::Process_vkQueueBindSparse(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkQueueBindSparse", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueBindSparse\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfo", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -676,14 +966,24 @@ void VulkanAsciiConsumer::Process_vkCreateFence(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateFence", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateFence\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFence", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pFence));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -698,12 +998,22 @@ void VulkanAsciiConsumer::Process_vkDestroyFence(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyFence", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyFence\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -719,13 +1029,23 @@ void VulkanAsciiConsumer::Process_vkResetFences(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkResetFences", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkResetFences\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "fenceCount", toStringFlags, tabCount, tabSize, ToString(fenceCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pFences", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(fenceCount, pFences, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -740,12 +1060,22 @@ void VulkanAsciiConsumer::Process_vkGetFenceStatus(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetFenceStatus", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetFenceStatus\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -763,15 +1093,25 @@ void VulkanAsciiConsumer::Process_vkWaitForFences(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkWaitForFences", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkWaitForFences\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "fenceCount", toStringFlags, tabCount, tabSize, ToString(fenceCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pFences", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(fenceCount, pFences, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "waitAll", toStringFlags, tabCount, tabSize, ToString(waitAll, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -788,14 +1128,24 @@ void VulkanAsciiConsumer::Process_vkCreateSemaphore(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateSemaphore", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateSemaphore\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSemaphore", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSemaphore));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -810,12 +1160,22 @@ void VulkanAsciiConsumer::Process_vkDestroySemaphore(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroySemaphore", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroySemaphore\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "semaphore", toStringFlags, tabCount, tabSize, HandleIdToString(semaphore));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -832,14 +1192,24 @@ void VulkanAsciiConsumer::Process_vkCreateEvent(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateEvent", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateEvent\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pEvent", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pEvent));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -854,12 +1224,22 @@ void VulkanAsciiConsumer::Process_vkDestroyEvent(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyEvent", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyEvent\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -874,12 +1254,22 @@ void VulkanAsciiConsumer::Process_vkGetEventStatus(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetEventStatus", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetEventStatus\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -894,12 +1284,22 @@ void VulkanAsciiConsumer::Process_vkSetEvent(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkSetEvent", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSetEvent\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -914,12 +1314,22 @@ void VulkanAsciiConsumer::Process_vkResetEvent(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkResetEvent", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkResetEvent\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -936,14 +1346,24 @@ void VulkanAsciiConsumer::Process_vkCreateQueryPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateQueryPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateQueryPool\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pQueryPool", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pQueryPool));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -958,12 +1378,22 @@ void VulkanAsciiConsumer::Process_vkDestroyQueryPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyQueryPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyQueryPool\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -984,11 +1414,16 @@ void VulkanAsciiConsumer::Process_vkGetQueryPoolResults(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetQueryPoolResults", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetQueryPoolResults\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
             FieldToString(strStrm, false, "firstQuery", toStringFlags, tabCount, tabSize, ToString(firstQuery, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "queryCount", toStringFlags, tabCount, tabSize, ToString(queryCount, toStringFlags, tabCount, tabSize));
@@ -996,6 +1431,11 @@ void VulkanAsciiConsumer::Process_vkGetQueryPoolResults(
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1012,14 +1452,24 @@ void VulkanAsciiConsumer::Process_vkCreateBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateBuffer\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pBuffer", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pBuffer));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1034,12 +1484,22 @@ void VulkanAsciiConsumer::Process_vkDestroyBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyBuffer\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1056,14 +1516,24 @@ void VulkanAsciiConsumer::Process_vkCreateBufferView(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateBufferView", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateBufferView\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pView", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pView));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1078,12 +1548,22 @@ void VulkanAsciiConsumer::Process_vkDestroyBufferView(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyBufferView", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyBufferView\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bufferView", toStringFlags, tabCount, tabSize, HandleIdToString(bufferView));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1100,14 +1580,24 @@ void VulkanAsciiConsumer::Process_vkCreateImage(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateImage", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateImage\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImage", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pImage));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1122,12 +1612,22 @@ void VulkanAsciiConsumer::Process_vkDestroyImage(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyImage", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyImage\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1143,13 +1643,23 @@ void VulkanAsciiConsumer::Process_vkGetImageSubresourceLayout(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetImageSubresourceLayout", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageSubresourceLayout\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
             FieldToString(strStrm, false, "pSubresource", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSubresource, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pLayout", toStringFlags, tabCount, tabSize, PointerDecoderToString(pLayout, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1166,14 +1676,24 @@ void VulkanAsciiConsumer::Process_vkCreateImageView(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateImageView", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateImageView\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pView", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pView));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1188,12 +1708,22 @@ void VulkanAsciiConsumer::Process_vkDestroyImageView(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyImageView", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyImageView\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "imageView", toStringFlags, tabCount, tabSize, HandleIdToString(imageView));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1210,14 +1740,24 @@ void VulkanAsciiConsumer::Process_vkCreateShaderModule(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateShaderModule", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateShaderModule\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pShaderModule", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pShaderModule));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1232,12 +1772,22 @@ void VulkanAsciiConsumer::Process_vkDestroyShaderModule(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyShaderModule", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyShaderModule\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "shaderModule", toStringFlags, tabCount, tabSize, HandleIdToString(shaderModule));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1254,14 +1804,24 @@ void VulkanAsciiConsumer::Process_vkCreatePipelineCache(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreatePipelineCache", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreatePipelineCache\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelineCache", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pPipelineCache));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1276,12 +1836,22 @@ void VulkanAsciiConsumer::Process_vkDestroyPipelineCache(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyPipelineCache", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyPipelineCache\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1298,14 +1868,24 @@ void VulkanAsciiConsumer::Process_vkGetPipelineCacheData(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPipelineCacheData", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPipelineCacheData\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
             FieldToString(strStrm, false, "[out]pDataSize", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1322,14 +1902,24 @@ void VulkanAsciiConsumer::Process_vkMergePipelineCaches(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkMergePipelineCaches", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkMergePipelineCaches\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "dstCache", toStringFlags, tabCount, tabSize, HandleIdToString(dstCache));
             FieldToString(strStrm, false, "srcCacheCount", toStringFlags, tabCount, tabSize, ToString(srcCacheCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSrcCaches", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(srcCacheCount, pSrcCaches, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1348,16 +1938,26 @@ void VulkanAsciiConsumer::Process_vkCreateGraphicsPipelines(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateGraphicsPipelines", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateGraphicsPipelines\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
             FieldToString(strStrm, false, "createInfoCount", toStringFlags, tabCount, tabSize, ToString(createInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelines", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(createInfoCount, pPipelines, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1376,16 +1976,26 @@ void VulkanAsciiConsumer::Process_vkCreateComputePipelines(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateComputePipelines", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateComputePipelines\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
             FieldToString(strStrm, false, "createInfoCount", toStringFlags, tabCount, tabSize, ToString(createInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelines", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(createInfoCount, pPipelines, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1400,12 +2010,22 @@ void VulkanAsciiConsumer::Process_vkDestroyPipeline(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyPipeline", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyPipeline\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1422,14 +2042,24 @@ void VulkanAsciiConsumer::Process_vkCreatePipelineLayout(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreatePipelineLayout", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreatePipelineLayout\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelineLayout", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pPipelineLayout));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1444,12 +2074,22 @@ void VulkanAsciiConsumer::Process_vkDestroyPipelineLayout(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyPipelineLayout", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyPipelineLayout\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipelineLayout", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineLayout));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1466,14 +2106,24 @@ void VulkanAsciiConsumer::Process_vkCreateSampler(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateSampler", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateSampler\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSampler", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSampler));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1488,12 +2138,22 @@ void VulkanAsciiConsumer::Process_vkDestroySampler(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroySampler", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroySampler\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "sampler", toStringFlags, tabCount, tabSize, HandleIdToString(sampler));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1510,14 +2170,24 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorSetLayout(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateDescriptorSetLayout", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDescriptorSetLayout\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSetLayout", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSetLayout));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1532,12 +2202,22 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorSetLayout(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyDescriptorSetLayout", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyDescriptorSetLayout\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorSetLayout", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorSetLayout));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1554,14 +2234,24 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateDescriptorPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDescriptorPool\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDescriptorPool", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDescriptorPool));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1576,12 +2266,22 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyDescriptorPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyDescriptorPool\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorPool", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorPool));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1597,13 +2297,23 @@ void VulkanAsciiConsumer::Process_vkResetDescriptorPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkResetDescriptorPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkResetDescriptorPool\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorPool", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorPool));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1620,14 +2330,24 @@ void VulkanAsciiConsumer::Process_vkFreeDescriptorSets(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkFreeDescriptorSets", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkFreeDescriptorSets\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorPool", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorPool));
             FieldToString(strStrm, false, "descriptorSetCount", toStringFlags, tabCount, tabSize, ToString(descriptorSetCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pDescriptorSets", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(descriptorSetCount, pDescriptorSets, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1644,14 +2364,24 @@ void VulkanAsciiConsumer::Process_vkUpdateDescriptorSets(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkUpdateDescriptorSets", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkUpdateDescriptorSets\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorWriteCount", toStringFlags, tabCount, tabSize, ToString(descriptorWriteCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pDescriptorWrites", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pDescriptorWrites, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "descriptorCopyCount", toStringFlags, tabCount, tabSize, ToString(descriptorCopyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pDescriptorCopies", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pDescriptorCopies, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1668,14 +2398,24 @@ void VulkanAsciiConsumer::Process_vkCreateFramebuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateFramebuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateFramebuffer\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFramebuffer", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pFramebuffer));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1690,12 +2430,22 @@ void VulkanAsciiConsumer::Process_vkDestroyFramebuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyFramebuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyFramebuffer\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "framebuffer", toStringFlags, tabCount, tabSize, HandleIdToString(framebuffer));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1712,14 +2462,24 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateRenderPass", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateRenderPass\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pRenderPass", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pRenderPass));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1734,12 +2494,22 @@ void VulkanAsciiConsumer::Process_vkDestroyRenderPass(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyRenderPass", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyRenderPass\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "renderPass", toStringFlags, tabCount, tabSize, HandleIdToString(renderPass));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1754,12 +2524,22 @@ void VulkanAsciiConsumer::Process_vkGetRenderAreaGranularity(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetRenderAreaGranularity", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetRenderAreaGranularity\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "renderPass", toStringFlags, tabCount, tabSize, HandleIdToString(renderPass));
             FieldToString(strStrm, false, "[out]pGranularity", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGranularity, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1776,14 +2556,24 @@ void VulkanAsciiConsumer::Process_vkCreateCommandPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateCommandPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateCommandPool\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCommandPool", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pCommandPool));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1798,12 +2588,22 @@ void VulkanAsciiConsumer::Process_vkDestroyCommandPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyCommandPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyCommandPool\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "commandPool", toStringFlags, tabCount, tabSize, HandleIdToString(commandPool));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1819,13 +2619,23 @@ void VulkanAsciiConsumer::Process_vkResetCommandPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkResetCommandPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkResetCommandPool\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "commandPool", toStringFlags, tabCount, tabSize, HandleIdToString(commandPool));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1841,13 +2651,23 @@ void VulkanAsciiConsumer::Process_vkFreeCommandBuffers(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkFreeCommandBuffers", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkFreeCommandBuffers\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "commandPool", toStringFlags, tabCount, tabSize, HandleIdToString(commandPool));
             FieldToString(strStrm, false, "commandBufferCount", toStringFlags, tabCount, tabSize, ToString(commandBufferCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCommandBuffers", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(commandBufferCount, pCommandBuffers, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1862,12 +2682,22 @@ void VulkanAsciiConsumer::Process_vkBeginCommandBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkBeginCommandBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkBeginCommandBuffer\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pBeginInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pBeginInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1881,11 +2711,21 @@ void VulkanAsciiConsumer::Process_vkEndCommandBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkEndCommandBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkEndCommandBuffer\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1900,12 +2740,22 @@ void VulkanAsciiConsumer::Process_vkResetCommandBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkResetCommandBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkResetCommandBuffer\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1920,12 +2770,22 @@ void VulkanAsciiConsumer::Process_vkCmdBindPipeline(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBindPipeline", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindPipeline\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pipelineBindPoint", toStringFlags, tabCount, tabSize, '"' + ToString(pipelineBindPoint, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1941,13 +2801,23 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewport(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetViewport", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetViewport\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstViewport", toStringFlags, tabCount, tabSize, ToString(firstViewport, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "viewportCount", toStringFlags, tabCount, tabSize, ToString(viewportCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pViewports", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pViewports, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1963,13 +2833,23 @@ void VulkanAsciiConsumer::Process_vkCmdSetScissor(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetScissor", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetScissor\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstScissor", toStringFlags, tabCount, tabSize, ToString(firstScissor, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "scissorCount", toStringFlags, tabCount, tabSize, ToString(scissorCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pScissors", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pScissors, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -1983,11 +2863,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetLineWidth(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetLineWidth", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetLineWidth\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "lineWidth", toStringFlags, tabCount, tabSize, ToString(lineWidth, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2003,13 +2893,23 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBias(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetDepthBias", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthBias\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthBiasConstantFactor", toStringFlags, tabCount, tabSize, ToString(depthBiasConstantFactor, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "depthBiasClamp", toStringFlags, tabCount, tabSize, ToString(depthBiasClamp, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "depthBiasSlopeFactor", toStringFlags, tabCount, tabSize, ToString(depthBiasSlopeFactor, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2023,11 +2923,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetBlendConstants(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetBlendConstants", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetBlendConstants\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "blendConstants", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(4, blendConstants, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2042,12 +2952,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBounds(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetDepthBounds", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthBounds\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "minDepthBounds", toStringFlags, tabCount, tabSize, ToString(minDepthBounds, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "maxDepthBounds", toStringFlags, tabCount, tabSize, ToString(maxDepthBounds, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2062,12 +2982,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilCompareMask(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetStencilCompareMask", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetStencilCompareMask\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "faceMask", toStringFlags, tabCount, tabSize, ToString(faceMask, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "compareMask", toStringFlags, tabCount, tabSize, ToString(compareMask, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2082,12 +3012,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilWriteMask(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetStencilWriteMask", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetStencilWriteMask\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "faceMask", toStringFlags, tabCount, tabSize, ToString(faceMask, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "writeMask", toStringFlags, tabCount, tabSize, ToString(writeMask, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2102,12 +3042,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilReference(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetStencilReference", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetStencilReference\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "faceMask", toStringFlags, tabCount, tabSize, ToString(faceMask, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "reference", toStringFlags, tabCount, tabSize, ToString(reference, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2127,9 +3077,14 @@ void VulkanAsciiConsumer::Process_vkCmdBindDescriptorSets(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBindDescriptorSets", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindDescriptorSets\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pipelineBindPoint", toStringFlags, tabCount, tabSize, '"' + ToString(pipelineBindPoint, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "layout", toStringFlags, tabCount, tabSize, HandleIdToString(layout));
@@ -2138,6 +3093,11 @@ void VulkanAsciiConsumer::Process_vkCmdBindDescriptorSets(
             FieldToString(strStrm, false, "pDescriptorSets", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(descriptorSetCount, pDescriptorSets, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dynamicOffsetCount", toStringFlags, tabCount, tabSize, ToString(dynamicOffsetCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pDynamicOffsets", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(dynamicOffsetCount, pDynamicOffsets, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2153,13 +3113,23 @@ void VulkanAsciiConsumer::Process_vkCmdBindIndexBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBindIndexBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindIndexBuffer\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "offset", toStringFlags, tabCount, tabSize, ToString(offset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "indexType", toStringFlags, tabCount, tabSize, '"' + ToString(indexType, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2176,14 +3146,24 @@ void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBindVertexBuffers", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindVertexBuffers\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstBinding", toStringFlags, tabCount, tabSize, ToString(firstBinding, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "bindingCount", toStringFlags, tabCount, tabSize, ToString(bindingCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBuffers", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(bindingCount, pBuffers, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pOffsets", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(bindingCount, pOffsets, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2200,14 +3180,24 @@ void VulkanAsciiConsumer::Process_vkCmdDraw(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDraw", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDraw\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "vertexCount", toStringFlags, tabCount, tabSize, ToString(vertexCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "instanceCount", toStringFlags, tabCount, tabSize, ToString(instanceCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "firstVertex", toStringFlags, tabCount, tabSize, ToString(firstVertex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "firstInstance", toStringFlags, tabCount, tabSize, ToString(firstInstance, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2225,15 +3215,25 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexed(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDrawIndexed", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndexed\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "indexCount", toStringFlags, tabCount, tabSize, ToString(indexCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "instanceCount", toStringFlags, tabCount, tabSize, ToString(instanceCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "firstIndex", toStringFlags, tabCount, tabSize, ToString(firstIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "vertexOffset", toStringFlags, tabCount, tabSize, ToString(vertexOffset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "firstInstance", toStringFlags, tabCount, tabSize, ToString(firstInstance, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2250,14 +3250,24 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirect(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDrawIndirect", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndirect\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "offset", toStringFlags, tabCount, tabSize, ToString(offset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "drawCount", toStringFlags, tabCount, tabSize, ToString(drawCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2274,14 +3284,24 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirect(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDrawIndexedIndirect", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndexedIndirect\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "offset", toStringFlags, tabCount, tabSize, ToString(offset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "drawCount", toStringFlags, tabCount, tabSize, ToString(drawCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2297,13 +3317,23 @@ void VulkanAsciiConsumer::Process_vkCmdDispatch(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDispatch", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDispatch\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "groupCountX", toStringFlags, tabCount, tabSize, ToString(groupCountX, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "groupCountY", toStringFlags, tabCount, tabSize, ToString(groupCountY, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "groupCountZ", toStringFlags, tabCount, tabSize, ToString(groupCountZ, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2318,12 +3348,22 @@ void VulkanAsciiConsumer::Process_vkCmdDispatchIndirect(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDispatchIndirect", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDispatchIndirect\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "offset", toStringFlags, tabCount, tabSize, ToString(offset, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2340,14 +3380,24 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyBuffer\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "srcBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(srcBuffer));
             FieldToString(strStrm, false, "dstBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(dstBuffer));
             FieldToString(strStrm, false, "regionCount", toStringFlags, tabCount, tabSize, ToString(regionCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pRegions", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pRegions, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2366,9 +3416,14 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImage(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyImage", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyImage\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "srcImage", toStringFlags, tabCount, tabSize, HandleIdToString(srcImage));
             FieldToString(strStrm, false, "srcImageLayout", toStringFlags, tabCount, tabSize, '"' + ToString(srcImageLayout, toStringFlags, tabCount, tabSize) + '"');
@@ -2376,6 +3431,11 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImage(
             FieldToString(strStrm, false, "dstImageLayout", toStringFlags, tabCount, tabSize, '"' + ToString(dstImageLayout, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "regionCount", toStringFlags, tabCount, tabSize, ToString(regionCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pRegions", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pRegions, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2395,9 +3455,14 @@ void VulkanAsciiConsumer::Process_vkCmdBlitImage(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBlitImage", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBlitImage\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "srcImage", toStringFlags, tabCount, tabSize, HandleIdToString(srcImage));
             FieldToString(strStrm, false, "srcImageLayout", toStringFlags, tabCount, tabSize, '"' + ToString(srcImageLayout, toStringFlags, tabCount, tabSize) + '"');
@@ -2406,6 +3471,11 @@ void VulkanAsciiConsumer::Process_vkCmdBlitImage(
             FieldToString(strStrm, false, "regionCount", toStringFlags, tabCount, tabSize, ToString(regionCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pRegions", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pRegions, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "filter", toStringFlags, tabCount, tabSize, '"' + ToString(filter, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2423,15 +3493,25 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBufferToImage(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyBufferToImage", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyBufferToImage\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "srcBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(srcBuffer));
             FieldToString(strStrm, false, "dstImage", toStringFlags, tabCount, tabSize, HandleIdToString(dstImage));
             FieldToString(strStrm, false, "dstImageLayout", toStringFlags, tabCount, tabSize, '"' + ToString(dstImageLayout, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "regionCount", toStringFlags, tabCount, tabSize, ToString(regionCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pRegions", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pRegions, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2449,15 +3529,25 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImageToBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyImageToBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyImageToBuffer\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "srcImage", toStringFlags, tabCount, tabSize, HandleIdToString(srcImage));
             FieldToString(strStrm, false, "srcImageLayout", toStringFlags, tabCount, tabSize, '"' + ToString(srcImageLayout, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "dstBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(dstBuffer));
             FieldToString(strStrm, false, "regionCount", toStringFlags, tabCount, tabSize, ToString(regionCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pRegions", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pRegions, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2474,14 +3564,24 @@ void VulkanAsciiConsumer::Process_vkCmdUpdateBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdUpdateBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdUpdateBuffer\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "dstBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(dstBuffer));
             FieldToString(strStrm, false, "dstOffset", toStringFlags, tabCount, tabSize, ToString(dstOffset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2498,14 +3598,24 @@ void VulkanAsciiConsumer::Process_vkCmdFillBuffer(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdFillBuffer", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdFillBuffer\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "dstBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(dstBuffer));
             FieldToString(strStrm, false, "dstOffset", toStringFlags, tabCount, tabSize, ToString(dstOffset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "size", toStringFlags, tabCount, tabSize, ToString(size, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "data", toStringFlags, tabCount, tabSize, ToString(data, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2523,15 +3633,25 @@ void VulkanAsciiConsumer::Process_vkCmdClearColorImage(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdClearColorImage", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdClearColorImage\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
             FieldToString(strStrm, false, "imageLayout", toStringFlags, tabCount, tabSize, '"' + ToString(imageLayout, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "pColor", toStringFlags, tabCount, tabSize, PointerDecoderToString(pColor, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "rangeCount", toStringFlags, tabCount, tabSize, ToString(rangeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pRanges", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pRanges, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2549,15 +3669,25 @@ void VulkanAsciiConsumer::Process_vkCmdClearDepthStencilImage(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdClearDepthStencilImage", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdClearDepthStencilImage\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
             FieldToString(strStrm, false, "imageLayout", toStringFlags, tabCount, tabSize, '"' + ToString(imageLayout, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "pDepthStencil", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDepthStencil, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "rangeCount", toStringFlags, tabCount, tabSize, ToString(rangeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pRanges", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pRanges, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2574,14 +3704,24 @@ void VulkanAsciiConsumer::Process_vkCmdClearAttachments(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdClearAttachments", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdClearAttachments\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "attachmentCount", toStringFlags, tabCount, tabSize, ToString(attachmentCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAttachments", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pAttachments, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "rectCount", toStringFlags, tabCount, tabSize, ToString(rectCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pRects", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pRects, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2600,9 +3740,14 @@ void VulkanAsciiConsumer::Process_vkCmdResolveImage(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdResolveImage", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdResolveImage\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "srcImage", toStringFlags, tabCount, tabSize, HandleIdToString(srcImage));
             FieldToString(strStrm, false, "srcImageLayout", toStringFlags, tabCount, tabSize, '"' + ToString(srcImageLayout, toStringFlags, tabCount, tabSize) + '"');
@@ -2610,6 +3755,11 @@ void VulkanAsciiConsumer::Process_vkCmdResolveImage(
             FieldToString(strStrm, false, "dstImageLayout", toStringFlags, tabCount, tabSize, '"' + ToString(dstImageLayout, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "regionCount", toStringFlags, tabCount, tabSize, ToString(regionCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pRegions", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pRegions, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2624,12 +3774,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetEvent(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetEvent", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetEvent\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
             FieldToString(strStrm, false, "stageMask", toStringFlags, tabCount, tabSize, ToString(stageMask, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2644,12 +3804,22 @@ void VulkanAsciiConsumer::Process_vkCmdResetEvent(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdResetEvent", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdResetEvent\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
             FieldToString(strStrm, false, "stageMask", toStringFlags, tabCount, tabSize, ToString(stageMask, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2672,9 +3842,14 @@ void VulkanAsciiConsumer::Process_vkCmdWaitEvents(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdWaitEvents", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWaitEvents\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "eventCount", toStringFlags, tabCount, tabSize, ToString(eventCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pEvents", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(eventCount, pEvents, toStringFlags, tabCount, tabSize));
@@ -2686,6 +3861,11 @@ void VulkanAsciiConsumer::Process_vkCmdWaitEvents(
             FieldToString(strStrm, false, "pBufferMemoryBarriers", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBufferMemoryBarriers, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "imageMemoryBarrierCount", toStringFlags, tabCount, tabSize, ToString(imageMemoryBarrierCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pImageMemoryBarriers", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pImageMemoryBarriers, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2707,9 +3887,14 @@ void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdPipelineBarrier", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdPipelineBarrier\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "srcStageMask", toStringFlags, tabCount, tabSize, ToString(srcStageMask, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dstStageMask", toStringFlags, tabCount, tabSize, ToString(dstStageMask, toStringFlags, tabCount, tabSize));
@@ -2720,6 +3905,11 @@ void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier(
             FieldToString(strStrm, false, "pBufferMemoryBarriers", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBufferMemoryBarriers, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "imageMemoryBarrierCount", toStringFlags, tabCount, tabSize, ToString(imageMemoryBarrierCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pImageMemoryBarriers", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pImageMemoryBarriers, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2735,13 +3925,23 @@ void VulkanAsciiConsumer::Process_vkCmdBeginQuery(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBeginQuery", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginQuery\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
             FieldToString(strStrm, false, "query", toStringFlags, tabCount, tabSize, ToString(query, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2756,12 +3956,22 @@ void VulkanAsciiConsumer::Process_vkCmdEndQuery(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdEndQuery", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndQuery\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
             FieldToString(strStrm, false, "query", toStringFlags, tabCount, tabSize, ToString(query, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2777,13 +3987,23 @@ void VulkanAsciiConsumer::Process_vkCmdResetQueryPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdResetQueryPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdResetQueryPool\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
             FieldToString(strStrm, false, "firstQuery", toStringFlags, tabCount, tabSize, ToString(firstQuery, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "queryCount", toStringFlags, tabCount, tabSize, ToString(queryCount, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2799,13 +4019,23 @@ void VulkanAsciiConsumer::Process_vkCmdWriteTimestamp(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdWriteTimestamp", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWriteTimestamp\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pipelineStage", toStringFlags, tabCount, tabSize, '"' + ToString(pipelineStage, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
             FieldToString(strStrm, false, "query", toStringFlags, tabCount, tabSize, ToString(query, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2825,9 +4055,14 @@ void VulkanAsciiConsumer::Process_vkCmdCopyQueryPoolResults(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyQueryPoolResults", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyQueryPoolResults\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
             FieldToString(strStrm, false, "firstQuery", toStringFlags, tabCount, tabSize, ToString(firstQuery, toStringFlags, tabCount, tabSize));
@@ -2836,6 +4071,11 @@ void VulkanAsciiConsumer::Process_vkCmdCopyQueryPoolResults(
             FieldToString(strStrm, false, "dstOffset", toStringFlags, tabCount, tabSize, ToString(dstOffset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2853,15 +4093,25 @@ void VulkanAsciiConsumer::Process_vkCmdPushConstants(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdPushConstants", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdPushConstants\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "layout", toStringFlags, tabCount, tabSize, HandleIdToString(layout));
             FieldToString(strStrm, false, "stageFlags", toStringFlags, tabCount, tabSize, ToString(stageFlags, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "offset", toStringFlags, tabCount, tabSize, ToString(offset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "size", toStringFlags, tabCount, tabSize, ToString(size, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pValues", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pValues));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2876,12 +4126,22 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBeginRenderPass", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginRenderPass\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pRenderPassBegin", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRenderPassBegin, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "contents", toStringFlags, tabCount, tabSize, '"' + ToString(contents, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2895,11 +4155,21 @@ void VulkanAsciiConsumer::Process_vkCmdNextSubpass(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdNextSubpass", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdNextSubpass\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "contents", toStringFlags, tabCount, tabSize, '"' + ToString(contents, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2912,10 +4182,20 @@ void VulkanAsciiConsumer::Process_vkCmdEndRenderPass(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdEndRenderPass", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndRenderPass\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2930,12 +4210,22 @@ void VulkanAsciiConsumer::Process_vkCmdExecuteCommands(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdExecuteCommands", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdExecuteCommands\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "commandBufferCount", toStringFlags, tabCount, tabSize, ToString(commandBufferCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCommandBuffers", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(commandBufferCount, pCommandBuffers, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2951,13 +4241,23 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkBindBufferMemory2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkBindBufferMemory2\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2973,13 +4273,23 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkBindImageMemory2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkBindImageMemory2\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -2996,14 +4306,24 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupPeerMemoryFeatures(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceGroupPeerMemoryFeatures", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceGroupPeerMemoryFeatures\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "heapIndex", toStringFlags, tabCount, tabSize, ToString(heapIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "localDeviceIndex", toStringFlags, tabCount, tabSize, ToString(localDeviceIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "remoteDeviceIndex", toStringFlags, tabCount, tabSize, ToString(remoteDeviceIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPeerMemoryFeatures", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPeerMemoryFeatures, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3017,11 +4337,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetDeviceMask(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetDeviceMask", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDeviceMask\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "deviceMask", toStringFlags, tabCount, tabSize, ToString(deviceMask, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3040,9 +4370,14 @@ void VulkanAsciiConsumer::Process_vkCmdDispatchBase(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDispatchBase", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDispatchBase\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "baseGroupX", toStringFlags, tabCount, tabSize, ToString(baseGroupX, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "baseGroupY", toStringFlags, tabCount, tabSize, ToString(baseGroupY, toStringFlags, tabCount, tabSize));
@@ -3050,6 +4385,11 @@ void VulkanAsciiConsumer::Process_vkCmdDispatchBase(
             FieldToString(strStrm, false, "groupCountX", toStringFlags, tabCount, tabSize, ToString(groupCountX, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "groupCountY", toStringFlags, tabCount, tabSize, ToString(groupCountY, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "groupCountZ", toStringFlags, tabCount, tabSize, ToString(groupCountZ, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3065,13 +4405,23 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroups(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkEnumeratePhysicalDeviceGroups", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkEnumeratePhysicalDeviceGroups\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPhysicalDeviceGroupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pPhysicalDeviceGroupProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3086,12 +4436,22 @@ void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetImageMemoryRequirements2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageMemoryRequirements2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3106,12 +4466,22 @@ void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetBufferMemoryRequirements2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetBufferMemoryRequirements2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3127,13 +4497,23 @@ void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetImageSparseMemoryRequirements2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageSparseMemoryRequirements2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSparseMemoryRequirementCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSparseMemoryRequirementCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSparseMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSparseMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3147,11 +4527,21 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFeatures2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceFeatures2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceFeatures2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pFeatures", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFeatures, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3165,11 +4555,21 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceProperties2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceProperties2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceProperties2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3184,12 +4584,22 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceFormatProperties2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceFormatProperties2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "format", toStringFlags, tabCount, tabSize, '"' + ToString(format, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFormatProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3205,13 +4615,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceImageFormatProperties2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceImageFormatProperties2\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pImageFormatInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImageFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3226,12 +4646,22 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceQueueFamilyProperties2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceQueueFamilyProperties2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pQueueFamilyPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pQueueFamilyPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pQueueFamilyProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pQueueFamilyProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3245,11 +4675,21 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceMemoryProperties2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceMemoryProperties2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pMemoryProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3265,13 +4705,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSparseImageFormatProperties2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSparseImageFormatProperties2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pFormatInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFormatInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3286,12 +4736,22 @@ void VulkanAsciiConsumer::Process_vkTrimCommandPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkTrimCommandPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkTrimCommandPool\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "commandPool", toStringFlags, tabCount, tabSize, HandleIdToString(commandPool));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3306,12 +4766,22 @@ void VulkanAsciiConsumer::Process_vkGetDeviceQueue2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceQueue2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceQueue2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pQueueInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pQueueInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pQueue", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pQueue));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3328,14 +4798,24 @@ void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversion(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateSamplerYcbcrConversion", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateSamplerYcbcrConversion\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pYcbcrConversion", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pYcbcrConversion));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3350,12 +4830,22 @@ void VulkanAsciiConsumer::Process_vkDestroySamplerYcbcrConversion(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroySamplerYcbcrConversion", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroySamplerYcbcrConversion\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "ycbcrConversion", toStringFlags, tabCount, tabSize, HandleIdToString(ycbcrConversion));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3372,14 +4862,24 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplate(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateDescriptorUpdateTemplate", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDescriptorUpdateTemplate\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDescriptorUpdateTemplate", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDescriptorUpdateTemplate));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3394,12 +4894,22 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorUpdateTemplate(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyDescriptorUpdateTemplate", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyDescriptorUpdateTemplate\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorUpdateTemplate", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorUpdateTemplate));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3414,12 +4924,22 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalBufferProperties(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceExternalBufferProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceExternalBufferProperties\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pExternalBufferInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalBufferInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pExternalBufferProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalBufferProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3434,12 +4954,22 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalFenceProperties(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceExternalFenceProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceExternalFenceProperties\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pExternalFenceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalFenceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pExternalFenceProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalFenceProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3454,12 +4984,22 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalSemaphoreProperties
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceExternalSemaphoreProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceExternalSemaphoreProperties\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pExternalSemaphoreInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalSemaphoreInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pExternalSemaphoreProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalSemaphoreProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3474,12 +5014,22 @@ void VulkanAsciiConsumer::Process_vkGetDescriptorSetLayoutSupport(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDescriptorSetLayoutSupport", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDescriptorSetLayoutSupport\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSupport", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSupport, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3498,9 +5048,14 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCount(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDrawIndirectCount", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndirectCount\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "offset", toStringFlags, tabCount, tabSize, ToString(offset, toStringFlags, tabCount, tabSize));
@@ -3508,6 +5063,11 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCount(
             FieldToString(strStrm, false, "countBufferOffset", toStringFlags, tabCount, tabSize, ToString(countBufferOffset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "maxDrawCount", toStringFlags, tabCount, tabSize, ToString(maxDrawCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3526,9 +5086,14 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCount(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDrawIndexedIndirectCount", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndexedIndirectCount\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "offset", toStringFlags, tabCount, tabSize, ToString(offset, toStringFlags, tabCount, tabSize));
@@ -3536,6 +5101,11 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCount(
             FieldToString(strStrm, false, "countBufferOffset", toStringFlags, tabCount, tabSize, ToString(countBufferOffset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "maxDrawCount", toStringFlags, tabCount, tabSize, ToString(maxDrawCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3552,14 +5122,24 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateRenderPass2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateRenderPass2\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pRenderPass", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pRenderPass));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3574,12 +5154,22 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBeginRenderPass2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginRenderPass2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pRenderPassBegin", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRenderPassBegin, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSubpassBeginInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSubpassBeginInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3594,12 +5184,22 @@ void VulkanAsciiConsumer::Process_vkCmdNextSubpass2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdNextSubpass2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdNextSubpass2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pSubpassBeginInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSubpassBeginInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSubpassEndInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSubpassEndInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3613,11 +5213,21 @@ void VulkanAsciiConsumer::Process_vkCmdEndRenderPass2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdEndRenderPass2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndRenderPass2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pSubpassEndInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSubpassEndInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3633,13 +5243,23 @@ void VulkanAsciiConsumer::Process_vkResetQueryPool(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkResetQueryPool", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkResetQueryPool\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
             FieldToString(strStrm, false, "firstQuery", toStringFlags, tabCount, tabSize, ToString(firstQuery, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "queryCount", toStringFlags, tabCount, tabSize, ToString(queryCount, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3655,13 +5275,23 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValue(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetSemaphoreCounterValue", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetSemaphoreCounterValue\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "semaphore", toStringFlags, tabCount, tabSize, HandleIdToString(semaphore));
             FieldToString(strStrm, false, "[out]pValue", toStringFlags, tabCount, tabSize, PointerDecoderToString(pValue, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3677,13 +5307,23 @@ void VulkanAsciiConsumer::Process_vkWaitSemaphores(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkWaitSemaphores", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkWaitSemaphores\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pWaitInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pWaitInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3698,12 +5338,22 @@ void VulkanAsciiConsumer::Process_vkSignalSemaphore(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkSignalSemaphore", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSignalSemaphore\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pSignalInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSignalInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3718,12 +5368,22 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddress(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetBufferDeviceAddress", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetBufferDeviceAddress\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3738,12 +5398,22 @@ void VulkanAsciiConsumer::Process_vkGetBufferOpaqueCaptureAddress(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetBufferOpaqueCaptureAddress", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetBufferOpaqueCaptureAddress\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3758,12 +5428,22 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddress(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceMemoryOpaqueCaptureAddress", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceMemoryOpaqueCaptureAddress\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3779,13 +5459,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceToolProperties(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceToolProperties", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceToolProperties\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pToolCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pToolCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pToolProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pToolProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3802,14 +5492,24 @@ void VulkanAsciiConsumer::Process_vkCreatePrivateDataSlot(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreatePrivateDataSlot", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreatePrivateDataSlot\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPrivateDataSlot", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pPrivateDataSlot));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3824,12 +5524,22 @@ void VulkanAsciiConsumer::Process_vkDestroyPrivateDataSlot(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyPrivateDataSlot", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyPrivateDataSlot\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "privateDataSlot", toStringFlags, tabCount, tabSize, HandleIdToString(privateDataSlot));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3847,15 +5557,25 @@ void VulkanAsciiConsumer::Process_vkSetPrivateData(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkSetPrivateData", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSetPrivateData\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "objectType", toStringFlags, tabCount, tabSize, '"' + ToString(objectType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "objectHandle", toStringFlags, tabCount, tabSize, ToString(objectHandle, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "privateDataSlot", toStringFlags, tabCount, tabSize, HandleIdToString(privateDataSlot));
             FieldToString(strStrm, false, "data", toStringFlags, tabCount, tabSize, ToString(data, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3872,14 +5592,24 @@ void VulkanAsciiConsumer::Process_vkGetPrivateData(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPrivateData", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPrivateData\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "objectType", toStringFlags, tabCount, tabSize, '"' + ToString(objectType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "objectHandle", toStringFlags, tabCount, tabSize, ToString(objectHandle, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "privateDataSlot", toStringFlags, tabCount, tabSize, HandleIdToString(privateDataSlot));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, PointerDecoderToString(pData, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3894,12 +5624,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetEvent2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetEvent2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetEvent2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
             FieldToString(strStrm, false, "pDependencyInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDependencyInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3914,12 +5654,22 @@ void VulkanAsciiConsumer::Process_vkCmdResetEvent2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdResetEvent2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdResetEvent2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
             FieldToString(strStrm, false, "stageMask", toStringFlags, tabCount, tabSize, ToString(stageMask, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3935,13 +5685,23 @@ void VulkanAsciiConsumer::Process_vkCmdWaitEvents2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdWaitEvents2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWaitEvents2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "eventCount", toStringFlags, tabCount, tabSize, ToString(eventCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pEvents", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(eventCount, pEvents, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pDependencyInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pDependencyInfos, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3955,11 +5715,21 @@ void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdPipelineBarrier2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdPipelineBarrier2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pDependencyInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDependencyInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3975,13 +5745,23 @@ void VulkanAsciiConsumer::Process_vkCmdWriteTimestamp2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdWriteTimestamp2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWriteTimestamp2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "stage", toStringFlags, tabCount, tabSize, ToString(stage, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
             FieldToString(strStrm, false, "query", toStringFlags, tabCount, tabSize, ToString(query, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -3998,14 +5778,24 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkQueueSubmit2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueSubmit2\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "submitCount", toStringFlags, tabCount, tabSize, ToString(submitCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSubmits", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSubmits, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4019,11 +5809,21 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBuffer2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyBuffer2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyBuffer2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCopyBufferInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCopyBufferInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4037,11 +5837,21 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImage2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyImage2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyImage2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCopyImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCopyImageInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4055,11 +5865,21 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBufferToImage2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyBufferToImage2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyBufferToImage2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCopyBufferToImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCopyBufferToImageInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4073,11 +5893,21 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImageToBuffer2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyImageToBuffer2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyImageToBuffer2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCopyImageToBufferInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCopyImageToBufferInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4091,11 +5921,21 @@ void VulkanAsciiConsumer::Process_vkCmdBlitImage2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBlitImage2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBlitImage2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pBlitImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pBlitImageInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4109,11 +5949,21 @@ void VulkanAsciiConsumer::Process_vkCmdResolveImage2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdResolveImage2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdResolveImage2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pResolveImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pResolveImageInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4127,11 +5977,21 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRendering(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBeginRendering", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginRendering\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pRenderingInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRenderingInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4144,10 +6004,20 @@ void VulkanAsciiConsumer::Process_vkCmdEndRendering(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdEndRendering", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndRendering\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4161,11 +6031,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetCullMode(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetCullMode", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetCullMode\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "cullMode", toStringFlags, tabCount, tabSize, ToString(cullMode, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4179,11 +6059,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetFrontFace(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetFrontFace", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetFrontFace\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "frontFace", toStringFlags, tabCount, tabSize, '"' + ToString(frontFace, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4197,11 +6087,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveTopology(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetPrimitiveTopology", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetPrimitiveTopology\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "primitiveTopology", toStringFlags, tabCount, tabSize, '"' + ToString(primitiveTopology, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4216,12 +6116,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportWithCount(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetViewportWithCount", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetViewportWithCount\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "viewportCount", toStringFlags, tabCount, tabSize, ToString(viewportCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pViewports", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pViewports, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4236,12 +6146,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetScissorWithCount(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetScissorWithCount", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetScissorWithCount\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "scissorCount", toStringFlags, tabCount, tabSize, ToString(scissorCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pScissors", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pScissors, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4260,9 +6180,14 @@ void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers2(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBindVertexBuffers2", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindVertexBuffers2\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstBinding", toStringFlags, tabCount, tabSize, ToString(firstBinding, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "bindingCount", toStringFlags, tabCount, tabSize, ToString(bindingCount, toStringFlags, tabCount, tabSize));
@@ -4270,6 +6195,11 @@ void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers2(
             FieldToString(strStrm, false, "pOffsets", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(bindingCount, pOffsets, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSizes", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(bindingCount, pSizes, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pStrides", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(bindingCount, pStrides, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4283,11 +6213,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthTestEnable(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetDepthTestEnable", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthTestEnable\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthTestEnable", toStringFlags, tabCount, tabSize, ToString(depthTestEnable, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4301,11 +6241,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthWriteEnable(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetDepthWriteEnable", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthWriteEnable\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthWriteEnable", toStringFlags, tabCount, tabSize, ToString(depthWriteEnable, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4319,11 +6269,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthCompareOp(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetDepthCompareOp", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthCompareOp\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthCompareOp", toStringFlags, tabCount, tabSize, '"' + ToString(depthCompareOp, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4337,11 +6297,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBoundsTestEnable(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetDepthBoundsTestEnable", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthBoundsTestEnable\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthBoundsTestEnable", toStringFlags, tabCount, tabSize, ToString(depthBoundsTestEnable, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4355,11 +6325,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilTestEnable(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetStencilTestEnable", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetStencilTestEnable\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "stencilTestEnable", toStringFlags, tabCount, tabSize, ToString(stencilTestEnable, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4377,15 +6357,25 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilOp(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetStencilOp", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetStencilOp\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "faceMask", toStringFlags, tabCount, tabSize, ToString(faceMask, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "failOp", toStringFlags, tabCount, tabSize, '"' + ToString(failOp, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "passOp", toStringFlags, tabCount, tabSize, '"' + ToString(passOp, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "depthFailOp", toStringFlags, tabCount, tabSize, '"' + ToString(depthFailOp, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "compareOp", toStringFlags, tabCount, tabSize, '"' + ToString(compareOp, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4399,11 +6389,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetRasterizerDiscardEnable(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetRasterizerDiscardEnable", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetRasterizerDiscardEnable\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "rasterizerDiscardEnable", toStringFlags, tabCount, tabSize, ToString(rasterizerDiscardEnable, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4417,11 +6417,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBiasEnable(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetDepthBiasEnable", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthBiasEnable\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthBiasEnable", toStringFlags, tabCount, tabSize, ToString(depthBiasEnable, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4435,11 +6445,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveRestartEnable(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetPrimitiveRestartEnable", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetPrimitiveRestartEnable\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "primitiveRestartEnable", toStringFlags, tabCount, tabSize, ToString(primitiveRestartEnable, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4454,12 +6474,22 @@ void VulkanAsciiConsumer::Process_vkGetDeviceBufferMemoryRequirements(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceBufferMemoryRequirements", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceBufferMemoryRequirements\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4474,12 +6504,22 @@ void VulkanAsciiConsumer::Process_vkGetDeviceImageMemoryRequirements(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceImageMemoryRequirements", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceImageMemoryRequirements\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4495,13 +6535,23 @@ void VulkanAsciiConsumer::Process_vkGetDeviceImageSparseMemoryRequirements(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceImageSparseMemoryRequirements", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceImageSparseMemoryRequirements\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSparseMemoryRequirementCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSparseMemoryRequirementCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSparseMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSparseMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4516,12 +6566,22 @@ void VulkanAsciiConsumer::Process_vkDestroySurfaceKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroySurfaceKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroySurfaceKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4538,14 +6598,24 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceSupportKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceSupportKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSurfaceSupportKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pSupported", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSupported, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4561,13 +6631,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceCapabilitiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSurfaceCapabilitiesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pSurfaceCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceCapabilities, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4584,14 +6664,24 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormatsKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceFormatsKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSurfaceFormatsKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pSurfaceFormatCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceFormatCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurfaceFormats", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSurfaceFormats, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4608,14 +6698,24 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfacePresentModesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSurfacePresentModesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pPresentModeCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentModeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPresentModes", toStringFlags, tabCount, tabSize, EnumPointerDecoderArrayToString(pPresentModeCount, pPresentModes, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4632,14 +6732,24 @@ void VulkanAsciiConsumer::Process_vkCreateSwapchainKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateSwapchainKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateSwapchainKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSwapchain", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSwapchain));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4654,12 +6764,22 @@ void VulkanAsciiConsumer::Process_vkDestroySwapchainKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroySwapchainKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroySwapchainKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4676,14 +6796,24 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainImagesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetSwapchainImagesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetSwapchainImagesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "[out]pSwapchainImageCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSwapchainImageCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSwapchainImages", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(pSwapchainImageCount, pSwapchainImages, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4702,16 +6832,26 @@ void VulkanAsciiConsumer::Process_vkAcquireNextImageKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkAcquireNextImageKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAcquireNextImageKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "semaphore", toStringFlags, tabCount, tabSize, HandleIdToString(semaphore));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
             FieldToString(strStrm, false, "[out]pImageIndex", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageIndex, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4726,12 +6866,22 @@ void VulkanAsciiConsumer::Process_vkQueuePresentKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkQueuePresentKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueuePresentKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "pPresentInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4746,12 +6896,22 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupPresentCapabilitiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceGroupPresentCapabilitiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceGroupPresentCapabilitiesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "[out]pDeviceGroupPresentCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDeviceGroupPresentCapabilities, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4767,13 +6927,23 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceGroupSurfacePresentModesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceGroupSurfacePresentModesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pModes", toStringFlags, tabCount, tabSize, PointerDecoderToString(pModes, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4790,14 +6960,24 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDevicePresentRectanglesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDevicePresentRectanglesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDevicePresentRectanglesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pRectCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRectCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pRects", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pRects, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4813,13 +6993,23 @@ void VulkanAsciiConsumer::Process_vkAcquireNextImage2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkAcquireNextImage2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAcquireNextImage2KHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAcquireInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAcquireInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImageIndex", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageIndex, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4835,13 +7025,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceDisplayPropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceDisplayPropertiesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4857,13 +7057,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPlanePropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceDisplayPlanePropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceDisplayPlanePropertiesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4880,14 +7090,24 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneSupportedDisplaysKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDisplayPlaneSupportedDisplaysKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDisplayPlaneSupportedDisplaysKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "planeIndex", toStringFlags, tabCount, tabSize, ToString(planeIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDisplayCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDisplays", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(pDisplayCount, pDisplays, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4904,14 +7124,24 @@ void VulkanAsciiConsumer::Process_vkGetDisplayModePropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDisplayModePropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDisplayModePropertiesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4929,15 +7159,25 @@ void VulkanAsciiConsumer::Process_vkCreateDisplayModeKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateDisplayModeKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDisplayModeKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMode", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pMode));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4954,14 +7194,24 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilitiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDisplayPlaneCapabilitiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDisplayPlaneCapabilitiesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "mode", toStringFlags, tabCount, tabSize, HandleIdToString(mode));
             FieldToString(strStrm, false, "planeIndex", toStringFlags, tabCount, tabSize, ToString(planeIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCapabilities, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -4978,14 +7228,24 @@ void VulkanAsciiConsumer::Process_vkCreateDisplayPlaneSurfaceKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateDisplayPlaneSurfaceKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDisplayPlaneSurfaceKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5003,15 +7263,25 @@ void VulkanAsciiConsumer::Process_vkCreateSharedSwapchainsKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateSharedSwapchainsKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateSharedSwapchainsKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchainCount", toStringFlags, tabCount, tabSize, ToString(swapchainCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSwapchains", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(swapchainCount, pSwapchains, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5028,14 +7298,24 @@ void VulkanAsciiConsumer::Process_vkCreateXlibSurfaceKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateXlibSurfaceKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateXlibSurfaceKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5052,14 +7332,24 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXlibPresentationSupportKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceXlibPresentationSupportKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceXlibPresentationSupportKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dpy", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dpy));
             FieldToString(strStrm, false, "visualID", toStringFlags, tabCount, tabSize, ToString(visualID, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5076,14 +7366,24 @@ void VulkanAsciiConsumer::Process_vkCreateXcbSurfaceKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateXcbSurfaceKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateXcbSurfaceKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5100,14 +7400,24 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceXcbPresentationSupportKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceXcbPresentationSupportKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceXcbPresentationSupportKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "connection", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(connection));
             FieldToString(strStrm, false, "visual_id", toStringFlags, tabCount, tabSize, ToString(visual_id, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5124,14 +7434,24 @@ void VulkanAsciiConsumer::Process_vkCreateWaylandSurfaceKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateWaylandSurfaceKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateWaylandSurfaceKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5147,13 +7467,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWaylandPresentationSupportK
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceWaylandPresentationSupportKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceWaylandPresentationSupportKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(display));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5170,14 +7500,24 @@ void VulkanAsciiConsumer::Process_vkCreateAndroidSurfaceKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateAndroidSurfaceKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateAndroidSurfaceKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5194,14 +7534,24 @@ void VulkanAsciiConsumer::Process_vkCreateWin32SurfaceKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateWin32SurfaceKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateWin32SurfaceKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5216,12 +7566,22 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceWin32PresentationSupportKHR
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceWin32PresentationSupportKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceWin32PresentationSupportKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5235,11 +7595,21 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRenderingKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBeginRenderingKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginRenderingKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pRenderingInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRenderingInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5252,10 +7622,20 @@ void VulkanAsciiConsumer::Process_vkCmdEndRenderingKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdEndRenderingKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndRenderingKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5269,11 +7649,21 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFeatures2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceFeatures2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceFeatures2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pFeatures", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFeatures, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5287,11 +7677,21 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceProperties2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceProperties2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5306,12 +7706,22 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFormatProperties2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceFormatProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceFormatProperties2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "format", toStringFlags, tabCount, tabSize, '"' + ToString(format, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFormatProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5327,13 +7737,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceImageFormatProperties2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceImageFormatProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceImageFormatProperties2KHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pImageFormatInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pImageFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImageFormatProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5348,12 +7768,22 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyProperties2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceQueueFamilyProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceQueueFamilyProperties2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pQueueFamilyPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pQueueFamilyPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pQueueFamilyProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pQueueFamilyProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5367,11 +7797,21 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMemoryProperties2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceMemoryProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceMemoryProperties2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pMemoryProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5387,13 +7827,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSparseImageFormatProperties
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSparseImageFormatProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSparseImageFormatProperties2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pFormatInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFormatInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5410,14 +7860,24 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupPeerMemoryFeaturesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceGroupPeerMemoryFeaturesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceGroupPeerMemoryFeaturesKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "heapIndex", toStringFlags, tabCount, tabSize, ToString(heapIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "localDeviceIndex", toStringFlags, tabCount, tabSize, ToString(localDeviceIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "remoteDeviceIndex", toStringFlags, tabCount, tabSize, ToString(remoteDeviceIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPeerMemoryFeatures", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPeerMemoryFeatures, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5431,11 +7891,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetDeviceMaskKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetDeviceMaskKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDeviceMaskKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "deviceMask", toStringFlags, tabCount, tabSize, ToString(deviceMask, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5454,9 +7924,14 @@ void VulkanAsciiConsumer::Process_vkCmdDispatchBaseKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDispatchBaseKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDispatchBaseKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "baseGroupX", toStringFlags, tabCount, tabSize, ToString(baseGroupX, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "baseGroupY", toStringFlags, tabCount, tabSize, ToString(baseGroupY, toStringFlags, tabCount, tabSize));
@@ -5464,6 +7939,11 @@ void VulkanAsciiConsumer::Process_vkCmdDispatchBaseKHR(
             FieldToString(strStrm, false, "groupCountX", toStringFlags, tabCount, tabSize, ToString(groupCountX, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "groupCountY", toStringFlags, tabCount, tabSize, ToString(groupCountY, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "groupCountZ", toStringFlags, tabCount, tabSize, ToString(groupCountZ, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5478,12 +7958,22 @@ void VulkanAsciiConsumer::Process_vkTrimCommandPoolKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkTrimCommandPoolKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkTrimCommandPoolKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "commandPool", toStringFlags, tabCount, tabSize, HandleIdToString(commandPool));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5499,13 +7989,23 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceGroupsKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkEnumeratePhysicalDeviceGroupsKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkEnumeratePhysicalDeviceGroupsKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPhysicalDeviceGroupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPhysicalDeviceGroupProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pPhysicalDeviceGroupProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5520,12 +8020,22 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalBufferPropertiesKHR
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceExternalBufferPropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceExternalBufferPropertiesKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pExternalBufferInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalBufferInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pExternalBufferProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalBufferProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5541,13 +8051,23 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetMemoryWin32HandleKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryWin32HandleKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetWin32HandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHandle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHandle));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5564,14 +8084,24 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandlePropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetMemoryWin32HandlePropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryWin32HandlePropertiesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "handle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(handle));
             FieldToString(strStrm, false, "[out]pMemoryWin32HandleProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryWin32HandleProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5587,13 +8117,23 @@ void VulkanAsciiConsumer::Process_vkGetMemoryFdKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetMemoryFdKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryFdKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetFdInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFd", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFd, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5610,14 +8150,24 @@ void VulkanAsciiConsumer::Process_vkGetMemoryFdPropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetMemoryFdPropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryFdPropertiesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "fd", toStringFlags, tabCount, tabSize, ToString(fd, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryFdProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryFdProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5632,12 +8182,22 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalSemaphoreProperties
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceExternalSemaphorePropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceExternalSemaphorePropertiesKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pExternalSemaphoreInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalSemaphoreInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pExternalSemaphoreProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalSemaphoreProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5652,12 +8212,22 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreWin32HandleKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkImportSemaphoreWin32HandleKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkImportSemaphoreWin32HandleKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportSemaphoreWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportSemaphoreWin32HandleInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5673,13 +8243,23 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreWin32HandleKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetSemaphoreWin32HandleKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetSemaphoreWin32HandleKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetWin32HandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHandle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHandle));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5694,12 +8274,22 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreFdKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkImportSemaphoreFdKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkImportSemaphoreFdKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportSemaphoreFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportSemaphoreFdInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5715,13 +8305,23 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreFdKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetSemaphoreFdKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetSemaphoreFdKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetFdInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFd", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFd, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5739,15 +8339,25 @@ void VulkanAsciiConsumer::Process_vkCmdPushDescriptorSetKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdPushDescriptorSetKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdPushDescriptorSetKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pipelineBindPoint", toStringFlags, tabCount, tabSize, '"' + ToString(pipelineBindPoint, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "layout", toStringFlags, tabCount, tabSize, HandleIdToString(layout));
             FieldToString(strStrm, false, "set", toStringFlags, tabCount, tabSize, ToString(set, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "descriptorWriteCount", toStringFlags, tabCount, tabSize, ToString(descriptorWriteCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pDescriptorWrites", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pDescriptorWrites, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5764,14 +8374,24 @@ void VulkanAsciiConsumer::Process_vkCreateDescriptorUpdateTemplateKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateDescriptorUpdateTemplateKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDescriptorUpdateTemplateKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDescriptorUpdateTemplate", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDescriptorUpdateTemplate));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5786,12 +8406,22 @@ void VulkanAsciiConsumer::Process_vkDestroyDescriptorUpdateTemplateKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyDescriptorUpdateTemplateKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyDescriptorUpdateTemplateKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorUpdateTemplate", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorUpdateTemplate));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5808,14 +8438,24 @@ void VulkanAsciiConsumer::Process_vkCreateRenderPass2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateRenderPass2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateRenderPass2KHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pRenderPass", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pRenderPass));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5830,12 +8470,22 @@ void VulkanAsciiConsumer::Process_vkCmdBeginRenderPass2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBeginRenderPass2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginRenderPass2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pRenderPassBegin", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRenderPassBegin, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSubpassBeginInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSubpassBeginInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5850,12 +8500,22 @@ void VulkanAsciiConsumer::Process_vkCmdNextSubpass2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdNextSubpass2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdNextSubpass2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pSubpassBeginInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSubpassBeginInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSubpassEndInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSubpassEndInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5869,11 +8529,21 @@ void VulkanAsciiConsumer::Process_vkCmdEndRenderPass2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdEndRenderPass2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndRenderPass2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pSubpassEndInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSubpassEndInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5888,12 +8558,22 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainStatusKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetSwapchainStatusKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetSwapchainStatusKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5908,12 +8588,22 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalFencePropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceExternalFencePropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceExternalFencePropertiesKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pExternalFenceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalFenceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pExternalFenceProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalFenceProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5928,12 +8618,22 @@ void VulkanAsciiConsumer::Process_vkImportFenceWin32HandleKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkImportFenceWin32HandleKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkImportFenceWin32HandleKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportFenceWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportFenceWin32HandleInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5949,13 +8649,23 @@ void VulkanAsciiConsumer::Process_vkGetFenceWin32HandleKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetFenceWin32HandleKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetFenceWin32HandleKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetWin32HandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetWin32HandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHandle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHandle));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5970,12 +8680,22 @@ void VulkanAsciiConsumer::Process_vkImportFenceFdKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkImportFenceFdKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkImportFenceFdKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportFenceFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportFenceFdInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -5991,13 +8711,23 @@ void VulkanAsciiConsumer::Process_vkGetFenceFdKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetFenceFdKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetFenceFdKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetFdInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetFdInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFd", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFd, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6015,15 +8745,25 @@ void VulkanAsciiConsumer::Process_vkEnumeratePhysicalDeviceQueueFamilyPerformanc
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCounterCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCounterCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCounters", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCounters, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCounterDescriptions", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCounterDescriptions, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6038,12 +8778,22 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceQueueFamilyPerformanceQuery
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pPerformanceQueryCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPerformanceQueryCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pNumPasses", toStringFlags, tabCount, tabSize, PointerDecoderToString(pNumPasses, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6058,12 +8808,22 @@ void VulkanAsciiConsumer::Process_vkAcquireProfilingLockKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkAcquireProfilingLockKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAcquireProfilingLockKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6076,10 +8836,20 @@ void VulkanAsciiConsumer::Process_vkReleaseProfilingLockKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkReleaseProfilingLockKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkReleaseProfilingLockKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6095,13 +8865,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceCapabilities2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSurfaceCapabilities2KHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurfaceCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceCapabilities, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6118,14 +8898,24 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceFormats2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceFormats2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSurfaceFormats2KHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurfaceFormatCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceFormatCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurfaceFormats", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSurfaceFormats, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6141,13 +8931,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayProperties2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceDisplayProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceDisplayProperties2KHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6163,13 +8963,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDisplayPlaneProperties2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceDisplayPlaneProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceDisplayPlaneProperties2KHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6186,14 +8996,24 @@ void VulkanAsciiConsumer::Process_vkGetDisplayModeProperties2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDisplayModeProperties2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDisplayModeProperties2KHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6209,13 +9029,23 @@ void VulkanAsciiConsumer::Process_vkGetDisplayPlaneCapabilities2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDisplayPlaneCapabilities2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDisplayPlaneCapabilities2KHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pDisplayPlaneInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayPlaneInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCapabilities, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6230,12 +9060,22 @@ void VulkanAsciiConsumer::Process_vkGetImageMemoryRequirements2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetImageMemoryRequirements2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageMemoryRequirements2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6250,12 +9090,22 @@ void VulkanAsciiConsumer::Process_vkGetBufferMemoryRequirements2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetBufferMemoryRequirements2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetBufferMemoryRequirements2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6271,13 +9121,23 @@ void VulkanAsciiConsumer::Process_vkGetImageSparseMemoryRequirements2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetImageSparseMemoryRequirements2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageSparseMemoryRequirements2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSparseMemoryRequirementCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSparseMemoryRequirementCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSparseMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSparseMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6294,14 +9154,24 @@ void VulkanAsciiConsumer::Process_vkCreateSamplerYcbcrConversionKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateSamplerYcbcrConversionKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateSamplerYcbcrConversionKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pYcbcrConversion", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pYcbcrConversion));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6316,12 +9186,22 @@ void VulkanAsciiConsumer::Process_vkDestroySamplerYcbcrConversionKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroySamplerYcbcrConversionKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroySamplerYcbcrConversionKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "ycbcrConversion", toStringFlags, tabCount, tabSize, HandleIdToString(ycbcrConversion));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6337,13 +9217,23 @@ void VulkanAsciiConsumer::Process_vkBindBufferMemory2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkBindBufferMemory2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkBindBufferMemory2KHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6359,13 +9249,23 @@ void VulkanAsciiConsumer::Process_vkBindImageMemory2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkBindImageMemory2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkBindImageMemory2KHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6380,12 +9280,22 @@ void VulkanAsciiConsumer::Process_vkGetDescriptorSetLayoutSupportKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDescriptorSetLayoutSupportKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDescriptorSetLayoutSupportKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSupport", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSupport, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6404,9 +9314,14 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCountKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDrawIndirectCountKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndirectCountKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "offset", toStringFlags, tabCount, tabSize, ToString(offset, toStringFlags, tabCount, tabSize));
@@ -6414,6 +9329,11 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCountKHR(
             FieldToString(strStrm, false, "countBufferOffset", toStringFlags, tabCount, tabSize, ToString(countBufferOffset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "maxDrawCount", toStringFlags, tabCount, tabSize, ToString(maxDrawCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6432,9 +9352,14 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCountKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDrawIndexedIndirectCountKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndexedIndirectCountKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "offset", toStringFlags, tabCount, tabSize, ToString(offset, toStringFlags, tabCount, tabSize));
@@ -6442,6 +9367,11 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCountKHR(
             FieldToString(strStrm, false, "countBufferOffset", toStringFlags, tabCount, tabSize, ToString(countBufferOffset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "maxDrawCount", toStringFlags, tabCount, tabSize, ToString(maxDrawCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6457,13 +9387,23 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreCounterValueKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetSemaphoreCounterValueKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetSemaphoreCounterValueKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "semaphore", toStringFlags, tabCount, tabSize, HandleIdToString(semaphore));
             FieldToString(strStrm, false, "[out]pValue", toStringFlags, tabCount, tabSize, PointerDecoderToString(pValue, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6479,13 +9419,23 @@ void VulkanAsciiConsumer::Process_vkWaitSemaphoresKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkWaitSemaphoresKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkWaitSemaphoresKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pWaitInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pWaitInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6500,12 +9450,22 @@ void VulkanAsciiConsumer::Process_vkSignalSemaphoreKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkSignalSemaphoreKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSignalSemaphoreKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pSignalInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSignalInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6521,13 +9481,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceFragmentShadingRatesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceFragmentShadingRatesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceFragmentShadingRatesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pFragmentShadingRateCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFragmentShadingRateCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFragmentShadingRates", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pFragmentShadingRates, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6542,12 +9512,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetFragmentShadingRateKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetFragmentShadingRateKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetFragmentShadingRateKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pFragmentSize", toStringFlags, tabCount, tabSize, PointerDecoderToString(pFragmentSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "combinerOps", toStringFlags, tabCount, tabSize, EnumPointerDecoderArrayToString(2, combinerOps, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6564,14 +9544,24 @@ void VulkanAsciiConsumer::Process_vkWaitForPresentKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkWaitForPresentKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkWaitForPresentKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "presentId", toStringFlags, tabCount, tabSize, ToString(presentId, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "timeout", toStringFlags, tabCount, tabSize, ToString(timeout, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6586,12 +9576,22 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetBufferDeviceAddressKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetBufferDeviceAddressKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6606,12 +9606,22 @@ void VulkanAsciiConsumer::Process_vkGetBufferOpaqueCaptureAddressKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetBufferOpaqueCaptureAddressKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetBufferOpaqueCaptureAddressKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6626,12 +9636,22 @@ void VulkanAsciiConsumer::Process_vkGetDeviceMemoryOpaqueCaptureAddressKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceMemoryOpaqueCaptureAddressKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceMemoryOpaqueCaptureAddressKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6647,13 +9667,23 @@ void VulkanAsciiConsumer::Process_vkCreateDeferredOperationKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateDeferredOperationKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDeferredOperationKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDeferredOperation", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDeferredOperation));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6668,12 +9698,22 @@ void VulkanAsciiConsumer::Process_vkDestroyDeferredOperationKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyDeferredOperationKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyDeferredOperationKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6688,12 +9728,22 @@ void VulkanAsciiConsumer::Process_vkGetDeferredOperationMaxConcurrencyKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeferredOperationMaxConcurrencyKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeferredOperationMaxConcurrencyKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6708,12 +9758,22 @@ void VulkanAsciiConsumer::Process_vkGetDeferredOperationResultKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeferredOperationResultKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeferredOperationResultKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6728,12 +9788,22 @@ void VulkanAsciiConsumer::Process_vkDeferredOperationJoinKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDeferredOperationJoinKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDeferredOperationJoinKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "operation", toStringFlags, tabCount, tabSize, HandleIdToString(operation));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6750,14 +9820,24 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutablePropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPipelineExecutablePropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPipelineExecutablePropertiesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pPipelineInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPipelineInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pExecutableCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExecutableCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6774,14 +9854,24 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutableStatisticsKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPipelineExecutableStatisticsKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPipelineExecutableStatisticsKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pExecutableInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExecutableInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pStatisticCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pStatisticCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pStatistics", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pStatistics, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6798,14 +9888,24 @@ void VulkanAsciiConsumer::Process_vkGetPipelineExecutableInternalRepresentations
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPipelineExecutableInternalRepresentationsKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPipelineExecutableInternalRepresentationsKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pExecutableInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExecutableInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pInternalRepresentationCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInternalRepresentationCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pInternalRepresentations", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pInternalRepresentations, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6820,12 +9920,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetEvent2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetEvent2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetEvent2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
             FieldToString(strStrm, false, "pDependencyInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDependencyInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6840,12 +9950,22 @@ void VulkanAsciiConsumer::Process_vkCmdResetEvent2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdResetEvent2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdResetEvent2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "event", toStringFlags, tabCount, tabSize, HandleIdToString(event));
             FieldToString(strStrm, false, "stageMask", toStringFlags, tabCount, tabSize, ToString(stageMask, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6861,13 +9981,23 @@ void VulkanAsciiConsumer::Process_vkCmdWaitEvents2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdWaitEvents2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWaitEvents2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "eventCount", toStringFlags, tabCount, tabSize, ToString(eventCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pEvents", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(eventCount, pEvents, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pDependencyInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pDependencyInfos, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6881,11 +10011,21 @@ void VulkanAsciiConsumer::Process_vkCmdPipelineBarrier2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdPipelineBarrier2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdPipelineBarrier2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pDependencyInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDependencyInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6901,13 +10041,23 @@ void VulkanAsciiConsumer::Process_vkCmdWriteTimestamp2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdWriteTimestamp2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWriteTimestamp2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "stage", toStringFlags, tabCount, tabSize, ToString(stage, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
             FieldToString(strStrm, false, "query", toStringFlags, tabCount, tabSize, ToString(query, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6924,14 +10074,24 @@ void VulkanAsciiConsumer::Process_vkQueueSubmit2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkQueueSubmit2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueSubmit2KHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "submitCount", toStringFlags, tabCount, tabSize, ToString(submitCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSubmits", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSubmits, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "fence", toStringFlags, tabCount, tabSize, HandleIdToString(fence));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6948,14 +10108,24 @@ void VulkanAsciiConsumer::Process_vkCmdWriteBufferMarker2AMD(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdWriteBufferMarker2AMD", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWriteBufferMarker2AMD\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "stage", toStringFlags, tabCount, tabSize, ToString(stage, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dstBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(dstBuffer));
             FieldToString(strStrm, false, "dstOffset", toStringFlags, tabCount, tabSize, ToString(dstOffset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "marker", toStringFlags, tabCount, tabSize, ToString(marker, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6970,12 +10140,22 @@ void VulkanAsciiConsumer::Process_vkGetQueueCheckpointData2NV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetQueueCheckpointData2NV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetQueueCheckpointData2NV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "[out]pCheckpointDataCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCheckpointDataCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCheckpointData", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCheckpointData, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -6989,11 +10169,21 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBuffer2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyBuffer2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyBuffer2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCopyBufferInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCopyBufferInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7007,11 +10197,21 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImage2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyImage2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyImage2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCopyImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCopyImageInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7025,11 +10225,21 @@ void VulkanAsciiConsumer::Process_vkCmdCopyBufferToImage2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyBufferToImage2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyBufferToImage2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCopyBufferToImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCopyBufferToImageInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7043,11 +10253,21 @@ void VulkanAsciiConsumer::Process_vkCmdCopyImageToBuffer2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyImageToBuffer2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyImageToBuffer2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCopyImageToBufferInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCopyImageToBufferInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7061,11 +10281,21 @@ void VulkanAsciiConsumer::Process_vkCmdBlitImage2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBlitImage2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBlitImage2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pBlitImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pBlitImageInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7079,11 +10309,21 @@ void VulkanAsciiConsumer::Process_vkCmdResolveImage2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdResolveImage2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdResolveImage2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pResolveImageInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pResolveImageInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7097,11 +10337,21 @@ void VulkanAsciiConsumer::Process_vkCmdTraceRaysIndirect2KHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdTraceRaysIndirect2KHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdTraceRaysIndirect2KHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "indirectDeviceAddress", toStringFlags, tabCount, tabSize, ToString(indirectDeviceAddress, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7116,12 +10366,22 @@ void VulkanAsciiConsumer::Process_vkGetDeviceBufferMemoryRequirementsKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceBufferMemoryRequirementsKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceBufferMemoryRequirementsKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7136,12 +10396,22 @@ void VulkanAsciiConsumer::Process_vkGetDeviceImageMemoryRequirementsKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceImageMemoryRequirementsKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceImageMemoryRequirementsKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7157,13 +10427,23 @@ void VulkanAsciiConsumer::Process_vkGetDeviceImageSparseMemoryRequirementsKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceImageSparseMemoryRequirementsKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceImageSparseMemoryRequirementsKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSparseMemoryRequirementCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSparseMemoryRequirementCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSparseMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pSparseMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7180,14 +10460,24 @@ void VulkanAsciiConsumer::Process_vkCreateDebugReportCallbackEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateDebugReportCallbackEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDebugReportCallbackEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCallback", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pCallback));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7202,12 +10492,22 @@ void VulkanAsciiConsumer::Process_vkDestroyDebugReportCallbackEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyDebugReportCallbackEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyDebugReportCallbackEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "callback", toStringFlags, tabCount, tabSize, HandleIdToString(callback));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7227,9 +10527,14 @@ void VulkanAsciiConsumer::Process_vkDebugReportMessageEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDebugReportMessageEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDebugReportMessageEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "objectType", toStringFlags, tabCount, tabSize, '"' + ToString(objectType, toStringFlags, tabCount, tabSize) + '"');
@@ -7238,6 +10543,11 @@ void VulkanAsciiConsumer::Process_vkDebugReportMessageEXT(
             FieldToString(strStrm, false, "messageCode", toStringFlags, tabCount, tabSize, ToString(messageCode, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pLayerPrefix", toStringFlags, tabCount, tabSize, StringDecoderToString(pLayerPrefix));
             FieldToString(strStrm, false, "pMessage", toStringFlags, tabCount, tabSize, StringDecoderToString(pMessage));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7252,12 +10562,22 @@ void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectTagEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDebugMarkerSetObjectTagEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDebugMarkerSetObjectTagEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pTagInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pTagInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7272,12 +10592,22 @@ void VulkanAsciiConsumer::Process_vkDebugMarkerSetObjectNameEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDebugMarkerSetObjectNameEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDebugMarkerSetObjectNameEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pNameInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pNameInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7291,11 +10621,21 @@ void VulkanAsciiConsumer::Process_vkCmdDebugMarkerBeginEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDebugMarkerBeginEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDebugMarkerBeginEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pMarkerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMarkerInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7308,10 +10648,20 @@ void VulkanAsciiConsumer::Process_vkCmdDebugMarkerEndEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDebugMarkerEndEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDebugMarkerEndEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7325,11 +10675,21 @@ void VulkanAsciiConsumer::Process_vkCmdDebugMarkerInsertEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDebugMarkerInsertEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDebugMarkerInsertEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pMarkerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMarkerInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7347,15 +10707,25 @@ void VulkanAsciiConsumer::Process_vkCmdBindTransformFeedbackBuffersEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBindTransformFeedbackBuffersEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindTransformFeedbackBuffersEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstBinding", toStringFlags, tabCount, tabSize, ToString(firstBinding, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "bindingCount", toStringFlags, tabCount, tabSize, ToString(bindingCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBuffers", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(bindingCount, pBuffers, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pOffsets", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(bindingCount, pOffsets, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSizes", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(bindingCount, pSizes, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7372,14 +10742,24 @@ void VulkanAsciiConsumer::Process_vkCmdBeginTransformFeedbackEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBeginTransformFeedbackEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginTransformFeedbackEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstCounterBuffer", toStringFlags, tabCount, tabSize, ToString(firstCounterBuffer, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "counterBufferCount", toStringFlags, tabCount, tabSize, ToString(counterBufferCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCounterBuffers", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(counterBufferCount, pCounterBuffers, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCounterBufferOffsets", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(counterBufferCount, pCounterBufferOffsets, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7396,14 +10776,24 @@ void VulkanAsciiConsumer::Process_vkCmdEndTransformFeedbackEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdEndTransformFeedbackEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndTransformFeedbackEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstCounterBuffer", toStringFlags, tabCount, tabSize, ToString(firstCounterBuffer, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "counterBufferCount", toStringFlags, tabCount, tabSize, ToString(counterBufferCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCounterBuffers", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(counterBufferCount, pCounterBuffers, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCounterBufferOffsets", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(counterBufferCount, pCounterBufferOffsets, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7420,14 +10810,24 @@ void VulkanAsciiConsumer::Process_vkCmdBeginQueryIndexedEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBeginQueryIndexedEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginQueryIndexedEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
             FieldToString(strStrm, false, "query", toStringFlags, tabCount, tabSize, ToString(query, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, ToString(index, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7443,13 +10843,23 @@ void VulkanAsciiConsumer::Process_vkCmdEndQueryIndexedEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdEndQueryIndexedEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndQueryIndexedEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
             FieldToString(strStrm, false, "query", toStringFlags, tabCount, tabSize, ToString(query, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, ToString(index, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7468,9 +10878,14 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectByteCountEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDrawIndirectByteCountEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndirectByteCountEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "instanceCount", toStringFlags, tabCount, tabSize, ToString(instanceCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "firstInstance", toStringFlags, tabCount, tabSize, ToString(firstInstance, toStringFlags, tabCount, tabSize));
@@ -7478,6 +10893,11 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectByteCountEXT(
             FieldToString(strStrm, false, "counterBufferOffset", toStringFlags, tabCount, tabSize, ToString(counterBufferOffset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "counterOffset", toStringFlags, tabCount, tabSize, ToString(counterOffset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "vertexStride", toStringFlags, tabCount, tabSize, ToString(vertexStride, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7492,12 +10912,22 @@ void VulkanAsciiConsumer::Process_vkGetImageViewHandleNVX(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetImageViewHandleNVX", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageViewHandleNVX\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7513,13 +10943,23 @@ void VulkanAsciiConsumer::Process_vkGetImageViewAddressNVX(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetImageViewAddressNVX", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageViewAddressNVX\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "imageView", toStringFlags, tabCount, tabSize, HandleIdToString(imageView));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7538,9 +10978,14 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCountAMD(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDrawIndirectCountAMD", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndirectCountAMD\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "offset", toStringFlags, tabCount, tabSize, ToString(offset, toStringFlags, tabCount, tabSize));
@@ -7548,6 +10993,11 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndirectCountAMD(
             FieldToString(strStrm, false, "countBufferOffset", toStringFlags, tabCount, tabSize, ToString(countBufferOffset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "maxDrawCount", toStringFlags, tabCount, tabSize, ToString(maxDrawCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7566,9 +11016,14 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCountAMD(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDrawIndexedIndirectCountAMD", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawIndexedIndirectCountAMD\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "offset", toStringFlags, tabCount, tabSize, ToString(offset, toStringFlags, tabCount, tabSize));
@@ -7576,6 +11031,11 @@ void VulkanAsciiConsumer::Process_vkCmdDrawIndexedIndirectCountAMD(
             FieldToString(strStrm, false, "countBufferOffset", toStringFlags, tabCount, tabSize, ToString(countBufferOffset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "maxDrawCount", toStringFlags, tabCount, tabSize, ToString(maxDrawCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7594,16 +11054,26 @@ void VulkanAsciiConsumer::Process_vkGetShaderInfoAMD(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetShaderInfoAMD", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetShaderInfoAMD\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "shaderStage", toStringFlags, tabCount, tabSize, '"' + ToString(shaderStage, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "infoType", toStringFlags, tabCount, tabSize, '"' + ToString(infoType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pInfoSize", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfoSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pInfo", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pInfo));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7620,14 +11090,24 @@ void VulkanAsciiConsumer::Process_vkCreateStreamDescriptorSurfaceGGP(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateStreamDescriptorSurfaceGGP", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateStreamDescriptorSurfaceGGP\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7648,11 +11128,16 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalImageFormatProperti
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceExternalImageFormatPropertiesNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceExternalImageFormatPropertiesNV\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "format", toStringFlags, tabCount, tabSize, '"' + ToString(format, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "type", toStringFlags, tabCount, tabSize, '"' + ToString(type, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "tiling", toStringFlags, tabCount, tabSize, '"' + ToString(tiling, toStringFlags, tabCount, tabSize) + '"');
@@ -7660,6 +11145,11 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceExternalImageFormatProperti
             FieldToString(strStrm, false, "flags", toStringFlags, tabCount, tabSize, ToString(flags, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "externalHandleType", toStringFlags, tabCount, tabSize, ToString(externalHandleType, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pExternalImageFormatProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pExternalImageFormatProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7676,14 +11166,24 @@ void VulkanAsciiConsumer::Process_vkGetMemoryWin32HandleNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetMemoryWin32HandleNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryWin32HandleNV\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, ToString(handleType, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHandle", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHandle));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7700,14 +11200,24 @@ void VulkanAsciiConsumer::Process_vkCreateViSurfaceNN(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateViSurfaceNN", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateViSurfaceNN\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7721,11 +11231,21 @@ void VulkanAsciiConsumer::Process_vkCmdBeginConditionalRenderingEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBeginConditionalRenderingEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginConditionalRenderingEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pConditionalRenderingBegin", toStringFlags, tabCount, tabSize, PointerDecoderToString(pConditionalRenderingBegin, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7738,10 +11258,20 @@ void VulkanAsciiConsumer::Process_vkCmdEndConditionalRenderingEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdEndConditionalRenderingEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndConditionalRenderingEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7757,13 +11287,23 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportWScalingNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetViewportWScalingNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetViewportWScalingNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstViewport", toStringFlags, tabCount, tabSize, ToString(firstViewport, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "viewportCount", toStringFlags, tabCount, tabSize, ToString(viewportCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pViewportWScalings", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pViewportWScalings, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7778,12 +11318,22 @@ void VulkanAsciiConsumer::Process_vkReleaseDisplayEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkReleaseDisplayEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkReleaseDisplayEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7799,13 +11349,23 @@ void VulkanAsciiConsumer::Process_vkAcquireXlibDisplayEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkAcquireXlibDisplayEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAcquireXlibDisplayEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "dpy", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dpy));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7822,14 +11382,24 @@ void VulkanAsciiConsumer::Process_vkGetRandROutputDisplayEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetRandROutputDisplayEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetRandROutputDisplayEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "dpy", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dpy));
             FieldToString(strStrm, false, "rrOutput", toStringFlags, tabCount, tabSize, ToString(rrOutput, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDisplay", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDisplay));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7845,13 +11415,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfaceCapabilities2EXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfaceCapabilities2EXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSurfaceCapabilities2EXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "surface", toStringFlags, tabCount, tabSize, HandleIdToString(surface));
             FieldToString(strStrm, false, "[out]pSurfaceCapabilities", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceCapabilities, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7867,13 +11447,23 @@ void VulkanAsciiConsumer::Process_vkDisplayPowerControlEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDisplayPowerControlEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDisplayPowerControlEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
             FieldToString(strStrm, false, "pDisplayPowerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayPowerInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7890,14 +11480,24 @@ void VulkanAsciiConsumer::Process_vkRegisterDeviceEventEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkRegisterDeviceEventEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkRegisterDeviceEventEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pDeviceEventInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDeviceEventInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFence", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pFence));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7915,15 +11515,25 @@ void VulkanAsciiConsumer::Process_vkRegisterDisplayEventEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkRegisterDisplayEventEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkRegisterDisplayEventEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
             FieldToString(strStrm, false, "pDisplayEventInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayEventInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pFence", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pFence));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7940,14 +11550,24 @@ void VulkanAsciiConsumer::Process_vkGetSwapchainCounterEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetSwapchainCounterEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetSwapchainCounterEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "counter", toStringFlags, tabCount, tabSize, '"' + ToString(counter, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pCounterValue", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCounterValue, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7963,13 +11583,23 @@ void VulkanAsciiConsumer::Process_vkGetRefreshCycleDurationGOOGLE(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetRefreshCycleDurationGOOGLE", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetRefreshCycleDurationGOOGLE\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "[out]pDisplayTimingProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDisplayTimingProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -7986,14 +11616,24 @@ void VulkanAsciiConsumer::Process_vkGetPastPresentationTimingGOOGLE(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPastPresentationTimingGOOGLE", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPastPresentationTimingGOOGLE\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
             FieldToString(strStrm, false, "[out]pPresentationTimingCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentationTimingCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPresentationTimings", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pPresentationTimings, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8009,13 +11649,23 @@ void VulkanAsciiConsumer::Process_vkCmdSetDiscardRectangleEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetDiscardRectangleEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDiscardRectangleEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstDiscardRectangle", toStringFlags, tabCount, tabSize, ToString(firstDiscardRectangle, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "discardRectangleCount", toStringFlags, tabCount, tabSize, ToString(discardRectangleCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pDiscardRectangles", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pDiscardRectangles, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8031,13 +11681,23 @@ void VulkanAsciiConsumer::Process_vkSetHdrMetadataEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkSetHdrMetadataEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSetHdrMetadataEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchainCount", toStringFlags, tabCount, tabSize, ToString(swapchainCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSwapchains", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(swapchainCount, pSwapchains, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pMetadata", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pMetadata, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8054,14 +11714,24 @@ void VulkanAsciiConsumer::Process_vkCreateIOSSurfaceMVK(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateIOSSurfaceMVK", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateIOSSurfaceMVK\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8078,14 +11748,24 @@ void VulkanAsciiConsumer::Process_vkCreateMacOSSurfaceMVK(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateMacOSSurfaceMVK", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateMacOSSurfaceMVK\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8100,12 +11780,22 @@ void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectNameEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkSetDebugUtilsObjectNameEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSetDebugUtilsObjectNameEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pNameInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pNameInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8120,12 +11810,22 @@ void VulkanAsciiConsumer::Process_vkSetDebugUtilsObjectTagEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkSetDebugUtilsObjectTagEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSetDebugUtilsObjectTagEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pTagInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pTagInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8139,11 +11839,21 @@ void VulkanAsciiConsumer::Process_vkQueueBeginDebugUtilsLabelEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkQueueBeginDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueBeginDebugUtilsLabelEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "pLabelInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pLabelInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8156,10 +11866,20 @@ void VulkanAsciiConsumer::Process_vkQueueEndDebugUtilsLabelEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkQueueEndDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueEndDebugUtilsLabelEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8173,11 +11893,21 @@ void VulkanAsciiConsumer::Process_vkQueueInsertDebugUtilsLabelEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkQueueInsertDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueInsertDebugUtilsLabelEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "pLabelInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pLabelInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8191,11 +11921,21 @@ void VulkanAsciiConsumer::Process_vkCmdBeginDebugUtilsLabelEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBeginDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBeginDebugUtilsLabelEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pLabelInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pLabelInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8208,10 +11948,20 @@ void VulkanAsciiConsumer::Process_vkCmdEndDebugUtilsLabelEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdEndDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdEndDebugUtilsLabelEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8225,11 +11975,21 @@ void VulkanAsciiConsumer::Process_vkCmdInsertDebugUtilsLabelEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdInsertDebugUtilsLabelEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdInsertDebugUtilsLabelEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pLabelInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pLabelInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8246,14 +12006,24 @@ void VulkanAsciiConsumer::Process_vkCreateDebugUtilsMessengerEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateDebugUtilsMessengerEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDebugUtilsMessengerEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMessenger", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pMessenger));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8268,12 +12038,22 @@ void VulkanAsciiConsumer::Process_vkDestroyDebugUtilsMessengerEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyDebugUtilsMessengerEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyDebugUtilsMessengerEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "messenger", toStringFlags, tabCount, tabSize, HandleIdToString(messenger));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8289,13 +12069,23 @@ void VulkanAsciiConsumer::Process_vkSubmitDebugUtilsMessageEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkSubmitDebugUtilsMessageEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSubmitDebugUtilsMessageEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "messageSeverity", toStringFlags, tabCount, tabSize, '"' + ToString(messageSeverity, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "messageTypes", toStringFlags, tabCount, tabSize, ToString(messageTypes, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCallbackData", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCallbackData, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8311,13 +12101,23 @@ void VulkanAsciiConsumer::Process_vkGetAndroidHardwareBufferPropertiesANDROID(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetAndroidHardwareBufferPropertiesANDROID", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetAndroidHardwareBufferPropertiesANDROID\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(buffer));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8333,13 +12133,23 @@ void VulkanAsciiConsumer::Process_vkGetMemoryAndroidHardwareBufferANDROID(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetMemoryAndroidHardwareBufferANDROID", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryAndroidHardwareBufferANDROID\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pBuffer", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pBuffer));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8353,11 +12163,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetSampleLocationsEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetSampleLocationsEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetSampleLocationsEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pSampleLocationsInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSampleLocationsInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8372,12 +12192,22 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceMultisamplePropertiesEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceMultisamplePropertiesEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceMultisamplePropertiesEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "samples", toStringFlags, tabCount, tabSize, '"' + ToString(samples, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pMultisampleProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMultisampleProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8393,13 +12223,23 @@ void VulkanAsciiConsumer::Process_vkGetImageDrmFormatModifierPropertiesEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetImageDrmFormatModifierPropertiesEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageDrmFormatModifierPropertiesEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8416,14 +12256,24 @@ void VulkanAsciiConsumer::Process_vkCreateValidationCacheEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateValidationCacheEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateValidationCacheEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pValidationCache", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pValidationCache));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8438,12 +12288,22 @@ void VulkanAsciiConsumer::Process_vkDestroyValidationCacheEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyValidationCacheEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyValidationCacheEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "validationCache", toStringFlags, tabCount, tabSize, HandleIdToString(validationCache));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8460,14 +12320,24 @@ void VulkanAsciiConsumer::Process_vkMergeValidationCachesEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkMergeValidationCachesEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkMergeValidationCachesEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "dstCache", toStringFlags, tabCount, tabSize, HandleIdToString(dstCache));
             FieldToString(strStrm, false, "srcCacheCount", toStringFlags, tabCount, tabSize, ToString(srcCacheCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSrcCaches", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(srcCacheCount, pSrcCaches, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8484,14 +12354,24 @@ void VulkanAsciiConsumer::Process_vkGetValidationCacheDataEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetValidationCacheDataEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetValidationCacheDataEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "validationCache", toStringFlags, tabCount, tabSize, HandleIdToString(validationCache));
             FieldToString(strStrm, false, "[out]pDataSize", toStringFlags, tabCount, tabSize, PointerDecoderToString(pDataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8506,12 +12386,22 @@ void VulkanAsciiConsumer::Process_vkCmdBindShadingRateImageNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBindShadingRateImageNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindShadingRateImageNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "imageView", toStringFlags, tabCount, tabSize, HandleIdToString(imageView));
             FieldToString(strStrm, false, "imageLayout", toStringFlags, tabCount, tabSize, '"' + ToString(imageLayout, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8527,13 +12417,23 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportShadingRatePaletteNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetViewportShadingRatePaletteNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetViewportShadingRatePaletteNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstViewport", toStringFlags, tabCount, tabSize, ToString(firstViewport, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "viewportCount", toStringFlags, tabCount, tabSize, ToString(viewportCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pShadingRatePalettes", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pShadingRatePalettes, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8549,13 +12449,23 @@ void VulkanAsciiConsumer::Process_vkCmdSetCoarseSampleOrderNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetCoarseSampleOrderNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetCoarseSampleOrderNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "sampleOrderType", toStringFlags, tabCount, tabSize, '"' + ToString(sampleOrderType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "customSampleOrderCount", toStringFlags, tabCount, tabSize, ToString(customSampleOrderCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCustomSampleOrders", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCustomSampleOrders, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8572,14 +12482,24 @@ void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateAccelerationStructureNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateAccelerationStructureNV\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pAccelerationStructure", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pAccelerationStructure));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8594,12 +12514,22 @@ void VulkanAsciiConsumer::Process_vkDestroyAccelerationStructureNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyAccelerationStructureNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyAccelerationStructureNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "accelerationStructure", toStringFlags, tabCount, tabSize, HandleIdToString(accelerationStructure));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8614,12 +12544,22 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureMemoryRequirementsNV
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetAccelerationStructureMemoryRequirementsNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetAccelerationStructureMemoryRequirementsNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8635,13 +12575,23 @@ void VulkanAsciiConsumer::Process_vkBindAccelerationStructureMemoryNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkBindAccelerationStructureMemoryNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkBindAccelerationStructureMemoryNV\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "bindInfoCount", toStringFlags, tabCount, tabSize, ToString(bindInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pBindInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pBindInfos, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8662,9 +12612,14 @@ void VulkanAsciiConsumer::Process_vkCmdBuildAccelerationStructureNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBuildAccelerationStructureNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBuildAccelerationStructureNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "instanceData", toStringFlags, tabCount, tabSize, HandleIdToString(instanceData));
@@ -8674,6 +12629,11 @@ void VulkanAsciiConsumer::Process_vkCmdBuildAccelerationStructureNV(
             FieldToString(strStrm, false, "src", toStringFlags, tabCount, tabSize, HandleIdToString(src));
             FieldToString(strStrm, false, "scratch", toStringFlags, tabCount, tabSize, HandleIdToString(scratch));
             FieldToString(strStrm, false, "scratchOffset", toStringFlags, tabCount, tabSize, ToString(scratchOffset, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8689,13 +12649,23 @@ void VulkanAsciiConsumer::Process_vkCmdCopyAccelerationStructureNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyAccelerationStructureNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyAccelerationStructureNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "dst", toStringFlags, tabCount, tabSize, HandleIdToString(dst));
             FieldToString(strStrm, false, "src", toStringFlags, tabCount, tabSize, HandleIdToString(src));
             FieldToString(strStrm, false, "mode", toStringFlags, tabCount, tabSize, '"' + ToString(mode, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8722,9 +12692,14 @@ void VulkanAsciiConsumer::Process_vkCmdTraceRaysNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdTraceRaysNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdTraceRaysNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "raygenShaderBindingTableBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(raygenShaderBindingTableBuffer));
             FieldToString(strStrm, false, "raygenShaderBindingOffset", toStringFlags, tabCount, tabSize, ToString(raygenShaderBindingOffset, toStringFlags, tabCount, tabSize));
@@ -8740,6 +12715,11 @@ void VulkanAsciiConsumer::Process_vkCmdTraceRaysNV(
             FieldToString(strStrm, false, "width", toStringFlags, tabCount, tabSize, ToString(width, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "height", toStringFlags, tabCount, tabSize, ToString(height, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "depth", toStringFlags, tabCount, tabSize, ToString(depth, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8758,16 +12738,26 @@ void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateRayTracingPipelinesNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateRayTracingPipelinesNV\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
             FieldToString(strStrm, false, "createInfoCount", toStringFlags, tabCount, tabSize, ToString(createInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelines", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(createInfoCount, pPipelines, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8786,16 +12776,26 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupHandlesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetRayTracingShaderGroupHandlesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetRayTracingShaderGroupHandlesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "firstGroup", toStringFlags, tabCount, tabSize, ToString(firstGroup, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "groupCount", toStringFlags, tabCount, tabSize, ToString(groupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8814,16 +12814,26 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupHandlesNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetRayTracingShaderGroupHandlesNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetRayTracingShaderGroupHandlesNV\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "firstGroup", toStringFlags, tabCount, tabSize, ToString(firstGroup, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "groupCount", toStringFlags, tabCount, tabSize, ToString(groupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8840,14 +12850,24 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureHandleNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetAccelerationStructureHandleNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetAccelerationStructureHandleNV\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "accelerationStructure", toStringFlags, tabCount, tabSize, HandleIdToString(accelerationStructure));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8865,15 +12885,25 @@ void VulkanAsciiConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdWriteAccelerationStructuresPropertiesNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWriteAccelerationStructuresPropertiesNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "accelerationStructureCount", toStringFlags, tabCount, tabSize, ToString(accelerationStructureCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAccelerationStructures", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(accelerationStructureCount, pAccelerationStructures, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "queryType", toStringFlags, tabCount, tabSize, '"' + ToString(queryType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
             FieldToString(strStrm, false, "firstQuery", toStringFlags, tabCount, tabSize, ToString(firstQuery, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8889,13 +12919,23 @@ void VulkanAsciiConsumer::Process_vkCompileDeferredNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCompileDeferredNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCompileDeferredNV\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "shader", toStringFlags, tabCount, tabSize, ToString(shader, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8912,14 +12952,24 @@ void VulkanAsciiConsumer::Process_vkGetMemoryHostPointerPropertiesEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetMemoryHostPointerPropertiesEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryHostPointerPropertiesEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "pHostPointer", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pHostPointer));
             FieldToString(strStrm, false, "[out]pMemoryHostPointerProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryHostPointerProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8936,14 +12986,24 @@ void VulkanAsciiConsumer::Process_vkCmdWriteBufferMarkerAMD(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdWriteBufferMarkerAMD", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWriteBufferMarkerAMD\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pipelineStage", toStringFlags, tabCount, tabSize, '"' + ToString(pipelineStage, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "dstBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(dstBuffer));
             FieldToString(strStrm, false, "dstOffset", toStringFlags, tabCount, tabSize, ToString(dstOffset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "marker", toStringFlags, tabCount, tabSize, ToString(marker, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8959,13 +13019,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCalibrateableTimeDomainsEXT
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceCalibrateableTimeDomainsEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceCalibrateableTimeDomainsEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pTimeDomainCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pTimeDomainCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pTimeDomains", toStringFlags, tabCount, tabSize, EnumPointerDecoderArrayToString(pTimeDomainCount, pTimeDomains, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -8983,15 +13053,25 @@ void VulkanAsciiConsumer::Process_vkGetCalibratedTimestampsEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetCalibratedTimestampsEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetCalibratedTimestampsEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "timestampCount", toStringFlags, tabCount, tabSize, ToString(timestampCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pTimestampInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pTimestampInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pTimestamps", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(timestampCount, pTimestamps, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMaxDeviation", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMaxDeviation, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9006,12 +13086,22 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMeshTasksNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDrawMeshTasksNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawMeshTasksNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "taskCount", toStringFlags, tabCount, tabSize, ToString(taskCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "firstTask", toStringFlags, tabCount, tabSize, ToString(firstTask, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9028,14 +13118,24 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMeshTasksIndirectNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDrawMeshTasksIndirectNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawMeshTasksIndirectNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "offset", toStringFlags, tabCount, tabSize, ToString(offset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "drawCount", toStringFlags, tabCount, tabSize, ToString(drawCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9054,9 +13154,14 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMeshTasksIndirectCountNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDrawMeshTasksIndirectCountNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawMeshTasksIndirectCountNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "buffer", toStringFlags, tabCount, tabSize, HandleIdToString(buffer));
             FieldToString(strStrm, false, "offset", toStringFlags, tabCount, tabSize, ToString(offset, toStringFlags, tabCount, tabSize));
@@ -9064,6 +13169,11 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMeshTasksIndirectCountNV(
             FieldToString(strStrm, false, "countBufferOffset", toStringFlags, tabCount, tabSize, ToString(countBufferOffset, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "maxDrawCount", toStringFlags, tabCount, tabSize, ToString(maxDrawCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9079,13 +13189,23 @@ void VulkanAsciiConsumer::Process_vkCmdSetExclusiveScissorNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetExclusiveScissorNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetExclusiveScissorNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstExclusiveScissor", toStringFlags, tabCount, tabSize, ToString(firstExclusiveScissor, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "exclusiveScissorCount", toStringFlags, tabCount, tabSize, ToString(exclusiveScissorCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pExclusiveScissors", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pExclusiveScissors, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9099,11 +13219,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetCheckpointNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetCheckpointNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetCheckpointNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pCheckpointMarker", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pCheckpointMarker));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9118,12 +13248,22 @@ void VulkanAsciiConsumer::Process_vkGetQueueCheckpointDataNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetQueueCheckpointDataNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetQueueCheckpointDataNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "[out]pCheckpointDataCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCheckpointDataCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCheckpointData", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCheckpointData, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9138,12 +13278,22 @@ void VulkanAsciiConsumer::Process_vkInitializePerformanceApiINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkInitializePerformanceApiINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkInitializePerformanceApiINTEL\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInitializeInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInitializeInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9156,10 +13306,20 @@ void VulkanAsciiConsumer::Process_vkUninitializePerformanceApiINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkUninitializePerformanceApiINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkUninitializePerformanceApiINTEL\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9174,12 +13334,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceMarkerINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetPerformanceMarkerINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetPerformanceMarkerINTEL\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pMarkerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMarkerInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9194,12 +13364,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceStreamMarkerINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetPerformanceStreamMarkerINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetPerformanceStreamMarkerINTEL\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pMarkerInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMarkerInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9214,12 +13394,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetPerformanceOverrideINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetPerformanceOverrideINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetPerformanceOverrideINTEL\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pOverrideInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pOverrideInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9235,13 +13425,23 @@ void VulkanAsciiConsumer::Process_vkAcquirePerformanceConfigurationINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkAcquirePerformanceConfigurationINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAcquirePerformanceConfigurationINTEL\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pAcquireInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAcquireInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pConfiguration", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pConfiguration));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9256,12 +13456,22 @@ void VulkanAsciiConsumer::Process_vkReleasePerformanceConfigurationINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkReleasePerformanceConfigurationINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkReleasePerformanceConfigurationINTEL\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "configuration", toStringFlags, tabCount, tabSize, HandleIdToString(configuration));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9276,12 +13486,22 @@ void VulkanAsciiConsumer::Process_vkQueueSetPerformanceConfigurationINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkQueueSetPerformanceConfigurationINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkQueueSetPerformanceConfigurationINTEL\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "queue", toStringFlags, tabCount, tabSize, HandleIdToString(queue));
             FieldToString(strStrm, false, "configuration", toStringFlags, tabCount, tabSize, HandleIdToString(configuration));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9297,13 +13517,23 @@ void VulkanAsciiConsumer::Process_vkGetPerformanceParameterINTEL(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPerformanceParameterINTEL", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPerformanceParameterINTEL\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "parameter", toStringFlags, tabCount, tabSize, '"' + ToString(parameter, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "[out]pValue", toStringFlags, tabCount, tabSize, PointerDecoderToString(pValue, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9318,12 +13548,22 @@ void VulkanAsciiConsumer::Process_vkSetLocalDimmingAMD(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkSetLocalDimmingAMD", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSetLocalDimmingAMD\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapChain", toStringFlags, tabCount, tabSize, HandleIdToString(swapChain));
             FieldToString(strStrm, false, "localDimmingEnable", toStringFlags, tabCount, tabSize, ToString(localDimmingEnable, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9340,14 +13580,24 @@ void VulkanAsciiConsumer::Process_vkCreateImagePipeSurfaceFUCHSIA(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateImagePipeSurfaceFUCHSIA", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateImagePipeSurfaceFUCHSIA\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9364,14 +13614,24 @@ void VulkanAsciiConsumer::Process_vkCreateMetalSurfaceEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateMetalSurfaceEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateMetalSurfaceEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9386,12 +13646,22 @@ void VulkanAsciiConsumer::Process_vkGetBufferDeviceAddressEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetBufferDeviceAddressEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetBufferDeviceAddressEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9407,13 +13677,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceToolPropertiesEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceToolPropertiesEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceToolPropertiesEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pToolCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pToolCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pToolProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pToolProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9429,13 +13709,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceCooperativeMatrixProperties
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceCooperativeMatrixPropertiesNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceCooperativeMatrixPropertiesNV\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pPropertyCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertyCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9451,13 +13741,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSupportedFramebufferMixedSa
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "[out]pCombinationCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCombinationCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCombinations", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCombinations, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9474,14 +13774,24 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceSurfacePresentModes2EXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceSurfacePresentModes2EXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceSurfacePresentModes2EXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPresentModeCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPresentModeCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPresentModes", toStringFlags, tabCount, tabSize, EnumPointerDecoderArrayToString(pPresentModeCount, pPresentModes, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9496,12 +13806,22 @@ void VulkanAsciiConsumer::Process_vkAcquireFullScreenExclusiveModeEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkAcquireFullScreenExclusiveModeEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAcquireFullScreenExclusiveModeEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9516,12 +13836,22 @@ void VulkanAsciiConsumer::Process_vkReleaseFullScreenExclusiveModeEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkReleaseFullScreenExclusiveModeEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkReleaseFullScreenExclusiveModeEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "swapchain", toStringFlags, tabCount, tabSize, HandleIdToString(swapchain));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9537,13 +13867,23 @@ void VulkanAsciiConsumer::Process_vkGetDeviceGroupSurfacePresentModes2EXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceGroupSurfacePresentModes2EXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceGroupSurfacePresentModes2EXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pSurfaceInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSurfaceInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pModes", toStringFlags, tabCount, tabSize, PointerDecoderToString(pModes, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9560,14 +13900,24 @@ void VulkanAsciiConsumer::Process_vkCreateHeadlessSurfaceEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateHeadlessSurfaceEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateHeadlessSurfaceEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9582,12 +13932,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetLineStippleEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetLineStippleEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetLineStippleEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "lineStippleFactor", toStringFlags, tabCount, tabSize, ToString(lineStippleFactor, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "lineStipplePattern", toStringFlags, tabCount, tabSize, ToString(lineStipplePattern, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9603,13 +13963,23 @@ void VulkanAsciiConsumer::Process_vkResetQueryPoolEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkResetQueryPoolEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkResetQueryPoolEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
             FieldToString(strStrm, false, "firstQuery", toStringFlags, tabCount, tabSize, ToString(firstQuery, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "queryCount", toStringFlags, tabCount, tabSize, ToString(queryCount, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9623,11 +13993,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetCullModeEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetCullModeEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetCullModeEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "cullMode", toStringFlags, tabCount, tabSize, ToString(cullMode, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9641,11 +14021,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetFrontFaceEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetFrontFaceEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetFrontFaceEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "frontFace", toStringFlags, tabCount, tabSize, '"' + ToString(frontFace, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9659,11 +14049,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveTopologyEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetPrimitiveTopologyEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetPrimitiveTopologyEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "primitiveTopology", toStringFlags, tabCount, tabSize, '"' + ToString(primitiveTopology, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9678,12 +14078,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetViewportWithCountEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetViewportWithCountEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetViewportWithCountEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "viewportCount", toStringFlags, tabCount, tabSize, ToString(viewportCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pViewports", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pViewports, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9698,12 +14108,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetScissorWithCountEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetScissorWithCountEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetScissorWithCountEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "scissorCount", toStringFlags, tabCount, tabSize, ToString(scissorCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pScissors", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pScissors, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9722,9 +14142,14 @@ void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers2EXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBindVertexBuffers2EXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindVertexBuffers2EXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "firstBinding", toStringFlags, tabCount, tabSize, ToString(firstBinding, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "bindingCount", toStringFlags, tabCount, tabSize, ToString(bindingCount, toStringFlags, tabCount, tabSize));
@@ -9732,6 +14157,11 @@ void VulkanAsciiConsumer::Process_vkCmdBindVertexBuffers2EXT(
             FieldToString(strStrm, false, "pOffsets", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(bindingCount, pOffsets, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pSizes", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(bindingCount, pSizes, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pStrides", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(bindingCount, pStrides, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9745,11 +14175,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthTestEnableEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetDepthTestEnableEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthTestEnableEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthTestEnable", toStringFlags, tabCount, tabSize, ToString(depthTestEnable, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9763,11 +14203,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthWriteEnableEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetDepthWriteEnableEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthWriteEnableEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthWriteEnable", toStringFlags, tabCount, tabSize, ToString(depthWriteEnable, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9781,11 +14231,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthCompareOpEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetDepthCompareOpEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthCompareOpEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthCompareOp", toStringFlags, tabCount, tabSize, '"' + ToString(depthCompareOp, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9799,11 +14259,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBoundsTestEnableEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetDepthBoundsTestEnableEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthBoundsTestEnableEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthBoundsTestEnable", toStringFlags, tabCount, tabSize, ToString(depthBoundsTestEnable, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9817,11 +14287,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilTestEnableEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetStencilTestEnableEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetStencilTestEnableEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "stencilTestEnable", toStringFlags, tabCount, tabSize, ToString(stencilTestEnable, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9839,15 +14319,25 @@ void VulkanAsciiConsumer::Process_vkCmdSetStencilOpEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetStencilOpEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetStencilOpEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "faceMask", toStringFlags, tabCount, tabSize, ToString(faceMask, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "failOp", toStringFlags, tabCount, tabSize, '"' + ToString(failOp, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "passOp", toStringFlags, tabCount, tabSize, '"' + ToString(passOp, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "depthFailOp", toStringFlags, tabCount, tabSize, '"' + ToString(depthFailOp, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "compareOp", toStringFlags, tabCount, tabSize, '"' + ToString(compareOp, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9862,12 +14352,22 @@ void VulkanAsciiConsumer::Process_vkGetGeneratedCommandsMemoryRequirementsNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetGeneratedCommandsMemoryRequirementsNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetGeneratedCommandsMemoryRequirementsNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryRequirements", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryRequirements, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9881,11 +14381,21 @@ void VulkanAsciiConsumer::Process_vkCmdPreprocessGeneratedCommandsNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdPreprocessGeneratedCommandsNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdPreprocessGeneratedCommandsNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pGeneratedCommandsInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGeneratedCommandsInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9900,12 +14410,22 @@ void VulkanAsciiConsumer::Process_vkCmdExecuteGeneratedCommandsNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdExecuteGeneratedCommandsNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdExecuteGeneratedCommandsNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "isPreprocessed", toStringFlags, tabCount, tabSize, ToString(isPreprocessed, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pGeneratedCommandsInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGeneratedCommandsInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9921,13 +14441,23 @@ void VulkanAsciiConsumer::Process_vkCmdBindPipelineShaderGroupNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBindPipelineShaderGroupNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindPipelineShaderGroupNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pipelineBindPoint", toStringFlags, tabCount, tabSize, '"' + ToString(pipelineBindPoint, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "groupIndex", toStringFlags, tabCount, tabSize, ToString(groupIndex, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9944,14 +14474,24 @@ void VulkanAsciiConsumer::Process_vkCreateIndirectCommandsLayoutNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateIndirectCommandsLayoutNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateIndirectCommandsLayoutNV\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pIndirectCommandsLayout", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pIndirectCommandsLayout));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9966,12 +14506,22 @@ void VulkanAsciiConsumer::Process_vkDestroyIndirectCommandsLayoutNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyIndirectCommandsLayoutNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyIndirectCommandsLayoutNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "indirectCommandsLayout", toStringFlags, tabCount, tabSize, HandleIdToString(indirectCommandsLayout));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -9987,13 +14537,23 @@ void VulkanAsciiConsumer::Process_vkAcquireDrmDisplayEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkAcquireDrmDisplayEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAcquireDrmDisplayEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "drmFd", toStringFlags, tabCount, tabSize, ToString(drmFd, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10010,14 +14570,24 @@ void VulkanAsciiConsumer::Process_vkGetDrmDisplayEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDrmDisplayEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDrmDisplayEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "drmFd", toStringFlags, tabCount, tabSize, ToString(drmFd, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "connectorId", toStringFlags, tabCount, tabSize, ToString(connectorId, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]display", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(display));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10034,14 +14604,24 @@ void VulkanAsciiConsumer::Process_vkCreatePrivateDataSlotEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreatePrivateDataSlotEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreatePrivateDataSlotEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPrivateDataSlot", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pPrivateDataSlot));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10056,12 +14636,22 @@ void VulkanAsciiConsumer::Process_vkDestroyPrivateDataSlotEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyPrivateDataSlotEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyPrivateDataSlotEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "privateDataSlot", toStringFlags, tabCount, tabSize, HandleIdToString(privateDataSlot));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10079,15 +14669,25 @@ void VulkanAsciiConsumer::Process_vkSetPrivateDataEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkSetPrivateDataEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSetPrivateDataEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "objectType", toStringFlags, tabCount, tabSize, '"' + ToString(objectType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "objectHandle", toStringFlags, tabCount, tabSize, ToString(objectHandle, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "privateDataSlot", toStringFlags, tabCount, tabSize, HandleIdToString(privateDataSlot));
             FieldToString(strStrm, false, "data", toStringFlags, tabCount, tabSize, ToString(data, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10104,14 +14704,24 @@ void VulkanAsciiConsumer::Process_vkGetPrivateDataEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPrivateDataEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPrivateDataEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "objectType", toStringFlags, tabCount, tabSize, '"' + ToString(objectType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "objectHandle", toStringFlags, tabCount, tabSize, ToString(objectHandle, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "privateDataSlot", toStringFlags, tabCount, tabSize, HandleIdToString(privateDataSlot));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, PointerDecoderToString(pData, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10126,12 +14736,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetFragmentShadingRateEnumNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetFragmentShadingRateEnumNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetFragmentShadingRateEnumNV\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "shadingRate", toStringFlags, tabCount, tabSize, '"' + ToString(shadingRate, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "combinerOps", toStringFlags, tabCount, tabSize, EnumPointerDecoderArrayToString(2, combinerOps, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10147,13 +14767,23 @@ void VulkanAsciiConsumer::Process_vkGetImageSubresourceLayout2EXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetImageSubresourceLayout2EXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetImageSubresourceLayout2EXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "image", toStringFlags, tabCount, tabSize, HandleIdToString(image));
             FieldToString(strStrm, false, "pSubresource", toStringFlags, tabCount, tabSize, PointerDecoderToString(pSubresource, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pLayout", toStringFlags, tabCount, tabSize, PointerDecoderToString(pLayout, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10168,12 +14798,22 @@ void VulkanAsciiConsumer::Process_vkAcquireWinrtDisplayNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkAcquireWinrtDisplayNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkAcquireWinrtDisplayNV\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "display", toStringFlags, tabCount, tabSize, HandleIdToString(display));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10189,13 +14829,23 @@ void VulkanAsciiConsumer::Process_vkGetWinrtDisplayNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetWinrtDisplayNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetWinrtDisplayNV\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "deviceRelativeId", toStringFlags, tabCount, tabSize, ToString(deviceRelativeId, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pDisplay", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pDisplay));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10212,14 +14862,24 @@ void VulkanAsciiConsumer::Process_vkCreateDirectFBSurfaceEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateDirectFBSurfaceEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateDirectFBSurfaceEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10235,13 +14895,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceDirectFBPresentationSupport
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceDirectFBPresentationSupportEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceDirectFBPresentationSupportEXT\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dfb", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(dfb));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10258,14 +14928,24 @@ void VulkanAsciiConsumer::Process_vkCmdSetVertexInputEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetVertexInputEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetVertexInputEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "vertexBindingDescriptionCount", toStringFlags, tabCount, tabSize, ToString(vertexBindingDescriptionCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pVertexBindingDescriptions", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pVertexBindingDescriptions, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "vertexAttributeDescriptionCount", toStringFlags, tabCount, tabSize, ToString(vertexAttributeDescriptionCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pVertexAttributeDescriptions", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pVertexAttributeDescriptions, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10281,13 +14961,23 @@ void VulkanAsciiConsumer::Process_vkGetMemoryZirconHandleFUCHSIA(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetMemoryZirconHandleFUCHSIA", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryZirconHandleFUCHSIA\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetZirconHandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetZirconHandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pZirconHandle", toStringFlags, tabCount, tabSize, PointerDecoderToString(pZirconHandle, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10304,14 +14994,24 @@ void VulkanAsciiConsumer::Process_vkGetMemoryZirconHandlePropertiesFUCHSIA(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetMemoryZirconHandlePropertiesFUCHSIA", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryZirconHandlePropertiesFUCHSIA\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "handleType", toStringFlags, tabCount, tabSize, '"' + ToString(handleType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "zirconHandle", toStringFlags, tabCount, tabSize, ToString(zirconHandle, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pMemoryZirconHandleProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryZirconHandleProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10326,12 +15026,22 @@ void VulkanAsciiConsumer::Process_vkImportSemaphoreZirconHandleFUCHSIA(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkImportSemaphoreZirconHandleFUCHSIA", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkImportSemaphoreZirconHandleFUCHSIA\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pImportSemaphoreZirconHandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pImportSemaphoreZirconHandleInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10347,13 +15057,23 @@ void VulkanAsciiConsumer::Process_vkGetSemaphoreZirconHandleFUCHSIA(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetSemaphoreZirconHandleFUCHSIA", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetSemaphoreZirconHandleFUCHSIA\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pGetZirconHandleInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pGetZirconHandleInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pZirconHandle", toStringFlags, tabCount, tabSize, PointerDecoderToString(pZirconHandle, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10368,12 +15088,22 @@ void VulkanAsciiConsumer::Process_vkCmdBindInvocationMaskHUAWEI(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdBindInvocationMaskHUAWEI", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdBindInvocationMaskHUAWEI\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "imageView", toStringFlags, tabCount, tabSize, HandleIdToString(imageView));
             FieldToString(strStrm, false, "imageLayout", toStringFlags, tabCount, tabSize, '"' + ToString(imageLayout, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10389,13 +15119,23 @@ void VulkanAsciiConsumer::Process_vkGetMemoryRemoteAddressNV(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetMemoryRemoteAddressNV", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetMemoryRemoteAddressNV\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pMemoryGetRemoteAddressInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMemoryGetRemoteAddressInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pAddress", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pAddress));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10409,11 +15149,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetPatchControlPointsEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetPatchControlPointsEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetPatchControlPointsEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "patchControlPoints", toStringFlags, tabCount, tabSize, ToString(patchControlPoints, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10427,11 +15177,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetRasterizerDiscardEnableEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetRasterizerDiscardEnableEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetRasterizerDiscardEnableEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "rasterizerDiscardEnable", toStringFlags, tabCount, tabSize, ToString(rasterizerDiscardEnable, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10445,11 +15205,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetDepthBiasEnableEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetDepthBiasEnableEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetDepthBiasEnableEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "depthBiasEnable", toStringFlags, tabCount, tabSize, ToString(depthBiasEnable, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10463,11 +15233,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetLogicOpEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetLogicOpEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetLogicOpEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "logicOp", toStringFlags, tabCount, tabSize, '"' + ToString(logicOp, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10481,11 +15261,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetPrimitiveRestartEnableEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetPrimitiveRestartEnableEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetPrimitiveRestartEnableEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "primitiveRestartEnable", toStringFlags, tabCount, tabSize, ToString(primitiveRestartEnable, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10502,14 +15292,24 @@ void VulkanAsciiConsumer::Process_vkCreateScreenSurfaceQNX(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateScreenSurfaceQNX", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateScreenSurfaceQNX\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "instance", toStringFlags, tabCount, tabSize, HandleIdToString(instance));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pSurface", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pSurface));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10525,13 +15325,23 @@ void VulkanAsciiConsumer::Process_vkGetPhysicalDeviceScreenPresentationSupportQN
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetPhysicalDeviceScreenPresentationSupportQNX", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetPhysicalDeviceScreenPresentationSupportQNX\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "physicalDevice", toStringFlags, tabCount, tabSize, HandleIdToString(physicalDevice));
             FieldToString(strStrm, false, "queueFamilyIndex", toStringFlags, tabCount, tabSize, ToString(queueFamilyIndex, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "window", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(window));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10546,12 +15356,22 @@ void VulkanAsciiConsumer::Process_vkCmdSetColorWriteEnableEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetColorWriteEnableEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetColorWriteEnableEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "attachmentCount", toStringFlags, tabCount, tabSize, ToString(attachmentCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pColorWriteEnables", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(attachmentCount, pColorWriteEnables, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10569,15 +15389,25 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMultiEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDrawMultiEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawMultiEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "drawCount", toStringFlags, tabCount, tabSize, ToString(drawCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pVertexInfo", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pVertexInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "instanceCount", toStringFlags, tabCount, tabSize, ToString(instanceCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "firstInstance", toStringFlags, tabCount, tabSize, ToString(firstInstance, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10596,9 +15426,14 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMultiIndexedEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdDrawMultiIndexedEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdDrawMultiIndexedEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "drawCount", toStringFlags, tabCount, tabSize, ToString(drawCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pIndexInfo", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pIndexInfo, toStringFlags, tabCount, tabSize));
@@ -10606,6 +15441,11 @@ void VulkanAsciiConsumer::Process_vkCmdDrawMultiIndexedEXT(
             FieldToString(strStrm, false, "firstInstance", toStringFlags, tabCount, tabSize, ToString(firstInstance, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pVertexOffset", toStringFlags, tabCount, tabSize, PointerDecoderToString(pVertexOffset, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10620,12 +15460,22 @@ void VulkanAsciiConsumer::Process_vkSetDeviceMemoryPriorityEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkSetDeviceMemoryPriorityEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkSetDeviceMemoryPriorityEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "memory", toStringFlags, tabCount, tabSize, HandleIdToString(memory));
             FieldToString(strStrm, false, "priority", toStringFlags, tabCount, tabSize, ToString(priority, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10640,12 +15490,22 @@ void VulkanAsciiConsumer::Process_vkGetDescriptorSetLayoutHostMappingInfoVALVE(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDescriptorSetLayoutHostMappingInfoVALVE", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDescriptorSetLayoutHostMappingInfoVALVE\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pBindingReference", toStringFlags, tabCount, tabSize, PointerDecoderToString(pBindingReference, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pHostMapping", toStringFlags, tabCount, tabSize, PointerDecoderToString(pHostMapping, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10660,12 +15520,22 @@ void VulkanAsciiConsumer::Process_vkGetDescriptorSetHostMappingVALVE(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDescriptorSetHostMappingVALVE", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDescriptorSetHostMappingVALVE\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "descriptorSet", toStringFlags, tabCount, tabSize, HandleIdToString(descriptorSet));
             FieldToString(strStrm, false, "[out]ppData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(ppData));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10680,12 +15550,22 @@ void VulkanAsciiConsumer::Process_vkGetShaderModuleIdentifierEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetShaderModuleIdentifierEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetShaderModuleIdentifierEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "shaderModule", toStringFlags, tabCount, tabSize, HandleIdToString(shaderModule));
             FieldToString(strStrm, false, "[out]pIdentifier", toStringFlags, tabCount, tabSize, PointerDecoderToString(pIdentifier, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10700,12 +15580,22 @@ void VulkanAsciiConsumer::Process_vkGetShaderModuleCreateInfoIdentifierEXT(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetShaderModuleCreateInfoIdentifierEXT", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetShaderModuleCreateInfoIdentifierEXT\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pIdentifier", toStringFlags, tabCount, tabSize, PointerDecoderToString(pIdentifier, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10722,14 +15612,24 @@ void VulkanAsciiConsumer::Process_vkGetFramebufferTilePropertiesQCOM(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetFramebufferTilePropertiesQCOM", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetFramebufferTilePropertiesQCOM\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "framebuffer", toStringFlags, tabCount, tabSize, HandleIdToString(framebuffer));
             FieldToString(strStrm, false, "[out]pPropertiesCount", toStringFlags, tabCount, tabSize, PointerDecoderToString(pPropertiesCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10745,13 +15645,23 @@ void VulkanAsciiConsumer::Process_vkGetDynamicRenderingTilePropertiesQCOM(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDynamicRenderingTilePropertiesQCOM", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDynamicRenderingTilePropertiesQCOM\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pRenderingInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRenderingInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pProperties", toStringFlags, tabCount, tabSize, PointerDecoderToString(pProperties, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10768,14 +15678,24 @@ void VulkanAsciiConsumer::Process_vkCreateAccelerationStructureKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateAccelerationStructureKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pCreateInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCreateInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pAccelerationStructure", toStringFlags, tabCount, tabSize, HandlePointerDecoderToString(pAccelerationStructure));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10790,12 +15710,22 @@ void VulkanAsciiConsumer::Process_vkDestroyAccelerationStructureKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkDestroyAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkDestroyAccelerationStructureKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "accelerationStructure", toStringFlags, tabCount, tabSize, HandleIdToString(accelerationStructure));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10811,13 +15741,23 @@ void VulkanAsciiConsumer::Process_vkCopyAccelerationStructureToMemoryKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCopyAccelerationStructureToMemoryKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCopyAccelerationStructureToMemoryKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "deferredOperation", toStringFlags, tabCount, tabSize, HandleIdToString(deferredOperation));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10833,13 +15773,23 @@ void VulkanAsciiConsumer::Process_vkCopyMemoryToAccelerationStructureKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCopyMemoryToAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCopyMemoryToAccelerationStructureKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "deferredOperation", toStringFlags, tabCount, tabSize, HandleIdToString(deferredOperation));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10859,17 +15809,27 @@ void VulkanAsciiConsumer::Process_vkWriteAccelerationStructuresPropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkWriteAccelerationStructuresPropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkWriteAccelerationStructuresPropertiesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "accelerationStructureCount", toStringFlags, tabCount, tabSize, ToString(accelerationStructureCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAccelerationStructures", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(accelerationStructureCount, pAccelerationStructures, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "queryType", toStringFlags, tabCount, tabSize, '"' + ToString(queryType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
             FieldToString(strStrm, false, "stride", toStringFlags, tabCount, tabSize, ToString(stride, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10883,11 +15843,21 @@ void VulkanAsciiConsumer::Process_vkCmdCopyAccelerationStructureKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyAccelerationStructureKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10901,11 +15871,21 @@ void VulkanAsciiConsumer::Process_vkCmdCopyAccelerationStructureToMemoryKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyAccelerationStructureToMemoryKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyAccelerationStructureToMemoryKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10919,11 +15899,21 @@ void VulkanAsciiConsumer::Process_vkCmdCopyMemoryToAccelerationStructureKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdCopyMemoryToAccelerationStructureKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdCopyMemoryToAccelerationStructureKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10938,12 +15928,22 @@ void VulkanAsciiConsumer::Process_vkGetAccelerationStructureDeviceAddressKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetAccelerationStructureDeviceAddressKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetAccelerationStructureDeviceAddressKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pInfo, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10961,15 +15961,25 @@ void VulkanAsciiConsumer::Process_vkCmdWriteAccelerationStructuresPropertiesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdWriteAccelerationStructuresPropertiesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdWriteAccelerationStructuresPropertiesKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "accelerationStructureCount", toStringFlags, tabCount, tabSize, ToString(accelerationStructureCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAccelerationStructures", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(accelerationStructureCount, pAccelerationStructures, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "queryType", toStringFlags, tabCount, tabSize, '"' + ToString(queryType, toStringFlags, tabCount, tabSize) + '"');
             FieldToString(strStrm, false, "queryPool", toStringFlags, tabCount, tabSize, HandleIdToString(queryPool));
             FieldToString(strStrm, false, "firstQuery", toStringFlags, tabCount, tabSize, ToString(firstQuery, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -10984,12 +15994,22 @@ void VulkanAsciiConsumer::Process_vkGetDeviceAccelerationStructureCompatibilityK
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetDeviceAccelerationStructureCompatibilityKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetDeviceAccelerationStructureCompatibilityKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pVersionInfo", toStringFlags, tabCount, tabSize, PointerDecoderToString(pVersionInfo, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pCompatibility", toStringFlags, tabCount, tabSize, EnumPointerDecoderToString(pCompatibility));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -11009,9 +16029,14 @@ void VulkanAsciiConsumer::Process_vkCmdTraceRaysKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdTraceRaysKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdTraceRaysKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pRaygenShaderBindingTable", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRaygenShaderBindingTable, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pMissShaderBindingTable", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMissShaderBindingTable, toStringFlags, tabCount, tabSize));
@@ -11020,6 +16045,11 @@ void VulkanAsciiConsumer::Process_vkCmdTraceRaysKHR(
             FieldToString(strStrm, false, "width", toStringFlags, tabCount, tabSize, ToString(width, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "height", toStringFlags, tabCount, tabSize, ToString(height, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "depth", toStringFlags, tabCount, tabSize, ToString(depth, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -11039,17 +16069,27 @@ void VulkanAsciiConsumer::Process_vkCreateRayTracingPipelinesKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCreateRayTracingPipelinesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCreateRayTracingPipelinesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "deferredOperation", toStringFlags, tabCount, tabSize, HandleIdToString(deferredOperation));
             FieldToString(strStrm, false, "pipelineCache", toStringFlags, tabCount, tabSize, HandleIdToString(pipelineCache));
             FieldToString(strStrm, false, "createInfoCount", toStringFlags, tabCount, tabSize, ToString(createInfoCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCreateInfos", toStringFlags, tabCount, tabSize, PointerDecoderArrayToString(*pCreateInfos, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pAllocator", toStringFlags, tabCount, tabSize, PointerDecoderToString(pAllocator, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pPipelines", toStringFlags, tabCount, tabSize, HandlePointerDecoderArrayToString(createInfoCount, pPipelines, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -11068,16 +16108,26 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingCaptureReplayShaderGroupHandles
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetRayTracingCaptureReplayShaderGroupHandlesKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetRayTracingCaptureReplayShaderGroupHandlesKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "firstGroup", toStringFlags, tabCount, tabSize, ToString(firstGroup, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "groupCount", toStringFlags, tabCount, tabSize, ToString(groupCount, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "dataSize", toStringFlags, tabCount, tabSize, ToString(dataSize, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "[out]pData", toStringFlags, tabCount, tabSize, DataPointerDecoderToString(pData));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -11095,15 +16145,25 @@ void VulkanAsciiConsumer::Process_vkCmdTraceRaysIndirectKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdTraceRaysIndirectKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdTraceRaysIndirectKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pRaygenShaderBindingTable", toStringFlags, tabCount, tabSize, PointerDecoderToString(pRaygenShaderBindingTable, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pMissShaderBindingTable", toStringFlags, tabCount, tabSize, PointerDecoderToString(pMissShaderBindingTable, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pHitShaderBindingTable", toStringFlags, tabCount, tabSize, PointerDecoderToString(pHitShaderBindingTable, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "pCallableShaderBindingTable", toStringFlags, tabCount, tabSize, PointerDecoderToString(pCallableShaderBindingTable, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "indirectDeviceAddress", toStringFlags, tabCount, tabSize, ToString(indirectDeviceAddress, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -11120,14 +16180,24 @@ void VulkanAsciiConsumer::Process_vkGetRayTracingShaderGroupStackSizeKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkGetRayTracingShaderGroupStackSizeKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
-            FieldToString(strStrm, true, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
-            FieldToString(strStrm, false, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkGetRayTracingShaderGroupStackSizeKHR\"");
+            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, '"' + ToString(returnValue, toStringFlags, tabCount, tabSize) + '"');
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
+            FieldToString(strStrm, true, "device", toStringFlags, tabCount, tabSize, HandleIdToString(device));
             FieldToString(strStrm, false, "pipeline", toStringFlags, tabCount, tabSize, HandleIdToString(pipeline));
             FieldToString(strStrm, false, "group", toStringFlags, tabCount, tabSize, ToString(group, toStringFlags, tabCount, tabSize));
             FieldToString(strStrm, false, "groupShader", toStringFlags, tabCount, tabSize, '"' + ToString(groupShader, toStringFlags, tabCount, tabSize) + '"');
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }
@@ -11141,11 +16211,21 @@ void VulkanAsciiConsumer::Process_vkCmdSetRayTracingPipelineStackSizeKHR(
     ToStringFlags toStringFlags = kToString_Default;
     uint32_t tabCount = 0;
     uint32_t tabSize = 4;
-    WriteApiCallToFile(call_info, "vkCmdSetRayTracingPipelineStackSizeKHR", toStringFlags, tabCount, tabSize,
+    WriteApiCallToFile(toStringFlags, tabCount, tabSize,
         [&](std::stringstream& strStrm)
         {
+            FieldToString(strStrm, true, "type", toStringFlags, tabCount, tabSize, "\"vkCall\"");
+            FieldToString(strStrm, false, "index", toStringFlags, tabCount, tabSize, std::to_string(call_info.index));
+            FieldToString(strStrm, false, "name", toStringFlags, tabCount, tabSize, "\"vkCmdSetRayTracingPipelineStackSizeKHR\"");
+            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\n");
+            tabCount += 1;
             FieldToString(strStrm, true, "commandBuffer", toStringFlags, tabCount, tabSize, HandleIdToString(commandBuffer));
             FieldToString(strStrm, false, "pipelineStackSize", toStringFlags, tabCount, tabSize, ToString(pipelineStackSize, toStringFlags, tabCount, tabSize));
+            tabCount -= 1;
+            strStrm << GetNewlineString(toStringFlags);
+            strStrm << GetTabString(toStringFlags, tabCount, tabSize);
+            strStrm << "}";
+
         }
     );
 }

--- a/framework/generated/vulkan_generators/vulkan_ascii_consumer_body_generator.py
+++ b/framework/generated/vulkan_generators/vulkan_ascii_consumer_body_generator.py
@@ -159,7 +159,8 @@ class VulkanAsciiConsumerBodyGenerator(BaseGenerator):
                     cmddef += '            FieldToString(strStrm, false, "return", toStringFlags, tabCount, tabSize, \'"\' + ToString(returnValue, toStringFlags, tabCount, tabSize) + \'"\');\n'
 
                 # Start a nested parameter block
-                cmddef += '''            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{\\n");\n'''
+                cmddef += '''            FieldToString(strStrm, false, "params", toStringFlags, tabCount, tabSize, "{");\n'''
+                cmddef += '''            strStrm << GetNewlineString(toStringFlags);\n'''
 
                 # Fill in all the arguments in the parameter block
                 cmddef += self.make_consumer_func_args(

--- a/framework/util/to_string.h
+++ b/framework/util/to_string.h
@@ -100,12 +100,13 @@ inline std::string
 ObjectToString(ToStringFlags toStringFlags, uint32_t& tabCount, uint32_t tabSize, ToStringFunctionType toStringFunction)
 {
     std::stringstream strStrm;
+    const auto        nl = GetNewlineString(toStringFlags);
     strStrm << '{';
-    strStrm << GetNewlineString(toStringFlags);
+    strStrm << nl;
     ++tabCount;
     toStringFunction(strStrm);
     --tabCount;
-    strStrm << GetNewlineString(toStringFlags);
+    strStrm << nl;
     strStrm << GetTabString(toStringFlags, tabCount, tabSize);
     strStrm << '}';
     return strStrm.str();

--- a/framework/util/to_string.h
+++ b/framework/util/to_string.h
@@ -36,7 +36,7 @@ enum ToStringFlagBits
 {
     kToString_Unformatted = 0,
     kToString_Formatted   = 1,
-    kToString_Default     = kToString_Formatted,
+    kToString_Default     = kToString_Unformatted,
 };
 
 typedef uint32_t ToStringFlags;

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,8 +5,4 @@ add_subdirectory(extract)
 add_subdirectory(optimize)
 add_subdirectory(capture)
 add_subdirectory(gfxrecon)
-
-# TOASCII build is currently disabled pending resolution of some issues
-if(BUILD_TOASCII)
 add_subdirectory(toascii)
-endif()


### PR DESCRIPTION
toascii - Minimal Change to Enable JSON Lines Output

The point of this PR is to enable a minimal diff from our current format to let it work as JSONLines. A larger change will follow later to address the requirements of users.

There is a different approach to this in PR https://github.com/LunarG/gfxreconstruct/pull/811. We only need one of these and that one is currently the preferred design.

Fixes Issue #765.
Fixes Issue #783
The output is like the following examples.
```json
{"type":"vkCall","index":40299,"name":"vkCreateCommandPool","return":"VK_SUCCESS","params":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO","pNext":null,"flags":2,"queueFamilyIndex":0},"pAllocator":null,"[out]pCommandPool":13926}}
{"type":"vkCall","index":40300,"name":"vkCreateCommandPool","return":"VK_SUCCESS","params":{"device":3,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO","pNext":null,"flags":2,"queueFamilyIndex":2},"pAllocator":null,"[out]pCommandPool":13927}}
{"type":"vkCall","index":40301,"name":"vkAllocateCommandBuffers","return":"VK_SUCCESS","params":{"device":3,"pAllocateInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO","pNext":null,"commandPool":118,"level":"VK_COMMAND_BUFFER_LEVEL_PRIMARY","commandBufferCount":1},"[out]pCommandBuffers":[120]}}
{"type":"vkCall","index":40302,"name":"vkAllocateCommandBuffers","return":"VK_SUCCESS","params":{"device":3,"pAllocateInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO","pNext":null,"commandPool":126,"level":"VK_COMMAND_BUFFER_LEVEL_PRIMARY","commandBufferCount":1},"[out]pCommandBuffers":[128]}}
{"type":"vkCall","index":40303,"name":"vkAllocateCommandBuffers","return":"VK_SUCCESS","params":{"device":3,"pAllocateInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO","pNext":null,"commandPool":118,"level":"VK_COMMAND_BUFFER_LEVEL_PRIMARY","commandBufferCount":1},"[out]pCommandBuffers":[129]}}
{"type":"vkCall","index":40304,"name":"vkAllocateCommandBuffers","return":"VK_SUCCESS","params":{"device":3,"pAllocateInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO","pNext":null,"commandPool":118,"level":"VK_COMMAND_BUFFER_LEVEL_PRIMARY","commandBufferCount":1},"[out]pCommandBuffers":[133]}}
{"type":"vkCall","index":40305,"name":"vkAllocateCommandBuffers","return":"VK_SUCCESS","params":{"device":3,"pAllocateInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO","pNext":null,"commandPool":126,"level":"VK_COMMAND_BUFFER_LEVEL_PRIMARY","commandBufferCount":1},"[out]pCommandBuffers":[134]}}
{"type":"vkCall","index":40306,"name":"vkAllocateCommandBuffers","return":"VK_SUCCESS","params":{"device":3,"pAllocateInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO","pNext":null,"commandPool":126,"level":"VK_COMMAND_BUFFER_LEVEL_PRIMARY","commandBufferCount":1},"[out]pCommandBuffers":[137]}}
{"type":"vkCall","index":40307,"name":"vkAllocateCommandBuffers","return":"VK_SUCCESS","params":{"device":3,"pAllocateInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO","pNext":null,"commandPool":118,"level":"VK_COMMAND_BUFFER_LEVEL_PRIMARY","commandBufferCount":1},"[out]pCommandBuffers":[139]}}
...
{"type":"vkCall","index":43519,"name":"vkAllocateCommandBuffers","return":"VK_SUCCESS","params":{"device":3,"pAllocateInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO","pNext":null,"commandPool":13512,"level":"VK_COMMAND_BUFFER_LEVEL_PRIMARY","commandBufferCount":1},"[out]pCommandBuffers":[20617]}}
{"type":"vkCall","index":43520,"name":"vkAllocateCommandBuffers","return":"VK_SUCCESS","params":{"device":3,"pAllocateInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO","pNext":null,"commandPool":13512,"level":"VK_COMMAND_BUFFER_LEVEL_PRIMARY","commandBufferCount":1},"[out]pCommandBuffers":[20618]}}
{"type":"vkCall","index":43521,"name":"vkBeginCommandBuffer","return":"VK_SUCCESS","params":{"commandBuffer":128,"pBeginInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO","pNext":null,"flags":1,"pInheritanceInfo":null}}}
{"type":"vkCall","index":43522,"name":"vkCmdPipelineBarrier","params":{"commandBuffer":128,"srcStageMask":128,"dstStageMask":4096,"dependencyFlags":0,"memoryBarrierCount":0,"pMemoryBarriers":[],"bufferMemoryBarrierCount":0,"pBufferMemoryBarriers":[],"imageMemoryBarrierCount":1,"pImageMemoryBarriers":[{"sType":"VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER","pNext":null,"srcAccessMask":32,"dstAccessMask":4096,           "oldLayout":"VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL","newLayout":"VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL","srcQueueFamilyIndex":4294967295,"dstQueueFamilyIndex":4294967295,"image":6607,"subresourceRange":{"aspectMask":1,"baseMipLevel":0,"levelCount":1,"baseArrayLayer":0,"layerCount":1}}]}}
{"type":"vkCall","index":43523,"name":"vkEndCommandBuffer","return":"VK_SUCCESS","params":{"commandBuffer":128}}
{"type":"vkCall","index":43524,"name":"vkBeginCommandBuffer","return":"VK_SUCCESS","params":{"commandBuffer":134,"pBeginInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO","pNext":null,"flags":1,"pInheritanceInfo":null}}}
{"type":"vkCall","index":43525,"name":"vkCmdPipelineBarrier","params":{"commandBuffer":134,"srcStageMask":1,"dstStageMask":8,"dependencyFlags":0,"memoryBarrierCount":0,"pMemoryBarriers":[],"bufferMemoryBarrierCount":0,"pBufferMemoryBarriers":[],"imageMemoryBarrierCount":9,"pImageMemoryBarriers":[{"sType":"VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER","pNext":null,"srcAccessMask":0,"dstAccessMask":32,"oldLayout":       "VK_IMAGE_LAYOUT_UNDEFINED","newLayout":"VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL","srcQueueFamilyIndex":4294967295,"dstQueueFamilyIndex":4294967295,"image":33257,"subresourceRange":{"aspectMask":1,"baseMipLevel":0,"levelCount":1,"baseArrayLayer":0,"layerCount":1}},{"sType":"VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER","pNext":null,"srcAccessMask":0,"dstAccessMask":32,"oldLayout":"VK_IMAGE_LAYOUT_UNDEFINED",          "newLayout":"VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL","srcQueueFamilyIndex":4294967295,"dstQueueFamilyIndex":4294967295,"image":33257,"subresourceRange":{"aspectMask":1,"baseMipLevel":1,"levelCount":1,"baseArrayLayer":0,"layerCount":1}},{"sType":"VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER","pNext":null,"srcAccessMask":0,"dstAccessMask":32,"oldLayout":"VK_IMAGE_LAYOUT_UNDEFINED","newLayout":                          "VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL","srcQueueFamilyIndex":4294967295,"dstQueueFamilyIndex":4294967295,"image":33257,"subresourceRange":{"aspectMask":1,"baseMipLevel":2,"levelCount":1,"baseArrayLayer":0,"layerCount":1}},{"sType":"VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER","pNext":null,"srcAccessMask":0,"dstAccessMask":32,"oldLayout":"VK_IMAGE_LAYOUT_UNDEFINED","newLayout":                                      "VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL","srcQueueFamilyIndex":4294967295,"dstQueueFamilyIndex":4294967295,"image":33257,"subresourceRange":{"aspectMask":1,"baseMipLevel":3,"levelCount":1,"baseArrayLayer":0,"layerCount":1}},{"sType":"VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER","pNext":null,"srcAccessMask":0,"dstAccessMask":32,"oldLayout":"VK_IMAGE_LAYOUT_UNDEFINED","newLayout":                                      "VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL","srcQueueFamilyIndex":4294967295,"dstQueueFamilyIndex":4294967295,"image":33257,"subresourceRange":{"aspectMask":1,"baseMipLevel":4,"levelCount":1,"baseArrayLayer":0,"layerCount":1}},{"sType":"VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER","pNext":null,"srcAccessMask":0,"dstAccessMask":32,"oldLayout":"VK_IMAGE_LAYOUT_UNDEFINED","newLayout":                                      "VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL","srcQueueFamilyIndex":4294967295,"dstQueueFamilyIndex":4294967295,"image":33257,"subresourceRange":{"aspectMask":1,"baseMipLevel":5,"levelCount":1,"baseArrayLayer":0,"layerCount":1}},{"sType":"VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER","pNext":null,"srcAccessMask":0,"dstAccessMask":32,"oldLayout":"VK_IMAGE_LAYOUT_UNDEFINED","newLayout":                                      "VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL","srcQueueFamilyIndex":4294967295,"dstQueueFamilyIndex":4294967295,"image":33257,"subresourceRange":{"aspectMask":1,"baseMipLevel":6,"levelCount":1,"baseArrayLayer":0,"layerCount":1}},{"sType":"VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER","pNext":null,"srcAccessMask":0,"dstAccessMask":32,"oldLayout":"VK_IMAGE_LAYOUT_UNDEFINED","newLayout":                                      "VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL","srcQueueFamilyIndex":4294967295,"dstQueueFamilyIndex":4294967295,"image":33257,"subresourceRange":{"aspectMask":1,"baseMipLevel":7,"levelCount":1,"baseArrayLayer":0,"layerCount":1}},{"sType":"VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER","pNext":null,"srcAccessMask":0,"dstAccessMask":32,"oldLayout":"VK_IMAGE_LAYOUT_UNDEFINED","newLayout":                                      "VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL","srcQueueFamilyIndex":4294967295,"dstQueueFamilyIndex":4294967295,"image":33257,"subresourceRange":{"aspectMask":1,"baseMipLevel":8,"levelCount":1,"baseArrayLayer":0,"layerCount":1}}]}}
{"type":"vkCall","index":43526,"name":"vkEndCommandBuffer","return":"VK_SUCCESS","params":{"commandBuffer":134}}
...
{"type":"vkCall","index":90397,"name":"vkBeginCommandBuffer","return":"VK_SUCCESS","params":{"commandBuffer":4392,"pBeginInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO","pNext":null,"flags":1,"pInheritanceInfo":null}}}
{"type":"vkCall","index":90398,"name":"vkCmdCopyBuffer","params":{"commandBuffer":4392,"srcBuffer":39907,"dstBuffer":39972,"regionCount":1,"pRegions":[{"srcOffset":3873472,"dstOffset":2133808,"size":1428}]}}
{"type":"vkCall","index":90399,"name":"vkCmdPipelineBarrier","params":{"commandBuffer":4392,"srcStageMask":4096,"dstStageMask":4,"dependencyFlags":0,"memoryBarrierCount":0,"pMemoryBarriers":[],"bufferMemoryBarrierCount":1,"pBufferMemoryBarriers":[{"sType":"VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER","pNext":null,"srcAccessMask":4096,"dstAccessMask":4,"srcQueueFamilyIndex":4294967295,"dstQueueFamilyIndex":4294967295,"buffer":39972,"offset":2133808,"size":1428}],"imageMemoryBarrierCount":0,"pImageMemoryBarriers":[]}}
{"type":"vkCall","index":90400,"name":"vkCmdCopyBuffer","params":{"commandBuffer":4392,"srcBuffer":39907,"dstBuffer":39974,"regionCount":1,"pRegions":[{"srcOffset":3874912,"dstOffset":216304,"size":174}]}}
{"type":"vkCall","index":90401,"name":"vkCmdPipelineBarrier","params":{"commandBuffer":4392,"srcStageMask":4096,"dstStageMask":4,"dependencyFlags":0,"memoryBarrierCount":0,"pMemoryBarriers":[],"bufferMemoryBarrierCount":1,"pBufferMemoryBarriers":[{"sType":"VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER","pNext":null,"srcAccessMask":4096,"dstAccessMask":2,"srcQueueFamilyIndex":4294967295,"dstQueueFamilyIndex":4294967295,"buffer":39974,"offset":216304,"size":174}],"imageMemoryBarrierCount":0,"pImageMemoryBarriers":[]}}
{"type":"vkCall","index":90402,"name":"vkEndCommandBuffer","return":"VK_SUCCESS","params":{"commandBuffer":4392}}
{"type":"vkCall","index":90403,"name":"vkResetCommandBuffer","return":"VK_SUCCESS","params":{"commandBuffer":4397,"flags":0}}
{"type":"vkCall","index":90404,"name":"vkBeginCommandBuffer","return":"VK_SUCCESS","params":{"commandBuffer":4397,"pBeginInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO","pNext":null,"flags":1,"pInheritanceInfo":null}}}
{"type":"vkCall","index":90405,"name":"vkCmdCopyBuffer","params":{"commandBuffer":4397,"srcBuffer":39907,"dstBuffer":39972,"regionCount":1,"pRegions":[{"srcOffset":3875088,"dstOffset":2135248,"size":26736}]}}
{"type":"vkCall","index":90406,"name":"vkCmdPipelineBarrier","params":{"commandBuffer":4397,"srcStageMask":4096,"dstStageMask":4,"dependencyFlags":0,"memoryBarrierCount":0,"pMemoryBarriers":[],"bufferMemoryBarrierCount":1,"pBufferMemoryBarriers":[{"sType":"VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER","pNext":null,"srcAccessMask":4096,"dstAccessMask":4,"srcQueueFamilyIndex":4294967295,"dstQueueFamilyIndex":4294967295,"buffer":39972,"offset":2135248,"size":26736}],"imageMemoryBarrierCount":0,"pImageMemoryBarriers":[]}}
{"type":"vkCall","index":90407,"name":"vkCmdCopyBuffer","params":{"commandBuffer":4397,"srcBuffer":39907,"dstBuffer":39974,"regionCount":1,"pRegions":[{"srcOffset":3901824,"dstOffset":216480,"size":6204}]}}
{"type":"vkCall","index":90408,"name":"vkCmdPipelineBarrier","params":{"commandBuffer":4397,"srcStageMask":4096,"dstStageMask":4,"dependencyFlags":0,"memoryBarrierCount":0,"pMemoryBarriers":[],"bufferMemoryBarrierCount":1,"pBufferMemoryBarriers":[{"sType":"VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER","pNext":null,"srcAccessMask":4096,"dstAccessMask":2,"srcQueueFamilyIndex":4294967295,"dstQueueFamilyIndex":4294967295,"buffer":39974,"offset":216480,"size":6204}],"imageMemoryBarrierCount":0,"pImageMemoryBarriers":[]}}
{"type":"vkCall","index":90409,"name":"vkEndCommandBuffer","return":"VK_SUCCESS","params":{"commandBuffer":4397}}
{"type":"vkCall","index":90410,"name":"vkQueuePresentKHR","return":"VK_SUCCESS","params":{"queue":15,"pPresentInfo":{"sType":"VK_STRUCTURE_TYPE_PRESENT_INFO_KHR","pNext":null,"waitSemaphoreCount":0,"pWaitSemaphores":[],"swapchainCount":1,"pSwapchains":[71],"pImageIndices":[3],"pResults":[]}}}
...
{"type":"vkCall","index":0,"name":"vkCreateInstance","return":"VK_SUCCESS","params":{"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO","pNext":{"sType":"VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT","pNext":null,"flags":10,"pfnCallback":"0x557803718b12","pUserData":"0x0"},"flags":0,"pApplicationInfo":{"sType":"VK_STRUCTURE_TYPE_APPLICATION_INFO","pNext":null,"pApplicationName":"Hello     Triangle","applicationVersion":0,"pEngineName":"Vulkan Samples","engineVersion":0,"apiVersion":4194304},"enabledLayerCount":0,"ppEnabledLayerNames":[],"enabledExtensionCount":3,"ppEnabledExtensionNames":["VK_KHR_surface","VK_EXT_debug_report","VK_KHR_xcb_surface"]},"pAllocator":null,"[out]pInstance":1}}
{"type":"vkCall","index":1,"name":"vkCreateDebugReportCallbackEXT","return":"VK_SUCCESS","params":{"instance":1,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT","pNext":null,"flags":10,"pfnCallback":"0x557803718b12","pUserData":"0x0"},"pAllocator":null,"[out]pCallback":2}}
{"type":"vkCall","index":2,"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCESS","params":{"instance":1,"[out]pPhysicalDeviceCount":2,"[out]pPhysicalDevices":[]}}
{"type":"vkCall","index":3,"name":"vkEnumeratePhysicalDevices","return":"VK_SUCCESS","params":{"instance":1,"[out]pPhysicalDeviceCount":2,"[out]pPhysicalDevices":[3,4]}}
{"type":"vkCall","index":4,"name":"vkGetPhysicalDeviceProperties","params":{"physicalDevice":3,"[out]pProperties":{"apiVersion":4206809,"driverVersion":2160869696,"vendorID":4318,"deviceID":7944,"deviceType":"VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU","deviceName":"NVIDIA GeForce RTX 2060","pipelineCacheUUID":"179-50-191-78-219-146-93-101-36-174-172-31-215-102-71-194","limits":{"maxImageDimension1D":32768,            "maxImageDimension2D":32768,"maxImageDimension3D":16384,"maxImageDimensionCube":32768,"maxImageArrayLayers":2048,"maxTexelBufferElements":134217728,"maxUniformBufferRange":65536,"maxStorageBufferRange":4294967295,"maxPushConstantsSize":256,"maxMemoryAllocationCount":4294967295,"maxSamplerAllocationCount":4000,"bufferImageGranularity":1024,"sparseAddressSpaceSize":1099511627775,"maxBoundDescriptorSets":32,        "maxPerStageDescriptorSamplers":1048576,"maxPerStageDescriptorUniformBuffers":1048576,"maxPerStageDescriptorStorageBuffers":1048576,"maxPerStageDescriptorSampledImages":1048576,"maxPerStageDescriptorStorageImages":1048576,"maxPerStageDescriptorInputAttachments":1048576,"maxPerStageResources":4294967295,"maxDescriptorSetSamplers":1048576,"maxDescriptorSetUniformBuffers":1048576,                                    "maxDescriptorSetUniformBuffersDynamic":15,"maxDescriptorSetStorageBuffers":1048576,"maxDescriptorSetStorageBuffersDynamic":16,"maxDescriptorSetSampledImages":1048576,"maxDescriptorSetStorageImages":1048576,"maxDescriptorSetInputAttachments":1048576,"maxVertexInputAttributes":32,"maxVertexInputBindings":32,"maxVertexInputAttributeOffset":2047,"maxVertexInputBindingStride":2048,"maxVertexOutputComponents":128,    "maxTessellationGenerationLevel":64,"maxTessellationPatchSize":32,"maxTessellationControlPerVertexInputComponents":128,"maxTessellationControlPerVertexOutputComponents":128,"maxTessellationControlPerPatchOutputComponents":120,"maxTessellationControlTotalOutputComponents":4216,"maxTessellationEvaluationInputComponents":128,"maxTessellationEvaluationOutputComponents":128,"maxGeometryShaderInvocations":32,          "maxGeometryInputComponents":128,"maxGeometryOutputComponents":128,"maxGeometryOutputVertices":1024,"maxGeometryTotalOutputComponents":1024,"maxFragmentInputComponents":128,"maxFragmentOutputAttachments":8,"maxFragmentDualSrcAttachments":1,"maxFragmentCombinedOutputResources":4294967295,"maxComputeSharedMemorySize":49152,"maxComputeWorkGroupCount":[2147483647,65535,65535],"maxComputeWorkGroupInvocations":1024,   "maxComputeWorkGroupSize":[1024,1024,64],"subPixelPrecisionBits":8,"subTexelPrecisionBits":8,"mipmapPrecisionBits":8,"maxDrawIndexedIndexValue":4294967295,"maxDrawIndirectCount":4294967295,"maxSamplerLodBias":15.000000,"maxSamplerAnisotropy":16.000000,"maxViewports":16,"maxViewportDimensions":[32768,32768],"viewportBoundsRange":[-65536.000000,65536.000000],"viewportSubPixelBits":8,"minMemoryMapAlignment":64,     "minTexelBufferOffsetAlignment":16,"minUniformBufferOffsetAlignment":64,"minStorageBufferOffsetAlignment":16,"minTexelOffset":-8,"maxTexelOffset":7,"minTexelGatherOffset":-32,"maxTexelGatherOffset":31,"minInterpolationOffset":-0.500000,"maxInterpolationOffset":0.437500,"subPixelInterpolationOffsetBits":4,"maxFramebufferWidth":32768,"maxFramebufferHeight":32768,"maxFramebufferLayers":2048,                         "framebufferColorSampleCounts":15,"framebufferDepthSampleCounts":15,"framebufferStencilSampleCounts":31,"framebufferNoAttachmentsSampleCounts":31,"maxColorAttachments":8,"sampledImageColorSampleCounts":15,"sampledImageIntegerSampleCounts":15,"sampledImageDepthSampleCounts":15,"sampledImageStencilSampleCounts":31,"storageImageSampleCounts":15,"maxSampleMaskWords":1,"timestampComputeAndGraphics":1,                 "timestampPeriod":1.000000,"maxClipDistances":8,"maxCullDistances":8,"maxCombinedClipAndCullDistances":8,"discreteQueuePriorities":2,"pointSizeRange":[1.000000,2047.937500],"lineWidthRange":[1.000000,64.000000],"pointSizeGranularity":0.062500,"lineWidthGranularity":0.062500,"strictLines":1,"standardSampleLocations":1,"optimalBufferCopyOffsetAlignment":1,"optimalBufferCopyRowPitchAlignment":1,                     "nonCoherentAtomSize":64},"sparseProperties":{"residencyStandard2DBlockShape":1,"residencyStandard2DMultisampleBlockShape":1,"residencyStandard3DBlockShape":1,"residencyAlignedMipSize":0,"residencyNonResidentStrict":1}}}}
{"type":"vkCall","index":5,"name":"vkGetPhysicalDeviceProperties","params":{"physicalDevice":4,"[out]pProperties":{"apiVersion":4198582,"driverVersion":1,"vendorID":65541,"deviceID":0,"deviceType":"VK_PHYSICAL_DEVICE_TYPE_CPU","deviceName":"llvmpipe (LLVM 12.0.1, 256 bits)","pipelineCacheUUID":"118-97-108-45-108-108-32-110-111-61-39-0-0-0-0-0","limits":{"maxImageDimension1D":16384,"maxImageDimension2D":16384,    "maxImageDimension3D":4096,"maxImageDimensionCube":32768,"maxImageArrayLayers":2048,"maxTexelBufferElements":134217728,"maxUniformBufferRange":65536,"maxStorageBufferRange":134217728,"maxPushConstantsSize":128,"maxMemoryAllocationCount":4294967295,"maxSamplerAllocationCount":32768,"bufferImageGranularity":64,"sparseAddressSpaceSize":0,"maxBoundDescriptorSets":8,"maxPerStageDescriptorSamplers":32,                 "maxPerStageDescriptorUniformBuffers":15,"maxPerStageDescriptorStorageBuffers":16,"maxPerStageDescriptorSampledImages":128,"maxPerStageDescriptorStorageImages":16,"maxPerStageDescriptorInputAttachments":8,"maxPerStageResources":128,"maxDescriptorSetSamplers":32768,"maxDescriptorSetUniformBuffers":256,"maxDescriptorSetUniformBuffersDynamic":256,"maxDescriptorSetStorageBuffers":256,                                 "maxDescriptorSetStorageBuffersDynamic":256,"maxDescriptorSetSampledImages":256,"maxDescriptorSetStorageImages":256,"maxDescriptorSetInputAttachments":256,"maxVertexInputAttributes":32,"maxVertexInputBindings":32,"maxVertexInputAttributeOffset":2047,"maxVertexInputBindingStride":2048,"maxVertexOutputComponents":128,"maxTessellationGenerationLevel":64,"maxTessellationPatchSize":32,                                 "maxTessellationControlPerVertexInputComponents":128,"maxTessellationControlPerVertexOutputComponents":128,"maxTessellationControlPerPatchOutputComponents":128,"maxTessellationControlTotalOutputComponents":4096,"maxTessellationEvaluationInputComponents":128,"maxTessellationEvaluationOutputComponents":128,"maxGeometryShaderInvocations":32,"maxGeometryInputComponents":64,"maxGeometryOutputComponents":128,          "maxGeometryOutputVertices":1024,"maxGeometryTotalOutputComponents":1024,"maxFragmentInputComponents":128,"maxFragmentOutputAttachments":8,"maxFragmentDualSrcAttachments":2,"maxFragmentCombinedOutputResources":8,"maxComputeSharedMemorySize":32768,"maxComputeWorkGroupCount":[65535,65535,65535],"maxComputeWorkGroupInvocations":1024,"maxComputeWorkGroupSize":[1024,1024,1024],"subPixelPrecisionBits":8,               "subTexelPrecisionBits":8,"mipmapPrecisionBits":8,"maxDrawIndexedIndexValue":4294967295,"maxDrawIndirectCount":4294967295,"maxSamplerLodBias":16.000000,"maxSamplerAnisotropy":16.000000,"maxViewports":16,"maxViewportDimensions":[16384,16384],"viewportBoundsRange":[-32768.000000,32768.000000],"viewportSubPixelBits":0,"minMemoryMapAlignment":64,"minTexelBufferOffsetAlignment":16,"minUniformBufferOffsetAlignment":16,"minStorageBufferOffsetAlignment":16,"minTexelOffset":-32,"maxTexelOffset":31,"minTexelGatherOffset":-32,"maxTexelGatherOffset":31,"minInterpolationOffset":-2.000000,"maxInterpolationOffset":2.000000,"subPixelInterpolationOffsetBits":8,"maxFramebufferWidth":16384,"maxFramebufferHeight":16384,"maxFramebufferLayers":2048,"framebufferColorSampleCounts":5,"framebufferDepthSampleCounts":5,                             "framebufferStencilSampleCounts":5,"framebufferNoAttachmentsSampleCounts":5,"maxColorAttachments":8,"sampledImageColorSampleCounts":5,"sampledImageIntegerSampleCounts":5,"sampledImageDepthSampleCounts":5,"sampledImageStencilSampleCounts":5,"storageImageSampleCounts":5,"maxSampleMaskWords":1,"timestampComputeAndGraphics":1,"timestampPeriod":1.000000,"maxClipDistances":8,"maxCullDistances":8,                       "maxCombinedClipAndCullDistances":8,"discreteQueuePriorities":2,"pointSizeRange":[0.000000,255.000000],"lineWidthRange":[1.000000,255.000000],"pointSizeGranularity":0.125000,"lineWidthGranularity":0.007812,"strictLines":1,"standardSampleLocations":1,"optimalBufferCopyOffsetAlignment":128,"optimalBufferCopyRowPitchAlignment":128,"nonCoherentAtomSize":64},"sparseProperties":{"residencyStandard2DBlockShape":0,      "residencyStandard2DMultisampleBlockShape":0,"residencyStandard3DBlockShape":0,"residencyAlignedMipSize":0,"residencyNonResidentStrict":0}}}}
...
{"type":"vkCall","index":90,"name":"vkResetCommandPool","return":"VK_SUCCESS","params":{"device":6,"commandPool":16,"flags":0}}
{"type":"vkCall","index":91,"name":"vkBeginCommandBuffer","return":"VK_SUCCESS","params":{"commandBuffer":17,"pBeginInfo":{"sType":"VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO","pNext":null,"flags":1,"pInheritanceInfo":null}}}
{"type":"vkCall","index":92,"name":"vkCmdBeginRenderPass","params":{"commandBuffer":17,"pRenderPassBegin":{"sType":"VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO","pNext":null,"renderPass":24,"framebuffer":30,"renderArea":{"offset":{"x":0,"y":0},"extent":{"width":1280,"height":720}},"clearValueCount":1,"pClearValues":[{"color":{"float32":[0.100000,0.100000,0.200000,1.000000],"int32":[1036831949,1036831949,1045220557, 1065353216],"uint32":[1036831949,1036831949,1045220557,1065353216]},"depthStencil":{"depth":0.100000,"stencil":1036831949}}]},"contents":"VK_SUBPASS_CONTENTS_INLINE"}}
{"type":"vkCall","index":93,"name":"vkCmdBindPipeline","params":{"commandBuffer":17,"pipelineBindPoint":"VK_PIPELINE_BIND_POINT_GRAPHICS","pipeline":28}}
{"type":"vkCall","index":94,"name":"vkCmdSetViewport","params":{"commandBuffer":17,"firstViewport":0,"viewportCount":1,"pViewports":[{"x":0.000000,"y":0.000000,"width":1280.000000,"height":720.000000,"minDepth":0.000000,"maxDepth":1.000000}]}}
{"type":"vkCall","index":95,"name":"vkCmdSetScissor","params":{"commandBuffer":17,"firstScissor":0,"scissorCount":1,"pScissors":[{"offset":{"x":0,"y":0},"extent":{"width":1280,"height":720}}]}}
{"type":"vkCall","index":96,"name":"vkCmdDraw","params":{"commandBuffer":17,"vertexCount":3,"instanceCount":1,"firstVertex":0,"firstInstance":0}}
{"type":"vkCall","index":97,"name":"vkCmdEndRenderPass","params":{"commandBuffer":17}}
{"type":"vkCall","index":98,"name":"vkEndCommandBuffer","return":"VK_SUCCESS","params":{"commandBuffer":17}}
{"type":"vkCall","index":99,"name":"vkCreateSemaphore","return":"VK_SUCCESS","params":{"device":6,"pCreateInfo":{"sType":"VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO","pNext":null,"flags":0},"pAllocator":null,"[out]pSemaphore":35}}
{"type":"vkCall","index":100,"name":"vkQueueSubmit","return":"VK_SUCCESS","params":{"queue":7,"submitCount":1,"pSubmits":[{"sType":"VK_STRUCTURE_TYPE_SUBMIT_INFO","pNext":null,"waitSemaphoreCount":1,"pWaitSemaphores":[34],"pWaitDstStageMask":[1024],"commandBufferCount":1,"pCommandBuffers":[17],"signalSemaphoreCount":1,"pSignalSemaphores":[35]}],"fence":15}}
{"type":"vkCall","index":101,"name":"vkQueuePresentKHR","return":"VK_SUCCESS","params":{"queue":7,"pPresentInfo":{"sType":"VK_STRUCTURE_TYPE_PRESENT_INFO_KHR","pNext":null,"waitSemaphoreCount":1,"pWaitSemaphores":[35],"swapchainCount":1,"pSwapchains":[8],"pImageIndices":[1],"pResults":[]}}}
{"type":"vkCall","index":102,"name":"vkDeviceWaitIdle","return":"VK_SUCCESS","params":{"device":6}}
{"type":"vkCall","index":103,"name":"vkQueueWaitIdle","return":"VK_SUCCESS","params":{"queue":7}}
{"type":"vkCall","index":104,"name":"vkDestroyFramebuffer","params":{"device":6,"framebuffer":29,"pAllocator":null}}
{"type":"vkCall","index":105,"name":"vkDestroyFramebuffer","params":{"device":6,"framebuffer":30,"pAllocator":null}}
{"type":"vkCall","index":106,"name":"vkDestroyFramebuffer","params":{"device":6,"framebuffer":31,"pAllocator":null}}
{"type":"vkCall","index":107,"name":"vkDestroyFence","params":{"device":6,"fence":12,"pAllocator":null}}
{"type":"vkCall","index":108,"name":"vkFreeCommandBuffers","params":{"device":6,"commandPool":13,"commandBufferCount":1,"pCommandBuffers":[14]}}
{"type":"vkCall","index":109,"name":"vkDestroyCommandPool","params":{"device":6,"commandPool":13,"pAllocator":null}}
{"type":"vkCall","index":110,"name":"vkDestroySemaphore","params":{"device":6,"semaphore":32,"pAllocator":null}}
{"type":"vkCall","index":111,"name":"vkDestroySemaphore","params":{"device":6,"semaphore":33,"pAllocator":null}}
{"type":"vkCall","index":112,"name":"vkDestroyFence","params":{"device":6,"fence":15,"pAllocator":null}}
{"type":"vkCall","index":113,"name":"vkFreeCommandBuffers","params":{"device":6,"commandPool":16,"commandBufferCount":1,"pCommandBuffers":[17]}}
{"type":"vkCall","index":114,"name":"vkDestroyCommandPool","params":{"device":6,"commandPool":16,"pAllocator":null}}
{"type":"vkCall","index":115,"name":"vkDestroySemaphore","params":{"device":6,"semaphore":34,"pAllocator":null}}
{"type":"vkCall","index":116,"name":"vkDestroySemaphore","params":{"device":6,"semaphore":35,"pAllocator":null}}
{"type":"vkCall","index":117,"name":"vkDestroyFence","params":{"device":6,"fence":18,"pAllocator":null}}
{"type":"vkCall","index":118,"name":"vkFreeCommandBuffers","params":{"device":6,"commandPool":19,"commandBufferCount":1,"pCommandBuffers":[20]}}
{"type":"vkCall","index":119,"name":"vkDestroyCommandPool","params":{"device":6,"commandPool":19,"pAllocator":null}}
{"type":"vkCall","index":120,"name":"vkDestroyPipeline","params":{"device":6,"pipeline":28,"pAllocator":null}}
{"type":"vkCall","index":121,"name":"vkDestroyPipelineLayout","params":{"device":6,"pipelineLayout":25,"pAllocator":null}}
{"type":"vkCall","index":122,"name":"vkDestroyRenderPass","params":{"device":6,"renderPass":24,"pAllocator":null}}
{"type":"vkCall","index":123,"name":"vkDestroyImageView","params":{"device":6,"imageView":21,"pAllocator":null}}
{"type":"vkCall","index":124,"name":"vkDestroyImageView","params":{"device":6,"imageView":22,"pAllocator":null}}
{"type":"vkCall","index":125,"name":"vkDestroyImageView","params":{"device":6,"imageView":23,"pAllocator":null}}
{"type":"vkCall","index":126,"name":"vkDestroySwapchainKHR","params":{"device":6,"swapchain":8,"pAllocator":null}}
{"type":"vkCall","index":127,"name":"vkDestroySurfaceKHR","params":{"instance":1,"surface":5,"pAllocator":null}}
{"type":"vkCall","index":128,"name":"vkDestroyDevice","params":{"device":6,"pAllocator":null}}
{"type":"vkCall","index":129,"name":"vkDestroyDebugReportCallbackEXT","params":{"instance":1,"callback":2,"pAllocator":null}}
{"type":"vkCall","index":130,"name":"vkDestroyInstance","params":{"instance":1,"pAllocator":null}}

```
