### PR TITLE
PrivateData handle unwrapped and duplicated

### DIFF
--- a/framework/decode/vulkan_handle_mapping_util.cpp
+++ b/framework/decode/vulkan_handle_mapping_util.cpp
@@ -149,7 +149,7 @@ uint64_t MapHandle(uint64_t object, VkObjectType object_type, const VulkanObject
                 object, object_info_table, &VulkanObjectInfoTable::GetIndirectCommandsLayoutNVInfo));
         case VK_OBJECT_TYPE_PRIVATE_DATA_SLOT_EXT:
             return format::ToHandleId(MapHandle<PrivateDataSlotEXTInfo>(
-                object, object_info_table, &VulkanObjectInfoTable::GetPrivateDataSlotEXTInfo));
+                object, object_info_table, &VulkanObjectInfoTable::GetPrivateDataSlotInfo));
         case VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV:
             return format::ToHandleId(MapHandle<AccelerationStructureNVInfo>(
                 object, object_info_table, &VulkanObjectInfoTable::GetAccelerationStructureNVInfo));

--- a/framework/decode/vulkan_object_cleanup_util.cpp
+++ b/framework/decode/vulkan_object_cleanup_util.cpp
@@ -548,19 +548,19 @@ void FreeAllLiveObjects(VulkanObjectInfoTable*                                  
                 ->DestroyDeferredOperationKHR(parent_info->handle, object_info->handle, nullptr);
         });
 
-    FreeChildObjects<DeviceInfo, PrivateDataSlotEXTInfo>(
+    FreeChildObjects<DeviceInfo, PrivateDataSlotInfo>(
         table,
         GFXRECON_STR(VkDevice),
         GFXRECON_STR(VkPrivateDataSlotEXT),
         remove_entries,
         report_leaks,
         &VulkanObjectInfoTable::GetDeviceInfo,
-        &VulkanObjectInfoTable::VisitPrivateDataSlotEXTInfo,
-        &VulkanObjectInfoTable::RemovePrivateDataSlotEXTInfo,
-        [&](const DeviceInfo* parent_info, const PrivateDataSlotEXTInfo* object_info) {
+        &VulkanObjectInfoTable::VisitPrivateDataSlotInfo,
+        &VulkanObjectInfoTable::RemovePrivateDataSlotInfo,
+        [&](const DeviceInfo* parent_info, const PrivateDataSlotInfo* object_info) {
             assert((parent_info != nullptr) && (object_info != nullptr));
             get_device_table(parent_info->handle)
-                ->DestroyPrivateDataSlotEXT(parent_info->handle, object_info->handle, nullptr);
+                ->DestroyPrivateDataSlot(parent_info->handle, object_info->handle, nullptr);
         });
 
     FreeChildObjects<InstanceInfo, DebugReportCallbackEXTInfo>(

--- a/framework/decode/vulkan_object_info.h
+++ b/framework/decode/vulkan_object_info.h
@@ -200,7 +200,6 @@ typedef VulkanObjectInfo<VkAccelerationStructureKHR>      AccelerationStructureK
 typedef VulkanObjectInfo<VkAccelerationStructureNV>       AccelerationStructureNVInfo;
 typedef VulkanObjectInfo<VkPerformanceConfigurationINTEL> PerformanceConfigurationINTELInfo;
 typedef VulkanObjectInfo<VkDeferredOperationKHR>          DeferredOperationKHRInfo;
-typedef VulkanObjectInfo<VkPrivateDataSlotEXT>            PrivateDataSlotEXTInfo;
 
 //
 // Declarations for Vulkan objects with additional replay state info.
@@ -430,6 +429,7 @@ struct FramebufferInfo : public VulkanObjectInfo<VkFramebuffer>
 
 typedef SamplerYcbcrConversionInfo   SamplerYcbcrConversionKHRInfo;
 typedef DescriptorUpdateTemplateInfo DescriptorUpdateTemplateKHRInfo;
+typedef PrivateDataSlotInfo          PrivateDataSlotEXTInfo;
 
 GFXRECON_END_NAMESPACE(decode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/encode/vulkan_handle_wrappers.h
+++ b/framework/encode/vulkan_handle_wrappers.h
@@ -79,7 +79,7 @@ struct ValidationCacheEXTWrapper            : public HandleWrapper<VkValidationC
 struct IndirectCommandsLayoutNVWrapper      : public HandleWrapper<VkIndirectCommandsLayoutNV> {};
 struct PerformanceConfigurationINTELWrapper : public HandleWrapper<VkPerformanceConfigurationINTEL> {};
 struct DeferredOperationKHRWrapper          : public HandleWrapper<VkDeferredOperationKHR> {};
-struct PrivateDataSlotEXTWrapper            : public HandleWrapper<VkPrivateDataSlotEXT> {};
+struct PrivateDataSlotWrapper               : public HandleWrapper<VkPrivateDataSlot> {};
 
 // This handle type has a create function, but no destroy function. The handle wrapper will be owned by its parent VkDisplayKHR
 // handle wrapper, which will filter duplicate handle retrievals and ensure that the wrapper is destroyed.
@@ -298,9 +298,6 @@ struct PipelineLayoutWrapper : public HandleWrapper<VkPipelineLayout>
     std::shared_ptr<PipelineLayoutDependencies> layout_dependencies;
 };
 
-struct PrivateDataSlotWrapper : public HandleWrapper<VkPrivateDataSlot>
-{};
-
 struct PipelineWrapper : public HandleWrapper<VkPipeline>
 {
     // Creation info for objects used to create the pipeline, which may have been destroyed after pipeline creation.
@@ -448,6 +445,7 @@ struct AccelerationStructureNVWrapper : public HandleWrapper<VkAccelerationStruc
 // Handle alias types for extension handle types that have been promoted to core types.
 typedef SamplerYcbcrConversionWrapper   SamplerYcbcrConversionKHRWrapper;
 typedef DescriptorUpdateTemplateWrapper DescriptorUpdateTemplateKHRWrapper;
+typedef PrivateDataSlotWrapper          PrivateDataSlotEXTWrapper;
 
 GFXRECON_END_NAMESPACE(encode)
 GFXRECON_END_NAMESPACE(gfxrecon)

--- a/framework/generated/generated_vulkan_api_call_encoders.cpp
+++ b/framework/generated/generated_vulkan_api_call_encoders.cpp
@@ -5404,16 +5404,17 @@ VKAPI_ATTR VkResult VKAPI_CALL SetPrivateData(
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkSetPrivateData>::Dispatch(VulkanCaptureManager::Get(), device, objectType, objectHandle, privateDataSlot, data);
 
     VkDevice device_unwrapped = GetWrappedHandle<VkDevice>(device);
+    uint64_t objectHandle_unwrapped = GetWrappedHandle(objectHandle, objectType);
     VkPrivateDataSlot privateDataSlot_unwrapped = GetWrappedHandle<VkPrivateDataSlot>(privateDataSlot);
 
-    VkResult result = GetDeviceTable(device)->SetPrivateData(device_unwrapped, objectType, objectHandle, privateDataSlot_unwrapped, data);
+    VkResult result = GetDeviceTable(device)->SetPrivateData(device_unwrapped, objectType, objectHandle_unwrapped, privateDataSlot_unwrapped, data);
 
     auto encoder = VulkanCaptureManager::Get()->BeginApiCallCapture(format::ApiCallId::ApiCall_vkSetPrivateData);
     if (encoder)
     {
         encoder->EncodeHandleValue(device);
         encoder->EncodeEnumValue(objectType);
-        encoder->EncodeUInt64Value(objectHandle);
+        encoder->EncodeUInt64Value(GetWrappedId(objectHandle, objectType));
         encoder->EncodeHandleValue(privateDataSlot);
         encoder->EncodeUInt64Value(data);
         encoder->EncodeEnumValue(result);
@@ -5437,16 +5438,17 @@ VKAPI_ATTR void VKAPI_CALL GetPrivateData(
     CustomEncoderPreCall<format::ApiCallId::ApiCall_vkGetPrivateData>::Dispatch(VulkanCaptureManager::Get(), device, objectType, objectHandle, privateDataSlot, pData);
 
     VkDevice device_unwrapped = GetWrappedHandle<VkDevice>(device);
+    uint64_t objectHandle_unwrapped = GetWrappedHandle(objectHandle, objectType);
     VkPrivateDataSlot privateDataSlot_unwrapped = GetWrappedHandle<VkPrivateDataSlot>(privateDataSlot);
 
-    GetDeviceTable(device)->GetPrivateData(device_unwrapped, objectType, objectHandle, privateDataSlot_unwrapped, pData);
+    GetDeviceTable(device)->GetPrivateData(device_unwrapped, objectType, objectHandle_unwrapped, privateDataSlot_unwrapped, pData);
 
     auto encoder = VulkanCaptureManager::Get()->BeginApiCallCapture(format::ApiCallId::ApiCall_vkGetPrivateData);
     if (encoder)
     {
         encoder->EncodeHandleValue(device);
         encoder->EncodeEnumValue(objectType);
-        encoder->EncodeUInt64Value(objectHandle);
+        encoder->EncodeUInt64Value(GetWrappedId(objectHandle, objectType));
         encoder->EncodeHandleValue(privateDataSlot);
         encoder->EncodeUInt64Ptr(pData);
         VulkanCaptureManager::Get()->EndApiCallCapture();

--- a/framework/generated/generated_vulkan_object_info_table_base2.h
+++ b/framework/generated/generated_vulkan_object_info_table_base2.h
@@ -71,7 +71,6 @@ class VulkanObjectInfoTableBase2 : VulkanObjectInfoTableBase
     void AddPipelineCacheInfo(PipelineCacheInfo&& info) { AddObjectInfo(std::move(info), &pipelineCache_map_); }
     void AddPipelineLayoutInfo(PipelineLayoutInfo&& info) { AddObjectInfo(std::move(info), &pipelineLayout_map_); }
     void AddPrivateDataSlotInfo(PrivateDataSlotInfo&& info) { AddObjectInfo(std::move(info), &privateDataSlot_map_); }
-    void AddPrivateDataSlotEXTInfo(PrivateDataSlotEXTInfo&& info) { AddObjectInfo(std::move(info), &privateDataSlotEXT_map_); }
     void AddQueryPoolInfo(QueryPoolInfo&& info) { AddObjectInfo(std::move(info), &queryPool_map_); }
     void AddQueueInfo(QueueInfo&& info) { AddObjectInfo(std::move(info), &queue_map_); }
     void AddRenderPassInfo(RenderPassInfo&& info) { AddObjectInfo(std::move(info), &renderPass_map_); }
@@ -113,7 +112,6 @@ class VulkanObjectInfoTableBase2 : VulkanObjectInfoTableBase
     void RemovePipelineCacheInfo(format::HandleId id) { pipelineCache_map_.erase(id); }
     void RemovePipelineLayoutInfo(format::HandleId id) { pipelineLayout_map_.erase(id); }
     void RemovePrivateDataSlotInfo(format::HandleId id) { privateDataSlot_map_.erase(id); }
-    void RemovePrivateDataSlotEXTInfo(format::HandleId id) { privateDataSlotEXT_map_.erase(id); }
     void RemoveQueryPoolInfo(format::HandleId id) { queryPool_map_.erase(id); }
     void RemoveQueueInfo(format::HandleId id) { queue_map_.erase(id); }
     void RemoveRenderPassInfo(format::HandleId id) { renderPass_map_.erase(id); }
@@ -155,7 +153,6 @@ class VulkanObjectInfoTableBase2 : VulkanObjectInfoTableBase
     const PipelineCacheInfo* GetPipelineCacheInfo(format::HandleId id) const { return GetObjectInfo<PipelineCacheInfo>(id, &pipelineCache_map_); }
     const PipelineLayoutInfo* GetPipelineLayoutInfo(format::HandleId id) const { return GetObjectInfo<PipelineLayoutInfo>(id, &pipelineLayout_map_); }
     const PrivateDataSlotInfo* GetPrivateDataSlotInfo(format::HandleId id) const { return GetObjectInfo<PrivateDataSlotInfo>(id, &privateDataSlot_map_); }
-    const PrivateDataSlotEXTInfo* GetPrivateDataSlotEXTInfo(format::HandleId id) const { return GetObjectInfo<PrivateDataSlotEXTInfo>(id, &privateDataSlotEXT_map_); }
     const QueryPoolInfo* GetQueryPoolInfo(format::HandleId id) const { return GetObjectInfo<QueryPoolInfo>(id, &queryPool_map_); }
     const QueueInfo* GetQueueInfo(format::HandleId id) const { return GetObjectInfo<QueueInfo>(id, &queue_map_); }
     const RenderPassInfo* GetRenderPassInfo(format::HandleId id) const { return GetObjectInfo<RenderPassInfo>(id, &renderPass_map_); }
@@ -197,7 +194,6 @@ class VulkanObjectInfoTableBase2 : VulkanObjectInfoTableBase
     PipelineCacheInfo* GetPipelineCacheInfo(format::HandleId id) { return GetObjectInfo<PipelineCacheInfo>(id, &pipelineCache_map_); }
     PipelineLayoutInfo* GetPipelineLayoutInfo(format::HandleId id) { return GetObjectInfo<PipelineLayoutInfo>(id, &pipelineLayout_map_); }
     PrivateDataSlotInfo* GetPrivateDataSlotInfo(format::HandleId id) { return GetObjectInfo<PrivateDataSlotInfo>(id, &privateDataSlot_map_); }
-    PrivateDataSlotEXTInfo* GetPrivateDataSlotEXTInfo(format::HandleId id) { return GetObjectInfo<PrivateDataSlotEXTInfo>(id, &privateDataSlotEXT_map_); }
     QueryPoolInfo* GetQueryPoolInfo(format::HandleId id) { return GetObjectInfo<QueryPoolInfo>(id, &queryPool_map_); }
     QueueInfo* GetQueueInfo(format::HandleId id) { return GetObjectInfo<QueueInfo>(id, &queue_map_); }
     RenderPassInfo* GetRenderPassInfo(format::HandleId id) { return GetObjectInfo<RenderPassInfo>(id, &renderPass_map_); }
@@ -239,7 +235,6 @@ class VulkanObjectInfoTableBase2 : VulkanObjectInfoTableBase
     void VisitPipelineCacheInfo(std::function<void(const PipelineCacheInfo*)> visitor) const {  for (const auto& entry : pipelineCache_map_) { visitor(&entry.second); }  }
     void VisitPipelineLayoutInfo(std::function<void(const PipelineLayoutInfo*)> visitor) const {  for (const auto& entry : pipelineLayout_map_) { visitor(&entry.second); }  }
     void VisitPrivateDataSlotInfo(std::function<void(const PrivateDataSlotInfo*)> visitor) const {  for (const auto& entry : privateDataSlot_map_) { visitor(&entry.second); }  }
-    void VisitPrivateDataSlotEXTInfo(std::function<void(const PrivateDataSlotEXTInfo*)> visitor) const {  for (const auto& entry : privateDataSlotEXT_map_) { visitor(&entry.second); }  }
     void VisitQueryPoolInfo(std::function<void(const QueryPoolInfo*)> visitor) const {  for (const auto& entry : queryPool_map_) { visitor(&entry.second); }  }
     void VisitQueueInfo(std::function<void(const QueueInfo*)> visitor) const {  for (const auto& entry : queue_map_) { visitor(&entry.second); }  }
     void VisitRenderPassInfo(std::function<void(const RenderPassInfo*)> visitor) const {  for (const auto& entry : renderPass_map_) { visitor(&entry.second); }  }
@@ -282,7 +277,6 @@ class VulkanObjectInfoTableBase2 : VulkanObjectInfoTableBase
      std::unordered_map<format::HandleId, PipelineCacheInfo> pipelineCache_map_;
      std::unordered_map<format::HandleId, PipelineLayoutInfo> pipelineLayout_map_;
      std::unordered_map<format::HandleId, PrivateDataSlotInfo> privateDataSlot_map_;
-     std::unordered_map<format::HandleId, PrivateDataSlotEXTInfo> privateDataSlotEXT_map_;
      std::unordered_map<format::HandleId, QueryPoolInfo> queryPool_map_;
      std::unordered_map<format::HandleId, QueueInfo> queue_map_;
      std::unordered_map<format::HandleId, RenderPassInfo> renderPass_map_;

--- a/framework/generated/generated_vulkan_replay_consumer.cpp
+++ b/framework/generated/generated_vulkan_replay_consumer.cpp
@@ -2679,9 +2679,10 @@ void VulkanReplayConsumer::Process_vkSetPrivateData(
     uint64_t                                    data)
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
+    uint64_t in_objectHandle = MapHandle(objectHandle, objectType);
     VkPrivateDataSlot in_privateDataSlot = MapHandle<PrivateDataSlotInfo>(privateDataSlot, &VulkanObjectInfoTable::GetPrivateDataSlotInfo);
 
-    VkResult replay_result = GetDeviceTable(in_device)->SetPrivateData(in_device, objectType, objectHandle, in_privateDataSlot, data);
+    VkResult replay_result = GetDeviceTable(in_device)->SetPrivateData(in_device, objectType, in_objectHandle, in_privateDataSlot, data);
     CheckResult("vkSetPrivateData", returnValue, replay_result);
 }
 
@@ -2694,10 +2695,11 @@ void VulkanReplayConsumer::Process_vkGetPrivateData(
     PointerDecoder<uint64_t>*                   pData)
 {
     VkDevice in_device = MapHandle<DeviceInfo>(device, &VulkanObjectInfoTable::GetDeviceInfo);
+    uint64_t in_objectHandle = MapHandle(objectHandle, objectType);
     VkPrivateDataSlot in_privateDataSlot = MapHandle<PrivateDataSlotInfo>(privateDataSlot, &VulkanObjectInfoTable::GetPrivateDataSlotInfo);
     uint64_t* out_pData = pData->IsNull() ? nullptr : pData->AllocateOutputData(1, static_cast<uint64_t>(0));
 
-    GetDeviceTable(in_device)->GetPrivateData(in_device, objectType, objectHandle, in_privateDataSlot, out_pData);
+    GetDeviceTable(in_device)->GetPrivateData(in_device, objectType, in_objectHandle, in_privateDataSlot, out_pData);
 }
 
 void VulkanReplayConsumer::Process_vkCmdSetEvent2(

--- a/framework/generated/generated_vulkan_state_table.h
+++ b/framework/generated/generated_vulkan_state_table.h
@@ -71,7 +71,6 @@ class VulkanStateTable : VulkanStateTableBase
     bool InsertWrapper(format::HandleId id, PipelineCacheWrapper* wrapper) { return InsertEntry(id, wrapper, pipelineCache_map_); }
     bool InsertWrapper(format::HandleId id, PipelineLayoutWrapper* wrapper) { return InsertEntry(id, wrapper, pipelineLayout_map_); }
     bool InsertWrapper(format::HandleId id, PrivateDataSlotWrapper* wrapper) { return InsertEntry(id, wrapper, privateDataSlot_map_); }
-    bool InsertWrapper(format::HandleId id, PrivateDataSlotEXTWrapper* wrapper) { return InsertEntry(id, wrapper, privateDataSlotEXT_map_); }
     bool InsertWrapper(format::HandleId id, QueryPoolWrapper* wrapper) { return InsertEntry(id, wrapper, queryPool_map_); }
     bool InsertWrapper(format::HandleId id, QueueWrapper* wrapper) { return InsertEntry(id, wrapper, queue_map_); }
     bool InsertWrapper(format::HandleId id, RenderPassWrapper* wrapper) { return InsertEntry(id, wrapper, renderPass_map_); }
@@ -113,7 +112,6 @@ class VulkanStateTable : VulkanStateTableBase
     bool RemoveWrapper(const PipelineCacheWrapper* wrapper) { return RemoveEntry(wrapper, pipelineCache_map_); }
     bool RemoveWrapper(const PipelineLayoutWrapper* wrapper) { return RemoveEntry(wrapper, pipelineLayout_map_); }
     bool RemoveWrapper(const PrivateDataSlotWrapper* wrapper) { return RemoveEntry(wrapper, privateDataSlot_map_); }
-    bool RemoveWrapper(const PrivateDataSlotEXTWrapper* wrapper) { return RemoveEntry(wrapper, privateDataSlotEXT_map_); }
     bool RemoveWrapper(const QueryPoolWrapper* wrapper) { return RemoveEntry(wrapper, queryPool_map_); }
     bool RemoveWrapper(const QueueWrapper* wrapper) { return RemoveEntry(wrapper, queue_map_); }
     bool RemoveWrapper(const RenderPassWrapper* wrapper) { return RemoveEntry(wrapper, renderPass_map_); }
@@ -155,7 +153,6 @@ class VulkanStateTable : VulkanStateTableBase
     const PipelineCacheWrapper* GetPipelineCacheWrapper(format::HandleId id) const { return GetWrapper<PipelineCacheWrapper>(id, pipelineCache_map_); }
     const PipelineLayoutWrapper* GetPipelineLayoutWrapper(format::HandleId id) const { return GetWrapper<PipelineLayoutWrapper>(id, pipelineLayout_map_); }
     const PrivateDataSlotWrapper* GetPrivateDataSlotWrapper(format::HandleId id) const { return GetWrapper<PrivateDataSlotWrapper>(id, privateDataSlot_map_); }
-    const PrivateDataSlotEXTWrapper* GetPrivateDataSlotEXTWrapper(format::HandleId id) const { return GetWrapper<PrivateDataSlotEXTWrapper>(id, privateDataSlotEXT_map_); }
     const QueryPoolWrapper* GetQueryPoolWrapper(format::HandleId id) const { return GetWrapper<QueryPoolWrapper>(id, queryPool_map_); }
     const QueueWrapper* GetQueueWrapper(format::HandleId id) const { return GetWrapper<QueueWrapper>(id, queue_map_); }
     const RenderPassWrapper* GetRenderPassWrapper(format::HandleId id) const { return GetWrapper<RenderPassWrapper>(id, renderPass_map_); }
@@ -197,7 +194,6 @@ class VulkanStateTable : VulkanStateTableBase
     PipelineCacheWrapper* GetPipelineCacheWrapper(format::HandleId id) { return GetWrapper<PipelineCacheWrapper>(id, pipelineCache_map_); }
     PipelineLayoutWrapper* GetPipelineLayoutWrapper(format::HandleId id) { return GetWrapper<PipelineLayoutWrapper>(id, pipelineLayout_map_); }
     PrivateDataSlotWrapper* GetPrivateDataSlotWrapper(format::HandleId id) { return GetWrapper<PrivateDataSlotWrapper>(id, privateDataSlot_map_); }
-    PrivateDataSlotEXTWrapper* GetPrivateDataSlotEXTWrapper(format::HandleId id) { return GetWrapper<PrivateDataSlotEXTWrapper>(id, privateDataSlotEXT_map_); }
     QueryPoolWrapper* GetQueryPoolWrapper(format::HandleId id) { return GetWrapper<QueryPoolWrapper>(id, queryPool_map_); }
     QueueWrapper* GetQueueWrapper(format::HandleId id) { return GetWrapper<QueueWrapper>(id, queue_map_); }
     RenderPassWrapper* GetRenderPassWrapper(format::HandleId id) { return GetWrapper<RenderPassWrapper>(id, renderPass_map_); }
@@ -239,7 +235,6 @@ class VulkanStateTable : VulkanStateTableBase
     void VisitWrappers(std::function<void(PipelineCacheWrapper*)> visitor) const { for (auto entry : pipelineCache_map_) { visitor(entry.second); } }
     void VisitWrappers(std::function<void(PipelineLayoutWrapper*)> visitor) const { for (auto entry : pipelineLayout_map_) { visitor(entry.second); } }
     void VisitWrappers(std::function<void(PrivateDataSlotWrapper*)> visitor) const { for (auto entry : privateDataSlot_map_) { visitor(entry.second); } }
-    void VisitWrappers(std::function<void(PrivateDataSlotEXTWrapper*)> visitor) const { for (auto entry : privateDataSlotEXT_map_) { visitor(entry.second); } }
     void VisitWrappers(std::function<void(QueryPoolWrapper*)> visitor) const { for (auto entry : queryPool_map_) { visitor(entry.second); } }
     void VisitWrappers(std::function<void(QueueWrapper*)> visitor) const { for (auto entry : queue_map_) { visitor(entry.second); } }
     void VisitWrappers(std::function<void(RenderPassWrapper*)> visitor) const { for (auto entry : renderPass_map_) { visitor(entry.second); } }
@@ -282,7 +277,6 @@ class VulkanStateTable : VulkanStateTableBase
     std::map<format::HandleId, PipelineCacheWrapper*> pipelineCache_map_;
     std::map<format::HandleId, PipelineLayoutWrapper*> pipelineLayout_map_;
     std::map<format::HandleId, PrivateDataSlotWrapper*> privateDataSlot_map_;
-    std::map<format::HandleId, PrivateDataSlotEXTWrapper*> privateDataSlotEXT_map_;
     std::map<format::HandleId, QueryPoolWrapper*> queryPool_map_;
     std::map<format::HandleId, QueueWrapper*> queue_map_;
     std::map<format::HandleId, RenderPassWrapper*> renderPass_map_;

--- a/framework/generated/vulkan_generators/base_generator.py
+++ b/framework/generated/vulkan_generators/base_generator.py
@@ -254,6 +254,12 @@ class BaseGenerator(OutputGenerator):
         },
         'vkGetPrivateDataEXT': {
             'objectHandle': 'objectType'
+        },
+        'vkSetPrivateData': {
+            'objectHandle': 'objectType'
+        },
+        'vkGetPrivateData': {
+            'objectHandle': 'objectType'
         }
     }
 
@@ -298,7 +304,7 @@ class BaseGenerator(OutputGenerator):
     ]
 
     DUPLICATE_HANDLE_TYPES = [
-        'VkDescriptorUpdateTemplateKHR', 'VkSamplerYcbcrConversionKHR'
+        'VkDescriptorUpdateTemplateKHR', 'VkSamplerYcbcrConversionKHR', 'VkPrivateDataSlotEXT'
     ]
 
     # Default C++ code indentation size.


### PR DESCRIPTION
SetPrivateData and GetPrivateData need unwrapped objectHandle, like PrivateDataEXT. Also, VkPrivateDataSlotEXT and VkPrivateDataSlot are should be integrated.